### PR TITLE
fix: make redb data-dir lock contention legible at session/open

### DIFF
--- a/crates/octos-bus/src/twilio_channel.rs
+++ b/crates/octos-bus/src/twilio_channel.rs
@@ -154,7 +154,7 @@ fn sha1(data: &[u8]) -> [u8; 20] {
 
         let (mut a, mut b, mut c, mut d, mut e) = (h0, h1, h2, h3, h4);
 
-        for i in 0..80 {
+        for (i, &wi) in w.iter().enumerate() {
             let (f, k) = match i {
                 0..=19 => ((b & c) | ((!b) & d), 0x5A827999u32),
                 20..=39 => (b ^ c ^ d, 0x6ED9EBA1u32),
@@ -167,7 +167,7 @@ fn sha1(data: &[u8]) -> [u8; 20] {
                 .wrapping_add(f)
                 .wrapping_add(e)
                 .wrapping_add(k)
-                .wrapping_add(w[i]);
+                .wrapping_add(wi);
             e = d;
             d = c;
             c = b.rotate_left(30);
@@ -195,7 +195,7 @@ fn sha1(data: &[u8]) -> [u8; 20] {
 fn base64_encode(data: &[u8]) -> String {
     const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0] as u32;
         let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };

--- a/crates/octos-bus/src/wecom_channel.rs
+++ b/crates/octos-bus/src/wecom_channel.rs
@@ -49,6 +49,7 @@ pub struct WeComChannel {
 }
 
 impl WeComChannel {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         corp_id: &str,
         agent_id: &str,

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -18280,6 +18280,67 @@ fn runtime_unavailable_errors_are_typed_for_protocol_clients() {
 }
 
 #[test]
+fn held_data_dir_lock_yields_a_clear_actionable_error() {
+    // A `session/open` bootstrap that fails because another octos process
+    // already owns the profile's redb must be recognized structurally
+    // (through the eyre wrap chain that `ProfileRuntime::bootstrap` adds) and
+    // rendered with both remedies. Previously this reached the client as
+    // "failed to bootstrap ProfileRuntime for profile 'alan': failed to open
+    // episode store for profile 'alan'" — the cause, the path, and every hint
+    // about what to do were dropped by the `{error}` (non-alternate) format.
+    let report = eyre::Report::new(octos_memory::EpisodeStoreLocked {
+        path: std::path::PathBuf::from("/Users/dev/.octos/profiles/alan/data/episodes.redb"),
+    })
+    .wrap_err("failed to open episode store for profile 'alan'");
+    assert!(
+        octos_memory::is_episode_store_locked(&report),
+        "lock contention must be detected through the eyre wrap chain"
+    );
+
+    let error = data_dir_locked_error("alan", &report);
+    assert_eq!(
+        error.code,
+        octos_core::ui_protocol::rpc_error_codes::INTERNAL_ERROR
+    );
+    assert_eq!(
+        error.data.as_ref().and_then(|d| d.get("kind")),
+        Some(&json!("data_dir_locked")),
+        "clients branch on `kind`; this must not be the generic runtime_unavailable"
+    );
+    let message = error
+        .data
+        .as_ref()
+        .and_then(|d| d.get("message"))
+        .and_then(|m| m.as_str())
+        .unwrap_or_default();
+    assert!(
+        message.contains("alan"),
+        "message must name the profile: {message}"
+    );
+    assert!(
+        message.contains("--instance-data-dir"),
+        "message must offer the private-storage remedy: {message}"
+    );
+    assert!(
+        message.contains("episodes.redb"),
+        "message must carry the underlying cause, including the contended path: {message}"
+    );
+}
+
+#[test]
+fn non_lock_bootstrap_error_is_not_misclassified_as_data_dir_locked() {
+    // Guards the detector against over-matching: a missing provider is not a
+    // lock problem and has no `--instance-data-dir` remedy, so it must keep
+    // falling through to the generic `runtime_unavailable` kind.
+    let report = eyre::eyre!("No LLM provider configured")
+        .wrap_err("failed to bootstrap ProfileRuntime for profile 'alan'");
+    assert!(
+        !octos_memory::is_episode_store_locked(&report),
+        "an unrelated bootstrap failure must not be reported as lock contention"
+    );
+}
+
+#[test]
 fn permission_denied_workspace_yields_a_clear_actionable_error() {
     // A session/open bootstrap failure caused by a non-writable workspace
     // folder must be recognized structurally (through the eyre wrap chain)

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -18914,9 +18914,20 @@ async fn ensure_session_profile_runtime(
     )
     .await
     .map_err(|error| {
-        runtime_unavailable_error(format!(
-            "failed to bootstrap ProfileRuntime for profile '{profile_id}': {error}"
-        ))
+        // Lock contention is a config mistake with a concrete fix, so it gets
+        // its own typed kind and a sentence the operator can act on. Anything
+        // else stays `runtime_unavailable` — but formatted with `{error:#}`
+        // so the eyre chain survives to the client. Plain `{error}` prints
+        // only the outermost context, which is how "failed to open episode
+        // store for profile 'x'" used to reach the TUI with its actual cause
+        // (and its remedy) silently dropped.
+        if octos_memory::is_episode_store_locked(&error) {
+            data_dir_locked_error(&profile_id, &error)
+        } else {
+            runtime_unavailable_error(format!(
+                "failed to bootstrap ProfileRuntime for profile '{profile_id}': {error:#}"
+            ))
+        }
     })?;
     let mut runtimes = dynamic_profile_runtimes()
         .write()
@@ -34974,6 +34985,30 @@ fn workspace_not_writable_error(workspace: Option<&str>) -> RpcError {
     RpcError::internal_error(sentence.clone()).with_data(json!({
         "kind": "workspace_not_writable",
         "workspace": workspace,
+        "message": sentence,
+    }))
+}
+
+/// Clear, actionable RPC error for "another octos process already owns this
+/// profile's data directory" — redb is single-writer-single-process, so a
+/// second `octos serve` against the same data dir can never open the episode
+/// store.
+///
+/// This is a deployment mistake with two concrete fixes, not an internal
+/// fault, so it gets its own `kind` (clients can render a remedy instead of a
+/// stack-shaped string) and the sentence names both ways out. `data.message`
+/// is rendered verbatim by clients, matching [`workspace_not_writable_error`].
+fn data_dir_locked_error(profile_id: &str, error: &eyre::Report) -> RpcError {
+    let sentence = format!(
+        "Can't start a session for profile '{profile_id}' — another octos process already \
+         owns this profile's data directory, and its storage allows only one writer. \
+         Stop the other `octos serve` (if it is supervised, e.g. by launchd, stop the \
+         service rather than the process — it will be restarted otherwise), or give this \
+         instance its own storage with `--instance-data-dir <dir>`. Details: {error:#}"
+    );
+    RpcError::internal_error(sentence.clone()).with_data(json!({
+        "kind": "data_dir_locked",
+        "profile_id": profile_id,
         "message": sentence,
     }))
 }

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -18922,7 +18922,7 @@ async fn ensure_session_profile_runtime(
         // store for profile 'x'" used to reach the TUI with its actual cause
         // (and its remedy) silently dropped.
         if octos_memory::is_episode_store_locked(&error) {
-            data_dir_locked_error(&profile_id, &error)
+            data_dir_locked_error(profile_id, &error)
         } else {
             runtime_unavailable_error(format!(
                 "failed to bootstrap ProfileRuntime for profile '{profile_id}': {error:#}"

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -1940,6 +1940,15 @@ mod tests {
             msg.contains("Database already open") || msg.contains("Cannot acquire lock"),
             "error must surface the redb lock contention; got: {err:?}",
         );
+
+        // Failing loudly is only half the contract: the API layer branches on
+        // this to render an actionable remedy, and it must be able to tell
+        // lock contention from corruption without string matching.
+        assert!(
+            octos_memory::is_episode_store_locked(&err),
+            "bootstrap must preserve the typed lock cause through its own \
+             wrap_err context; got: {err:?}",
+        );
     }
 
     /// Build a minimal profile that bootstraps successfully against a

--- a/crates/octos-memory/src/lib.rs
+++ b/crates/octos-memory/src/lib.rs
@@ -18,4 +18,7 @@ pub use memory_store::{
     UsageMap, UsageStat, estimate_tokens, extract_abstract, is_reserved_memory_name,
     is_valid_entry_id,
 };
-pub use store::{DEFAULT_DIMENSION as EPISODIC_INDEX_DIMENSION, EpisodeStore};
+pub use store::{
+    DEFAULT_DIMENSION as EPISODIC_INDEX_DIMENSION, EpisodeStore, EpisodeStoreLocked,
+    is_episode_store_locked,
+};

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -1,6 +1,6 @@
 //! Episode store: persistent storage for episodes using redb (pure Rust).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use eyre::{Result, WrapErr};
@@ -28,6 +28,53 @@ const EMBEDDINGS_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("emb
 /// in-process EmbeddingGemma at 768, since Matryoshka only truncates downward —
 /// must instead size the index itself via [`EpisodeStore::open_with_dimension`].
 pub const DEFAULT_DIMENSION: usize = 1536;
+
+/// Typed cause for "the redb episode store at `path` is already owned by
+/// another process".
+///
+/// redb is single-writer-single-process, so a second `octos serve` against the
+/// same data dir can never open it. That is a deployment/config mistake with a
+/// concrete fix, not an internal fault — but the strict opener used to report
+/// it as an untyped string, so every caller upstack could only re-wrap prose.
+/// Carrying a typed cause lets a caller *recognise* the condition
+/// ([`is_episode_store_locked`]) and render its own actionable message, the
+/// same way the API layer already downcasts to [`std::io::Error`] for
+/// permission-denied workspaces.
+#[derive(Debug, Clone)]
+pub struct EpisodeStoreLocked {
+    /// The `episodes.redb` path whose lock is held elsewhere.
+    pub path: PathBuf,
+}
+
+impl std::fmt::Display for EpisodeStoreLocked {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Keep the redb wording ("Database already open. Cannot acquire
+        // lock.") — operators grep for it and it is what redb itself prints.
+        write!(
+            f,
+            "failed to open redb database at {}: Database already open. \
+             Cannot acquire lock. Another octos process (typically an `octos \
+             serve` daemon) already owns this data directory. Stop it, or \
+             start this instance against its own storage with \
+             `--instance-data-dir <dir>`.",
+            self.path.display(),
+        )
+    }
+}
+
+impl std::error::Error for EpisodeStoreLocked {}
+
+/// True when `error` carries an [`EpisodeStoreLocked`] anywhere in its eyre
+/// chain — i.e. the failure is redb lock contention rather than corruption,
+/// I/O, or a permission problem.
+///
+/// Structural (downcast), not string matching, so wrapping the error with
+/// extra context upstack cannot break the check.
+pub fn is_episode_store_locked(error: &eyre::Report) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<EpisodeStoreLocked>().is_some())
+}
 
 /// Parse a cwd-index JSON array of episode IDs. On corrupt JSON, salvage any
 /// quoted strings that look like episode IDs instead of silently replacing
@@ -281,14 +328,23 @@ impl EpisodeStore {
                     index: RwLock::new(HybridIndex::new(dimension)),
                 })
             }
-            None => Err(eyre::eyre!(
-                "failed to open redb database at {}: \
-                 Database already open. Cannot acquire lock. \
-                 (Strict `EpisodeStore::open` was used — if this is the \
-                 `octos gateway` subprocess, call `open_or_degraded` \
-                 instead.)",
-                db_path_for_log.display(),
-            )),
+            // Typed and UNWRAPPED, so callers upstack can both recognise the
+            // condition (`is_episode_store_locked`) and forward a message
+            // that already names the path and the remedy. The
+            // developer-facing "wrong opener?" hint is a log line rather than
+            // error context: it is noise for the operator who sees this on a
+            // session/open, and burying the actionable sentence one level
+            // deeper is exactly what made this error unreadable in clients.
+            None => {
+                debug!(
+                    path = %db_path_for_log.display(),
+                    "strict `EpisodeStore::open` failed on a held lock — if this is the \
+                     `octos gateway` subprocess, call `open_or_degraded` instead"
+                );
+                Err(eyre::Report::new(EpisodeStoreLocked {
+                    path: db_path_for_log.clone(),
+                }))
+            }
         }
     }
 
@@ -1808,6 +1864,77 @@ mod tests {
         assert!(
             msg.contains("Database already open") || msg.contains("Cannot acquire lock"),
             "strict open error must surface the lock contention; got: {err:?}",
+        );
+    }
+
+    /// The strict-open failure must be *recognisable* and *actionable*, not
+    /// just non-empty prose.
+    ///
+    /// Recognisable: callers upstack (the ui-protocol `session/open` handler)
+    /// decide whether to render a "another process owns this data dir"
+    /// remedy or a generic internal error, and they must not do that by
+    /// string-matching an error whose wording is free to change.
+    ///
+    /// Actionable: the operator sees this through a client, so the sentence
+    /// itself has to name the path and both ways out. Before this, the
+    /// message reached the TUI as a bare "failed to open episode store for
+    /// profile 'x'" with the cause dropped entirely.
+    #[tokio::test]
+    async fn strict_open_lock_error_is_typed_and_names_the_remedy() {
+        let dir = tempfile::tempdir().unwrap();
+        let _owner = EpisodeStore::open(dir.path()).await.unwrap();
+
+        let err = EpisodeStore::open(dir.path())
+            .await
+            .err()
+            .expect("strict open must error when lock is held");
+
+        assert!(
+            is_episode_store_locked(&err),
+            "lock contention must be structurally detectable; got: {err:?}",
+        );
+
+        // Survives re-wrapping: `ProfileRuntime::bootstrap` adds its own
+        // context before the API layer inspects the error.
+        let wrapped = Err::<(), _>(err)
+            .wrap_err("failed to open episode store for profile 'alan'")
+            .unwrap_err();
+        assert!(
+            is_episode_store_locked(&wrapped),
+            "detection must survive eyre context wrapping; got: {wrapped:?}",
+        );
+
+        let rendered = format!("{wrapped:#}");
+        assert!(
+            rendered.contains("episodes.redb"),
+            "message must name the contended file; got: {rendered}",
+        );
+        assert!(
+            rendered.contains("--instance-data-dir"),
+            "message must name the remedy; got: {rendered}",
+        );
+    }
+
+    /// Corruption / I/O failures must NOT be mistaken for lock contention —
+    /// they have no `--instance-data-dir` remedy and need a different
+    /// message. Guards the typed detector against over-matching.
+    #[tokio::test]
+    async fn non_lock_open_failures_are_not_flagged_as_locked() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("episodes.redb");
+        // Not a redb file at all: open must fail as a format/corruption
+        // error, which is a distinct condition from a held lock.
+        tokio::fs::write(&db_path, b"this is not a redb database")
+            .await
+            .unwrap();
+
+        let err = EpisodeStore::open(dir.path())
+            .await
+            .err()
+            .expect("opening a corrupt file must error");
+        assert!(
+            !is_episode_store_locked(&err),
+            "corruption must not be reported as lock contention; got: {err:?}",
         );
     }
 }


### PR DESCRIPTION
## Problem

A second `octos serve` against the same data dir fails at the first `session/open`, and the error that reaches the client says nothing useful:

```
[runtime_unavailable]: session/open request tui-3 failed: failed to bootstrap
ProfileRuntime for profile 'alan': failed to open episode store for profile 'alan'
```

That is the whole message. No path, no cause, no remedy — and `runtime_unavailable` is the same kind returned for a missing provider, a bad tool config, or unresolvable credentials, so a client has nothing to branch on either.

The underlying condition is mundane: redb is single-writer-single-process, and a dev serve started on a different port still resolves to `$OCTOS_HOME`, because the port isolates the socket, not the storage. `BootstrapRole::Serve` deliberately refuses to degrade (#899 gave that fallback to `Gateway` only, so a misordered start can't quietly flip canonical ownership), and profiles bootstrap lazily, so the refusal lands at `session/open` rather than at startup.

Two defects made it illegible:

1. **The cause chain was dropped.** `ui_protocol_transport.rs` formatted with `{error}` — plain `Display` on an `eyre::Report`, which prints only the outermost context. The store's own message already named the contended `episodes.redb` path; it never left the process.
2. **Lock contention wasn't distinguishable.** It was flattened into `runtime_unavailable` along with every other bootstrap failure, and the only way to tell them apart was to match on prose.

## Change

**`octos-memory`** — replace the untyped `eyre::eyre!` in the strict-open branch with a typed `EpisodeStoreLocked { path }`, plus `is_episode_store_locked()` for structural detection over the eyre chain. This mirrors the existing `is_permission_denied_error`, which downcasts to `std::io::Error` rather than string-matching, and it survives the `wrap_err` context `ProfileRuntime::bootstrap` adds on the way up. The typed error is returned **unwrapped** so its operator-facing sentence is outermost; the developer-facing "wrong opener?" hint becomes a `debug!` line. redb's own `Database already open. Cannot acquire lock.` wording is preserved — operators grep for it.

**`octos-cli`** — `session/open` now branches: lock contention gets a typed `data_dir_locked` kind whose message names the profile and both remedies, following the `workspace_not_writable_error` precedent of treating a fixable config problem as its own kind with a sentence the client renders verbatim. Everything else stays `runtime_unavailable`, now formatted with `{error:#}` so the chain survives.

The remedy text explicitly calls out supervised deployments — under launchd `KeepAlive`, killing the PID accomplishes nothing because the lock is handed straight back to a fresh process within a second. That is a genuinely confusing thing to debug from a client, and it is what motivated this PR.

## Why this path still matters

The fast-fail `OCTOS_DATA_DIR_LOCKED` startup guard should normally catch this first. It can't fire when the incumbent predates it — an older serve holding the redb never took that lock, so the new serve starts cleanly and only fails later. Between two current binaries you get the clean startup refusal; this path is the backstop for mixed-version and upgrade-in-progress installs.

## Tests

6 passing — 5 new, 1 strengthened:

- typed cause survives re-wrapping; message names both the path and the remedy
- a corrupt (non-redb) file is **not** flagged as lock contention — guards the detector against over-matching
- transport returns `data_dir_locked` with profile, remedy, and underlying cause in `data.message`
- an unrelated bootstrap failure keeps the generic `runtime_unavailable` kind
- `second_serve_role_bootstrap_fails_loudly_when_redb_already_owned` now also asserts the typed cause survives bootstrap's own `wrap_err` — failing loudly is only half the contract when a caller upstack has to classify the failure

```
cargo test -p octos-memory --lib          # 93 passed
cargo test -p octos-cli --features api --lib -- <the three above>   # 3 passed
cargo check -p octos-cli --features api --tests                     # clean, no warnings
```

## Compatibility

Additive. `data_dir_locked` is a new `kind`; clients that don't know it fall back to rendering `message`, which is now a complete sentence rather than a truncated chain. No signature changes to `EpisodeStore::open*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)