### PR TITLE
fix: ungate Message import (#2103) + rustfmt scatter_join_state (#2105) — main CI red

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -14,7 +14,8 @@ use octos_bus::file_handle::{
     encode_profile_file_handle, encode_tmp_upload_handle, resolve_legacy_file_request,
     resolve_scoped_file_handle, resolve_workspace_file_handle,
 };
-#[cfg(test)]
+// `Message` is used by non-test lib code (`dedupe_history_rows` below),
+// so this import must not be test-gated.
 use octos_core::Message;
 use octos_core::{MAIN_PROFILE_ID, SessionKey};
 use serde::{Deserialize, Serialize};

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -12598,10 +12598,7 @@ fn enqueue_agent_terminal_continuations(
     // check skips re-observation, restart-safe); a genuinely re-expanded
     // group gets a new epoch at spawn admission and joins again.
     let join_group_key = agent_continuation_group_id(agent);
-    let join_state = state
-        .scatter_join_state
-        .entry(join_group_key)
-        .or_default();
+    let join_state = state.scatter_join_state.entry(join_group_key).or_default();
     let mut cwd_hasher = std::collections::hash_map::DefaultHasher::new();
     std::hash::Hash::hash(&agent.cwd, &mut cwd_hasher);
     let cwd_hash = std::hash::Hasher::finish(&cwd_hasher);
@@ -12641,10 +12638,7 @@ fn enqueue_agent_terminal_continuations(
     };
     enqueue_and_persist_continuation(state, scatter);
     let join_group_key = agent_continuation_group_id(agent);
-    let join_state = state
-        .scatter_join_state
-        .entry(join_group_key)
-        .or_default();
+    let join_state = state.scatter_join_state.entry(join_group_key).or_default();
     join_state.last_joined_key = Some(join_key);
 }
 


### PR DESCRIPTION
## Problem

Two post-merge regressions turned main's CI red (both PRs' CI runs predated their merges):

1. **#2103** added `dedupe_history_rows`, which references `octos_core::Message` from non-test lib code — but the import stayed `#[cfg(test)]`-gated. check-matrix (`clippy --all-targets` compiles the plain lib) and the API feature tests fail with `E0425`.
2. **#2105** introduced a chained `scatter_join_state` call that stable rustfmt wants on one line — `check` job's Check formatting fails.

## Fix

- Remove the `#[cfg(test)]` gate from `use octos_core::Message;`
- Collapse the two chained calls to the one-line form