### PR TITLE
fix(ui-protocol): scoped goal-event generations + goal-frame capability gating + forwarder hardening (#2065 rebased)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,14 @@ jobs:
       - name: Background activity human sink (octos-cli)
         run: cargo test -p octos-cli --features api background_activity -- --nocapture
 
+      # #2062 goal-chip null snapshot: session/open must push an explicit
+      # `session/goal/cleared` when no goal is bound, so a goal cleared
+      # elsewhere can't survive a reconnect as a stale cached chip. Lives in
+      # the `api`-gated ui_protocol module — invisible to the unfeatured runs
+      # above, same reason as the §6 guard.
+      - name: Session-open goal null snapshot (octos-cli)
+        run: cargo test -p octos-cli --features api session_open_goal -- --nocapture
+
       # The smart_home/* WS methods are `api`-gated too, so the unfeatured
       # integration run above compiles this file to zero tests. Run it
       # explicitly: it is the only end-to-end coverage of the WS dispatch →

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,13 +477,14 @@ jobs:
       - name: Background activity human sink (octos-cli)
         run: cargo test -p octos-cli --features api background_activity -- --nocapture
 
-      # #2062 goal-chip null snapshot: session/open must push an explicit
-      # `session/goal/cleared` when no goal is bound, so a goal cleared
-      # elsewhere can't survive a reconnect as a stale cached chip. Lives in
-      # the `api`-gated ui_protocol module — invisible to the unfeatured runs
+      # #2065 goal-frame substrate: per-scope generation identities for the
+      # #1959 send guard (one cwd scope's clear must not suppress a sibling
+      # scope's repaint on a shared wire session id), goal-frame capability
+      # gating, and live-forwarder lifecycle hardening. Lives in the
+      # `api`-gated ui_protocol module — invisible to the unfeatured runs
       # above, same reason as the §6 guard.
-      - name: Session-open goal null snapshot (octos-cli)
-        run: cargo test -p octos-cli --features api session_open_goal -- --nocapture
+      - name: Goal-frame scoping + gating + forwarder (octos-cli)
+        run: cargo test -p octos-cli --features api -- goal_scope_guard session_open_goal --nocapture
 
       # The smart_home/* WS methods are `api`-gated too, so the unfeatured
       # integration run above compiles this file to zero tests. Run it

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -14,7 +14,8 @@ use octos_bus::file_handle::{
     encode_profile_file_handle, encode_tmp_upload_handle, resolve_legacy_file_request,
     resolve_scoped_file_handle, resolve_workspace_file_handle,
 };
-#[cfg(test)]
+// `Message` is used by non-test lib code (`dedupe_history_rows` below),
+// so this import must not be test-gated.
 use octos_core::Message;
 use octos_core::{MAIN_PROFILE_ID, SessionKey};
 use serde::{Deserialize, Serialize};

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35342,16 +35342,17 @@ fn should_report_zero_cache_reads_explicitly_on_a_cold_session() {
 }
 
 // ---------------------------------------------------------------------------
-// #2062 round 6 — the goal snapshot rides IN the `session/open` RPC RESPONSE
-// (`SessionOpenResult::goal_state`): either the goal object or EXPLICIT
-// `null`, always present on new servers. The response's fixed position in
-// the client's own processing order makes the snapshot race-free by
-// construction — the client applies it while handling the open result,
-// before any subsequently delivered frame, and every later goal frame is by
-// definition newer and simply overwrites it. Rounds 2-5 pursued
-// ordered-notification delivery instead; codex's null-suppresses-null proof
-// showed that abstraction unsound, and the notification machinery was
-// deleted wholesale in favor of this field.
+// #2062 rounds 6-8 — the VERSIONED goal snapshot rides IN the `session/open`
+// RPC RESPONSE (`SessionOpenResult::goal_state`):
+// `{ "version": u64, "goal": object|null }`, always present on new servers.
+// The version is the scope's latest #1959 generation — the same number
+// space stamped on SessionGoalUpdated/Cleared frames — captured together
+// with the state under ONE state-lock acquisition. The wire does NOT carry
+// freshness (codex round-7 F1: producers release the guard and enqueue
+// later, so no server-side ordering scheme can — five notification rounds,
+// response position, and capture-at-enqueue all failed on that rock); the
+// DATA carries it, and the client resolves any arrival order by version
+// (apply iff version >= last applied, within one connection).
 //
 // CI: these run under the `session_open_goal` name filter in
 // .github/workflows/ci.yml (test-octos-cli job) — the `api`-gated module is
@@ -35402,12 +35403,14 @@ async fn open_session_result_frame(
     result
 }
 
-/// #2062 round 6, tests (a)+(d) — an open with NO goal bound answers with
-/// an EXPLICIT `"goal_state": null` in the RPC result: the key is PRESENT
-/// (null is a statement, not an omission — an absent key is the old-server
-/// legacy shape a new client treats as no-op).
+/// #2062 round 8 — an open with NO goal bound answers with an EXPLICIT
+/// versioned null snapshot: the `goal_state` key is PRESENT (a statement,
+/// not an omission), carries a `version` (u64) and `goal: null`. Also pins
+/// the old-server compat contract: the same result payload with the field
+/// STRIPPED still parses (`#[serde(default)]` → `Null`), which is exactly
+/// what a new client sees from an old server.
 #[tokio::test]
-async fn session_open_goal_state_response_is_explicit_null_when_no_goal_bound() {
+async fn session_open_goal_state_response_is_versioned_null_when_no_goal_bound() {
     let temp = tempfile::tempdir().expect("tempdir");
     let state = state_with_sessions(temp.path());
     let ledger = Arc::new(UiProtocolLedger::new(16));
@@ -35423,9 +35426,29 @@ async fn session_open_goal_state_response_is_explicit_null_when_no_goal_bound() 
         "the field is ALWAYS present on a new server: {result:?}"
     );
     assert!(
-        result["goal_state"].is_null(),
-        "no goal bound => explicit null: {:?}",
+        result["goal_state"]["version"].is_u64(),
+        "the snapshot is versioned: {:?}",
         result["goal_state"]
+    );
+    assert!(
+        result["goal_state"]["goal"].is_null(),
+        "no goal bound => goal: null: {:?}",
+        result["goal_state"]
+    );
+
+    // Old-server compat: strip the field and reparse — a new client
+    // receiving an old server's payload sees the serde default (`Null`,
+    // legacy no-op), never a parse failure.
+    let mut legacy = frame["result"].clone();
+    legacy
+        .as_object_mut()
+        .expect("result object")
+        .remove("goal_state");
+    let parsed: SessionOpenResult =
+        serde_json::from_value(legacy).expect("old-server payload (field absent) still parses");
+    assert!(
+        parsed.goal_state.is_null(),
+        "absent field defaults to Null (old server, no snapshot)"
     );
 }
 
@@ -35463,16 +35486,20 @@ async fn session_open_goal_state_response_carries_bound_goal() {
 
     let goal_state = &frame["result"]["goal_state"];
     assert!(
-        goal_state.is_object(),
+        goal_state["version"].is_u64(),
+        "the snapshot is versioned: {goal_state:?}"
+    );
+    assert!(
+        goal_state["goal"].is_object(),
         "a bound goal rides in the response: {goal_state:?}"
     );
     assert_eq!(
-        goal_state["objective"],
+        goal_state["goal"]["objective"],
         json!("ship the goal snapshot in the open response")
     );
-    assert_eq!(goal_state["status"], json!("active"));
+    assert_eq!(goal_state["goal"]["status"], json!("active"));
     assert!(
-        goal_state["goal_id"].is_string(),
+        goal_state["goal"]["goal_id"].is_string(),
         "the goal object carries its id: {goal_state:?}"
     );
 }
@@ -35511,7 +35538,7 @@ async fn session_open_goal_state_response_carries_budget_limited_goal() {
 
     let goal_state = &frame["result"]["goal_state"];
     assert_eq!(
-        goal_state["status"],
+        goal_state["goal"]["status"],
         json!("budget_limited"),
         "any bound status rides in the response: {goal_state:?}"
     );
@@ -35552,7 +35579,7 @@ async fn session_open_goal_state_response_null_for_other_profile_goal() {
         .expect("cleanup goal");
 
     assert!(
-        frame["result"]["goal_state"].is_null(),
+        frame["result"]["goal_state"]["goal"].is_null(),
         "the open resolves `_main`; tenant-x's goal must not leak into its \
          response: {:?}",
         frame["result"]["goal_state"]
@@ -35600,12 +35627,12 @@ async fn session_open_goal_state_response_scoped_to_pinned_scope() {
     let _ = orchestrator.set_goal_scope(&wire, None);
 
     assert!(
-        frame_a["result"]["goal_state"].is_null(),
+        frame_a["result"]["goal_state"]["goal"].is_null(),
         "scope A reports its own (empty) slot, not folder B's goal: {:?}",
         frame_a["result"]["goal_state"]
     );
     assert_eq!(
-        frame_b["result"]["goal_state"]["objective"],
+        frame_b["result"]["goal_state"]["goal"]["objective"],
         json!("folder B's goal"),
         "scope B's own open still carries its goal: {:?}",
         frame_b["result"]["goal_state"]
@@ -35656,7 +35683,7 @@ fn session_open_goal_state_snapshot_uses_pinned_key_not_cwd_map() {
     let _ = orchestrator.set_goal_scope(&wire, None);
 
     assert_eq!(
-        snapshot["objective"],
+        snapshot["goal"]["objective"],
         json!("folder A's live goal"),
         "the snapshot must read the OPEN-pinned key (folder A), not the \
          flipped cwd map (folder B): {snapshot:?}"
@@ -35680,7 +35707,7 @@ async fn session_open_goal_state_response_null_again_after_out_of_band_clear() {
     let session_id = SessionKey("local:goal-state-oob-clear".into());
 
     let first = open_session_result_frame(&state, &ledger, &session_id, "open-gs-1").await;
-    assert!(first["result"]["goal_state"].is_null());
+    assert!(first["result"]["goal_state"]["goal"].is_null());
 
     default_agent_orchestrator()
         .set_goal(GoalSetRequest {
@@ -35694,7 +35721,7 @@ async fn session_open_goal_state_response_null_again_after_out_of_band_clear() {
         .expect("bind goal");
     let second = open_session_result_frame(&state, &ledger, &session_id, "open-gs-2").await;
     assert_eq!(
-        second["result"]["goal_state"]["objective"],
+        second["result"]["goal_state"]["goal"]["objective"],
         json!("cleared while you were away")
     );
 
@@ -35708,9 +35735,176 @@ async fn session_open_goal_state_response_null_again_after_out_of_band_clear() {
         .expect("clear goal out of band");
     let third = open_session_result_frame(&state, &ledger, &session_id, "open-gs-3").await;
     assert!(
-        third["result"]["goal_state"].is_null(),
+        third["result"]["goal_state"]["goal"].is_null(),
         "a goal cleared elsewhere must not survive the reopen: {:?}",
         third["result"]["goal_state"]
+    );
+}
+
+/// #2062 round 8, test (a) — the snapshot's version and state are captured
+/// under ONE state-lock acquisition and cannot disagree: after a repaint
+/// frame at generation G, the response's version is >= G with matching
+/// state; after an OUT-OF-BAND clear at generation G' (never admitted
+/// through the send guard — nothing enqueued anywhere), the reopen's
+/// version is >= G' with `goal: null`. The clear leg is what pins the
+/// version SOURCE: allocation-time bookkeeping (the state-lock
+/// `goal_scope_versions`), not the send guard's admission watermark — a
+/// version sourced from admission bookkeeping (a separate lock, a separate
+/// notion of "happened") would sit below G' and let the pre-clear frame
+/// beat the null under the client rule.
+#[tokio::test]
+async fn session_open_goal_state_response_version_consistent_with_state() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-state-version-consistency".into());
+    let orchestrator = default_agent_orchestrator();
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "versioned goal".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal");
+    let repaint_json = orchestrator
+        .session_goal_updated_event_json(&session_id, MAIN_PROFILE_ID)
+        .expect("repaint for the live goal");
+    let repaint_generation = repaint_json["generation"].as_u64().expect("generation");
+
+    let bound = open_session_result_frame(&state, &ledger, &session_id, "open-gs-vc1").await;
+    let bound_version = bound["result"]["goal_state"]["version"]
+        .as_u64()
+        .expect("version");
+    assert!(
+        bound_version >= repaint_generation,
+        "the snapshot's version covers the latest frame's generation \
+         ({bound_version} vs {repaint_generation})"
+    );
+    assert_eq!(
+        bound["result"]["goal_state"]["goal"]["objective"],
+        json!("versioned goal"),
+        "version and state travel together: {:?}",
+        bound["result"]["goal_state"]
+    );
+
+    // OUT-OF-BAND clear: allocates a generation but never admits/enqueues
+    // a frame anywhere.
+    let clear_result = orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("clear goal out of band");
+    let clear_generation = clear_result["generation"].as_u64().expect("generation");
+
+    let cleared = open_session_result_frame(&state, &ledger, &session_id, "open-gs-vc2").await;
+    let cleared_version = cleared["result"]["goal_state"]["version"]
+        .as_u64()
+        .expect("version");
+    assert!(
+        cleared["result"]["goal_state"]["goal"].is_null(),
+        "cleared out of band => goal: null: {:?}",
+        cleared["result"]["goal_state"]
+    );
+    assert!(
+        cleared_version >= clear_generation,
+        "the null is versioned AT the clear's allocation ({cleared_version} vs \
+         {clear_generation}) — a stale pre-clear frame can never beat it"
+    );
+}
+
+/// #2062 round 8, test (b) — order independence: a repaint at a HIGHER
+/// version arriving before OR after the response resolves to the same
+/// final state under the documented client rule (apply iff version >= last
+/// applied). Asserted at the protocol level with real versioned artifacts:
+/// the response from a real open, the frame from the real builder.
+#[tokio::test]
+async fn session_open_goal_state_version_resolves_order_both_ways() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-state-order-both-ways".into());
+    let orchestrator = default_agent_orchestrator();
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "snapshot state".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal");
+
+    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-order").await;
+    let response_version = frame["result"]["goal_state"]["version"]
+        .as_u64()
+        .expect("version");
+    let response_goal = frame["result"]["goal_state"]["goal"].clone();
+
+    // A NEWER frame, built after the response (real builder, real
+    // generation — strictly greater than the response's version).
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "newer frame state".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("newer mutation");
+    let newer_json = orchestrator
+        .session_goal_updated_event_json(&session_id, MAIN_PROFILE_ID)
+        .expect("newer repaint");
+    let newer_generation = newer_json["generation"].as_u64().expect("generation");
+    let newer_goal = newer_json["goal"].clone();
+    assert!(newer_generation > response_version);
+
+    orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup goal");
+
+    // The documented client rule: apply iff version >= last applied.
+    fn apply(last_applied: &mut Option<u64>, chip: &mut Value, version: u64, goal: &Value) {
+        let admit = match last_applied {
+            Some(last) => version >= *last,
+            None => true,
+        };
+        if admit {
+            *last_applied = Some(version);
+            *chip = goal.clone();
+        }
+    }
+    // Order 1: response first, frame second.
+    let (mut last1, mut chip1) = (None, Value::Null);
+    apply(&mut last1, &mut chip1, response_version, &response_goal);
+    apply(&mut last1, &mut chip1, newer_generation, &newer_goal);
+    // Order 2: frame first, response second (the round-7 F1 hazard order).
+    let (mut last2, mut chip2) = (None, Value::Null);
+    apply(&mut last2, &mut chip2, newer_generation, &newer_goal);
+    apply(&mut last2, &mut chip2, response_version, &response_goal);
+
+    assert_eq!(
+        chip1, chip2,
+        "both arrival orders resolve to the same final state"
+    );
+    assert_eq!(
+        chip1["objective"],
+        json!("newer frame state"),
+        "the newer state wins regardless of arrival order: {chip1:?}"
     );
 }
 
@@ -35721,12 +35915,13 @@ async fn session_open_goal_state_response_null_again_after_out_of_band_clear() {
 /// capture. Barrier: the test holds the sessions-manager lock (which the
 /// open acquires AFTER the round-6 early-capture site and BEFORE the
 /// response enqueue), mutates the goal and delivers the repaint through
-/// the real ephemeral path inside that window, then releases. Asserts
-/// both directions: the repaint frame precedes the response on the wire,
-/// the response carries the POST-repaint state, and no goal frame carrying
-/// older state follows the response.
+/// the real ephemeral path inside that window, then releases. Asserts:
+/// the repaint frame precedes the response on the wire, the response
+/// carries the POST-repaint state with a version >= the repaint frame's
+/// generation (same number space — the client rule resolves either
+/// arrival order), and no goal frame follows the response.
 #[tokio::test]
-async fn session_open_goal_state_response_fresh_at_enqueue_after_mid_open_repaint() {
+async fn session_open_goal_state_response_reflects_mid_open_mutation() {
     use crate::autonomy::agent_orchestrator::{
         AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
     };
@@ -35806,6 +36001,7 @@ async fn session_open_goal_state_response_fresh_at_enqueue_after_mid_open_repain
         .expect("repaint for the live goal");
     let repaint: octos_core::ui_protocol::SessionGoalUpdatedEvent =
         serde_json::from_value(repaint_json).expect("updated event");
+    let repaint_generation = repaint.generation;
     send_notification_ephemeral(&ws, &ledger, UiNotification::SessionGoalUpdated(repaint))
         .expect("deliver the mid-open repaint");
     drop(gate);
@@ -35830,10 +36026,19 @@ async fn session_open_goal_state_response_fresh_at_enqueue_after_mid_open_repain
     };
     assert!(saw_repaint, "the mid-open repaint precedes the response");
     assert_eq!(
-        result["result"]["goal_state"]["objective"],
+        result["result"]["goal_state"]["goal"]["objective"],
         json!("after the mid-open repaint"),
-        "the snapshot is captured at enqueue, after the repaint: {:?}",
+        "the snapshot reflects the mid-open mutation: {:?}",
         result["result"]["goal_state"]
+    );
+    assert!(
+        result["result"]["goal_state"]["version"]
+            .as_u64()
+            .expect("version")
+            >= repaint_generation,
+        "the snapshot's version covers the repaint it reflects \
+         ({:?} vs frame generation {repaint_generation})",
+        result["result"]["goal_state"]["version"]
     );
     // No goal frame carrying older state may follow the response.
     let quiet = tokio::time::Duration::from_millis(400);
@@ -35943,9 +36148,9 @@ async fn session_open_goal_state_response_pinned_across_mid_open_scope_flip() {
     let _ = orchestrator.set_goal_scope(&wire, None);
 
     assert_eq!(
-        result["result"]["goal_state"]["objective"],
+        result["result"]["goal_state"]["goal"]["objective"],
         json!("folder A's live goal"),
-        "the enqueue-time snapshot must use the OPEN-pinned key (folder A), \
+        "the snapshot must use the OPEN-pinned key (folder A), \
          not the flipped cwd map (folder B): {:?}",
         result["result"]["goal_state"]
     );

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35342,35 +35342,30 @@ fn should_report_zero_cache_reads_explicitly_on_a_cold_session() {
 }
 
 // ---------------------------------------------------------------------------
-// #2062 — session/open pushes an explicit NO-GOAL snapshot (goal-chip null
-// state). "No goal" used to be represented by SILENCE on (re)open, so a client
-// that cached a goal chip and reconnected after the goal was cleared elsewhere
-// (a second connection, another process on the same data dir, or a serve
-// restart that rebuilt the ledger) kept rendering the stale chip —
-// absence-of-message is indistinguishable from message-not-yet-arrived. The
-// open path now emits the SAME `session/goal/cleared` shape the explicit
-// `session/goal/clear` RPC emits whenever no goal is bound for the resolved
-// (session, profile), ephemeral (one client's catch-up state, not session
-// history) and AFTER the ledger replay loop so a replayed stale
-// `session/goal/updated` can never land behind it.
+// #2062 round 6 — the goal snapshot rides IN the `session/open` RPC RESPONSE
+// (`SessionOpenResult::goal_state`): either the goal object or EXPLICIT
+// `null`, always present on new servers. The response's fixed position in
+// the client's own processing order makes the snapshot race-free by
+// construction — the client applies it while handling the open result,
+// before any subsequently delivered frame, and every later goal frame is by
+// definition newer and simply overwrites it. Rounds 2-5 pursued
+// ordered-notification delivery instead; codex's null-suppresses-null proof
+// showed that abstraction unsound, and the notification machinery was
+// deleted wholesale in favor of this field.
 //
 // CI: these run under the `session_open_goal` name filter in
 // .github/workflows/ci.yml (test-octos-cli job) — the `api`-gated module is
 // invisible to the unfeatured lib/integration steps (#2029).
 // ---------------------------------------------------------------------------
 
-/// Open `session_id` on a FRESH connection against the shared `state`/`ledger`
-/// (modelling a reconnect) and return every `session/goal/cleared` params
-/// payload pushed before the `session/opened` lifecycle notification (method
-/// `session/open`) — the last frame the open path sends before handing the
-/// connection to the live forwarder. A cleared emitted after that boundary
-/// would be indistinguishable from a live event, so collection stops there.
-async fn open_session_collecting_goal_cleared_frames(
+/// Open `session_id` on a fresh connection and return the `session/open`
+/// RPC RESULT frame — the #2062 goal snapshot rides in it.
+async fn open_session_result_frame(
     state: &Arc<AppState>,
     ledger: &Arc<UiProtocolLedger>,
     session_id: &SessionKey,
     request_id: &str,
-) -> Vec<Value> {
+) -> Value {
     let (ws, mut rx) = ws_connection_for_test(64);
     let approvals = PendingApprovalStore::default();
     let questions = PendingQuestionStore::default();
@@ -35403,89 +35398,97 @@ async fn open_session_collecting_goal_cleared_frames(
         json!(request_id),
         "first frame is the RPC result"
     );
-    let mut cleared_frames = Vec::new();
-    loop {
-        let frame = recv_rpc_json(&mut rx).await;
-        match frame["method"].as_str() {
-            Some("session/goal/cleared") => cleared_frames.push(frame["params"].clone()),
-            // The `session/opened` lifecycle notification closes the open
-            // path's DIRECT send sequence.
-            Some("session/open") => break,
-            _ => {}
-        }
-    }
-    // #2062 fix round (codex #2065 H3): the null snapshot is delivered by the
-    // live-forwarder task — it must serialize BEHIND the broadcast backlog
-    // that raced the open handshake, so it lands after `session/opened`, not
-    // between the direct sends. Poll a bounded quiet window past the
-    // boundary: presence resolves as soon as the frame arrives; absence
-    // costs the full window once.
-    let quiet = tokio::time::Duration::from_millis(700);
-    while let Ok(frame) = tokio::time::timeout(quiet, recv_rpc_json(&mut rx)).await {
-        if frame["method"] == json!("session/goal/cleared") {
-            cleared_frames.push(frame["params"].clone());
-        }
-    }
     abort_live_forwarders(&forwarders, ledger).await;
-    cleared_frames
+    result
 }
 
-/// #2062 fix round (codex #2065 H1) — the spurious-cleared profile skew: goal
-/// RPCs can bind under a caller-REQUESTED profile while `session/open`
-/// resolves the connection/auth profile (a bare open defaults to `_main`).
-/// The client's chip — and its cleared reducer — are SESSION-keyed with no
-/// profile check, so a profile-mismatched "absent" verdict on the server
-/// would blank a live chip. Existence under ANY profile must suppress the
-/// null.
+/// #2062 round 6, tests (a)+(d) — an open with NO goal bound answers with
+/// an EXPLICIT `"goal_state": null` in the RPC result: the key is PRESENT
+/// (null is a statement, not an omission — an absent key is the old-server
+/// legacy shape a new client treats as no-op).
 #[tokio::test]
-async fn session_open_goal_null_snapshot_suppressed_when_goal_bound_under_other_profile() {
+async fn session_open_goal_state_response_is_explicit_null_when_no_goal_bound() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-state-unbound".into());
+
+    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-a").await;
+
+    let result = frame["result"]
+        .as_object()
+        .expect("session/open result object");
+    assert!(
+        result.contains_key("goal_state"),
+        "the field is ALWAYS present on a new server: {result:?}"
+    );
+    assert!(
+        result["goal_state"].is_null(),
+        "no goal bound => explicit null: {:?}",
+        result["goal_state"]
+    );
+}
+
+/// #2062 round 6, test (b) — an open with a bound ACTIVE goal carries the
+/// goal object (same shape as `SessionGoalUpdated`'s `goal` field) in the
+/// response.
+#[tokio::test]
+async fn session_open_goal_state_response_carries_bound_goal() {
     use crate::autonomy::agent_orchestrator::{
         AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
     };
     let temp = tempfile::tempdir().expect("tempdir");
     let state = state_with_sessions(temp.path());
     let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-snap-other-profile".into());
+    let session_id = SessionKey("local:goal-state-bound".into());
     default_agent_orchestrator()
         .set_goal(GoalSetRequest {
             session_id: session_id.clone(),
-            profile_id: "tenant-x".into(),
-            objective: "bound under a caller-requested profile".into(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "ship the goal snapshot in the open response".into(),
             status: None,
             token_budget: None,
             transition_actor: None,
         })
-        .expect("bind goal under tenant-x");
+        .expect("bind goal");
 
-    let cleared =
-        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-d").await;
+    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-b").await;
 
     default_agent_orchestrator()
         .clear_goal(GoalSessionRequest {
             session_id: session_id.clone(),
-            profile_id: "tenant-x".into(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
         })
         .expect("cleanup goal");
 
+    let goal_state = &frame["result"]["goal_state"];
     assert!(
-        cleared.is_empty(),
-        "codex #2065 H1: the open resolves `_main` but the goal lives under \
-         `tenant-x`; a cleared here would blank the live session-keyed chip: {cleared:?}"
+        goal_state.is_object(),
+        "a bound goal rides in the response: {goal_state:?}"
+    );
+    assert_eq!(
+        goal_state["objective"],
+        json!("ship the goal snapshot in the open response")
+    );
+    assert_eq!(goal_state["status"], json!("active"));
+    assert!(
+        goal_state["goal_id"].is_string(),
+        "the goal object carries its id: {goal_state:?}"
     );
 }
 
-/// #2062 fix round (codex #2065 H2, held): ANY stored status suppresses the
-/// null — a `budget_limited` goal is still a live chip (frozen for
-/// scheduling, not for display), so the open must not blank it.
+/// #2062 round 6, test (b) — a `budget_limited` goal is still the session's
+/// goal (frozen for scheduling, not for display): the response carries it
+/// with its real status, never `null`.
 #[tokio::test]
-async fn session_open_goal_null_snapshot_suppressed_when_goal_budget_limited() {
+async fn session_open_goal_state_response_carries_budget_limited_goal() {
     use crate::autonomy::agent_orchestrator::{
         AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
     };
     let temp = tempfile::tempdir().expect("tempdir");
     let state = state_with_sessions(temp.path());
     let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-snap-budget-limited".into());
+    let session_id = SessionKey("local:goal-state-budget-limited".into());
     default_agent_orchestrator()
         .set_goal(GoalSetRequest {
             session_id: session_id.clone(),
@@ -35497,8 +35500,7 @@ async fn session_open_goal_null_snapshot_suppressed_when_goal_budget_limited() {
         })
         .expect("bind budget_limited goal");
 
-    let cleared =
-        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-e").await;
+    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-bl").await;
 
     default_agent_orchestrator()
         .clear_goal(GoalSessionRequest {
@@ -35507,195 +35509,178 @@ async fn session_open_goal_null_snapshot_suppressed_when_goal_budget_limited() {
         })
         .expect("cleanup goal");
 
-    assert!(
-        cleared.is_empty(),
-        "a budget_limited goal is still bound; the open must not blank it: {cleared:?}"
+    let goal_state = &frame["result"]["goal_state"];
+    assert_eq!(
+        goal_state["status"],
+        json!("budget_limited"),
+        "any bound status rides in the response: {goal_state:?}"
     );
 }
 
-/// #2062 fix round (codex #2065 H3, round-3 PATH B) — ordering at the
-/// protocol layer, asserted on WIRE FRAME ORDER, not client state. The open
-/// subscribes to the live broadcast BEFORE its replay snapshot, so a stale
-/// `session/goal/updated` can be sitting in the receiver when the open's
-/// synchronous drain runs; the ledger-send lane does not run the #1959
-/// generation guard and the client's `updated` reducer applies
-/// unconditionally, so if the null were emitted before that backlog
-/// flushes, the stale update would repaint the chip the null just blanked.
-/// The null must therefore be the FINAL goal-state frame of the open
-/// sequence: backlog first, null second — the exact contract of
-/// `drain_open_backlog_then_emit_goal_null`, the same helper the open
-/// handler runs synchronously.
+/// #2062 round 6, test (c) — a goal bound under a DIFFERENT profile than
+/// this open resolves reads as `null`: the snapshot carries objective text
+/// and goes only to this connection, whose own `goal/get` equally reports
+/// "none". (The old broadcast-era "blank a live chip" hazard does not
+/// apply: this response reaches only the connection that opened.)
 #[tokio::test]
-async fn session_open_goal_null_snapshot_ordered_after_buffered_stale_update() {
-    let (ws, mut rx_frames) = ws_connection_for_test(64);
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-order".into());
-    // Subscribe FIRST — mirrors handle_session_open, which subscribes
-    // before the replay snapshot; the event appended below then sits in
-    // this receiver's buffer exactly like one that raced the handshake.
-    let live_rx = ledger.subscribe(&session_id);
-    ledger.append_notification(UiNotification::SessionGoalUpdated(
-        octos_core::ui_protocol::SessionGoalUpdatedEvent {
-            session_id: session_id.clone(),
-            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-            goal: octos_core::ui_protocol::UiGoalRecord {
-                profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-                goal_id: "goal-stale".into(),
-                objective: "stale positive state raced the open".into(),
-                status: "active".into(),
-                token_budget: 1_000,
-                tokens_used: 10,
-                time_used_seconds: 1,
-                created_at_ms: 0,
-                updated_at_ms: 0,
-            },
-            transition_actor: "backend".into(),
-            // Unstamped, like a pre-#1959 producer — the guardless
-            // ledger-send lane delivers it regardless.
-            generation: 0,
-        },
-    ));
-    let null =
-        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
-            session_id: session_id.clone(),
-            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-            cleared: true,
-            goal: None,
-            transition_actor: "backend".into(),
-            generation: 0,
-        });
-    let _rx = drain_open_backlog_then_emit_goal_null(
-        &ws,
-        &ledger,
-        live_rx,
-        0,
-        ConnectionId::next(),
-        ConnectionUiFeatures::stdio_defaults(),
-        None,
-        &session_id,
-        Some(null),
-    )
-    .await;
-
-    let first = recv_rpc_json(&mut rx_frames).await;
-    assert_eq!(
-        first["method"],
-        json!("session/goal/updated"),
-        "the raced stale update must flush FIRST: {first}"
-    );
-    let second = recv_rpc_json(&mut rx_frames).await;
-    assert_eq!(
-        second["method"],
-        json!("session/goal/cleared"),
-        "the null must be the FINAL goal-state frame of the open sequence: {second}"
-    );
-    assert_eq!(second["params"]["cleared"], json!(true));
-}
-
-/// #2062 RED→GREEN: a session that opens with NO goal bound must receive an
-/// explicit `session/goal/cleared` null snapshot — silence is not a goal
-/// state. Payload matches the explicit `session/goal/clear` RPC shape:
-/// `cleared: true`, `goal: null`, a real (#1959) generation stamp, and the
-/// wire session id the client keys the chip by.
-#[tokio::test]
-async fn session_open_goal_null_snapshot_emitted_when_no_goal_bound() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-snap-unbound".into());
-
-    let cleared =
-        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-a").await;
-
-    assert_eq!(
-        cleared.len(),
-        1,
-        "open with no goal bound must push exactly one explicit no-goal snapshot"
-    );
-    let event = &cleared[0];
-    assert_eq!(event["session_id"], json!(session_id.0));
-    assert_eq!(event["profile_id"], json!(MAIN_PROFILE_ID));
-    assert_eq!(
-        event["cleared"],
-        json!(true),
-        "the client nulls the chip only on cleared=true"
-    );
-    assert!(
-        event["goal"].is_null(),
-        "a null snapshot carries no goal record"
-    );
-    assert!(
-        event["generation"].as_u64().unwrap_or(0) > 0,
-        "#1959 — every goal chip event must carry a real generation stamp"
-    );
-}
-
-/// #2062 inverse guard: a session that opens WITH a goal bound must NOT
-/// receive a `session/goal/cleared` — a spurious cleared would blank a live
-/// chip. The positive snapshot path (durable ledger replay + live charge
-/// pushes) stays untouched.
-#[tokio::test]
-async fn session_open_goal_null_snapshot_suppressed_when_goal_bound() {
+async fn session_open_goal_state_response_null_for_other_profile_goal() {
     use crate::autonomy::agent_orchestrator::{
         AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
     };
     let temp = tempfile::tempdir().expect("tempdir");
     let state = state_with_sessions(temp.path());
     let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-snap-bound".into());
+    let session_id = SessionKey("local:goal-state-other-profile".into());
     default_agent_orchestrator()
         .set_goal(GoalSetRequest {
             session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "keep the chip painted across reconnect".into(),
+            profile_id: "tenant-x".into(),
+            objective: "bound under a caller-requested profile".into(),
             status: None,
             token_budget: None,
             transition_actor: None,
         })
-        .expect("bind goal");
+        .expect("bind goal under tenant-x");
 
-    let cleared =
-        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-b").await;
+    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-c1").await;
 
-    // Cleanup the process-global orchestrator BEFORE asserting so a failure
-    // does not leak the goal into sibling tests.
     default_agent_orchestrator()
         .clear_goal(GoalSessionRequest {
             session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
+            profile_id: "tenant-x".into(),
         })
         .expect("cleanup goal");
 
     assert!(
-        cleared.is_empty(),
-        "open with a bound goal must not push a cleared (it would blank a live chip): {cleared:?}"
+        frame["result"]["goal_state"].is_null(),
+        "the open resolves `_main`; tenant-x's goal must not leak into its \
+         response: {:?}",
+        frame["result"]["goal_state"]
     );
 }
 
-/// #2062 end-to-end shape from the issue: bind a goal, clear it "elsewhere"
-/// (directly on the orchestrator — no ledger event, exactly like a second
-/// connection or another process on the same data dir), then re-open. The
-/// reopen must re-emit the cleared null snapshot (idempotent null), and its
-/// #1959 generation must supersede the one from the first open so a stale
-/// update can never outrank it.
+/// #2062 round 6, test (c) — cwd-scope isolation through the response: a
+/// goal bound under sibling scope B never appears in scope A's open
+/// response, and scope B's own open still carries it (sibling unaffected).
 #[tokio::test]
-async fn session_open_goal_null_snapshot_reemitted_when_goal_cleared_elsewhere() {
+async fn session_open_goal_state_response_scoped_to_pinned_scope() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let orchestrator = default_agent_orchestrator();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let wire = SessionKey("local:goal-state-scoped".into());
+    // Folder B registers its scope and binds a goal under it.
+    let _pinned_b = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "folder B's goal".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal under folder B's scope");
+    // Folder A opens the same wire session under ITS scope.
+    let _pinned_a = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    let frame_a = open_session_result_frame(&state, &ledger, &wire, "open-gs-scope-a").await;
+    // Folder B reopens under its own scope: the sibling is unaffected.
+    let _pinned_b2 = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+    let frame_b = open_session_result_frame(&state, &ledger, &wire, "open-gs-scope-b").await;
+
+    orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup goal");
+    let _ = orchestrator.set_goal_scope(&wire, None);
+
+    assert!(
+        frame_a["result"]["goal_state"].is_null(),
+        "scope A reports its own (empty) slot, not folder B's goal: {:?}",
+        frame_a["result"]["goal_state"]
+    );
+    assert_eq!(
+        frame_b["result"]["goal_state"]["objective"],
+        json!("folder B's goal"),
+        "scope B's own open still carries its goal: {:?}",
+        frame_b["result"]["goal_state"]
+    );
+}
+
+/// #2062 round 6 (Z1/W5 lineage) — the snapshot inspects the goal-store key
+/// PINNED at open-registration (the key `set_goal_scope` RETURNS from
+/// inside its own lock), never a re-resolution of the process-global
+/// last-writer-wins cwd map, which a concurrent same-wire/different-cwd
+/// open can flip between registration and snapshot computation. Pinned:
+/// folder A's open still reports folder A's goal after the flip; a
+/// re-resolving mutant would inspect folder B's (empty) slot and answer
+/// `null` — silently blanking A's live chip.
+#[test]
+fn session_open_goal_state_snapshot_uses_pinned_key_not_cwd_map() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let orchestrator = default_agent_orchestrator();
+    let wire = SessionKey("local:goal-state-cwd-pin".into());
+    // Folder A registers, pins the returned key, and binds its goal.
+    let pinned_a = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "folder A's live goal".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal under folder A's cwd scope");
+    // A concurrent same-wire open for a DIFFERENT folder flips the map
+    // before the snapshot is computed.
+    let _flipped = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+
+    let snapshot = orchestrator.session_open_goal_state(&pinned_a, MAIN_PROFILE_ID);
+
+    // Cleanup the process-global store BEFORE asserting.
+    let _ = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup goal");
+    let _ = orchestrator.set_goal_scope(&wire, None);
+
+    assert_eq!(
+        snapshot["objective"],
+        json!("folder A's live goal"),
+        "the snapshot must read the OPEN-pinned key (folder A), not the \
+         flipped cwd map (folder B): {snapshot:?}"
+    );
+}
+
+/// #2062 round 6 — the original issue's end-to-end shape against the
+/// response: open (null) -> bind -> reopen (goal) -> clear OUT OF BAND
+/// (directly on the orchestrator, exactly like a second connection or
+/// another process on the same data dir) -> reopen answers `null` again.
+/// A goal cleared elsewhere cannot survive as a stale chip: every reopen
+/// re-states the truth in its own response.
+#[tokio::test]
+async fn session_open_goal_state_response_null_again_after_out_of_band_clear() {
     use crate::autonomy::agent_orchestrator::{
         AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
     };
     let temp = tempfile::tempdir().expect("tempdir");
     let state = state_with_sessions(temp.path());
     let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-snap-reopen".into());
+    let session_id = SessionKey("local:goal-state-oob-clear".into());
 
-    // First open: nothing bound yet → explicit null snapshot.
-    let first =
-        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-c1").await;
-    assert_eq!(
-        first.len(),
-        1,
-        "first open with no goal pushes the null snapshot"
-    );
+    let first = open_session_result_frame(&state, &ledger, &session_id, "open-gs-1").await;
+    assert!(first["result"]["goal_state"].is_null());
 
     default_agent_orchestrator()
         .set_goal(GoalSetRequest {
@@ -35707,179 +35692,39 @@ async fn session_open_goal_null_snapshot_reemitted_when_goal_cleared_elsewhere()
             transition_actor: None,
         })
         .expect("bind goal");
-
-    // Reconnect while the goal is live → no cleared.
-    let bound =
-        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-c2").await;
-    assert!(
-        bound.is_empty(),
-        "reopen with the goal live must stay positive: {bound:?}"
+    let second = open_session_result_frame(&state, &ledger, &session_id, "open-gs-2").await;
+    assert_eq!(
+        second["result"]["goal_state"]["objective"],
+        json!("cleared while you were away")
     );
 
     // The goal is cleared elsewhere: this connection's ledger never sees a
-    // `session/goal/cleared`, so WITHOUT the open-path push the client's
-    // cached chip would survive the next reconnect on silence alone.
+    // cleared frame — the next open's RESPONSE is what states the truth.
     default_agent_orchestrator()
         .clear_goal(GoalSessionRequest {
             session_id: session_id.clone(),
             profile_id: MAIN_PROFILE_ID.to_owned(),
         })
-        .expect("clear goal elsewhere");
-
-    let reopened =
-        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-c3").await;
-    assert_eq!(
-        reopened.len(),
-        1,
-        "reopen after an out-of-band clear must re-push the null snapshot"
-    );
-    let first_generation = first[0]["generation"].as_u64().expect("generation");
-    let reopened_generation = reopened[0]["generation"].as_u64().expect("generation");
+        .expect("clear goal out of band");
+    let third = open_session_result_frame(&state, &ledger, &session_id, "open-gs-3").await;
     assert!(
-        reopened_generation > first_generation,
-        "each emission is freshly stamped for the emit-time superseded-abandon \
-         bookkeeping ({reopened_generation} vs {first_generation})"
+        third["result"]["goal_state"].is_null(),
+        "a goal cleared elsewhere must not survive the reopen: {:?}",
+        third["result"]["goal_state"]
     );
 }
 
-/// A minimal valid frame used to occupy a capacity-1 writer queue so the
-/// #2062 null snapshot is forced to park on backpressure.
+/// A minimal valid frame used to occupy a capacity-1 writer queue.
 fn plug_frame() -> WsMessage {
     frame_for(&json!({"jsonrpc": "2.0", "method": "test/plug"})).expect("plug frame")
 }
 
-/// #2062 round 4 (codex #2065 round-3 W2 + W8) — THE NULL IS A SNAPSHOT,
-/// NOT A COMMAND: it is emitted synchronously in the open sequence and
-/// abandons itself when a newer goal frame was already admitted for the
-/// session. Unlike the retired round-3 test this drives the NEWER frame
-/// through the REAL production send path (`send_notification_durable`:
-/// guard-admit → ledger append → direct delivery to THIS wire), so the
-/// superseder is genuinely enqueued and delivered — not a bare guard call
-/// that "positively accepts the production failure" (W8). The final wire
-/// state must be the update, with no cleared frame after it.
-#[tokio::test]
-async fn session_open_goal_null_snapshot_abandoned_when_newer_frame_already_delivered() {
-    let (ws, mut rx) = ws_connection_for_test(64);
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-superseded".into());
-    ws.update_live_features(ConnectionUiFeatures::stdio_defaults());
-    // Fabricated generations sit FAR above anything the real allocator
-    // reaches in a test process: the S3 registry maps every REAL generation
-    // to its owner's scoped key, so a low fabricated value would collide
-    // with a sibling test's allocation and resolve to a foreign identity.
-    // Unregistered generations fall back to the (per-test-unique) wire key.
-    let null =
-        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
-            session_id: session_id.clone(),
-            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-            cleared: true,
-            goal: None,
-            transition_actor: "backend".into(),
-            generation: 9_100_000_001,
-        });
-    // The newer frame is admitted, ledgered, AND delivered to this wire
-    // through the same durable path the goal RPC handler uses.
-    let newer =
-        UiNotification::SessionGoalUpdated(octos_core::ui_protocol::SessionGoalUpdatedEvent {
-            session_id: session_id.clone(),
-            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-            goal: octos_core::ui_protocol::UiGoalRecord {
-                profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-                goal_id: "goal-live".into(),
-                objective: "set before the null could enqueue".into(),
-                status: "active".into(),
-                token_budget: 1_000,
-                tokens_used: 0,
-                time_used_seconds: 0,
-                created_at_ms: 0,
-                updated_at_ms: 0,
-            },
-            transition_actor: "user".into(),
-            generation: 9_100_000_002,
-        });
-    send_notification_durable(&ws, &ledger, newer).expect("deliver the newer frame");
-
-    let outcome =
-        emit_open_goal_null_now(&ws, &ledger, null, ConnectionUiFeatures::stdio_defaults());
-    assert!(
-        outcome.is_ok(),
-        "abandoning a superseded null is a clean outcome: {outcome:?}"
-    );
-
-    let first = recv_rpc_json(&mut rx).await;
-    assert_eq!(
-        first["method"],
-        json!("session/goal/updated"),
-        "the delivered newer frame is the final goal state: {first}"
-    );
-    let late = tokio::time::timeout(
-        tokio::time::Duration::from_millis(400),
-        recv_rpc_json(&mut rx),
-    )
-    .await;
-    assert!(
-        late.is_err(),
-        "a superseded null must be ABANDONED, never delivered after the newer frame: {late:?}"
-    );
-}
-
-/// #2062 round 4 (codex #2065 round-3 PATH B(3)) — backpressure coupling:
-/// the null is emitted synchronously in the open section with NO parked
-/// retry. If the writer is full, the same section was already dropping
-/// replay frames; the null's drop is accounted into the SAME shared
-/// dropped-frame counter every backpressure-dropped durable frame feeds,
-/// so the `protocol/replay_lossy` signal the client already surfaces
-/// ("reconnect to rehydrate" — it performs no automatic resync) carries
-/// it, and the reopen it prompts re-emits the snapshot (idempotent null).
-#[tokio::test]
-async fn session_open_goal_null_snapshot_backpressure_drop_signals_replay_lossy() {
-    let (ws, mut rx) = ws_connection_for_test(1);
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-backpressure".into());
-    ws.send_durable(plug_frame(), "test/plug")
-        .expect("plug the writer queue");
-    let dropped_before = ws.metrics().dropped_count.load(Ordering::Relaxed);
-    let null =
-        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
-            session_id: session_id.clone(),
-            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-            cleared: true,
-            goal: None,
-            transition_actor: "backend".into(),
-            // Above the real allocator's range — see the S3 registry note
-            // in `…abandoned_when_newer_frame_already_delivered`.
-            generation: 9_200_000_001,
-        });
-
-    let outcome =
-        emit_open_goal_null_now(&ws, &ledger, null, ConnectionUiFeatures::stdio_defaults());
-    assert!(
-        matches!(outcome, Err(SendError::BackpressureDrop)),
-        "a full writer drops the null exactly once, no parked retry: {outcome:?}"
-    );
-    assert!(
-        ws.metrics().dropped_count.load(Ordering::Relaxed) > dropped_before,
-        "the drop must be accounted into the shared dropped-frame counter"
-    );
-
-    // Drain the plug: no cleared frame may ever arrive (single attempt).
-    let plug = recv_rpc_json(&mut rx).await;
-    assert_eq!(plug["method"], json!("test/plug"));
-    // The retained debt flushes as `protocol/replay_lossy` at the next send
-    // opportunity — the same mechanism every dropped durable frame uses.
-    emit_replay_lossy_opportunistic(&ws, &ledger, session_id.0.as_str());
-    let lossy = tokio::time::timeout(tokio::time::Duration::from_secs(5), recv_rpc_json(&mut rx))
-        .await
-        .expect("the accounted drop surfaces as replay_lossy");
-    assert_eq!(lossy["method"], json!("protocol/replay_lossy"));
-}
-
-/// #2062 round 3 (codex #2065 round-2 Z5) — capability gating on ALL lanes:
-/// a connection that did not negotiate `coding.goal_runtime.v1` (the same
-/// capability the goal RPC surface requires) must receive ZERO goal frames
-/// through the full open sequence — replay, forwarder drain, live pump, and
-/// the null snapshot alike. Round 2 gated only the null's CONSTRUCTION;
-/// replayed/pumped `session/goal/*` frames still leaked through.
+/// #2062 round 3 (codex #2065 round-2 Z5) — capability gating on the shared
+/// filter: a connection that did not negotiate `coding.goal_runtime.v1`
+/// (the same capability the goal RPC surface requires) must receive ZERO
+/// goal FRAMES through the full open sequence — replay and live pump alike.
+/// (The response-carried `goal_state` field is deliberately ungated: it is
+/// not a frame, and an old client simply ignores the unknown field.)
 #[tokio::test]
 async fn session_open_goal_frames_gated_when_goal_runtime_not_negotiated() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -35967,68 +35812,14 @@ async fn session_open_goal_frames_gated_when_goal_runtime_not_negotiated() {
     );
 }
 
-/// #2062 rounds 3–4 (codex #2065 round-2 Z1 + round-3 W5) — the null's
-/// suppression lookup must inspect the goal-store key PINNED at this open's
-/// registration, not a re-resolution of the process-global last-writer-wins
-/// cwd map: a concurrent same-wire/different-cwd open can flip that map
-/// mid-open, and a recomputed key would then inspect the OTHER folder's
-/// (empty) slot and emit a spurious cleared for THIS folder's live chip.
-/// The pin is the key `set_goal_scope` RETURNS from inside its own lock —
-/// the real registration-to-capture path (one acquisition, W5): a
-/// registration-vs-capture interleave is unrepresentable at this site, so
-/// the flip below can only ever happen AFTER the pin, which is exactly
-/// what the suppression must survive.
-#[test]
-fn session_open_goal_null_snapshot_pinned_key_survives_concurrent_cwd_flip() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let orchestrator = default_agent_orchestrator();
-    let wire = SessionKey("local:goal-null-cwd-pin".into());
-    // This open registers folder A's scope and pins the key HANDED BACK
-    // from inside the registration's own lock — the same call
-    // `register_session_ledger_scope` threads into `SessionOpenOutcome`.
-    let pinned = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "folder A's live goal".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal under folder A's cwd scope");
-    // A concurrent same-wire open for a DIFFERENT folder flips the
-    // last-writer-wins map before the null snapshot is computed.
-    let _flipped = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
-
-    let verdict = orchestrator.session_goal_hydrate_cleared_event_json(&pinned, MAIN_PROFILE_ID);
-
-    // Cleanup the process-global store BEFORE asserting.
-    orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
-    orchestrator
-        .clear_goal(GoalSessionRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup goal");
-    orchestrator.set_goal_scope(&wire, None);
-
-    assert!(
-        verdict.is_none(),
-        "suppression must inspect the OPEN-pinned key (folder A), not the \
-         flipped cwd map (folder B): {verdict:?}"
-    );
-}
-
 /// #2062 round 3 (codex #2065 round-2 Z5-lifecycle) — a re-open must fully
 /// retire the previous live forwarder BEFORE the replacement starts pumping,
 /// so "one live lane per (connection, session)" holds across reopens and an
 /// event is never double-delivered by two overlapping pumps. (The
 /// production open path retires even earlier — before the replay baseline
 /// is computed, round-3 W6.1 — this pins the in-spawn defense direct
-/// callers rely on.)
+/// callers rely on. Handover semantics are at-least-once, not exactly-once:
+/// see the retire-before-baseline comment in `handle_session_open`.)
 #[tokio::test]
 async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
     let (ws, mut rx) = ws_connection_for_test(64);
@@ -36092,7 +35883,7 @@ async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
     abort_live_forwarders(&forwarders, &ledger).await;
 }
 
-/// #2062 round 4 (codex #2065 round-3 W6, PATH B absence-by-construction) —
+/// #2062 round 4 (codex #2065 round-3 W6, absence-by-construction) —
 /// through `WsConnection::new_stdio`: the stdio durable lane parks
 /// COOPERATIVELY (non-blocking `try_send` probe + async sleep, see
 /// `send_durable_offloaded`), so a forwarder parked on a FULL stdio queue is
@@ -36155,257 +35946,5 @@ async fn session_open_goal_stdio_lane_retire_leaves_no_inflight_send() {
     assert!(
         frames.try_recv().is_err(),
         "no in-flight send may survive lane retirement"
-    );
-}
-
-/// #2062 round 5 (codex #2065 round-4 S3) — cross-scope watermark
-/// pollution: two cwd scopes share one wire session id. Scope B's repaint
-/// (built by the real orchestrator builder, delivered through the real
-/// ephemeral path — but only to B's connection) must advance B's watermark
-/// ONLY; scope A's null — for A's folder, where a stale chip legitimately
-/// needs clearing — must still deliver. With a wire-keyed watermark, B's
-/// later-generation frame falsely abandoned A's null and connection A
-/// received NOTHING: #2062 surviving through watermark pollution.
-#[tokio::test]
-async fn session_open_goal_null_snapshot_survives_other_scope_watermark_pollution() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let orchestrator = default_agent_orchestrator();
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let wire = SessionKey("local:goal-null-scope-pollution".into());
-    // Folder B registers its scope and binds a live goal under it.
-    let pinned_b = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "folder B's live goal".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal under folder B's cwd scope");
-    // Folder A opens the same wire session: registers (flips the map) and
-    // pins its own scope, then builds its null — no goal under scope A.
-    let pinned_a = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
-    let null_json = orchestrator
-        .session_goal_hydrate_cleared_event_json(&pinned_a, MAIN_PROFILE_ID)
-        .expect("scope A has no goal; the null must be built");
-    let null: octos_core::ui_protocol::SessionGoalClearedEvent =
-        serde_json::from_value(null_json).expect("cleared event");
-    // Scope B's repaint is built AFTER A's null (higher generation — the
-    // exact pollution ordering: the turn-end accountant fires while A's
-    // open is between null construction and emit) and delivered through
-    // the REAL ephemeral path to B's OWN connection.
-    let b_update_json = orchestrator
-        .session_goal_updated_event_json(&pinned_b, MAIN_PROFILE_ID)
-        .expect("scope B has a goal; the repaint must be built");
-    let b_update: octos_core::ui_protocol::SessionGoalUpdatedEvent =
-        serde_json::from_value(b_update_json).expect("updated event");
-    assert!(
-        b_update.generation > null.generation,
-        "the pollution ordering requires B's frame to be newer"
-    );
-    let (ws_b, mut rx_b) = ws_connection_for_test(8);
-    ws_b.update_live_features(ConnectionUiFeatures::stdio_defaults());
-    send_notification_ephemeral(&ws_b, &ledger, UiNotification::SessionGoalUpdated(b_update))
-        .expect("deliver B's repaint to B's connection");
-    let b_frame = recv_rpc_json(&mut rx_b).await;
-    assert_eq!(
-        b_frame["method"],
-        json!("session/goal/updated"),
-        "B's repaint was admitted and delivered (its watermark moved)"
-    );
-
-    // A's null must still deliver: B's record moved SCOPE B's watermark,
-    // not scope A's.
-    let (ws_a, mut rx_a) = ws_connection_for_test(8);
-    let outcome = emit_open_goal_null_now(
-        &ws_a,
-        &ledger,
-        UiNotification::SessionGoalCleared(null),
-        ConnectionUiFeatures::stdio_defaults(),
-    );
-
-    // Cleanup the process-global store BEFORE asserting.
-    let _ = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
-    orchestrator
-        .clear_goal(GoalSessionRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup B's goal");
-    let _ = orchestrator.set_goal_scope(&wire, None);
-
-    assert!(outcome.is_ok(), "the null emit must not error: {outcome:?}");
-    let a_frame = tokio::time::timeout(
-        tokio::time::Duration::from_secs(5),
-        recv_rpc_json(&mut rx_a),
-    )
-    .await
-    .expect("scope A's null must DELIVER despite scope B's newer frame");
-    assert_eq!(
-        a_frame["method"],
-        json!("session/goal/cleared"),
-        "cross-scope pollution must not abandon the null: {a_frame}"
-    );
-}
-
-/// #2062 round 5 (codex #2065 round-4 S2) — the dropped-null recovery
-/// chain, end to end WITHOUT manual queue manipulation: the writer is full
-/// when the real open emits the null (the null is the first dropped frame),
-/// the opportunistic lossy emit fails on the same full queue, and the
-/// PUMP's first action flushes the retained debt through its
-/// capacity-aware lane the moment the client drains the queue — so the
-/// "reconnect to rehydrate" prompt is guaranteed, and the reopen it
-/// prompts re-emits the null.
-#[tokio::test]
-async fn session_open_goal_null_drop_pump_flushes_replay_lossy_then_reopen_reemits() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-lossy-chain".into());
-    // Capacity 2: the plug takes one slot, the open's RPC result (a
-    // lifecycle frame that must not drop) takes the other — the queue is
-    // full at exactly the moment the null tries to enqueue.
-    let (ws, mut rx) = ws_connection_for_test(2);
-    ws.send_durable(plug_frame(), "test/plug")
-        .expect("plug one writer slot");
-    let approvals = PendingApprovalStore::default();
-    let questions = PendingQuestionStore::default();
-    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let opened = handle_session_open(
-        &ws,
-        &state,
-        &ledger,
-        &approvals,
-        &questions,
-        &forwarders,
-        None,
-        ConnectionUiFeatures::stdio_defaults(),
-        "open-lossy-chain".into(),
-        SessionOpenParams {
-            session_id: session_id.clone(),
-            topic: None,
-            profile_id: None,
-            cwd: None,
-            sandbox: None,
-            after: None,
-        },
-        false,
-    )
-    .await;
-    assert!(opened, "the open itself succeeds; only frames dropped");
-
-    // The client drains the queue: plug, then the open's RPC result.
-    let plug = recv_rpc_json(&mut rx).await;
-    assert_eq!(plug["method"], json!("test/plug"));
-    let result = recv_rpc_json(&mut rx).await;
-    assert_eq!(result["id"], json!("open-lossy-chain"));
-    // Capacity is free now — the pump's debt flush must deliver the lossy
-    // signal with no further action from anyone.
-    let lossy = tokio::time::timeout(tokio::time::Duration::from_secs(5), recv_rpc_json(&mut rx))
-        .await
-        .expect("the pump's first action flushes the replay-lossy debt");
-    assert_eq!(
-        lossy["method"],
-        json!("protocol/replay_lossy"),
-        "the dropped null must surface the reconnect prompt: {lossy}"
-    );
-
-    // The prompted reconnect (a fresh connection, as a real client would)
-    // re-emits the null.
-    let reopened =
-        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-lossy-2")
-            .await;
-    abort_live_forwarders(&forwarders, &ledger).await;
-    assert_eq!(
-        reopened.len(),
-        1,
-        "the reopen must re-emit the dropped null snapshot"
-    );
-}
-
-/// #2062 round 5 (codex #2065 round-4 S7) — the INTERLEAVED supersession:
-/// the newer frame lands AFTER the null passed its entry guard but before
-/// the in-lock section — the exact window a spawned turn task occupies.
-/// Only the final in-lock recheck can catch this (the entry guard already
-/// admitted); deleting just that recheck fails THIS test while the
-/// early-delivery test (`…abandoned_when_newer_frame_already_delivered`)
-/// still passes. The newer frame goes through the real durable send path.
-#[tokio::test]
-async fn session_open_goal_null_snapshot_abandoned_by_in_lock_recheck_when_frame_interleaves() {
-    let (ws, mut rx) = ws_connection_for_test(64);
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-null-interleaved".into());
-    ws.update_live_features(ConnectionUiFeatures::stdio_defaults());
-    let null =
-        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
-            session_id: session_id.clone(),
-            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-            cleared: true,
-            goal: None,
-            transition_actor: "backend".into(),
-            // Unregistered generations (far above the real allocator's
-            // range — see the S3 registry note in
-            // `…abandoned_when_newer_frame_already_delivered`) resolve to
-            // the wire-key watermark fallback — both frames share it,
-            // exactly like two frames of one scope.
-            generation: 9_300_000_001,
-        });
-    let newer = octos_core::ui_protocol::SessionGoalUpdatedEvent {
-        session_id: session_id.clone(),
-        profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-        goal: octos_core::ui_protocol::UiGoalRecord {
-            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
-            goal_id: "goal-live".into(),
-            objective: "set in the entry-guard-to-lock window".into(),
-            status: "active".into(),
-            token_budget: 1_000,
-            tokens_used: 0,
-            time_used_seconds: 0,
-            created_at_ms: 0,
-            updated_at_ms: 0,
-        },
-        transition_actor: "user".into(),
-        generation: 9_300_000_002,
-    };
-    let hook = || {
-        send_notification_durable(
-            &ws,
-            &ledger,
-            UiNotification::SessionGoalUpdated(newer.clone()),
-        )
-        .expect("deliver the newer frame inside the window");
-    };
-
-    let outcome = emit_open_goal_null_with_pre_lock_hook(
-        &ws,
-        &ledger,
-        null,
-        ConnectionUiFeatures::stdio_defaults(),
-        Some(&hook),
-    );
-    assert!(
-        outcome.is_ok(),
-        "abandoning at the in-lock recheck is a clean outcome: {outcome:?}"
-    );
-
-    let first = recv_rpc_json(&mut rx).await;
-    assert_eq!(
-        first["method"],
-        json!("session/goal/updated"),
-        "the interleaved newer frame is the final goal state: {first}"
-    );
-    let late = tokio::time::timeout(
-        tokio::time::Duration::from_millis(400),
-        recv_rpc_json(&mut rx),
-    )
-    .await;
-    assert!(
-        late.is_err(),
-        "the in-lock recheck must abandon the null, never deliver it after \
-         the newer frame: {late:?}"
     );
 }

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35342,817 +35342,110 @@ fn should_report_zero_cache_reads_explicitly_on_a_cold_session() {
 }
 
 // ---------------------------------------------------------------------------
-// #2062 rounds 6-8 — the VERSIONED goal snapshot rides IN the `session/open`
-// RPC RESPONSE (`SessionOpenResult::goal_state`):
-// `{ "version": u64, "goal": object|null }`, always present on new servers.
-// The version is the scope's latest #1959 generation — the same number
-// space stamped on SessionGoalUpdated/Cleared frames — captured together
-// with the state under ONE state-lock acquisition. The wire does NOT carry
-// freshness (codex round-7 F1: producers release the guard and enqueue
-// later, so no server-side ordering scheme can — five notification rounds,
-// response position, and capture-at-enqueue all failed on that rock); the
-// DATA carries it, and the client resolves any arrival order by version
-// (apply iff version >= last applied, within one connection).
+// #2065 — UI-protocol goal-frame substrate: per-scope generation identities
+// for the #1959 send guard, goal-frame capability gating on the shared
+// filter, and live-forwarder lifecycle hardening (cooperative cancellable
+// stdio sends + retire-before-baseline handover).
 //
-// CI: these run under the `session_open_goal` name filter in
-// .github/workflows/ci.yml (test-octos-cli job) — the `api`-gated module is
-// invisible to the unfeatured lib/integration steps (#2029).
+// CI: these run under the `goal_scope_guard` / `session_open_goal` name
+// filters in .github/workflows/ci.yml (test-octos-cli job) — the `api`-gated
+// module is invisible to the unfeatured lib/integration steps (#2029).
 // ---------------------------------------------------------------------------
 
-/// Open `session_id` on a fresh connection and return the `session/open`
-/// RPC RESULT frame — the #2062 goal snapshot rides in it.
-async fn open_session_result_frame(
-    state: &Arc<AppState>,
-    ledger: &Arc<UiProtocolLedger>,
-    session_id: &SessionKey,
-    request_id: &str,
-) -> Value {
-    let (ws, mut rx) = ws_connection_for_test(64);
-    let approvals = PendingApprovalStore::default();
-    let questions = PendingQuestionStore::default();
-    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let opened = handle_session_open(
-        &ws,
-        state,
-        ledger,
-        &approvals,
-        &questions,
-        &forwarders,
-        None,
-        ConnectionUiFeatures::stdio_defaults(),
-        request_id.to_owned(),
-        SessionOpenParams {
-            session_id: session_id.clone(),
-            topic: None,
-            profile_id: None,
-            cwd: None,
-            sandbox: None,
-            after: None,
-        },
-        false,
-    )
-    .await;
-    assert!(opened, "session/open must succeed for {session_id}");
-    let result = recv_rpc_json(&mut rx).await;
-    assert_eq!(
-        result["id"],
-        json!(request_id),
-        "first frame is the RPC result"
-    );
-    abort_live_forwarders(&forwarders, ledger).await;
-    result
-}
-
-/// #2062 round 8 — an open with NO goal bound answers with an EXPLICIT
-/// versioned null snapshot: the `goal_state` key is PRESENT (a statement,
-/// not an omission), carries a `version` (u64) and `goal: null`. Also pins
-/// the old-server compat contract: the same result payload with the field
-/// STRIPPED still parses (`#[serde(default)]` → `Null`), which is exactly
-/// what a new client sees from an old server.
-#[tokio::test]
-async fn session_open_goal_state_response_is_versioned_null_when_no_goal_bound() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-state-unbound".into());
-
-    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-a").await;
-
-    let result = frame["result"]
-        .as_object()
-        .expect("session/open result object");
-    assert!(
-        result.contains_key("goal_state"),
-        "the field is ALWAYS present on a new server: {result:?}"
-    );
-    assert!(
-        result["goal_state"]["version"].is_u64(),
-        "the snapshot is versioned: {:?}",
-        result["goal_state"]
-    );
-    assert!(
-        result["goal_state"]["goal"].is_null(),
-        "no goal bound => goal: null: {:?}",
-        result["goal_state"]
-    );
-
-    // Old-server compat: strip the field and reparse — a new client
-    // receiving an old server's payload sees the serde default (`Null`,
-    // legacy no-op), never a parse failure.
-    let mut legacy = frame["result"].clone();
-    legacy
-        .as_object_mut()
-        .expect("result object")
-        .remove("goal_state");
-    let parsed: SessionOpenResult =
-        serde_json::from_value(legacy).expect("old-server payload (field absent) still parses");
-    assert!(
-        parsed.goal_state.is_null(),
-        "absent field defaults to Null (old server, no snapshot)"
-    );
-}
-
-/// #2062 round 6, test (b) — an open with a bound ACTIVE goal carries the
-/// goal object (same shape as `SessionGoalUpdated`'s `goal` field) in the
-/// response.
-#[tokio::test]
-async fn session_open_goal_state_response_carries_bound_goal() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-state-bound".into());
-    default_agent_orchestrator()
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "ship the goal snapshot in the open response".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal");
-
-    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-b").await;
-
-    default_agent_orchestrator()
-        .clear_goal(GoalSessionRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup goal");
-
-    let goal_state = &frame["result"]["goal_state"];
-    assert!(
-        goal_state["version"].is_u64(),
-        "the snapshot is versioned: {goal_state:?}"
-    );
-    assert!(
-        goal_state["goal"].is_object(),
-        "a bound goal rides in the response: {goal_state:?}"
-    );
-    assert_eq!(
-        goal_state["goal"]["objective"],
-        json!("ship the goal snapshot in the open response")
-    );
-    assert_eq!(goal_state["goal"]["status"], json!("active"));
-    assert!(
-        goal_state["goal"]["goal_id"].is_string(),
-        "the goal object carries its id: {goal_state:?}"
-    );
-}
-
-/// #2062 round 6, test (b) — a `budget_limited` goal is still the session's
-/// goal (frozen for scheduling, not for display): the response carries it
-/// with its real status, never `null`.
-#[tokio::test]
-async fn session_open_goal_state_response_carries_budget_limited_goal() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-state-budget-limited".into());
-    default_agent_orchestrator()
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "budget exhausted but still the session's goal".into(),
-            status: Some("budget_limited".into()),
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind budget_limited goal");
-
-    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-bl").await;
-
-    default_agent_orchestrator()
-        .clear_goal(GoalSessionRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup goal");
-
-    let goal_state = &frame["result"]["goal_state"];
-    assert_eq!(
-        goal_state["goal"]["status"],
-        json!("budget_limited"),
-        "any bound status rides in the response: {goal_state:?}"
-    );
-}
-
-/// #2062 round 6, test (c) — a goal bound under a DIFFERENT profile than
-/// this open resolves reads as `null`: the snapshot carries objective text
-/// and goes only to this connection, whose own `goal/get` equally reports
-/// "none". (The old broadcast-era "blank a live chip" hazard does not
-/// apply: this response reaches only the connection that opened.)
-#[tokio::test]
-async fn session_open_goal_state_response_null_for_other_profile_goal() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-state-other-profile".into());
-    default_agent_orchestrator()
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: "tenant-x".into(),
-            objective: "bound under a caller-requested profile".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal under tenant-x");
-
-    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-c1").await;
-
-    default_agent_orchestrator()
-        .clear_goal(GoalSessionRequest {
-            session_id: session_id.clone(),
-            profile_id: "tenant-x".into(),
-        })
-        .expect("cleanup goal");
-
-    assert!(
-        frame["result"]["goal_state"]["goal"].is_null(),
-        "the open resolves `_main`; tenant-x's goal must not leak into its \
-         response: {:?}",
-        frame["result"]["goal_state"]
-    );
-}
-
-/// #2062 round 6, test (c) — cwd-scope isolation through the response: a
-/// goal bound under sibling scope B never appears in scope A's open
-/// response, and scope B's own open still carries it (sibling unaffected).
-#[tokio::test]
-async fn session_open_goal_state_response_scoped_to_pinned_scope() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let orchestrator = default_agent_orchestrator();
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let wire = SessionKey("local:goal-state-scoped".into());
-    // Folder B registers its scope and binds a goal under it.
-    let _pinned_b = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "folder B's goal".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal under folder B's scope");
-    // Folder A opens the same wire session under ITS scope.
-    let _pinned_a = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
-    let frame_a = open_session_result_frame(&state, &ledger, &wire, "open-gs-scope-a").await;
-    // Folder B reopens under its own scope: the sibling is unaffected.
-    let _pinned_b2 = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
-    let frame_b = open_session_result_frame(&state, &ledger, &wire, "open-gs-scope-b").await;
-
-    orchestrator
-        .clear_goal(GoalSessionRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup goal");
-    let _ = orchestrator.set_goal_scope(&wire, None);
-
-    assert!(
-        frame_a["result"]["goal_state"]["goal"].is_null(),
-        "scope A reports its own (empty) slot, not folder B's goal: {:?}",
-        frame_a["result"]["goal_state"]
-    );
-    assert_eq!(
-        frame_b["result"]["goal_state"]["goal"]["objective"],
-        json!("folder B's goal"),
-        "scope B's own open still carries its goal: {:?}",
-        frame_b["result"]["goal_state"]
-    );
-}
-
-/// #2062 round 6 (Z1/W5 lineage) — the snapshot inspects the goal-store key
-/// PINNED at open-registration (the key `set_goal_scope` RETURNS from
-/// inside its own lock), never a re-resolution of the process-global
-/// last-writer-wins cwd map, which a concurrent same-wire/different-cwd
-/// open can flip between registration and snapshot computation. Pinned:
-/// folder A's open still reports folder A's goal after the flip; a
-/// re-resolving mutant would inspect folder B's (empty) slot and answer
-/// `null` — silently blanking A's live chip.
+/// #2065 — the scoped-generation registry, asserted at the send guard.
+///
+/// Two cwd scopes can share ONE wire session id (`appui.sessions_in_cwd`:
+/// the same session key opened from two folders). The #1959 guard is
+/// strictly monotonic per key, so while it was keyed by the WIRE id the two
+/// scopes shared a watermark — and a goal frame's generation is allocated
+/// when it is BUILT, not when it is delivered. Folder B builds a repaint
+/// (generation G_b), folder A then clears its own goal (generation
+/// G_a > G_b) and A's clear is delivered first: the shared watermark jumps
+/// to G_a, and B's still-in-flight repaint is dropped as "stale" even
+/// though it describes a different folder's live goal. B's chip silently
+/// stops updating.
+///
+/// This is the pre-existing defect the registry fixes; the test FAILS on
+/// main (wire-keyed watermark) and passes with per-scope identities.
 #[test]
-fn session_open_goal_state_snapshot_uses_pinned_key_not_cwd_map() {
+fn goal_scope_guard_admits_sibling_scope_repaint_after_other_scope_clear() {
     use crate::autonomy::agent_orchestrator::{
         AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
     };
     let orchestrator = default_agent_orchestrator();
-    let wire = SessionKey("local:goal-state-cwd-pin".into());
-    // Folder A registers, pins the returned key, and binds its goal.
-    let pinned_a = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    // ONE wire session id, opened from two folders.
+    let wire = SessionKey("local:goal-scope-guard".into());
+
+    // Folder B: register its scope, bind a goal, and BUILD its repaint.
+    orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
     orchestrator
         .set_goal(GoalSetRequest {
             session_id: wire.clone(),
             profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "folder A's live goal".into(),
+            objective: "folder B's live goal".into(),
             status: None,
             token_budget: None,
             transition_actor: None,
         })
-        .expect("bind goal under folder A's cwd scope");
-    // A concurrent same-wire open for a DIFFERENT folder flips the map
-    // before the snapshot is computed.
-    let _flipped = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+        .expect("bind folder B's goal");
+    let scoped_b = orchestrator.scoped_goal_key(&wire);
+    let b_repaint_json = orchestrator
+        .session_goal_updated_event_json(&scoped_b, MAIN_PROFILE_ID)
+        .expect("folder B has a live goal to repaint");
+    let b_repaint: octos_core::ui_protocol::SessionGoalUpdatedEvent =
+        serde_json::from_value(b_repaint_json).expect("updated event");
 
-    let snapshot = orchestrator.session_open_goal_state(&pinned_a, MAIN_PROFILE_ID);
+    // Folder A: register its scope, bind and CLEAR its own goal. The clear
+    // allocates a LATER generation than B's already-built repaint.
+    orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "folder A's goal".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind folder A's goal");
+    let a_clear_json = orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("clear folder A's goal");
+    let a_clear: octos_core::ui_protocol::SessionGoalClearedEvent =
+        serde_json::from_value(a_clear_json).expect("cleared event");
 
     // Cleanup the process-global store BEFORE asserting.
-    let _ = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
-    orchestrator
-        .clear_goal(GoalSessionRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup goal");
+    orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+    let _ = orchestrator.clear_goal(GoalSessionRequest {
+        session_id: wire.clone(),
+        profile_id: MAIN_PROFILE_ID.to_owned(),
+    });
     let _ = orchestrator.set_goal_scope(&wire, None);
 
-    assert_eq!(
-        snapshot["goal"]["objective"],
-        json!("folder A's live goal"),
-        "the snapshot must read the OPEN-pinned key (folder A), not the \
-         flipped cwd map (folder B): {snapshot:?}"
-    );
-}
-
-/// #2062 round 6 — the original issue's end-to-end shape against the
-/// response: open (null) -> bind -> reopen (goal) -> clear OUT OF BAND
-/// (directly on the orchestrator, exactly like a second connection or
-/// another process on the same data dir) -> reopen answers `null` again.
-/// A goal cleared elsewhere cannot survive as a stale chip: every reopen
-/// re-states the truth in its own response.
-#[tokio::test]
-async fn session_open_goal_state_response_null_again_after_out_of_band_clear() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-state-oob-clear".into());
-
-    let first = open_session_result_frame(&state, &ledger, &session_id, "open-gs-1").await;
-    assert!(first["result"]["goal_state"]["goal"].is_null());
-
-    default_agent_orchestrator()
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "cleared while you were away".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal");
-    let second = open_session_result_frame(&state, &ledger, &session_id, "open-gs-2").await;
-    assert_eq!(
-        second["result"]["goal_state"]["goal"]["objective"],
-        json!("cleared while you were away")
-    );
-
-    // The goal is cleared elsewhere: this connection's ledger never sees a
-    // cleared frame — the next open's RESPONSE is what states the truth.
-    default_agent_orchestrator()
-        .clear_goal(GoalSessionRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("clear goal out of band");
-    let third = open_session_result_frame(&state, &ledger, &session_id, "open-gs-3").await;
     assert!(
-        third["result"]["goal_state"]["goal"].is_null(),
-        "a goal cleared elsewhere must not survive the reopen: {:?}",
-        third["result"]["goal_state"]
+        a_clear.generation > b_repaint.generation,
+        "the hazard needs A's clear allocated AFTER B's repaint was built \
+         ({} vs {})",
+        a_clear.generation,
+        b_repaint.generation
     );
-}
+    // Both frames carry the same WIRE session id — the shared key that made
+    // them collide.
+    assert_eq!(a_clear.session_id, b_repaint.session_id);
 
-/// #2062 round 8, test (a) — the snapshot's version and state are captured
-/// under ONE state-lock acquisition and cannot disagree: after a repaint
-/// frame at generation G, the response's version is >= G with matching
-/// state; after an OUT-OF-BAND clear at generation G' (never admitted
-/// through the send guard — nothing enqueued anywhere), the reopen's
-/// version is >= G' with `goal: null`. The clear leg is what pins the
-/// version SOURCE: allocation-time bookkeeping (the state-lock
-/// `goal_scope_versions`), not the send guard's admission watermark — a
-/// version sourced from admission bookkeeping (a separate lock, a separate
-/// notion of "happened") would sit below G' and let the pre-clear frame
-/// beat the null under the client rule.
-#[tokio::test]
-async fn session_open_goal_state_response_version_consistent_with_state() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-state-version-consistency".into());
-    let orchestrator = default_agent_orchestrator();
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "versioned goal".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal");
-    let repaint_json = orchestrator
-        .session_goal_updated_event_json(&session_id, MAIN_PROFILE_ID)
-        .expect("repaint for the live goal");
-    let repaint_generation = repaint_json["generation"].as_u64().expect("generation");
-
-    let bound = open_session_result_frame(&state, &ledger, &session_id, "open-gs-vc1").await;
-    let bound_version = bound["result"]["goal_state"]["version"]
-        .as_u64()
-        .expect("version");
+    // Delivery order: A's clear reaches the guard first, then B's repaint.
     assert!(
-        bound_version >= repaint_generation,
-        "the snapshot's version covers the latest frame's generation \
-         ({bound_version} vs {repaint_generation})"
-    );
-    assert_eq!(
-        bound["result"]["goal_state"]["goal"]["objective"],
-        json!("versioned goal"),
-        "version and state travel together: {:?}",
-        bound["result"]["goal_state"]
-    );
-
-    // OUT-OF-BAND clear: allocates a generation but never admits/enqueues
-    // a frame anywhere.
-    let clear_result = orchestrator
-        .clear_goal(GoalSessionRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("clear goal out of band");
-    let clear_generation = clear_result["generation"].as_u64().expect("generation");
-
-    let cleared = open_session_result_frame(&state, &ledger, &session_id, "open-gs-vc2").await;
-    let cleared_version = cleared["result"]["goal_state"]["version"]
-        .as_u64()
-        .expect("version");
-    assert!(
-        cleared["result"]["goal_state"]["goal"].is_null(),
-        "cleared out of band => goal: null: {:?}",
-        cleared["result"]["goal_state"]
+        goal_event_passes_generation_guard(&UiNotification::SessionGoalCleared(a_clear)),
+        "folder A's clear is admitted"
     );
     assert!(
-        cleared_version >= clear_generation,
-        "the null is versioned AT the clear's allocation ({cleared_version} vs \
-         {clear_generation}) — a stale pre-clear frame can never beat it"
-    );
-}
-
-/// #2062 round 8, test (b) — order independence: a repaint at a HIGHER
-/// version arriving before OR after the response resolves to the same
-/// final state under the documented client rule (apply iff version >= last
-/// applied). Asserted at the protocol level with real versioned artifacts:
-/// the response from a real open, the frame from the real builder.
-#[tokio::test]
-async fn session_open_goal_state_version_resolves_order_both_ways() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-state-order-both-ways".into());
-    let orchestrator = default_agent_orchestrator();
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "snapshot state".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal");
-
-    let frame = open_session_result_frame(&state, &ledger, &session_id, "open-gs-order").await;
-    let response_version = frame["result"]["goal_state"]["version"]
-        .as_u64()
-        .expect("version");
-    let response_goal = frame["result"]["goal_state"]["goal"].clone();
-
-    // A NEWER frame, built after the response (real builder, real
-    // generation — strictly greater than the response's version).
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "newer frame state".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("newer mutation");
-    let newer_json = orchestrator
-        .session_goal_updated_event_json(&session_id, MAIN_PROFILE_ID)
-        .expect("newer repaint");
-    let newer_generation = newer_json["generation"].as_u64().expect("generation");
-    let newer_goal = newer_json["goal"].clone();
-    assert!(newer_generation > response_version);
-
-    orchestrator
-        .clear_goal(GoalSessionRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup goal");
-
-    // The documented client rule: apply iff version >= last applied.
-    fn apply(last_applied: &mut Option<u64>, chip: &mut Value, version: u64, goal: &Value) {
-        let admit = match last_applied {
-            Some(last) => version >= *last,
-            None => true,
-        };
-        if admit {
-            *last_applied = Some(version);
-            *chip = goal.clone();
-        }
-    }
-    // Order 1: response first, frame second.
-    let (mut last1, mut chip1) = (None, Value::Null);
-    apply(&mut last1, &mut chip1, response_version, &response_goal);
-    apply(&mut last1, &mut chip1, newer_generation, &newer_goal);
-    // Order 2: frame first, response second (the round-7 F1 hazard order).
-    let (mut last2, mut chip2) = (None, Value::Null);
-    apply(&mut last2, &mut chip2, newer_generation, &newer_goal);
-    apply(&mut last2, &mut chip2, response_version, &response_goal);
-
-    assert_eq!(
-        chip1, chip2,
-        "both arrival orders resolve to the same final state"
-    );
-    assert_eq!(
-        chip1["objective"],
-        json!("newer frame state"),
-        "the newer state wins regardless of arrival order: {chip1:?}"
-    );
-}
-
-/// #2062 round 7 (codex R6-OPEN-SNAPSHOT-ORDER) — the response's
-/// `goal_state` is captured AT ENQUEUE, so a goal repaint landing in the
-/// window between open-start and response-enqueue is REFLECTED by the
-/// response instead of being overwritten backwards by a stale early
-/// capture. Barrier: the test holds the sessions-manager lock (which the
-/// open acquires AFTER the round-6 early-capture site and BEFORE the
-/// response enqueue), mutates the goal and delivers the repaint through
-/// the real ephemeral path inside that window, then releases. Asserts:
-/// the repaint frame precedes the response on the wire, the response
-/// carries the POST-repaint state with a version >= the repaint frame's
-/// generation (same number space — the client rule resolves either
-/// arrival order), and no goal frame follows the response.
-#[tokio::test]
-async fn session_open_goal_state_response_reflects_mid_open_mutation() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let session_id = SessionKey("local:goal-state-fresh-at-enqueue".into());
-    let orchestrator = default_agent_orchestrator();
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "before the mid-open repaint".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind the pre-open goal");
-
-    let (ws, mut rx) = ws_connection_for_test(64);
-    ws.update_live_features(ConnectionUiFeatures::stdio_defaults());
-    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    // BARRIER: hold the sessions-manager lock so the spawned open blocks
-    // inside `open_session_result` — after the (round-6) early-capture
-    // site, before the response enqueue.
-    let sessions_gate = state.sessions.as_ref().expect("sessions").clone();
-    let gate = sessions_gate.lock().await;
-    let open_task = tokio::spawn({
-        let ws = ws.clone();
-        let state = state.clone();
-        let ledger = ledger.clone();
-        let forwarders = forwarders.clone();
-        let session_id = session_id.clone();
-        async move {
-            let approvals = PendingApprovalStore::default();
-            let questions = PendingQuestionStore::default();
-            handle_session_open(
-                &ws,
-                &state,
-                &ledger,
-                &approvals,
-                &questions,
-                &forwarders,
-                None,
-                ConnectionUiFeatures::stdio_defaults(),
-                "open-fresh".into(),
-                SessionOpenParams {
-                    session_id,
-                    topic: None,
-                    profile_id: None,
-                    cwd: None,
-                    sandbox: None,
-                    after: None,
-                },
-                false,
-            )
-            .await
-        }
-    });
-    // Let the open reach the barrier.
-    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
-    // The mid-open mutation: an already-running turn's goal_update — the
-    // store changes AND the repaint is delivered to THIS wire through the
-    // real ephemeral path (guard-admitted, watermark moved).
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "after the mid-open repaint".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("mid-open goal mutation");
-    let repaint_json = orchestrator
-        .session_goal_updated_event_json(&session_id, MAIN_PROFILE_ID)
-        .expect("repaint for the live goal");
-    let repaint: octos_core::ui_protocol::SessionGoalUpdatedEvent =
-        serde_json::from_value(repaint_json).expect("updated event");
-    let repaint_generation = repaint.generation;
-    send_notification_ephemeral(&ws, &ledger, UiNotification::SessionGoalUpdated(repaint))
-        .expect("deliver the mid-open repaint");
-    drop(gate);
-    assert!(open_task.await.expect("open task"), "open must succeed");
-
-    // Wire order: the repaint frame precedes the response; the response's
-    // snapshot reflects the POST-repaint state.
-    let mut saw_repaint = false;
-    let result = loop {
-        let frame = recv_rpc_json(&mut rx).await;
-        if frame["method"] == json!("session/goal/updated") {
-            assert_eq!(
-                frame["params"]["goal"]["objective"],
-                json!("after the mid-open repaint")
-            );
-            saw_repaint = true;
-            continue;
-        }
-        if frame["id"] == json!("open-fresh") {
-            break frame;
-        }
-    };
-    assert!(saw_repaint, "the mid-open repaint precedes the response");
-    assert_eq!(
-        result["result"]["goal_state"]["goal"]["objective"],
-        json!("after the mid-open repaint"),
-        "the snapshot reflects the mid-open mutation: {:?}",
-        result["result"]["goal_state"]
-    );
-    assert!(
-        result["result"]["goal_state"]["version"]
-            .as_u64()
-            .expect("version")
-            >= repaint_generation,
-        "the snapshot's version covers the repaint it reflects \
-         ({:?} vs frame generation {repaint_generation})",
-        result["result"]["goal_state"]["version"]
-    );
-    // No goal frame carrying older state may follow the response.
-    let quiet = tokio::time::Duration::from_millis(400);
-    while let Ok(frame) = tokio::time::timeout(quiet, recv_rpc_json(&mut rx)).await {
-        if let Some(method) = frame["method"].as_str() {
-            assert!(
-                !method.starts_with("session/goal/"),
-                "no goal frame may follow the response: {frame}"
-            );
-        }
-    }
-    orchestrator
-        .clear_goal(GoalSessionRequest {
-            session_id: session_id.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup goal");
-}
-
-/// #2062 round 7 (codex R6-PIN-MUTATION-COVERAGE) — the PRODUCTION path's
-/// snapshot must use the open-pinned scoped key, not a re-resolution at
-/// the enqueue callsite: with folder A's goal bound and the open in
-/// flight, a concurrent same-wire open flips the last-writer-wins cwd map
-/// to folder B inside the window — the response must still carry folder
-/// A's goal. A callsite mutant that re-resolves the key would read folder
-/// B's empty slot and answer `null`.
-#[tokio::test]
-async fn session_open_goal_state_response_pinned_across_mid_open_scope_flip() {
-    use crate::autonomy::agent_orchestrator::{
-        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
-    };
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = state_with_sessions(temp.path());
-    let ledger = Arc::new(UiProtocolLedger::new(16));
-    let wire = SessionKey("local:goal-state-mid-open-flip".into());
-    let orchestrator = default_agent_orchestrator();
-    let _pinned_a = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
-    orchestrator
-        .set_goal(GoalSetRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-            objective: "folder A's live goal".into(),
-            status: None,
-            token_budget: None,
-            transition_actor: None,
-        })
-        .expect("bind goal under folder A's cwd scope");
-
-    let (ws, mut rx) = ws_connection_for_test(64);
-    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let sessions_gate = state.sessions.as_ref().expect("sessions").clone();
-    let gate = sessions_gate.lock().await;
-    let open_task = tokio::spawn({
-        let ws = ws.clone();
-        let state = state.clone();
-        let ledger = ledger.clone();
-        let forwarders = forwarders.clone();
-        let wire = wire.clone();
-        async move {
-            let approvals = PendingApprovalStore::default();
-            let questions = PendingQuestionStore::default();
-            handle_session_open(
-                &ws,
-                &state,
-                &ledger,
-                &approvals,
-                &questions,
-                &forwarders,
-                None,
-                ConnectionUiFeatures::stdio_defaults(),
-                "open-flip".into(),
-                SessionOpenParams {
-                    session_id: wire,
-                    topic: None,
-                    profile_id: None,
-                    cwd: None,
-                    sandbox: None,
-                    after: None,
-                },
-                false,
-            )
-            .await
-        }
-    });
-    // The open captured its pin (folder A) before blocking at the barrier;
-    // a concurrent same-wire open now flips the map to folder B.
-    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
-    let _flipped = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
-    drop(gate);
-    assert!(open_task.await.expect("open task"), "open must succeed");
-
-    let result = loop {
-        let frame = recv_rpc_json(&mut rx).await;
-        if frame["id"] == json!("open-flip") {
-            break frame;
-        }
-    };
-
-    // Cleanup the process-global store BEFORE asserting.
-    let _ = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
-    orchestrator
-        .clear_goal(GoalSessionRequest {
-            session_id: wire.clone(),
-            profile_id: MAIN_PROFILE_ID.to_owned(),
-        })
-        .expect("cleanup goal");
-    let _ = orchestrator.set_goal_scope(&wire, None);
-
-    assert_eq!(
-        result["result"]["goal_state"]["goal"]["objective"],
-        json!("folder A's live goal"),
-        "the snapshot must use the OPEN-pinned key (folder A), \
-         not the flipped cwd map (folder B): {:?}",
-        result["result"]["goal_state"]
+        goal_event_passes_generation_guard(&UiNotification::SessionGoalUpdated(b_repaint)),
+        "folder B's repaint must still be admitted: it belongs to a DIFFERENT \
+         cwd scope, so folder A's later-allocated clear must not advance the \
+         watermark it is checked against"
     );
 }
 
@@ -36161,12 +35454,11 @@ fn plug_frame() -> WsMessage {
     frame_for(&json!({"jsonrpc": "2.0", "method": "test/plug"})).expect("plug frame")
 }
 
-/// #2062 round 3 (codex #2065 round-2 Z5) — capability gating on the shared
-/// filter: a connection that did not negotiate `coding.goal_runtime.v1`
-/// (the same capability the goal RPC surface requires) must receive ZERO
-/// goal FRAMES through the full open sequence — replay and live pump alike.
-/// (The response-carried `goal_state` field is deliberately ungated: it is
-/// not a frame, and an old client simply ignores the unknown field.)
+/// #2065 — capability gating on the shared filter: a connection that did
+/// not negotiate `coding.goal_runtime.v1` (the same capability the goal RPC
+/// surface requires) must receive ZERO `session/goal/*` frames through the
+/// full open sequence — replay and live pump alike. Without the gate such a
+/// client received frames it can only report as unknown notifications.
 #[tokio::test]
 async fn session_open_goal_frames_gated_when_goal_runtime_not_negotiated() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -36254,14 +35546,14 @@ async fn session_open_goal_frames_gated_when_goal_runtime_not_negotiated() {
     );
 }
 
-/// #2062 round 3 (codex #2065 round-2 Z5-lifecycle) — a re-open must fully
+/// #2065 — a re-open must fully
 /// retire the previous live forwarder BEFORE the replacement starts pumping,
 /// so "one live lane per (connection, session)" holds across reopens and an
 /// event is never double-delivered by two overlapping pumps. (The
 /// production open path retires even earlier — before the replay baseline
-/// is computed, round-3 W6.1 — this pins the in-spawn defense direct
-/// callers rely on. Handover semantics are at-least-once, not exactly-once:
-/// see the retire-before-baseline comment in `handle_session_open`.)
+/// is computed — this pins the in-spawn defense direct callers rely on.
+/// Handover semantics are at-least-once, not exactly-once: see the
+/// retire-before-baseline comment in `handle_session_open`.)
 #[tokio::test]
 async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
     let (ws, mut rx) = ws_connection_for_test(64);
@@ -36325,8 +35617,8 @@ async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
     abort_live_forwarders(&forwarders, &ledger).await;
 }
 
-/// #2062 round 4 (codex #2065 round-3 W6, absence-by-construction) —
-/// through `WsConnection::new_stdio`: the stdio durable lane parks
+/// #2065 (absence-by-construction) — through `WsConnection::new_stdio`:
+/// the stdio durable lane parks
 /// COOPERATIVELY (non-blocking `try_send` probe + async sleep, see
 /// `send_durable_offloaded`), so a forwarder parked on a FULL stdio queue is
 /// fully retired by abort+join — cancellation lands at the probe's await and

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35503,6 +35503,9 @@ async fn session_open_goal_frames_gated_when_goal_runtime_not_negotiated() {
         &questions,
         &forwarders,
         None,
+        // #2067 — the open-path delivery filter pin; no connection-level pin
+        // in this test, so filtering is per-profile-scope only.
+        None,
         features,
         "open-no-goal-runtime".into(),
         SessionOpenParams {
@@ -35570,6 +35573,7 @@ async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
         ws.connection_id(),
         ConnectionUiFeatures::stdio_defaults(),
         None,
+        None,
         first_rx,
         forwarders.clone(),
     )
@@ -35584,6 +35588,7 @@ async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
         0,
         ws.connection_id(),
         ConnectionUiFeatures::stdio_defaults(),
+        None,
         None,
         second_rx,
         forwarders.clone(),
@@ -35643,6 +35648,7 @@ async fn session_open_goal_stdio_lane_retire_leaves_no_inflight_send() {
         0,
         ws.connection_id(),
         ConnectionUiFeatures::stdio_defaults(),
+        None,
         None,
         live_rx,
         forwarders.clone(),

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35738,7 +35738,340 @@ async fn session_open_goal_null_snapshot_reemitted_when_goal_cleared_elsewhere()
     let reopened_generation = reopened[0]["generation"].as_u64().expect("generation");
     assert!(
         reopened_generation > first_generation,
-        "the re-emitted null snapshot must carry a newer generation \
-         ({reopened_generation} vs {first_generation})"
+        "each emission is freshly stamped for the delivery loop's \
+         superseded-abandon bookkeeping ({reopened_generation} vs {first_generation})"
     );
+}
+
+/// A minimal valid frame used to occupy a capacity-1 writer queue so the
+/// #2062 null snapshot is forced to park on backpressure.
+fn plug_frame() -> WsMessage {
+    frame_for(&json!({"jsonrpc": "2.0", "method": "test/plug"})).expect("plug frame")
+}
+
+/// #2062 round 3 (codex #2065 round-2 Z2) — THE NULL IS A SNAPSHOT, NOT A
+/// COMMAND. Direct-path senders (the goal RPC durable send, the accountant's
+/// ephemeral repaint) share this connection's writer queue but not the
+/// forwarder task, so they cannot be serialized against a parked null — the
+/// null must instead ABANDON itself the moment any newer goal frame has been
+/// admitted for the session. An abandoned null is CORRECT: a newer
+/// authoritative frame reached the client, so the stale-chip condition the
+/// null exists to fix is already gone.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_abandoned_when_superseded_while_parked() {
+    let (ws, mut rx) = ws_connection_for_test(1);
+    // Fill the single writer slot: the null cannot enqueue and must park.
+    ws.send_durable(plug_frame(), "test/plug")
+        .expect("plug the writer queue");
+    let session_id = SessionKey("local:goal-null-superseded".into());
+    let null =
+        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            cleared: true,
+            goal: None,
+            transition_actor: "backend".into(),
+            generation: 5,
+        });
+    let ws_null = ws.clone();
+    let features = ConnectionUiFeatures::stdio_defaults();
+    let delivery =
+        tokio::spawn(async move { send_open_catchup_notification(&ws_null, null, features).await });
+    // Let the null hit backpressure and park.
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    // A NEWER goal frame is admitted through the same #1959 guard entry the
+    // production direct senders use (RPC durable path / accountant path) —
+    // the session watermark moves past the parked null's generation.
+    let newer =
+        UiNotification::SessionGoalUpdated(octos_core::ui_protocol::SessionGoalUpdatedEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            goal: octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+                goal_id: "goal-live".into(),
+                objective: "set while the null was parked".into(),
+                status: "active".into(),
+                token_budget: 1_000,
+                tokens_used: 0,
+                time_used_seconds: 0,
+                created_at_ms: 0,
+                updated_at_ms: 0,
+            },
+            transition_actor: "user".into(),
+            generation: 6,
+        });
+    assert!(
+        goal_event_passes_generation_guard(&newer),
+        "the newer update must be admitted and recorded as the watermark"
+    );
+    // Free the writer slot — the parked null now CAN send, and must not.
+    let plug = recv_rpc_json(&mut rx).await;
+    assert_eq!(plug["method"], json!("test/plug"));
+    delivery
+        .await
+        .expect("delivery task")
+        .expect("abandoning is a clean outcome");
+    let late = tokio::time::timeout(
+        tokio::time::Duration::from_millis(400),
+        recv_rpc_json(&mut rx),
+    )
+    .await;
+    assert!(
+        late.is_err(),
+        "a superseded null must be ABANDONED, never delivered after the newer frame: {late:?}"
+    );
+}
+
+/// #2062 round 3 (codex #2065 round-2 Z3) — PARK-DON'T-DROP: a writer queue
+/// filled by a large replay parks the null until capacity frees; it is never
+/// terminally dropped on a live connection. (The round-2 bounded retry gave
+/// up after ~150ms and lost the frame — no cursor, so `replay_lossy` could
+/// never recover it.)
+#[tokio::test]
+async fn session_open_goal_null_snapshot_parks_until_writer_capacity_frees() {
+    let (ws, mut rx) = ws_connection_for_test(1);
+    ws.send_durable(plug_frame(), "test/plug")
+        .expect("plug the writer queue");
+    let session_id = SessionKey("local:goal-null-parked".into());
+    let null =
+        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            cleared: true,
+            goal: None,
+            transition_actor: "backend".into(),
+            generation: 5,
+        });
+    let ws_null = ws.clone();
+    let features = ConnectionUiFeatures::stdio_defaults();
+    let delivery =
+        tokio::spawn(async move { send_open_catchup_notification(&ws_null, null, features).await });
+    // Park well past the round-2 bounded-retry budget before freeing the
+    // queue: a live connection must still receive the null afterwards.
+    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+    let plug = recv_rpc_json(&mut rx).await;
+    assert_eq!(plug["method"], json!("test/plug"));
+    let cleared = tokio::time::timeout(tokio::time::Duration::from_secs(5), recv_rpc_json(&mut rx))
+        .await
+        .expect("the parked null must deliver once capacity frees (never dropped)");
+    assert_eq!(
+        cleared["method"],
+        json!("session/goal/cleared"),
+        "the parked null must deliver once capacity frees: {cleared}"
+    );
+    delivery
+        .await
+        .expect("delivery task")
+        .expect("parked null delivers on a live connection");
+}
+
+/// #2062 round 3 (codex #2065 round-2 Z5) — capability gating on ALL lanes:
+/// a connection that did not negotiate `coding.goal_runtime.v1` (the same
+/// capability the goal RPC surface requires) must receive ZERO goal frames
+/// through the full open sequence — replay, forwarder drain, live pump, and
+/// the null snapshot alike. Round 2 gated only the null's CONSTRUCTION;
+/// replayed/pumped `session/goal/*` frames still leaked through.
+#[tokio::test]
+async fn session_open_goal_frames_gated_when_goal_runtime_not_negotiated() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-capability".into());
+    // Seed the REPLAY lane with a durable goal frame from another connection.
+    ledger.append_notification_from(
+        UiNotification::SessionGoalUpdated(octos_core::ui_protocol::SessionGoalUpdatedEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            goal: octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+                goal_id: "goal-replayed".into(),
+                objective: "durable goal history".into(),
+                status: "active".into(),
+                token_budget: 1_000,
+                tokens_used: 1,
+                time_used_seconds: 1,
+                created_at_ms: 0,
+                updated_at_ms: 0,
+            },
+            transition_actor: "backend".into(),
+            generation: 0,
+        }),
+        ConnectionId::next(),
+    );
+
+    let features = ConnectionUiFeatures {
+        coding_goal_runtime_v1: false,
+        ..ConnectionUiFeatures::stdio_defaults()
+    };
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let opened = handle_session_open(
+        &ws,
+        &state,
+        &ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        None,
+        features,
+        "open-no-goal-runtime".into(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: None,
+        },
+        false,
+    )
+    .await;
+    assert!(opened, "session/open must succeed");
+    // Feed the LIVE PUMP lane too, from another connection.
+    ledger.append_notification_from(
+        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            cleared: true,
+            goal: None,
+            transition_actor: "user".into(),
+            generation: 0,
+        }),
+        ConnectionId::next(),
+    );
+    // Collect the full open sequence plus a quiet window of live pumping.
+    let mut goal_frames = Vec::new();
+    let quiet = tokio::time::Duration::from_millis(700);
+    while let Ok(frame) = tokio::time::timeout(quiet, recv_rpc_json(&mut rx)).await {
+        if let Some(method) = frame["method"].as_str() {
+            if method.starts_with("session/goal/") {
+                goal_frames.push(frame.clone());
+            }
+        }
+    }
+    abort_live_forwarders(&forwarders, &ledger).await;
+    assert!(
+        goal_frames.is_empty(),
+        "a connection without coding.goal_runtime.v1 must see zero goal frames: {goal_frames:?}"
+    );
+}
+
+/// #2062 round 3 (codex #2065 round-2 Z1) — the null's suppression lookup
+/// must inspect the goal-store key PINNED at this open's registration, not a
+/// re-resolution of the process-global last-writer-wins cwd map: a
+/// concurrent same-wire/different-cwd open can flip that map mid-open, and
+/// a recomputed key would then inspect the OTHER folder's (empty) slot and
+/// emit a spurious cleared for THIS folder's live chip.
+#[test]
+fn session_open_goal_null_snapshot_pinned_key_survives_concurrent_cwd_flip() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let orchestrator = default_agent_orchestrator();
+    let wire = SessionKey("local:goal-null-cwd-pin".into());
+    orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "folder A's live goal".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal under folder A's cwd scope");
+    // This open pins its goal-store identity at registration time.
+    let pinned = orchestrator.scoped_goal_key(&wire);
+    // A concurrent same-wire open for a DIFFERENT folder flips the
+    // last-writer-wins map before the null snapshot is computed.
+    orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+
+    let verdict = orchestrator.session_goal_hydrate_cleared_event_json(&pinned, MAIN_PROFILE_ID);
+
+    // Cleanup the process-global store BEFORE asserting.
+    orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup goal");
+    orchestrator.set_goal_scope(&wire, None);
+
+    assert!(
+        verdict.is_none(),
+        "suppression must inspect the OPEN-pinned key (folder A), not the \
+         flipped cwd map (folder B): {verdict:?}"
+    );
+}
+
+/// #2062 round 3 (codex #2065 round-2 Z5-lifecycle) — a re-open must fully
+/// retire the previous live forwarder BEFORE the replacement starts pumping,
+/// so "one live lane per (connection, session)" holds across reopens and an
+/// event is never double-delivered by two overlapping pumps.
+#[tokio::test]
+async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-lane-handover".into());
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+    let first_rx = ledger.subscribe(&session_id);
+    spawn_live_forwarder_with_goal_null_snapshot(
+        ws.clone(),
+        ledger.clone(),
+        session_id.clone(),
+        0,
+        ws.connection_id(),
+        ConnectionUiFeatures::stdio_defaults(),
+        None,
+        first_rx,
+        forwarders.clone(),
+        None,
+    )
+    .await;
+
+    // Re-open on the SAME connection and session.
+    let second_rx = ledger.subscribe(&session_id);
+    spawn_live_forwarder_with_goal_null_snapshot(
+        ws.clone(),
+        ledger.clone(),
+        session_id.clone(),
+        0,
+        ws.connection_id(),
+        ConnectionUiFeatures::stdio_defaults(),
+        None,
+        second_rx,
+        forwarders.clone(),
+        None,
+    )
+    .await;
+
+    // An event appended after the handover must arrive exactly once.
+    ledger.append_notification_from(
+        UiNotification::MessageDelta(MessageDeltaEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: TurnId::new(),
+            text: "exactly once".into(),
+        }),
+        ConnectionId::next(),
+    );
+    let delivered =
+        tokio::time::timeout(tokio::time::Duration::from_secs(5), recv_rpc_json(&mut rx))
+            .await
+            .expect("the replacement forwarder delivers the live event");
+    assert_eq!(delivered["method"], json!("message/delta"));
+    let duplicate = tokio::time::timeout(
+        tokio::time::Duration::from_millis(400),
+        recv_rpc_json(&mut rx),
+    )
+    .await;
+    assert!(
+        duplicate.is_err(),
+        "the retired forwarder must not double-deliver: {duplicate:?}"
+    );
+    abort_live_forwarders(&forwarders, &ledger).await;
 }

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35513,16 +35513,18 @@ async fn session_open_goal_null_snapshot_suppressed_when_goal_budget_limited() {
     );
 }
 
-/// #2062 fix round (codex #2065 H3) — ordering at the protocol layer,
-/// asserted on WIRE FRAME ORDER, not client state. The open subscribes to
-/// the live broadcast BEFORE its replay snapshot, so a stale
-/// `session/goal/updated` can be sitting in the receiver when the forwarder
-/// starts; the forwarder's ledger-send path does not run the #1959
+/// #2062 fix round (codex #2065 H3, round-3 PATH B) — ordering at the
+/// protocol layer, asserted on WIRE FRAME ORDER, not client state. The open
+/// subscribes to the live broadcast BEFORE its replay snapshot, so a stale
+/// `session/goal/updated` can be sitting in the receiver when the open's
+/// synchronous drain runs; the ledger-send lane does not run the #1959
 /// generation guard and the client's `updated` reducer applies
 /// unconditionally, so if the null were emitted before that backlog
 /// flushes, the stale update would repaint the chip the null just blanked.
 /// The null must therefore be the FINAL goal-state frame of the open
-/// sequence: backlog first, null second.
+/// sequence: backlog first, null second — the exact contract of
+/// `drain_open_backlog_then_emit_goal_null`, the same helper the open
+/// handler runs synchronously.
 #[tokio::test]
 async fn session_open_goal_null_snapshot_ordered_after_buffered_stale_update() {
     let (ws, mut rx_frames) = ws_connection_for_test(64);
@@ -35549,7 +35551,7 @@ async fn session_open_goal_null_snapshot_ordered_after_buffered_stale_update() {
             },
             transition_actor: "backend".into(),
             // Unstamped, like a pre-#1959 producer — the guardless
-            // forwarder lane delivers it regardless.
+            // ledger-send lane delivers it regardless.
             generation: 0,
         },
     ));
@@ -35562,17 +35564,15 @@ async fn session_open_goal_null_snapshot_ordered_after_buffered_stale_update() {
             transition_actor: "backend".into(),
             generation: 0,
         });
-    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    spawn_live_forwarder_with_goal_null_snapshot(
-        ws.clone(),
-        ledger.clone(),
-        session_id.clone(),
+    let _rx = drain_open_backlog_then_emit_goal_null(
+        &ws,
+        &ledger,
+        live_rx,
         0,
-        ws.connection_id(),
+        ConnectionId::next(),
         ConnectionUiFeatures::stdio_defaults(),
         None,
-        live_rx,
-        forwarders.clone(),
+        &session_id,
         Some(null),
     )
     .await;
@@ -35590,7 +35590,6 @@ async fn session_open_goal_null_snapshot_ordered_after_buffered_stale_update() {
         "the null must be the FINAL goal-state frame of the open sequence: {second}"
     );
     assert_eq!(second["params"]["cleared"], json!(true));
-    abort_live_forwarders(&forwarders, &ledger).await;
 }
 
 /// #2062 RED→GREEN: a session that opens with NO goal bound must receive an
@@ -35738,8 +35737,8 @@ async fn session_open_goal_null_snapshot_reemitted_when_goal_cleared_elsewhere()
     let reopened_generation = reopened[0]["generation"].as_u64().expect("generation");
     assert!(
         reopened_generation > first_generation,
-        "each emission is freshly stamped for the delivery loop's \
-         superseded-abandon bookkeeping ({reopened_generation} vs {first_generation})"
+        "each emission is freshly stamped for the emit-time superseded-abandon \
+         bookkeeping ({reopened_generation} vs {first_generation})"
     );
 }
 
@@ -35749,21 +35748,21 @@ fn plug_frame() -> WsMessage {
     frame_for(&json!({"jsonrpc": "2.0", "method": "test/plug"})).expect("plug frame")
 }
 
-/// #2062 round 3 (codex #2065 round-2 Z2) — THE NULL IS A SNAPSHOT, NOT A
-/// COMMAND. Direct-path senders (the goal RPC durable send, the accountant's
-/// ephemeral repaint) share this connection's writer queue but not the
-/// forwarder task, so they cannot be serialized against a parked null — the
-/// null must instead ABANDON itself the moment any newer goal frame has been
-/// admitted for the session. An abandoned null is CORRECT: a newer
-/// authoritative frame reached the client, so the stale-chip condition the
-/// null exists to fix is already gone.
+/// #2062 round 4 (codex #2065 round-3 W2 + W8) — THE NULL IS A SNAPSHOT,
+/// NOT A COMMAND: it is emitted synchronously in the open sequence and
+/// abandons itself when a newer goal frame was already admitted for the
+/// session. Unlike the retired round-3 test this drives the NEWER frame
+/// through the REAL production send path (`send_notification_durable`:
+/// guard-admit → ledger append → direct delivery to THIS wire), so the
+/// superseder is genuinely enqueued and delivered — not a bare guard call
+/// that "positively accepts the production failure" (W8). The final wire
+/// state must be the update, with no cleared frame after it.
 #[tokio::test]
-async fn session_open_goal_null_snapshot_abandoned_when_superseded_while_parked() {
-    let (ws, mut rx) = ws_connection_for_test(1);
-    // Fill the single writer slot: the null cannot enqueue and must park.
-    ws.send_durable(plug_frame(), "test/plug")
-        .expect("plug the writer queue");
+async fn session_open_goal_null_snapshot_abandoned_when_newer_frame_already_delivered() {
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
     let session_id = SessionKey("local:goal-null-superseded".into());
+    ws.update_live_features(ConnectionUiFeatures::stdio_defaults());
     let null =
         UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
             session_id: session_id.clone(),
@@ -35773,15 +35772,8 @@ async fn session_open_goal_null_snapshot_abandoned_when_superseded_while_parked(
             transition_actor: "backend".into(),
             generation: 5,
         });
-    let ws_null = ws.clone();
-    let features = ConnectionUiFeatures::stdio_defaults();
-    let delivery =
-        tokio::spawn(async move { send_open_catchup_notification(&ws_null, null, features).await });
-    // Let the null hit backpressure and park.
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-    // A NEWER goal frame is admitted through the same #1959 guard entry the
-    // production direct senders use (RPC durable path / accountant path) —
-    // the session watermark moves past the parked null's generation.
+    // The newer frame is admitted, ledgered, AND delivered to this wire
+    // through the same durable path the goal RPC handler uses.
     let newer =
         UiNotification::SessionGoalUpdated(octos_core::ui_protocol::SessionGoalUpdatedEvent {
             session_id: session_id.clone(),
@@ -35789,7 +35781,7 @@ async fn session_open_goal_null_snapshot_abandoned_when_superseded_while_parked(
             goal: octos_core::ui_protocol::UiGoalRecord {
                 profile_id: Some(MAIN_PROFILE_ID.to_owned()),
                 goal_id: "goal-live".into(),
-                objective: "set while the null was parked".into(),
+                objective: "set before the null could enqueue".into(),
                 status: "active".into(),
                 token_budget: 1_000,
                 tokens_used: 0,
@@ -35800,17 +35792,21 @@ async fn session_open_goal_null_snapshot_abandoned_when_superseded_while_parked(
             transition_actor: "user".into(),
             generation: 6,
         });
+    send_notification_durable(&ws, &ledger, newer).expect("deliver the newer frame");
+
+    let outcome =
+        emit_open_goal_null_now(&ws, &ledger, null, ConnectionUiFeatures::stdio_defaults());
     assert!(
-        goal_event_passes_generation_guard(&newer),
-        "the newer update must be admitted and recorded as the watermark"
+        outcome.is_ok(),
+        "abandoning a superseded null is a clean outcome: {outcome:?}"
     );
-    // Free the writer slot — the parked null now CAN send, and must not.
-    let plug = recv_rpc_json(&mut rx).await;
-    assert_eq!(plug["method"], json!("test/plug"));
-    delivery
-        .await
-        .expect("delivery task")
-        .expect("abandoning is a clean outcome");
+
+    let first = recv_rpc_json(&mut rx).await;
+    assert_eq!(
+        first["method"],
+        json!("session/goal/updated"),
+        "the delivered newer frame is the final goal state: {first}"
+    );
     let late = tokio::time::timeout(
         tokio::time::Duration::from_millis(400),
         recv_rpc_json(&mut rx),
@@ -35822,17 +35818,22 @@ async fn session_open_goal_null_snapshot_abandoned_when_superseded_while_parked(
     );
 }
 
-/// #2062 round 3 (codex #2065 round-2 Z3) — PARK-DON'T-DROP: a writer queue
-/// filled by a large replay parks the null until capacity frees; it is never
-/// terminally dropped on a live connection. (The round-2 bounded retry gave
-/// up after ~150ms and lost the frame — no cursor, so `replay_lossy` could
-/// never recover it.)
+/// #2062 round 4 (codex #2065 round-3 PATH B(3)) — backpressure coupling:
+/// the null is emitted synchronously in the open section with NO parked
+/// retry. If the writer is full, the same section was already dropping
+/// replay frames; the null's drop is accounted into the SAME shared
+/// dropped-frame counter every backpressure-dropped durable frame feeds,
+/// so the `protocol/replay_lossy` signal the client already surfaces
+/// ("reconnect to rehydrate" — it performs no automatic resync) carries
+/// it, and the reopen it prompts re-emits the snapshot (idempotent null).
 #[tokio::test]
-async fn session_open_goal_null_snapshot_parks_until_writer_capacity_frees() {
+async fn session_open_goal_null_snapshot_backpressure_drop_signals_replay_lossy() {
     let (ws, mut rx) = ws_connection_for_test(1);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-backpressure".into());
     ws.send_durable(plug_frame(), "test/plug")
         .expect("plug the writer queue");
-    let session_id = SessionKey("local:goal-null-parked".into());
+    let dropped_before = ws.metrics().dropped_count.load(Ordering::Relaxed);
     let null =
         UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
             session_id: session_id.clone(),
@@ -35842,27 +35843,28 @@ async fn session_open_goal_null_snapshot_parks_until_writer_capacity_frees() {
             transition_actor: "backend".into(),
             generation: 5,
         });
-    let ws_null = ws.clone();
-    let features = ConnectionUiFeatures::stdio_defaults();
-    let delivery =
-        tokio::spawn(async move { send_open_catchup_notification(&ws_null, null, features).await });
-    // Park well past the round-2 bounded-retry budget before freeing the
-    // queue: a live connection must still receive the null afterwards.
-    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+
+    let outcome =
+        emit_open_goal_null_now(&ws, &ledger, null, ConnectionUiFeatures::stdio_defaults());
+    assert!(
+        matches!(outcome, Err(SendError::BackpressureDrop)),
+        "a full writer drops the null exactly once, no parked retry: {outcome:?}"
+    );
+    assert!(
+        ws.metrics().dropped_count.load(Ordering::Relaxed) > dropped_before,
+        "the drop must be accounted into the shared dropped-frame counter"
+    );
+
+    // Drain the plug: no cleared frame may ever arrive (single attempt).
     let plug = recv_rpc_json(&mut rx).await;
     assert_eq!(plug["method"], json!("test/plug"));
-    let cleared = tokio::time::timeout(tokio::time::Duration::from_secs(5), recv_rpc_json(&mut rx))
+    // The retained debt flushes as `protocol/replay_lossy` at the next send
+    // opportunity — the same mechanism every dropped durable frame uses.
+    emit_replay_lossy_opportunistic(&ws, &ledger, session_id.0.as_str());
+    let lossy = tokio::time::timeout(tokio::time::Duration::from_secs(5), recv_rpc_json(&mut rx))
         .await
-        .expect("the parked null must deliver once capacity frees (never dropped)");
-    assert_eq!(
-        cleared["method"],
-        json!("session/goal/cleared"),
-        "the parked null must deliver once capacity frees: {cleared}"
-    );
-    delivery
-        .await
-        .expect("delivery task")
-        .expect("parked null delivers on a live connection");
+        .expect("the accounted drop surfaces as replay_lossy");
+    assert_eq!(lossy["method"], json!("protocol/replay_lossy"));
 }
 
 /// #2062 round 3 (codex #2065 round-2 Z5) — capability gating on ALL lanes:
@@ -35958,12 +35960,17 @@ async fn session_open_goal_frames_gated_when_goal_runtime_not_negotiated() {
     );
 }
 
-/// #2062 round 3 (codex #2065 round-2 Z1) — the null's suppression lookup
-/// must inspect the goal-store key PINNED at this open's registration, not a
-/// re-resolution of the process-global last-writer-wins cwd map: a
-/// concurrent same-wire/different-cwd open can flip that map mid-open, and
-/// a recomputed key would then inspect the OTHER folder's (empty) slot and
-/// emit a spurious cleared for THIS folder's live chip.
+/// #2062 rounds 3–4 (codex #2065 round-2 Z1 + round-3 W5) — the null's
+/// suppression lookup must inspect the goal-store key PINNED at this open's
+/// registration, not a re-resolution of the process-global last-writer-wins
+/// cwd map: a concurrent same-wire/different-cwd open can flip that map
+/// mid-open, and a recomputed key would then inspect the OTHER folder's
+/// (empty) slot and emit a spurious cleared for THIS folder's live chip.
+/// The pin is the key `set_goal_scope` RETURNS from inside its own lock —
+/// the real registration-to-capture path (one acquisition, W5): a
+/// registration-vs-capture interleave is unrepresentable at this site, so
+/// the flip below can only ever happen AFTER the pin, which is exactly
+/// what the suppression must survive.
 #[test]
 fn session_open_goal_null_snapshot_pinned_key_survives_concurrent_cwd_flip() {
     use crate::autonomy::agent_orchestrator::{
@@ -35971,7 +35978,10 @@ fn session_open_goal_null_snapshot_pinned_key_survives_concurrent_cwd_flip() {
     };
     let orchestrator = default_agent_orchestrator();
     let wire = SessionKey("local:goal-null-cwd-pin".into());
-    orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    // This open registers folder A's scope and pins the key HANDED BACK
+    // from inside the registration's own lock — the same call
+    // `register_session_ledger_scope` threads into `SessionOpenOutcome`.
+    let pinned = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
     orchestrator
         .set_goal(GoalSetRequest {
             session_id: wire.clone(),
@@ -35982,11 +35992,9 @@ fn session_open_goal_null_snapshot_pinned_key_survives_concurrent_cwd_flip() {
             transition_actor: None,
         })
         .expect("bind goal under folder A's cwd scope");
-    // This open pins its goal-store identity at registration time.
-    let pinned = orchestrator.scoped_goal_key(&wire);
     // A concurrent same-wire open for a DIFFERENT folder flips the
     // last-writer-wins map before the null snapshot is computed.
-    orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+    let _flipped = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
 
     let verdict = orchestrator.session_goal_hydrate_cleared_event_json(&pinned, MAIN_PROFILE_ID);
 
@@ -36010,7 +36018,10 @@ fn session_open_goal_null_snapshot_pinned_key_survives_concurrent_cwd_flip() {
 /// #2062 round 3 (codex #2065 round-2 Z5-lifecycle) — a re-open must fully
 /// retire the previous live forwarder BEFORE the replacement starts pumping,
 /// so "one live lane per (connection, session)" holds across reopens and an
-/// event is never double-delivered by two overlapping pumps.
+/// event is never double-delivered by two overlapping pumps. (The
+/// production open path retires even earlier — before the replay baseline
+/// is computed, round-3 W6.1 — this pins the in-spawn defense direct
+/// callers rely on.)
 #[tokio::test]
 async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
     let (ws, mut rx) = ws_connection_for_test(64);
@@ -36019,7 +36030,7 @@ async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
     let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
     let first_rx = ledger.subscribe(&session_id);
-    spawn_live_forwarder_with_goal_null_snapshot(
+    spawn_live_forwarder(
         ws.clone(),
         ledger.clone(),
         session_id.clone(),
@@ -36029,13 +36040,12 @@ async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
         None,
         first_rx,
         forwarders.clone(),
-        None,
     )
     .await;
 
     // Re-open on the SAME connection and session.
     let second_rx = ledger.subscribe(&session_id);
-    spawn_live_forwarder_with_goal_null_snapshot(
+    spawn_live_forwarder(
         ws.clone(),
         ledger.clone(),
         session_id.clone(),
@@ -36045,7 +36055,6 @@ async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
         None,
         second_rx,
         forwarders.clone(),
-        None,
     )
     .await;
 
@@ -36074,4 +36083,70 @@ async fn session_open_goal_reopen_hands_over_live_forwarder_lane() {
         "the retired forwarder must not double-deliver: {duplicate:?}"
     );
     abort_live_forwarders(&forwarders, &ledger).await;
+}
+
+/// #2062 round 4 (codex #2065 round-3 W6, PATH B absence-by-construction) —
+/// through `WsConnection::new_stdio`: the stdio durable lane parks
+/// COOPERATIVELY (non-blocking `try_send` probe + async sleep, see
+/// `send_durable_offloaded`), so a forwarder parked on a FULL stdio queue is
+/// fully retired by abort+join — cancellation lands at the probe's await and
+/// the enqueue is atomic. There is no `spawn_blocking(SyncSender::send)`
+/// closure anymore, so no detached in-flight hop can enqueue a stale frame
+/// AFTER the lane was retired.
+#[tokio::test]
+async fn session_open_goal_stdio_lane_retire_leaves_no_inflight_send() {
+    let (writer, frames) = std::sync::mpsc::sync_channel::<WsMessage>(1);
+    // Fill the single stdio slot BEFORE the pump runs: its send must park.
+    writer.try_send(plug_frame()).expect("plug the stdio queue");
+    let ws = WsConnection::new_stdio(writer);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-stdio-retire".into());
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+    let live_rx = ledger.subscribe(&session_id);
+    spawn_live_forwarder(
+        ws.clone(),
+        ledger.clone(),
+        session_id.clone(),
+        0,
+        ws.connection_id(),
+        ConnectionUiFeatures::stdio_defaults(),
+        None,
+        live_rx,
+        forwarders.clone(),
+    )
+    .await;
+    // A live event reaches the pump; its stdio enqueue parks on the full
+    // queue (cooperative probe loop, never a blocking SyncSender::send).
+    ledger.append_notification_from(
+        UiNotification::MessageDelta(MessageDeltaEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: TurnId::new(),
+            text: "parked in flight".into(),
+        }),
+        ConnectionId::next(),
+    );
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Retire the lane: abort + join. The join is the proof point — after it
+    // returns there is nothing left that could still enqueue.
+    let lane = forwarders
+        .lock()
+        .await
+        .remove(&session_id)
+        .expect("live lane registered");
+    lane.abort();
+    let _ = lane.await;
+
+    // Drain the plug, then nothing else may EVER arrive: the parked frame
+    // died with the lane (its enqueue was atomic and never happened), and
+    // no detached closure exists to deliver it later.
+    let plug = frames.try_recv().expect("plug frame still queued");
+    drop(plug);
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    assert!(
+        frames.try_recv().is_err(),
+        "no in-flight send may survive lane retirement"
+    );
 }

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35714,6 +35714,243 @@ async fn session_open_goal_state_response_null_again_after_out_of_band_clear() {
     );
 }
 
+/// #2062 round 7 (codex R6-OPEN-SNAPSHOT-ORDER) — the response's
+/// `goal_state` is captured AT ENQUEUE, so a goal repaint landing in the
+/// window between open-start and response-enqueue is REFLECTED by the
+/// response instead of being overwritten backwards by a stale early
+/// capture. Barrier: the test holds the sessions-manager lock (which the
+/// open acquires AFTER the round-6 early-capture site and BEFORE the
+/// response enqueue), mutates the goal and delivers the repaint through
+/// the real ephemeral path inside that window, then releases. Asserts
+/// both directions: the repaint frame precedes the response on the wire,
+/// the response carries the POST-repaint state, and no goal frame carrying
+/// older state follows the response.
+#[tokio::test]
+async fn session_open_goal_state_response_fresh_at_enqueue_after_mid_open_repaint() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-state-fresh-at-enqueue".into());
+    let orchestrator = default_agent_orchestrator();
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "before the mid-open repaint".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind the pre-open goal");
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    ws.update_live_features(ConnectionUiFeatures::stdio_defaults());
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    // BARRIER: hold the sessions-manager lock so the spawned open blocks
+    // inside `open_session_result` — after the (round-6) early-capture
+    // site, before the response enqueue.
+    let sessions_gate = state.sessions.as_ref().expect("sessions").clone();
+    let gate = sessions_gate.lock().await;
+    let open_task = tokio::spawn({
+        let ws = ws.clone();
+        let state = state.clone();
+        let ledger = ledger.clone();
+        let forwarders = forwarders.clone();
+        let session_id = session_id.clone();
+        async move {
+            let approvals = PendingApprovalStore::default();
+            let questions = PendingQuestionStore::default();
+            handle_session_open(
+                &ws,
+                &state,
+                &ledger,
+                &approvals,
+                &questions,
+                &forwarders,
+                None,
+                ConnectionUiFeatures::stdio_defaults(),
+                "open-fresh".into(),
+                SessionOpenParams {
+                    session_id,
+                    topic: None,
+                    profile_id: None,
+                    cwd: None,
+                    sandbox: None,
+                    after: None,
+                },
+                false,
+            )
+            .await
+        }
+    });
+    // Let the open reach the barrier.
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    // The mid-open mutation: an already-running turn's goal_update — the
+    // store changes AND the repaint is delivered to THIS wire through the
+    // real ephemeral path (guard-admitted, watermark moved).
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "after the mid-open repaint".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("mid-open goal mutation");
+    let repaint_json = orchestrator
+        .session_goal_updated_event_json(&session_id, MAIN_PROFILE_ID)
+        .expect("repaint for the live goal");
+    let repaint: octos_core::ui_protocol::SessionGoalUpdatedEvent =
+        serde_json::from_value(repaint_json).expect("updated event");
+    send_notification_ephemeral(&ws, &ledger, UiNotification::SessionGoalUpdated(repaint))
+        .expect("deliver the mid-open repaint");
+    drop(gate);
+    assert!(open_task.await.expect("open task"), "open must succeed");
+
+    // Wire order: the repaint frame precedes the response; the response's
+    // snapshot reflects the POST-repaint state.
+    let mut saw_repaint = false;
+    let result = loop {
+        let frame = recv_rpc_json(&mut rx).await;
+        if frame["method"] == json!("session/goal/updated") {
+            assert_eq!(
+                frame["params"]["goal"]["objective"],
+                json!("after the mid-open repaint")
+            );
+            saw_repaint = true;
+            continue;
+        }
+        if frame["id"] == json!("open-fresh") {
+            break frame;
+        }
+    };
+    assert!(saw_repaint, "the mid-open repaint precedes the response");
+    assert_eq!(
+        result["result"]["goal_state"]["objective"],
+        json!("after the mid-open repaint"),
+        "the snapshot is captured at enqueue, after the repaint: {:?}",
+        result["result"]["goal_state"]
+    );
+    // No goal frame carrying older state may follow the response.
+    let quiet = tokio::time::Duration::from_millis(400);
+    while let Ok(frame) = tokio::time::timeout(quiet, recv_rpc_json(&mut rx)).await {
+        if let Some(method) = frame["method"].as_str() {
+            assert!(
+                !method.starts_with("session/goal/"),
+                "no goal frame may follow the response: {frame}"
+            );
+        }
+    }
+    orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup goal");
+}
+
+/// #2062 round 7 (codex R6-PIN-MUTATION-COVERAGE) — the PRODUCTION path's
+/// snapshot must use the open-pinned scoped key, not a re-resolution at
+/// the enqueue callsite: with folder A's goal bound and the open in
+/// flight, a concurrent same-wire open flips the last-writer-wins cwd map
+/// to folder B inside the window — the response must still carry folder
+/// A's goal. A callsite mutant that re-resolves the key would read folder
+/// B's empty slot and answer `null`.
+#[tokio::test]
+async fn session_open_goal_state_response_pinned_across_mid_open_scope_flip() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let wire = SessionKey("local:goal-state-mid-open-flip".into());
+    let orchestrator = default_agent_orchestrator();
+    let _pinned_a = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "folder A's live goal".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal under folder A's cwd scope");
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let sessions_gate = state.sessions.as_ref().expect("sessions").clone();
+    let gate = sessions_gate.lock().await;
+    let open_task = tokio::spawn({
+        let ws = ws.clone();
+        let state = state.clone();
+        let ledger = ledger.clone();
+        let forwarders = forwarders.clone();
+        let wire = wire.clone();
+        async move {
+            let approvals = PendingApprovalStore::default();
+            let questions = PendingQuestionStore::default();
+            handle_session_open(
+                &ws,
+                &state,
+                &ledger,
+                &approvals,
+                &questions,
+                &forwarders,
+                None,
+                ConnectionUiFeatures::stdio_defaults(),
+                "open-flip".into(),
+                SessionOpenParams {
+                    session_id: wire,
+                    topic: None,
+                    profile_id: None,
+                    cwd: None,
+                    sandbox: None,
+                    after: None,
+                },
+                false,
+            )
+            .await
+        }
+    });
+    // The open captured its pin (folder A) before blocking at the barrier;
+    // a concurrent same-wire open now flips the map to folder B.
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    let _flipped = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+    drop(gate);
+    assert!(open_task.await.expect("open task"), "open must succeed");
+
+    let result = loop {
+        let frame = recv_rpc_json(&mut rx).await;
+        if frame["id"] == json!("open-flip") {
+            break frame;
+        }
+    };
+
+    // Cleanup the process-global store BEFORE asserting.
+    let _ = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup goal");
+    let _ = orchestrator.set_goal_scope(&wire, None);
+
+    assert_eq!(
+        result["result"]["goal_state"]["objective"],
+        json!("folder A's live goal"),
+        "the enqueue-time snapshot must use the OPEN-pinned key (folder A), \
+         not the flipped cwd map (folder B): {:?}",
+        result["result"]["goal_state"]
+    );
+}
+
 /// A minimal valid frame used to occupy a capacity-1 writer queue.
 fn plug_frame() -> WsMessage {
     frame_for(&json!({"jsonrpc": "2.0", "method": "test/plug"})).expect("plug frame")

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35340,3 +35340,230 @@ fn should_report_zero_cache_reads_explicitly_on_a_cold_session() {
     assert_eq!(usage["cached_input_tokens"], 0);
     assert!(usage.get("cached_input_tokens").is_some());
 }
+
+// ---------------------------------------------------------------------------
+// #2062 — session/open pushes an explicit NO-GOAL snapshot (goal-chip null
+// state). "No goal" used to be represented by SILENCE on (re)open, so a client
+// that cached a goal chip and reconnected after the goal was cleared elsewhere
+// (a second connection, another process on the same data dir, or a serve
+// restart that rebuilt the ledger) kept rendering the stale chip —
+// absence-of-message is indistinguishable from message-not-yet-arrived. The
+// open path now emits the SAME `session/goal/cleared` shape the explicit
+// `session/goal/clear` RPC emits whenever no goal is bound for the resolved
+// (session, profile), ephemeral (one client's catch-up state, not session
+// history) and AFTER the ledger replay loop so a replayed stale
+// `session/goal/updated` can never land behind it.
+//
+// CI: these run under the `session_open_goal` name filter in
+// .github/workflows/ci.yml (test-octos-cli job) — the `api`-gated module is
+// invisible to the unfeatured lib/integration steps (#2029).
+// ---------------------------------------------------------------------------
+
+/// Open `session_id` on a FRESH connection against the shared `state`/`ledger`
+/// (modelling a reconnect) and return every `session/goal/cleared` params
+/// payload pushed before the `session/opened` lifecycle notification (method
+/// `session/open`) — the last frame the open path sends before handing the
+/// connection to the live forwarder. A cleared emitted after that boundary
+/// would be indistinguishable from a live event, so collection stops there.
+async fn open_session_collecting_goal_cleared_frames(
+    state: &Arc<AppState>,
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    request_id: &str,
+) -> Vec<Value> {
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let opened = handle_session_open(
+        &ws,
+        state,
+        ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        request_id.to_owned(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: None,
+        },
+        false,
+    )
+    .await;
+    assert!(opened, "session/open must succeed for {session_id}");
+    let result = recv_rpc_json(&mut rx).await;
+    assert_eq!(
+        result["id"],
+        json!(request_id),
+        "first frame is the RPC result"
+    );
+    let mut cleared_frames = Vec::new();
+    loop {
+        let frame = recv_rpc_json(&mut rx).await;
+        match frame["method"].as_str() {
+            Some("session/goal/cleared") => cleared_frames.push(frame["params"].clone()),
+            // The `session/opened` lifecycle notification closes the open
+            // path's send sequence.
+            Some("session/open") => break,
+            _ => {}
+        }
+    }
+    abort_live_forwarders(&forwarders, ledger).await;
+    cleared_frames
+}
+
+/// #2062 RED→GREEN: a session that opens with NO goal bound must receive an
+/// explicit `session/goal/cleared` null snapshot — silence is not a goal
+/// state. Payload matches the explicit `session/goal/clear` RPC shape:
+/// `cleared: true`, `goal: null`, a real (#1959) generation stamp, and the
+/// wire session id the client keys the chip by.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_emitted_when_no_goal_bound() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-snap-unbound".into());
+
+    let cleared =
+        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-a").await;
+
+    assert_eq!(
+        cleared.len(),
+        1,
+        "open with no goal bound must push exactly one explicit no-goal snapshot"
+    );
+    let event = &cleared[0];
+    assert_eq!(event["session_id"], json!(session_id.0));
+    assert_eq!(event["profile_id"], json!(MAIN_PROFILE_ID));
+    assert_eq!(
+        event["cleared"],
+        json!(true),
+        "the client nulls the chip only on cleared=true"
+    );
+    assert!(
+        event["goal"].is_null(),
+        "a null snapshot carries no goal record"
+    );
+    assert!(
+        event["generation"].as_u64().unwrap_or(0) > 0,
+        "#1959 — every goal chip event must carry a real generation stamp"
+    );
+}
+
+/// #2062 inverse guard: a session that opens WITH a goal bound must NOT
+/// receive a `session/goal/cleared` — a spurious cleared would blank a live
+/// chip. The positive snapshot path (durable ledger replay + live charge
+/// pushes) stays untouched.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_suppressed_when_goal_bound() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-snap-bound".into());
+    default_agent_orchestrator()
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "keep the chip painted across reconnect".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal");
+
+    let cleared =
+        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-b").await;
+
+    // Cleanup the process-global orchestrator BEFORE asserting so a failure
+    // does not leak the goal into sibling tests.
+    default_agent_orchestrator()
+        .clear_goal(GoalSessionRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup goal");
+
+    assert!(
+        cleared.is_empty(),
+        "open with a bound goal must not push a cleared (it would blank a live chip): {cleared:?}"
+    );
+}
+
+/// #2062 end-to-end shape from the issue: bind a goal, clear it "elsewhere"
+/// (directly on the orchestrator — no ledger event, exactly like a second
+/// connection or another process on the same data dir), then re-open. The
+/// reopen must re-emit the cleared null snapshot (idempotent null), and its
+/// #1959 generation must supersede the one from the first open so a stale
+/// update can never outrank it.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_reemitted_when_goal_cleared_elsewhere() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-snap-reopen".into());
+
+    // First open: nothing bound yet → explicit null snapshot.
+    let first =
+        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-c1").await;
+    assert_eq!(
+        first.len(),
+        1,
+        "first open with no goal pushes the null snapshot"
+    );
+
+    default_agent_orchestrator()
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "cleared while you were away".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal");
+
+    // Reconnect while the goal is live → no cleared.
+    let bound =
+        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-c2").await;
+    assert!(
+        bound.is_empty(),
+        "reopen with the goal live must stay positive: {bound:?}"
+    );
+
+    // The goal is cleared elsewhere: this connection's ledger never sees a
+    // `session/goal/cleared`, so WITHOUT the open-path push the client's
+    // cached chip would survive the next reconnect on silence alone.
+    default_agent_orchestrator()
+        .clear_goal(GoalSessionRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("clear goal elsewhere");
+
+    let reopened =
+        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-c3").await;
+    assert_eq!(
+        reopened.len(),
+        1,
+        "reopen after an out-of-band clear must re-push the null snapshot"
+    );
+    let first_generation = first[0]["generation"].as_u64().expect("generation");
+    let reopened_generation = reopened[0]["generation"].as_u64().expect("generation");
+    assert!(
+        reopened_generation > first_generation,
+        "the re-emitted null snapshot must carry a newer generation \
+         ({reopened_generation} vs {first_generation})"
+    );
+}

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35763,6 +35763,11 @@ async fn session_open_goal_null_snapshot_abandoned_when_newer_frame_already_deli
     let ledger = Arc::new(UiProtocolLedger::new(16));
     let session_id = SessionKey("local:goal-null-superseded".into());
     ws.update_live_features(ConnectionUiFeatures::stdio_defaults());
+    // Fabricated generations sit FAR above anything the real allocator
+    // reaches in a test process: the S3 registry maps every REAL generation
+    // to its owner's scoped key, so a low fabricated value would collide
+    // with a sibling test's allocation and resolve to a foreign identity.
+    // Unregistered generations fall back to the (per-test-unique) wire key.
     let null =
         UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
             session_id: session_id.clone(),
@@ -35770,7 +35775,7 @@ async fn session_open_goal_null_snapshot_abandoned_when_newer_frame_already_deli
             cleared: true,
             goal: None,
             transition_actor: "backend".into(),
-            generation: 5,
+            generation: 9_100_000_001,
         });
     // The newer frame is admitted, ledgered, AND delivered to this wire
     // through the same durable path the goal RPC handler uses.
@@ -35790,7 +35795,7 @@ async fn session_open_goal_null_snapshot_abandoned_when_newer_frame_already_deli
                 updated_at_ms: 0,
             },
             transition_actor: "user".into(),
-            generation: 6,
+            generation: 9_100_000_002,
         });
     send_notification_durable(&ws, &ledger, newer).expect("deliver the newer frame");
 
@@ -35841,7 +35846,9 @@ async fn session_open_goal_null_snapshot_backpressure_drop_signals_replay_lossy(
             cleared: true,
             goal: None,
             transition_actor: "backend".into(),
-            generation: 5,
+            // Above the real allocator's range — see the S3 registry note
+            // in `…abandoned_when_newer_frame_already_delivered`.
+            generation: 9_200_000_001,
         });
 
     let outcome =
@@ -36148,5 +36155,257 @@ async fn session_open_goal_stdio_lane_retire_leaves_no_inflight_send() {
     assert!(
         frames.try_recv().is_err(),
         "no in-flight send may survive lane retirement"
+    );
+}
+
+/// #2062 round 5 (codex #2065 round-4 S3) — cross-scope watermark
+/// pollution: two cwd scopes share one wire session id. Scope B's repaint
+/// (built by the real orchestrator builder, delivered through the real
+/// ephemeral path — but only to B's connection) must advance B's watermark
+/// ONLY; scope A's null — for A's folder, where a stale chip legitimately
+/// needs clearing — must still deliver. With a wire-keyed watermark, B's
+/// later-generation frame falsely abandoned A's null and connection A
+/// received NOTHING: #2062 surviving through watermark pollution.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_survives_other_scope_watermark_pollution() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let orchestrator = default_agent_orchestrator();
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let wire = SessionKey("local:goal-null-scope-pollution".into());
+    // Folder B registers its scope and binds a live goal under it.
+    let pinned_b = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "folder B's live goal".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal under folder B's cwd scope");
+    // Folder A opens the same wire session: registers (flips the map) and
+    // pins its own scope, then builds its null — no goal under scope A.
+    let pinned_a = orchestrator.set_goal_scope(&wire, Some("aaaa1111".into()));
+    let null_json = orchestrator
+        .session_goal_hydrate_cleared_event_json(&pinned_a, MAIN_PROFILE_ID)
+        .expect("scope A has no goal; the null must be built");
+    let null: octos_core::ui_protocol::SessionGoalClearedEvent =
+        serde_json::from_value(null_json).expect("cleared event");
+    // Scope B's repaint is built AFTER A's null (higher generation — the
+    // exact pollution ordering: the turn-end accountant fires while A's
+    // open is between null construction and emit) and delivered through
+    // the REAL ephemeral path to B's OWN connection.
+    let b_update_json = orchestrator
+        .session_goal_updated_event_json(&pinned_b, MAIN_PROFILE_ID)
+        .expect("scope B has a goal; the repaint must be built");
+    let b_update: octos_core::ui_protocol::SessionGoalUpdatedEvent =
+        serde_json::from_value(b_update_json).expect("updated event");
+    assert!(
+        b_update.generation > null.generation,
+        "the pollution ordering requires B's frame to be newer"
+    );
+    let (ws_b, mut rx_b) = ws_connection_for_test(8);
+    ws_b.update_live_features(ConnectionUiFeatures::stdio_defaults());
+    send_notification_ephemeral(&ws_b, &ledger, UiNotification::SessionGoalUpdated(b_update))
+        .expect("deliver B's repaint to B's connection");
+    let b_frame = recv_rpc_json(&mut rx_b).await;
+    assert_eq!(
+        b_frame["method"],
+        json!("session/goal/updated"),
+        "B's repaint was admitted and delivered (its watermark moved)"
+    );
+
+    // A's null must still deliver: B's record moved SCOPE B's watermark,
+    // not scope A's.
+    let (ws_a, mut rx_a) = ws_connection_for_test(8);
+    let outcome = emit_open_goal_null_now(
+        &ws_a,
+        &ledger,
+        UiNotification::SessionGoalCleared(null),
+        ConnectionUiFeatures::stdio_defaults(),
+    );
+
+    // Cleanup the process-global store BEFORE asserting.
+    let _ = orchestrator.set_goal_scope(&wire, Some("bbbb2222".into()));
+    orchestrator
+        .clear_goal(GoalSessionRequest {
+            session_id: wire.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup B's goal");
+    let _ = orchestrator.set_goal_scope(&wire, None);
+
+    assert!(outcome.is_ok(), "the null emit must not error: {outcome:?}");
+    let a_frame = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        recv_rpc_json(&mut rx_a),
+    )
+    .await
+    .expect("scope A's null must DELIVER despite scope B's newer frame");
+    assert_eq!(
+        a_frame["method"],
+        json!("session/goal/cleared"),
+        "cross-scope pollution must not abandon the null: {a_frame}"
+    );
+}
+
+/// #2062 round 5 (codex #2065 round-4 S2) — the dropped-null recovery
+/// chain, end to end WITHOUT manual queue manipulation: the writer is full
+/// when the real open emits the null (the null is the first dropped frame),
+/// the opportunistic lossy emit fails on the same full queue, and the
+/// PUMP's first action flushes the retained debt through its
+/// capacity-aware lane the moment the client drains the queue — so the
+/// "reconnect to rehydrate" prompt is guaranteed, and the reopen it
+/// prompts re-emits the null.
+#[tokio::test]
+async fn session_open_goal_null_drop_pump_flushes_replay_lossy_then_reopen_reemits() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-lossy-chain".into());
+    // Capacity 2: the plug takes one slot, the open's RPC result (a
+    // lifecycle frame that must not drop) takes the other — the queue is
+    // full at exactly the moment the null tries to enqueue.
+    let (ws, mut rx) = ws_connection_for_test(2);
+    ws.send_durable(plug_frame(), "test/plug")
+        .expect("plug one writer slot");
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let opened = handle_session_open(
+        &ws,
+        &state,
+        &ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "open-lossy-chain".into(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: None,
+        },
+        false,
+    )
+    .await;
+    assert!(opened, "the open itself succeeds; only frames dropped");
+
+    // The client drains the queue: plug, then the open's RPC result.
+    let plug = recv_rpc_json(&mut rx).await;
+    assert_eq!(plug["method"], json!("test/plug"));
+    let result = recv_rpc_json(&mut rx).await;
+    assert_eq!(result["id"], json!("open-lossy-chain"));
+    // Capacity is free now — the pump's debt flush must deliver the lossy
+    // signal with no further action from anyone.
+    let lossy = tokio::time::timeout(tokio::time::Duration::from_secs(5), recv_rpc_json(&mut rx))
+        .await
+        .expect("the pump's first action flushes the replay-lossy debt");
+    assert_eq!(
+        lossy["method"],
+        json!("protocol/replay_lossy"),
+        "the dropped null must surface the reconnect prompt: {lossy}"
+    );
+
+    // The prompted reconnect (a fresh connection, as a real client would)
+    // re-emits the null.
+    let reopened =
+        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-lossy-2")
+            .await;
+    abort_live_forwarders(&forwarders, &ledger).await;
+    assert_eq!(
+        reopened.len(),
+        1,
+        "the reopen must re-emit the dropped null snapshot"
+    );
+}
+
+/// #2062 round 5 (codex #2065 round-4 S7) — the INTERLEAVED supersession:
+/// the newer frame lands AFTER the null passed its entry guard but before
+/// the in-lock section — the exact window a spawned turn task occupies.
+/// Only the final in-lock recheck can catch this (the entry guard already
+/// admitted); deleting just that recheck fails THIS test while the
+/// early-delivery test (`…abandoned_when_newer_frame_already_delivered`)
+/// still passes. The newer frame goes through the real durable send path.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_abandoned_by_in_lock_recheck_when_frame_interleaves() {
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-interleaved".into());
+    ws.update_live_features(ConnectionUiFeatures::stdio_defaults());
+    let null =
+        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            cleared: true,
+            goal: None,
+            transition_actor: "backend".into(),
+            // Unregistered generations (far above the real allocator's
+            // range — see the S3 registry note in
+            // `…abandoned_when_newer_frame_already_delivered`) resolve to
+            // the wire-key watermark fallback — both frames share it,
+            // exactly like two frames of one scope.
+            generation: 9_300_000_001,
+        });
+    let newer = octos_core::ui_protocol::SessionGoalUpdatedEvent {
+        session_id: session_id.clone(),
+        profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+        goal: octos_core::ui_protocol::UiGoalRecord {
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            goal_id: "goal-live".into(),
+            objective: "set in the entry-guard-to-lock window".into(),
+            status: "active".into(),
+            token_budget: 1_000,
+            tokens_used: 0,
+            time_used_seconds: 0,
+            created_at_ms: 0,
+            updated_at_ms: 0,
+        },
+        transition_actor: "user".into(),
+        generation: 9_300_000_002,
+    };
+    let hook = || {
+        send_notification_durable(
+            &ws,
+            &ledger,
+            UiNotification::SessionGoalUpdated(newer.clone()),
+        )
+        .expect("deliver the newer frame inside the window");
+    };
+
+    let outcome = emit_open_goal_null_with_pre_lock_hook(
+        &ws,
+        &ledger,
+        null,
+        ConnectionUiFeatures::stdio_defaults(),
+        Some(&hook),
+    );
+    assert!(
+        outcome.is_ok(),
+        "abandoning at the in-lock recheck is a clean outcome: {outcome:?}"
+    );
+
+    let first = recv_rpc_json(&mut rx).await;
+    assert_eq!(
+        first["method"],
+        json!("session/goal/updated"),
+        "the interleaved newer frame is the final goal state: {first}"
+    );
+    let late = tokio::time::timeout(
+        tokio::time::Duration::from_millis(400),
+        recv_rpc_json(&mut rx),
+    )
+    .await;
+    assert!(
+        late.is_err(),
+        "the in-lock recheck must abandon the null, never deliver it after \
+         the newer frame: {late:?}"
     );
 }

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35409,13 +35409,188 @@ async fn open_session_collecting_goal_cleared_frames(
         match frame["method"].as_str() {
             Some("session/goal/cleared") => cleared_frames.push(frame["params"].clone()),
             // The `session/opened` lifecycle notification closes the open
-            // path's send sequence.
+            // path's DIRECT send sequence.
             Some("session/open") => break,
             _ => {}
         }
     }
+    // #2062 fix round (codex #2065 H3): the null snapshot is delivered by the
+    // live-forwarder task — it must serialize BEHIND the broadcast backlog
+    // that raced the open handshake, so it lands after `session/opened`, not
+    // between the direct sends. Poll a bounded quiet window past the
+    // boundary: presence resolves as soon as the frame arrives; absence
+    // costs the full window once.
+    let quiet = tokio::time::Duration::from_millis(700);
+    while let Ok(frame) = tokio::time::timeout(quiet, recv_rpc_json(&mut rx)).await {
+        if frame["method"] == json!("session/goal/cleared") {
+            cleared_frames.push(frame["params"].clone());
+        }
+    }
     abort_live_forwarders(&forwarders, ledger).await;
     cleared_frames
+}
+
+/// #2062 fix round (codex #2065 H1) — the spurious-cleared profile skew: goal
+/// RPCs can bind under a caller-REQUESTED profile while `session/open`
+/// resolves the connection/auth profile (a bare open defaults to `_main`).
+/// The client's chip — and its cleared reducer — are SESSION-keyed with no
+/// profile check, so a profile-mismatched "absent" verdict on the server
+/// would blank a live chip. Existence under ANY profile must suppress the
+/// null.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_suppressed_when_goal_bound_under_other_profile() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-snap-other-profile".into());
+    default_agent_orchestrator()
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: "tenant-x".into(),
+            objective: "bound under a caller-requested profile".into(),
+            status: None,
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind goal under tenant-x");
+
+    let cleared =
+        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-d").await;
+
+    default_agent_orchestrator()
+        .clear_goal(GoalSessionRequest {
+            session_id: session_id.clone(),
+            profile_id: "tenant-x".into(),
+        })
+        .expect("cleanup goal");
+
+    assert!(
+        cleared.is_empty(),
+        "codex #2065 H1: the open resolves `_main` but the goal lives under \
+         `tenant-x`; a cleared here would blank the live session-keyed chip: {cleared:?}"
+    );
+}
+
+/// #2062 fix round (codex #2065 H2, held): ANY stored status suppresses the
+/// null — a `budget_limited` goal is still a live chip (frozen for
+/// scheduling, not for display), so the open must not blank it.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_suppressed_when_goal_budget_limited() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSessionRequest, GoalSetRequest,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-snap-budget-limited".into());
+    default_agent_orchestrator()
+        .set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            objective: "budget exhausted but still the session's goal".into(),
+            status: Some("budget_limited".into()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("bind budget_limited goal");
+
+    let cleared =
+        open_session_collecting_goal_cleared_frames(&state, &ledger, &session_id, "open-e").await;
+
+    default_agent_orchestrator()
+        .clear_goal(GoalSessionRequest {
+            session_id: session_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+        })
+        .expect("cleanup goal");
+
+    assert!(
+        cleared.is_empty(),
+        "a budget_limited goal is still bound; the open must not blank it: {cleared:?}"
+    );
+}
+
+/// #2062 fix round (codex #2065 H3) — ordering at the protocol layer,
+/// asserted on WIRE FRAME ORDER, not client state. The open subscribes to
+/// the live broadcast BEFORE its replay snapshot, so a stale
+/// `session/goal/updated` can be sitting in the receiver when the forwarder
+/// starts; the forwarder's ledger-send path does not run the #1959
+/// generation guard and the client's `updated` reducer applies
+/// unconditionally, so if the null were emitted before that backlog
+/// flushes, the stale update would repaint the chip the null just blanked.
+/// The null must therefore be the FINAL goal-state frame of the open
+/// sequence: backlog first, null second.
+#[tokio::test]
+async fn session_open_goal_null_snapshot_ordered_after_buffered_stale_update() {
+    let (ws, mut rx_frames) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:goal-null-order".into());
+    // Subscribe FIRST — mirrors handle_session_open, which subscribes
+    // before the replay snapshot; the event appended below then sits in
+    // this receiver's buffer exactly like one that raced the handshake.
+    let live_rx = ledger.subscribe(&session_id);
+    ledger.append_notification(UiNotification::SessionGoalUpdated(
+        octos_core::ui_protocol::SessionGoalUpdatedEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            goal: octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+                goal_id: "goal-stale".into(),
+                objective: "stale positive state raced the open".into(),
+                status: "active".into(),
+                token_budget: 1_000,
+                tokens_used: 10,
+                time_used_seconds: 1,
+                created_at_ms: 0,
+                updated_at_ms: 0,
+            },
+            transition_actor: "backend".into(),
+            // Unstamped, like a pre-#1959 producer — the guardless
+            // forwarder lane delivers it regardless.
+            generation: 0,
+        },
+    ));
+    let null =
+        UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(MAIN_PROFILE_ID.to_owned()),
+            cleared: true,
+            goal: None,
+            transition_actor: "backend".into(),
+            generation: 0,
+        });
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    spawn_live_forwarder_with_goal_null_snapshot(
+        ws.clone(),
+        ledger.clone(),
+        session_id.clone(),
+        0,
+        ws.connection_id(),
+        ConnectionUiFeatures::stdio_defaults(),
+        None,
+        live_rx,
+        forwarders.clone(),
+        Some(null),
+    )
+    .await;
+
+    let first = recv_rpc_json(&mut rx_frames).await;
+    assert_eq!(
+        first["method"],
+        json!("session/goal/updated"),
+        "the raced stale update must flush FIRST: {first}"
+    );
+    let second = recv_rpc_json(&mut rx_frames).await;
+    assert_eq!(
+        second["method"],
+        json!("session/goal/cleared"),
+        "the null must be the FINAL goal-state frame of the open sequence: {second}"
+    );
+    assert_eq!(second["params"]["cleared"], json!(true));
+    abort_live_forwarders(&forwarders, &ledger).await;
 }
 
 /// #2062 RED→GREEN: a session that opens with NO goal bound must receive an

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -16952,6 +16952,11 @@ async fn handle_session_open(
 ) -> bool {
     normalize_session_open_params_topic(&mut params);
     let topic_scope = params.topic.clone();
+    // #2062 — captured before `params` moves into `open_session_result`: the
+    // goal-chip null snapshot below resolves its profile with the SAME
+    // `resolve_autonomy_profile_id` the goal RPC surface uses, and that
+    // resolution wants the client's requested profile as its first input.
+    let requested_profile_id = params.profile_id.clone();
 
     // Subscribe to the live ledger broadcast BEFORE the replay query so any
     // event that lands while we're still computing replay/opened sits in the
@@ -17102,6 +17107,52 @@ async fn handle_session_open(
         for (task, _data_dir) in store.raw_tasks_for_session(&session_id.0) {
             if let Some(notification) = replay_task_updated_notification(&session_id, &task) {
                 let _ = send_notification_ephemeral(ws, ledger, notification);
+            }
+        }
+    }
+
+    // #2062 — goal-chip NULL snapshot. The chip is client state fed by server
+    // pushes, and everything above only re-delivers what the ledger retained:
+    // a goal cleared elsewhere (a second connection, another process on this
+    // data dir, or a serve restart that rebuilt the ledger) leaves this
+    // reconnect SILENT about goal state, so a client's cached chip survives —
+    // absence-of-message is indistinguishable from message-not-yet-arrived.
+    // Push the SAME `session/goal/cleared` the explicit clear RPC emits
+    // whenever no goal is bound for the resolved (session, profile): now
+    // "removed", "never existed", and "removed while you were away" are one
+    // message (codex `ThreadGoalCleared` parity). Sent EPHEMERAL like the
+    // task snapshot above (one client's catch-up state, not session history —
+    // reopen spam must not grow the durable ledger), AFTER the replay loop so
+    // a replayed stale `session/goal/updated` cannot land behind it on the
+    // wire, and stamped with a fresh #1959 generation so it also outranks one
+    // on the client's ordering rule. When a goal IS bound this emits nothing:
+    // the positive replay/live paths own the chip, and a spurious cleared
+    // would blank a live one.
+    if let Ok(goal_profile_id) = resolve_autonomy_profile_id(
+        Some(&session_id),
+        requested_profile_id.as_deref(),
+        connection_profile_id,
+    ) {
+        if let Some(cleared_json) = default_agent_orchestrator()
+            .session_goal_hydrate_cleared_event_json(&session_id, &goal_profile_id)
+        {
+            match serde_json::from_value::<octos_core::ui_protocol::SessionGoalClearedEvent>(
+                cleared_json,
+            ) {
+                Ok(event) => {
+                    let _ = send_notification_ephemeral(
+                        ws,
+                        ledger,
+                        UiNotification::SessionGoalCleared(event),
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        session_id = %session_id,
+                        "session/open no-goal snapshot produced an unparseable cleared event",
+                    );
+                }
             }
         }
     }

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -17018,11 +17018,6 @@ async fn handle_session_open(
 ) -> bool {
     normalize_session_open_params_topic(&mut params);
     let topic_scope = params.topic.clone();
-    // #2062 — captured before `params` moves into `open_session_result`: the
-    // goal-chip null snapshot below resolves its profile with the SAME
-    // `resolve_autonomy_profile_id` the goal RPC surface uses, and that
-    // resolution wants the client's requested profile as its first input.
-    let requested_profile_id = params.profile_id.clone();
 
     // Subscribe to the live ledger broadcast BEFORE the replay query so any
     // event that lands while we're still computing replay/opened sits in the
@@ -17175,10 +17170,6 @@ async fn handle_session_open(
     // event that happened to land between replay and the session/open
     // append, exactly the gap codex flagged.
     let baseline_seq = outcome.replay_baseline_seq;
-    // #2062 codex round-2 Z1 — the open-registration-pinned goal-store key;
-    // the null snapshot below inspects THIS, never a re-resolution of the
-    // last-writer-wins cwd map.
-    let pinned_goal_key = outcome.pinned_goal_key.clone();
     let session_id = match &outcome.opened_event.event {
         UiProtocolLedgerEvent::Notification(UiNotification::SessionOpened(opened)) => {
             opened.session_id.clone()
@@ -17209,78 +17200,13 @@ async fn handle_session_open(
         }
     }
 
-    // #2062 — goal-chip NULL snapshot. The chip is client state fed by server
-    // pushes, and everything above only re-delivers what the ledger retained:
-    // a goal cleared elsewhere (a second connection, another process on this
-    // data dir, or a serve restart that rebuilt the ledger) leaves this
-    // reconnect SILENT about goal state, so a client's cached chip survives —
-    // absence-of-message is indistinguishable from message-not-yet-arrived.
-    // When no goal record exists for this session's goal-store key, build the
-    // SAME `session/goal/cleared` the explicit clear RPC emits: "removed",
-    // "never existed", and "removed while you were away" become one message
-    // (codex `ThreadGoalCleared` parity). When a goal IS bound — under ANY
-    // profile (codex #2065 H1: the chip and its cleared reducer are
-    // session-keyed with no profile check, and goal RPCs may have bound it
-    // under a caller-requested profile this open does not resolve) — this
-    // stays `None`: the positive replay/live paths own the chip, and a
-    // spurious cleared would blank a live one.
-    //
-    // Gated on the same `coding.goal_runtime.v1` capability the goal RPC
-    // surface requires (codex #2065 P2): a client without goal support must
-    // never see goal frames.
-    let open_goal_null: Option<UiNotification> = if features.goal_runtime_available() {
-        resolve_autonomy_profile_id(
-            Some(&session_id),
-            requested_profile_id.as_deref(),
-            connection_profile_id,
-        )
-        .ok()
-        .and_then(|goal_profile_id| {
-            default_agent_orchestrator()
-                .session_goal_hydrate_cleared_event_json(&pinned_goal_key, &goal_profile_id)
-        })
-        .and_then(|cleared_json| {
-            match serde_json::from_value::<octos_core::ui_protocol::SessionGoalClearedEvent>(
-                cleared_json,
-            ) {
-                Ok(event) => Some(UiNotification::SessionGoalCleared(event)),
-                Err(error) => {
-                    tracing::warn!(
-                        %error,
-                        session_id = %session_id,
-                        "session/open no-goal snapshot produced an unparseable cleared event",
-                    );
-                    None
-                }
-            }
-        })
-    } else {
-        None
-    };
-    // codex #2065 round-3 PATH B — the null is delivered SYNCHRONOUSLY here,
-    // in the open sequence itself, on the same writer lane as the replay
-    // frames above: drain the broadcast backlog that raced the handshake
-    // (H3 — a stale `session/goal/updated` buffered since the subscribe
-    // must flush BEFORE the null), then emit the null with an
-    // admission-adjacent superseded re-check. The read loop dispatches
-    // commands inline-awaited, so no same-connection RPC can interleave
-    // into this section; spawned turn tasks CAN, which is exactly what the
-    // guard-lock-held re-check in `emit_open_goal_null_now` closes. The
-    // parked-retry task this replaces could abandon on frames that never
-    // reached this client and outlived every ordering argument — the
-    // synchronous emit needs neither.
-    let live_rx = drain_open_backlog_then_emit_goal_null(
-        ws,
-        ledger,
-        live_rx,
-        baseline_seq,
-        ws.connection_id,
-        features,
-        topic_scope.as_deref(),
-        &session_id,
-        open_goal_null,
-    )
-    .await;
+    // #2062 round 6 — the goal snapshot is carried IN the `session/open`
+    // RPC RESPONSE (`SessionOpenResult::goal_state`, computed in
+    // `open_session_result` against the registration-pinned scoped key):
+    // the response's fixed position in the client's own processing order
+    // makes the snapshot race-free by construction, so this handler emits
+    // NO goal frames of its own — every live goal frame the pump later
+    // delivers is by definition newer and simply overwrites the snapshot.
 
     // #1594 follow-up: the SessionOpened NOTIFICATION is a documented
     // capability-discovery path (UPCR-2026-007), so an ingress connection's
@@ -17580,242 +17506,6 @@ fn stdio_session_open_candidate_profile(
         .or_else(|| current_profile_id.map(ToOwned::to_owned))
 }
 
-/// codex #2065 round-3 PATH B — the synchronous open-section half of the
-/// #2062 goal null snapshot: drain the live-broadcast backlog that raced the
-/// open handshake, then emit the null, both on the CALLER's task (the open
-/// handler), on the same writer lane as the replay frames that preceded it.
-/// Returns the receiver for the subsequent [`spawn_live_forwarder`] hand-off.
-///
-/// Ordering (H3): the subscription predates the replay snapshot, so a stale
-/// `session/goal/updated` that raced the handshake is sitting in `rx` now —
-/// it must flush BEFORE the null (the pump's ledger-send lane runs no
-/// generation guard and the client's `updated` reducer applies
-/// unconditionally). Everything that arrives after this drain is pumped
-/// after the open completes — genuinely newer state that may follow the
-/// null.
-///
-/// Lag honesty (codex round-3 W7): a `Lagged` HERE can drop post-baseline
-/// frames from the broadcast ring, not just pre-open history — the durable
-/// ledger still has them, so account the skips into the connection's
-/// dropped-frame counter and raise `protocol/replay_lossy`, exactly like a
-/// backpressure-dropped durable frame. The client surfaces "reconnect to
-/// rehydrate"; nothing here pretends the drain recovered the loss.
-#[allow(clippy::too_many_arguments)]
-async fn drain_open_backlog_then_emit_goal_null(
-    ws: &WsConnection,
-    ledger: &Arc<UiProtocolLedger>,
-    mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
-    baseline_seq: u64,
-    self_connection_id: ConnectionId,
-    features: ConnectionUiFeatures,
-    topic_scope: Option<&str>,
-    session_id: &SessionKey,
-    open_goal_null: Option<UiNotification>,
-) -> tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent> {
-    use tokio::sync::broadcast::error::TryRecvError;
-    loop {
-        match rx.try_recv() {
-            Ok(event) => {
-                if matches!(
-                    forward_live_ledger_event(
-                        ws,
-                        ledger,
-                        event,
-                        baseline_seq,
-                        self_connection_id,
-                        features,
-                        topic_scope,
-                    )
-                    .await,
-                    Err(SendError::Closed | SendError::FatalClosed)
-                ) {
-                    // Writer gone: the null below fails the same way; the
-                    // caller's remaining sends surface the teardown.
-                    break;
-                }
-            }
-            Err(TryRecvError::Empty) => break,
-            Err(TryRecvError::Lagged(skipped)) => {
-                ws.metrics
-                    .dropped_count
-                    .fetch_add(skipped, Ordering::Relaxed);
-                emit_replay_lossy_opportunistic(ws, ledger, session_id.0.as_str());
-                log_live_forwarder_lag(session_id, skipped, features);
-            }
-            Err(TryRecvError::Closed) => break,
-        }
-    }
-    if let Some(notification) = open_goal_null {
-        let _ = emit_open_goal_null_now(ws, ledger, notification, features);
-    }
-    rx
-}
-
-/// #2062 (codex #2065 rounds 1–3) — emit the open-time goal NULL snapshot,
-/// synchronously, exactly once. THE NULL IS A SNAPSHOT, NOT A COMMAND: it
-/// only needs delivering while nothing newer has been delivered, so instead
-/// of racing newer frames it yields to them.
-///
-/// - EPHEMERAL in content: never appended to the ledger — a reopen is one
-///   client's catch-up state, not session history. The frame carries no
-///   cursor, so no cursor-based recovery exists for it either.
-/// - SUPERSEDED-ABANDON, admission-adjacent (round-3 W2, round-4 S3): the
-///   #1959 guard lock is held across the final watermark re-read AND the
-///   non-blocking enqueue, and the watermark is keyed by the SCOPED goal
-///   identity (`goal_event_watermark_identity`) — another cwd scope's
-///   frames on the same wire session move a DIFFERENT watermark and can
-///   never abandon this null (cross-scope pollution, the round-4 S3 bug).
-///   Every producer records its generation under that same lock BEFORE
-///   enqueueing, so either a same-scope newer frame's record precedes this
-///   check (→ abandon — sound per-scope: a same-scope superseder implies
-///   the goal now EXISTS under this scope, and RPC-created goals ledger
-///   their positive state durably (`session/goal/set` appends before any
-///   per-connection filtering), so it reaches this client via the
-///   post-open pump) or its record waits on the lock until the null is
-///   already enqueued (→ wire order null-then-newer, newest wins). The
-///   honest residual: a goal created by the model's tool DURING a turn has
-///   ephemeral-only positive frames — if its repaint is admitted in this
-///   instant and then dropped by its own lossy enqueue, the chip stays
-///   empty until the next repaint/reopen — the pre-existing spec §9
-///   ephemeral-chip lossiness class. There is no parked window: same-
-///   connection RPCs cannot interleave at all (the read loops dispatch
-///   inline-awaited), and spawned turn tasks are exactly what the held
-///   lock serializes against.
-/// - BACKPRESSURE couples to `protocol/replay_lossy` (round-3 PATH B(3)):
-///   a full writer here means the SAME section was already dropping replay
-///   frames. The drop is accounted into the shared dropped-frame counter
-///   and the lossy signal raised opportunistically — and if that emit ALSO
-///   fails on the still-full queue, the debt survives and the live pump's
-///   FIRST action flushes it through the capacity-aware lane (round-4 S2,
-///   `flush_replay_lossy_debt_cooperatively`), so the client always gets
-///   the "reconnect to rehydrate" prompt (it performs no automatic resync
-///   — verified in the octoscode reducer), and the reopen it is told to
-///   perform re-emits this snapshot (idempotent null). On the stdio lane
-///   this is a deliberate divergence from the blocking durable enqueue:
-///   the null uses the non-blocking try lane so the supersession check
-///   stays atomic — a drop there is recovered identically.
-fn emit_open_goal_null_now(
-    ws: &WsConnection,
-    ledger: &UiProtocolLedger,
-    notification: UiNotification,
-    features: ConnectionUiFeatures,
-) -> Result<(), SendError> {
-    emit_open_goal_null_with_pre_lock_hook(ws, ledger, notification, features, None)
-}
-
-/// Body of [`emit_open_goal_null_now`] with a test seam (codex #2065
-/// round-4 S7): `pre_lock_hook` runs after the entry guard admitted this
-/// null but before the final in-lock recheck — the exact window a spawned
-/// turn task can occupy — so a test can deliver a REAL newer frame there
-/// and pin that the in-lock recheck (not the entry guard) abandons the
-/// null. Production always passes `None`.
-fn emit_open_goal_null_with_pre_lock_hook(
-    ws: &WsConnection,
-    ledger: &UiProtocolLedger,
-    notification: UiNotification,
-    features: ConnectionUiFeatures,
-    pre_lock_hook: Option<&dyn Fn()>,
-) -> Result<(), SendError> {
-    // Entry admit: records this null's generation as its scope's watermark
-    // (or abandons immediately when a newer goal frame already admitted).
-    if !goal_event_passes_generation_guard(&notification) {
-        return Ok(());
-    }
-    let (wire_session, own_generation) = match &notification {
-        UiNotification::SessionGoalCleared(event) => (event.session_id.0.clone(), event.generation),
-        UiNotification::SessionGoalUpdated(event) => (event.session_id.0.clone(), event.generation),
-        _ => (String::new(), 0),
-    };
-    // S3: the recheck below compares against the SCOPED watermark identity
-    // (resolved before the guard lock; the orchestrator-state and guard
-    // locks never nest). The wire session id stays for logs + the client-
-    // facing lossy signal.
-    let watermark_identity = goal_event_watermark_identity(&wire_session, own_generation);
-    let method = notification.method().to_string();
-    let filter_event = UiProtocolLedgerEvent::Notification(notification.clone());
-    let delivery_metric = ui_protocol_delivery_metric(&filter_event);
-    // Same per-connection capability filter as every other direct send,
-    // against the open's negotiated `features` (exactly like the open's
-    // replay loop), not the WsConnection snapshot.
-    if !live_event_passes_capability_filter(&filter_event, features) {
-        return Ok(());
-    }
-    let rpc = match notification.into_rpc_notification() {
-        Ok(rpc) => rpc,
-        Err(error) => {
-            tracing::warn!(
-                target: "octos::ui_protocol::ws",
-                method = %method,
-                error = %error,
-                "failed to serialize open goal null snapshot"
-            );
-            return Err(SendError::BackpressureDrop);
-        }
-    };
-    let Some(frame) = frame_for(&rpc) else {
-        return Err(SendError::BackpressureDrop);
-    };
-    if let Some(hook) = pre_lock_hook {
-        hook();
-    }
-    // Final re-read + enqueue under ONE guard-lock acquisition. No await and
-    // no blocking call happens under the lock (`try_enqueue` is a
-    // non-blocking `try_send` on both lanes).
-    let send_outcome = {
-        let watermarks = goal_event_guard_map()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if own_generation > 0
-            && watermarks
-                .get(watermark_identity.as_str())
-                .copied()
-                .unwrap_or(0)
-                > own_generation
-        {
-            tracing::debug!(
-                target: "octos::ui_protocol::ws",
-                method = %method,
-                session_id = %wire_session,
-                "open goal null snapshot superseded by a newer goal frame; abandoned"
-            );
-            return Ok(());
-        }
-        ws.try_enqueue(frame)
-    };
-    match send_outcome {
-        Ok(()) => {
-            record_ui_protocol_delivery_metric(delivery_metric);
-            Ok(())
-        }
-        Err(SendError::BackpressureDrop) => {
-            // Account the loss into the shared dropped-frame counter (the
-            // same one every backpressure-dropped durable frame feeds) and
-            // raise the lossy signal; the client's recovery action — a
-            // reopen — re-emits this snapshot.
-            ws.metrics.dropped_count.fetch_add(1, Ordering::Relaxed);
-            metrics::counter!("ws.send.drop.backpressure", "method" => method.clone()).increment(1);
-            emit_replay_lossy_opportunistic(ws, ledger, wire_session.as_str());
-            tracing::warn!(
-                target: "octos::ui_protocol::ws",
-                method = %method,
-                session_id = %wire_session,
-                "open goal null snapshot dropped under backpressure; replay_lossy raised, \
-                 the next reopen re-emits it"
-            );
-            Err(SendError::BackpressureDrop)
-        }
-        Err(error) => {
-            tracing::debug!(
-                target: "octos::ui_protocol::ws",
-                method = %method,
-                error = ?error,
-                "open goal null snapshot not delivered; connection gone"
-            );
-            Err(error)
-        }
-    }
-}
-
 /// Deliver one live broadcast ledger event to `ws` through the forwarder's
 /// full filter pipeline: baseline cursor (events `<= baseline_seq` were
 /// already shipped via replay), self-connection dedupe (Codex MUST-FIX-2 —
@@ -17825,9 +17515,8 @@ fn emit_open_goal_null_with_pre_lock_hook(
 /// connection evaluates `EnvelopeV2` while legacy/v1 connections keep the
 /// original event byte-for-byte), and the per-connection capability filter.
 ///
-/// Shared by `spawn_live_forwarder_with_goal_null_snapshot`'s open-backlog
-/// drain and its live pump loop (#2062) so the two stay filter-for-filter
-/// identical. `Ok(())` covers "sent", "filtered", AND backpressure
+/// The per-event body of `spawn_live_forwarder`'s pump loop. `Ok(())`
+/// covers "sent", "filtered", AND backpressure
 /// (`send_ledger_event_durable` already opportunistically emits
 /// `replay_lossy`; the caller keeps pumping so a recovered consumer gets
 /// caught up). `Err` is only the #924 BLOCK 2 writer-fatal pair — a closed
@@ -17891,62 +17580,6 @@ fn log_live_forwarder_lag(session_id: &SessionKey, skipped: u64, features: Conne
     );
 }
 
-/// codex #2065 round-4 S2 — deliver any accumulated replay-lossy debt
-/// through a capacity-aware park before the pump forwards its first event.
-///
-/// The debt can otherwise exist with NO delivered signal: the open-section
-/// null (cursorless — no cursor-based recovery exists for it) and even the
-/// `SessionOpened` frame can drop on a full writer, and the opportunistic
-/// lossy emit fails on that same full queue and restores the count; the
-/// ledgered lossy row's broadcast copy is self-connection-deduped, and no
-/// later send was guaranteed to happen. The chain then dead-ended: the
-/// client never saw the "reconnect to rehydrate" prompt, so the dropped
-/// null was never re-emitted. The pump — which already parks cooperatively
-/// on capacity — is the natural retry lane: one ledgered lossy row per
-/// accumulated batch, the frame parked (non-blocking probe + async sleep,
-/// cancellable at every await, atomic enqueue) until delivered. Debt that
-/// accumulates while parked is taken by the next loop pass; a dead
-/// connection makes delivery moot.
-async fn flush_replay_lossy_debt_cooperatively(
-    ws: &WsConnection,
-    ledger: &Arc<UiProtocolLedger>,
-    session_id: &SessionKey,
-) {
-    const CAPACITY_PROBE_WINDOW: std::time::Duration = std::time::Duration::from_millis(15);
-    loop {
-        let dropped = ws.metrics.dropped_count.swap(0, Ordering::Relaxed);
-        if dropped == 0 {
-            return;
-        }
-        let last_cursor = ws.metrics.snapshot_last_cursor();
-        let lossy = UiNotification::ReplayLossy(ReplayLossyEvent {
-            session_id: session_id.clone(),
-            dropped_count: dropped,
-            last_durable_cursor: last_cursor,
-        });
-        // One durable row per batch (same as the opportunistic emitter);
-        // tagged with our connection id so this pump's own broadcast copy
-        // is self-deduped.
-        let event = ledger.append_notification_from(lossy, ws.connection_id);
-        let Some(frame) = frame_from_ledger(event.event) else {
-            return;
-        };
-        loop {
-            if ws.is_failed() {
-                return;
-            }
-            match ws.try_enqueue(frame.clone()) {
-                Ok(()) => break,
-                Err(SendError::BackpressureDrop) => {
-                    tokio::time::sleep(CAPACITY_PROBE_WINDOW).await;
-                }
-                // Closed / latched: the connection is gone, delivery moot.
-                Err(_) => return,
-            }
-        }
-    }
-}
-
 /// Pump live ledger events for `session_id` into the connection's WS write
 /// channel. Filters out events with `cursor.seq <= baseline_seq` (which
 /// were already shipped via replay) and applies the same capability
@@ -17954,14 +17587,12 @@ async fn flush_replay_lossy_debt_cooperatively(
 /// closes (peer gone), the broadcast sender is dropped (rare), or the
 /// connection cleanup aborts the handle.
 ///
-/// codex #2065 round-3 PATH B — this is a PUMP ONLY. The #2062 goal null
-/// snapshot and the open-backlog drain both moved onto the open handler
-/// itself (`drain_open_backlog_then_emit_goal_null`), synchronous in the
-/// open sequence; by the time this task starts, the backlog is empty and
-/// the null (if any) is already on the wire. Every await point here (recv,
-/// the offloaded send's capacity park) is cancellable and every enqueue is
-/// an atomic `try_send`, so abort+join retires the lane with no detached
-/// in-flight work — the round-3 W6 hazard (an uncancellable
+/// #2062 round 6 — this is a PUMP ONLY: the goal snapshot rides in the
+/// `session/open` RPC response (`SessionOpenResult::goal_state`), so no
+/// goal frames originate here. Every await point (recv, the offloaded
+/// send's capacity park) is cancellable and every enqueue is an atomic
+/// `try_send`, so abort+join retires the lane with no detached in-flight
+/// work — the round-3 W6 hazard (an uncancellable
 /// `spawn_blocking(SyncSender::send)` outliving the abort) is gone by
 /// construction, see `send_durable_offloaded`.
 // Each parameter is an independent piece of the forwarder's runtime state
@@ -18012,16 +17643,6 @@ async fn spawn_live_forwarder(
 
     let session_for_log = session_id.clone();
     let task = tokio::spawn(async move {
-        // codex #2065 round-4 S2 — FIRST action, before forwarding any
-        // event: deliver any pending replay-lossy debt. The open section
-        // can leave debt with NO delivered signal — the null (and even the
-        // SessionOpened frame) dropped on a full writer, and the
-        // opportunistic lossy emit failing on that same full queue and
-        // restoring the count. The pump is the natural retry lane: it
-        // parks cooperatively on capacity, so the "reconnect to rehydrate"
-        // prompt reaches the client as soon as the queue frees, and the
-        // reopen it prompts re-emits the dropped null. Zero new tasks.
-        flush_replay_lossy_debt_cooperatively(&ws, &ledger, &session_for_log).await;
         loop {
             match rx.recv().await {
                 Ok(event) => {
@@ -18515,12 +18136,6 @@ struct SessionOpenOutcome {
     /// would starve it. See `connection_filterable_profile_scope`.
     profile_scope: Option<String>,
     profile_id: String,
-    /// #2062 codex round-2 Z1 — THIS open's goal-store identity, pinned at
-    /// open-registration time (right after `register_session_ledger_scope`).
-    /// The goal null snapshot inspects THIS key, never a re-resolution of
-    /// the last-writer-wins cwd map that a concurrent same-wire open could
-    /// flip mid-open. Mirrors the turn path's turn-pinned scoped key.
-    pinned_goal_key: SessionKey,
 }
 
 // Threading both the approval store and the (UPCR-2026-023) question store
@@ -18743,6 +18358,23 @@ async fn open_session_result(
     // wire-id fallthrough unless an earlier profiled open scoped this wire).
     let pinned_goal_key = pinned_goal_key
         .unwrap_or_else(|| default_agent_orchestrator().scoped_goal_key(&params.session_id));
+    // #2062 round 6 — the goal snapshot rides IN this open's RPC response
+    // (see `session_open_goal_state` for why the response's fixed position
+    // in the client's processing order makes it race-free by construction).
+    // Resolved with the SAME profile resolution the goal RPC surface uses,
+    // against the registration-pinned scoped key captured above. A
+    // resolution error yields `null` — never leak, never fabricate (the
+    // open itself already passed `validate_session_scope`, so this is
+    // effectively unreachable).
+    let goal_state = resolve_autonomy_profile_id(
+        Some(&params.session_id),
+        params.profile_id.as_deref(),
+        connection_profile_id,
+    )
+    .map(|goal_profile_id| {
+        default_agent_orchestrator().session_open_goal_state(&pinned_goal_key, &goal_profile_id)
+    })
+    .unwrap_or(Value::Null);
     let Some(sessions) = resolve_sessions_for_lookup(
         state,
         connection_profile_id,
@@ -18875,7 +18507,7 @@ async fn open_session_result(
         unreachable!("session/open ledger append returns session/open notification");
     };
     Ok(SessionOpenOutcome {
-        result: SessionOpenResult::new(opened),
+        result: SessionOpenResult::new(opened).with_goal_state(goal_state),
         replay,
         pending_approvals,
         pending_questions,
@@ -18883,7 +18515,6 @@ async fn open_session_result(
         replay_baseline_seq,
         profile_scope,
         profile_id: ledger_profile_id,
-        pinned_goal_key,
     })
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -17032,13 +17032,14 @@ async fn handle_session_open(
     // codex #2065 round-3 W6.1 — retire the PREVIOUS forwarder for this
     // session BEFORE `open_session_result` computes the replay baseline
     // (order: subscribe new receiver → retire old lane → baseline → replay
-    // → drain → null → pump). With the old order the previous pump stayed
-    // live through the new replay window and could deliver a post-baseline
-    // event CONCURRENTLY with the replay that also carries it. abort+join
-    // fully retires the lane: every await point in the forwarder (recv,
-    // the offloaded send's capacity park) is cancellable, and an enqueue
-    // is an atomic `try_send` — there is no detached in-flight segment for
-    // the join to miss (see `send_durable_offloaded`).
+    // → response, carrying the #2062 `goal_state` snapshot → pump). With
+    // the old order the previous pump stayed live through the new replay
+    // window and could deliver a post-baseline event CONCURRENTLY with the
+    // replay that also carries it. abort+join fully retires the lane:
+    // every await point in the forwarder (recv, the offloaded send's
+    // capacity park) is cancellable, and an enqueue is an atomic
+    // `try_send` — there is no detached in-flight segment for the join to
+    // miss (see `send_durable_offloaded`).
     //
     // Delivery semantics across the handover are AT-LEAST-ONCE, not
     // exactly-once (codex #2065 round-4 S5, tracked): a durable frame the
@@ -17100,6 +17101,8 @@ async fn handle_session_open(
     if session_ingress {
         filter_capabilities_for_session_ingress(&mut outcome.result.opened.capabilities);
     }
+    let pinned_goal_key = outcome.pinned_goal_key.clone();
+    let goal_profile_id = outcome.goal_profile_id.clone();
     let result = match serde_json::to_value(outcome.result) {
         Ok(result) => result,
         Err(error) => {
@@ -17114,8 +17117,20 @@ async fn handle_session_open(
         }
     };
     // session/open reply is the lifecycle frame that the client blocks on;
-    // if it fails the connection is doomed for this command.
-    if send_rpc_result(ws, id, result).is_err() {
+    // if it fails the connection is doomed for this command. The #2062
+    // `goal_state` snapshot is captured AT this enqueue (codex
+    // R6-OPEN-SNAPSHOT-ORDER) — see the sender for the two-direction
+    // total-order argument.
+    if send_open_result_with_goal_state_at_enqueue(
+        ws,
+        id,
+        result,
+        &pinned_goal_key,
+        goal_profile_id.as_deref(),
+    )
+    .await
+    .is_err()
+    {
         return false;
     }
     // Replay frames are durable: drops surface as `protocol/replay_lossy`
@@ -18136,6 +18151,16 @@ struct SessionOpenOutcome {
     /// would starve it. See `connection_filterable_profile_scope`.
     profile_scope: Option<String>,
     profile_id: String,
+    /// #2062 round 7 — THIS open's goal-store identity, pinned at
+    /// open-registration (the key `set_goal_scope` returns from inside its
+    /// own lock; legacy fallback: one map read). The response's
+    /// `goal_state` is captured against THIS key at enqueue time by
+    /// `send_open_result_with_goal_state_at_enqueue`.
+    pinned_goal_key: SessionKey,
+    /// The open's resolved goal profile (same resolver as the goal RPC
+    /// surface); `None` (resolution error, effectively unreachable) keeps
+    /// the snapshot at `null`.
+    goal_profile_id: Option<String>,
 }
 
 // Threading both the approval store and the (UPCR-2026-023) question store
@@ -18358,23 +18383,25 @@ async fn open_session_result(
     // wire-id fallthrough unless an earlier profiled open scoped this wire).
     let pinned_goal_key = pinned_goal_key
         .unwrap_or_else(|| default_agent_orchestrator().scoped_goal_key(&params.session_id));
-    // #2062 round 6 — the goal snapshot rides IN this open's RPC response
-    // (see `session_open_goal_state` for why the response's fixed position
-    // in the client's processing order makes it race-free by construction).
-    // Resolved with the SAME profile resolution the goal RPC surface uses,
-    // against the registration-pinned scoped key captured above. A
-    // resolution error yields `null` — never leak, never fabricate (the
-    // open itself already passed `validate_session_scope`, so this is
-    // effectively unreachable).
-    let goal_state = resolve_autonomy_profile_id(
+    // #2062 rounds 6–7 — the goal snapshot rides IN this open's RPC
+    // response, but it is CAPTURED AT ENQUEUE, not here (codex
+    // R6-OPEN-SNAPSHOT-ORDER: several awaits separate this point from the
+    // response enqueue, and an already-spawned turn's repaint landing in
+    // that window would make an early-captured snapshot overwrite the
+    // fresher frame backwards on the client). Only the PROFILE RESOLUTION
+    // is captured here, where `params` lives — the SAME resolution the
+    // goal RPC surface uses; a resolution error resolves to `None` and the
+    // snapshot stays `null` (never leak, never fabricate; the open already
+    // passed `validate_session_scope`, so the error arm is effectively
+    // unreachable). The snapshot itself is computed by
+    // `send_open_result_with_goal_state_at_enqueue` against the pinned key
+    // above at the moment the response joins the writer queue.
+    let goal_profile_id = resolve_autonomy_profile_id(
         Some(&params.session_id),
         params.profile_id.as_deref(),
         connection_profile_id,
     )
-    .map(|goal_profile_id| {
-        default_agent_orchestrator().session_open_goal_state(&pinned_goal_key, &goal_profile_id)
-    })
-    .unwrap_or(Value::Null);
+    .ok();
     let Some(sessions) = resolve_sessions_for_lookup(
         state,
         connection_profile_id,
@@ -18507,7 +18534,7 @@ async fn open_session_result(
         unreachable!("session/open ledger append returns session/open notification");
     };
     Ok(SessionOpenOutcome {
-        result: SessionOpenResult::new(opened).with_goal_state(goal_state),
+        result: SessionOpenResult::new(opened),
         replay,
         pending_approvals,
         pending_questions,
@@ -18515,6 +18542,8 @@ async fn open_session_result(
         replay_baseline_seq,
         profile_scope,
         profile_id: ledger_profile_id,
+        pinned_goal_key,
+        goal_profile_id,
     })
 }
 
@@ -37168,6 +37197,168 @@ fn send_rpc_result(ws: &WsConnection, id: String, result: Value) -> Result<(), S
     }
 }
 
+/// #2062 round 7 (codex R6-OPEN-SNAPSHOT-ORDER) — enqueue the
+/// `session/open` RPC result with its `goal_state` snapshot captured AT
+/// ENQUEUE, not at the round-6 early site several awaits upstream (where an
+/// already-spawned turn's goal repaint could land in the window and the
+/// stale unversioned response would then overwrite the fresher frame
+/// backwards on the client). Response position alone is not snapshot
+/// freshness — the capture must join the writer queue at its build
+/// position.
+///
+/// Per attempt: read the pinned scope's #1959 watermark (guard lock,
+/// released) → snapshot the goal state (orchestrator state lock, released)
+/// → build the frame → under ONE guard-lock acquisition, re-read the
+/// watermark and, if unmoved, `try_enqueue` in-section. Watermark-first
+/// ordering is deliberate: a producer landing between the watermark read
+/// and the snapshot moves the watermark while its mutation is already IN
+/// the snapshot, so the recheck retries with an already-fresh capture —
+/// conservative, never stale.
+///
+/// The two-direction total-order argument (replacing round 6's
+/// fixed-position claim): every goal producer records its generation under
+/// the guard lock BEFORE enqueueing, so a live goal frame either
+/// (a) admitted before this in-section enqueue — the watermark moved, this
+/// loop recaptures, and the response carries state ≥ that frame (client
+/// order frame → response: a fresher-or-equal overwrite, correct); or
+/// (b) admits after — its own enqueue then follows this one on the FIFO
+/// per-connection writer (client order response → frame: newer overwrites,
+/// correct). Out-of-order builds among the frames themselves are already
+/// collapsed by the #1959 send guard. The response therefore slots into
+/// the LIVE total order at its build position. (Replayed HISTORICAL goal
+/// frames ride the client's cursor semantics — snapshot-vs-replay
+/// precedence is the pairing client change's domain.)
+///
+/// Why capture-then-recheck instead of holding a lock across the enqueue:
+/// the lifecycle lane's stdio enqueue is a BLOCKING `SyncSender::send`
+/// (`enqueue_durable_or_lifecycle`), and holding the orchestrator state
+/// lock or the guard lock across a blocking channel send would stall every
+/// goal producer process-wide behind one slow stdio consumer.
+/// `try_enqueue` is non-blocking on both lanes, so the guard-lock section
+/// spans exactly [recheck + try_enqueue].
+///
+/// Lifecycle semantics are preserved per lane: WS backpressure/closed
+/// latch the connection failed exactly like `send_lifecycle`; a full stdio
+/// queue parks cooperatively (the stdio lifecycle lane never drops) and
+/// each retry re-verifies freshness. The recapture loop is bounded: after
+/// `MAX_GOAL_STATE_RECAPTURES` consecutive stale detections (a sustained
+/// same-scope goal-frame storm inside microsecond windows — unreachable in
+/// practice, goal frames are RPC/turn-scale), the freshest capture is
+/// enqueued anyway and the residual at-most-one-frame staleness is logged.
+async fn send_open_result_with_goal_state_at_enqueue(
+    ws: &WsConnection,
+    id: String,
+    mut result: Value,
+    pinned_goal_key: &SessionKey,
+    goal_profile_id: Option<&str>,
+) -> Result<(), SendError> {
+    const MAX_GOAL_STATE_RECAPTURES: u32 = 16;
+    const STDIO_CAPACITY_PROBE_WINDOW: std::time::Duration = std::time::Duration::from_millis(15);
+    enum EnqueueOutcome {
+        Sent,
+        Stale,
+        Full,
+        Failed(SendError),
+    }
+    let mut recaptures: u32 = 0;
+    loop {
+        let expected_watermark = {
+            let watermarks = goal_event_guard_map()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            watermarks
+                .get(pinned_goal_key.0.as_str())
+                .copied()
+                .unwrap_or(0)
+        };
+        let goal_state = match goal_profile_id {
+            Some(profile_id) => {
+                default_agent_orchestrator().session_open_goal_state(pinned_goal_key, profile_id)
+            }
+            None => Value::Null,
+        };
+        result["goal_state"] = goal_state;
+        let Some(frame) = frame_for(&RpcResponse::success(id.clone(), result.clone())) else {
+            // Oversized result: same fallback as `send_rpc_result`.
+            return send_minimal_rpc_error_fallback(ws, Some(id));
+        };
+        let outcome = {
+            let watermarks = goal_event_guard_map()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let current = watermarks
+                .get(pinned_goal_key.0.as_str())
+                .copied()
+                .unwrap_or(0);
+            if current != expected_watermark && recaptures < MAX_GOAL_STATE_RECAPTURES {
+                EnqueueOutcome::Stale
+            } else {
+                if current != expected_watermark {
+                    tracing::debug!(
+                        target: "octos::ui_protocol::ws",
+                        session = %pinned_goal_key.0,
+                        recaptures,
+                        "goal_state recapture bound hit; enqueueing the freshest capture"
+                    );
+                }
+                match ws.try_enqueue(frame) {
+                    Ok(()) => EnqueueOutcome::Sent,
+                    Err(SendError::BackpressureDrop) => EnqueueOutcome::Full,
+                    Err(error) => EnqueueOutcome::Failed(error),
+                }
+            }
+        };
+        match outcome {
+            EnqueueOutcome::Sent => return Ok(()),
+            EnqueueOutcome::Stale => {
+                recaptures += 1;
+                continue;
+            }
+            EnqueueOutcome::Full => {
+                if ws.stdio_writer.is_some() {
+                    // The stdio lifecycle lane never drops: park
+                    // cooperatively and retry — the retry re-verifies
+                    // freshness before enqueueing.
+                    tokio::time::sleep(STDIO_CAPACITY_PROBE_WINDOW).await;
+                    continue;
+                }
+                // WS lifecycle backpressure is a connection failure —
+                // mirror `send_lifecycle`'s arm (#922.2).
+                metrics::counter!("ws.send.error.lifecycle").increment(1);
+                tracing::warn!(
+                    target: "octos::ui_protocol::ws",
+                    reason = "backpressure",
+                    "lifecycle ws send failed; aborting connection"
+                );
+                ws.mark_failed();
+                return Err(SendError::LifecycleFailure(
+                    "writer channel full for lifecycle frame".into(),
+                ));
+            }
+            EnqueueOutcome::Failed(SendError::Closed) => {
+                metrics::counter!("ws.send.error.lifecycle").increment(1);
+                tracing::warn!(
+                    target: "octos::ui_protocol::ws",
+                    reason = "closed",
+                    "lifecycle ws send failed; aborting connection"
+                );
+                ws.mark_failed();
+                return Err(SendError::LifecycleFailure(
+                    "writer channel closed for lifecycle frame".into(),
+                ));
+            }
+            EnqueueOutcome::Failed(SendError::FatalClosed) => {
+                // #924 BLOCK 2: a prior lifecycle send already latched the
+                // connection failed; surface the lifecycle-shape error.
+                return Err(SendError::LifecycleFailure(
+                    "connection already latched as failed".into(),
+                ));
+            }
+            EnqueueOutcome::Failed(error) => return Err(error),
+        }
+    }
+}
+
 fn send_ui_rpc_result(ws: &WsConnection, id: String, result: UiRpcResult) -> Result<(), SendError> {
     let value = result
         .into_result_value()
@@ -37367,19 +37558,20 @@ fn send_notification_lifecycle_forced_backpressure_fixture(
 /// #1959 process-global watermark map: SCOPED goal identity → highest
 /// goal-frame generation an admitted `SessionGoalUpdated` /
 /// `SessionGoalCleared` has recorded. Module-scoped (not fn-local in the
-/// guard) so the #2062 open-time null snapshot can hold THIS lock across
-/// its final superseded re-check AND its non-blocking enqueue
-/// (`emit_open_goal_null_now`) — every producer records its generation
-/// here BEFORE enqueueing, which is what makes that check-and-send atomic
-/// against them (codex #2065 rounds 2–3).
+/// guard) because it has TWO consumers: the send guard below, and the
+/// #2062 open-response snapshot
+/// (`send_open_result_with_goal_state_at_enqueue`), which uses the pinned
+/// scope's watermark as its freshness marker and holds THIS lock across
+/// its recheck + non-blocking response enqueue — every producer records
+/// its generation here BEFORE enqueueing, which is what slots the response
+/// into the live total order at its build position (codex #2065 round 7).
 ///
 /// codex #2065 round-4 S3 — the key is the SCOPED goal-store key resolved
 /// via [`goal_event_watermark_identity`], NOT the plain wire session id
-/// the frames carry: two cwd scopes can share one wire id, and wire-keyed
-/// watermarks let connection B's scope-B repaint (delivered only to B)
-/// advance the watermark that connection A's scope-A null checks — the
-/// null would abandon with A receiving nothing, #2062 surviving through
-/// cross-scope watermark pollution.
+/// the frames carry: two cwd scopes can share one wire id, and a
+/// wire-keyed watermark advanced by scope A's clear would falsely drop
+/// scope B's later-delivered-but-earlier-built live repaint at the send
+/// guard (cross-scope suppression among real frames).
 static GOAL_EVENT_GENERATION_GUARD: OnceLock<StdMutex<HashMap<String, u64>>> = OnceLock::new();
 
 fn goal_event_guard_map() -> &'static StdMutex<HashMap<String, u64>> {

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -17516,6 +17516,7 @@ async fn forward_live_ledger_event(
     self_connection_id: ConnectionId,
     features: ConnectionUiFeatures,
     topic_scope: Option<&str>,
+    profile_scope: Option<&str>,
 ) -> Result<(), SendError> {
     if event.cursor.seq <= baseline_seq {
         return Ok(());
@@ -17526,7 +17527,11 @@ async fn forward_live_ledger_event(
     if !ledger_event_matches_topic_scope(&event.event, topic_scope) {
         return Ok(());
     }
-    if !ledger_event_matches_profile_scope(&event.event, &ws.snapshot_live_profile_id()) {
+    // #2067 (H2) — the profile scope is captured at session/open, never
+    // re-read from the connection: a later `session/open` on the same
+    // connection can resolve a different profile, and the shared cell would
+    // retarget this pump mid-flight.
+    if !ledger_event_matches_profile_scope(&event.event, profile_scope) {
         return Ok(());
     }
     let projected = features
@@ -17590,6 +17595,7 @@ async fn spawn_live_forwarder(
     self_connection_id: ConnectionId,
     features: ConnectionUiFeatures,
     topic_scope: Option<String>,
+    profile_scope: Option<String>,
     mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
     forwarders: SharedLiveForwarders,
 ) {
@@ -17638,6 +17644,7 @@ async fn spawn_live_forwarder(
                             self_connection_id,
                             features,
                             topic_scope.as_deref(),
+                            profile_scope.as_deref(),
                         )
                         .await,
                         // #924 BLOCK 2: a closed writer OR a latched failure
@@ -18117,7 +18124,6 @@ struct SessionOpenOutcome {
     /// or `None` when its scope is not a tenant boundary and filtering it
     /// would starve it. See `connection_filterable_profile_scope`.
     profile_scope: Option<String>,
-    profile_id: String,
 }
 
 // Threading both the approval store and the (UPCR-2026-023) question store
@@ -18466,7 +18472,6 @@ async fn open_session_result(
         opened_event,
         replay_baseline_seq,
         profile_scope,
-        profile_id: ledger_profile_id,
     })
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -802,31 +802,23 @@ impl WsConnection {
         }
     }
 
-    /// codex #2065 round-2 Z3 — park until the writer MAY have capacity
-    /// again, or `window` elapses (the caller's cadence for re-checking its
-    /// abandon conditions between attempts). WS lane: the writer channel's
-    /// own `reserve()` readiness — the permit is dropped immediately because
-    /// the caller re-runs its superseded check before actually sending, and
-    /// losing the freed slot to a concurrent sender just re-parks. stdio
-    /// lane: the bounded std `SyncSender` has no async readiness primitive —
-    /// a plain bounded sleep, with the caller's `try_enqueue` as the probe.
-    /// Never blocks an executor worker on either lane.
-    async fn await_writer_capacity(&self, window: std::time::Duration) {
-        if self.stdio_writer.is_some() {
-            tokio::time::sleep(window).await;
-            return;
-        }
-        let _ = tokio::time::timeout(window, self.writer.reserve()).await;
-    }
-
-    /// codex #2065 round-2 Z3 — await-safe durable enqueue for async tasks.
-    /// The stdio durable lane (`enqueue_durable_or_lifecycle`) is a BLOCKING
-    /// `SyncSender::send`: correct backpressure on a blocking-capable
-    /// caller, an executor-worker stall when a full stdio queue parks an
-    /// async task. Here the stdio send hops to the blocking pool instead —
-    /// the caller awaits each hop before its next send, so per-task frame
-    /// order is preserved — while the WS lane keeps its non-blocking
-    /// `try_send` semantics via [`Self::send_durable`].
+    /// codex #2065 round-2 Z3 + round-3 W6 — await-safe durable enqueue for
+    /// the live-forwarder task. The stdio durable lane
+    /// (`enqueue_durable_or_lifecycle`) is a BLOCKING `SyncSender::send`:
+    /// correct backpressure on a blocking-capable caller, an
+    /// executor-worker stall when a full stdio queue parks an async task
+    /// (round-2 Z3) — and a round-3 W6 hazard when hopped to
+    /// `spawn_blocking`, because an in-flight blocking closure survives the
+    /// task's abort and can enqueue a stale frame AFTER the lane was
+    /// retired. Here the stdio lane instead parks COOPERATIVELY: a
+    /// non-blocking `try_send` probe with a bounded async sleep between
+    /// probes. That keeps the stdio never-drop durable semantics (the frame
+    /// waits for capacity, exactly like the blocking send did), never
+    /// occupies an executor worker, and — the W6 point — is cancellable at
+    /// every await with an ATOMIC enqueue: after abort+join there is no
+    /// detached in-flight work that could still enqueue. The WS lane keeps
+    /// its non-blocking `try_send`+`replay_lossy` semantics via
+    /// [`Self::send_durable`], byte-identical to the sync callers.
     async fn send_durable_offloaded(
         &self,
         frame: WsMessage,
@@ -835,31 +827,36 @@ impl WsConnection {
         if self.stdio_writer.is_none() {
             return self.send_durable(frame, method);
         }
-        if self.failed.load(std::sync::atomic::Ordering::Acquire) {
-            return Err(SendError::FatalClosed);
-        }
-        let writer = self
-            .stdio_writer
-            .as_ref()
-            .expect("stdio_writer checked above")
-            .clone();
-        match tokio::task::spawn_blocking(move || writer.send(frame)).await {
-            Ok(Ok(())) => Ok(()),
-            // Disconnected writer, or the blocking pool was torn down at
-            // shutdown — either way the connection is going away; mirror
-            // `send_durable`'s Closed accounting.
-            Ok(Err(_)) | Err(_) => {
-                metrics::counter!("ws.send.drop.closed", "method" => method.to_string())
-                    .increment(1);
-                metrics::counter!("ws.send.error.durable", "method" => method.to_string())
-                    .increment(1);
-                tracing::warn!(
-                    target: "octos::ui_protocol::ws",
-                    method,
-                    reason = "closed",
-                    "durable ws send failed; client gone"
-                );
-                Err(SendError::Closed)
+        const CAPACITY_PROBE_WINDOW: std::time::Duration = std::time::Duration::from_millis(15);
+        let mut frame = frame;
+        loop {
+            if self.failed.load(std::sync::atomic::Ordering::Acquire) {
+                return Err(SendError::FatalClosed);
+            }
+            let writer = self
+                .stdio_writer
+                .as_ref()
+                .expect("stdio_writer checked above");
+            match writer.try_send(frame) {
+                Ok(()) => return Ok(()),
+                Err(std::sync::mpsc::TrySendError::Full(returned)) => {
+                    frame = returned;
+                    tokio::time::sleep(CAPACITY_PROBE_WINDOW).await;
+                }
+                Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                    // Mirror `send_durable`'s Closed accounting.
+                    metrics::counter!("ws.send.drop.closed", "method" => method.to_string())
+                        .increment(1);
+                    metrics::counter!("ws.send.error.durable", "method" => method.to_string())
+                        .increment(1);
+                    tracing::warn!(
+                        target: "octos::ui_protocol::ws",
+                        method,
+                        reason = "closed",
+                        "durable ws send failed; client gone"
+                    );
+                    return Err(SendError::Closed);
+                }
             }
         }
     }
@@ -4003,10 +4000,15 @@ fn combine_typed_prompt_with_transcript(typed_prompt: &str, transcript: &str) ->
 /// MUST be called before the flow replays the session (`session/open` calls
 /// it right after the runtime cache materializes, before
 /// `replay_after_with_head`) so replay and subsequent appends agree.
+/// Returns the goal-store key this open's registration established for the
+/// session key — handed back from INSIDE `set_goal_scope`'s own lock (codex
+/// #2065 round-3 W5), so the caller's pin and the registration are one
+/// acquisition and no concurrent same-wire open can flip the
+/// last-writer-wins map in between.
 fn register_session_ledger_scope(
     ledger: &UiProtocolLedger,
     runtime: &crate::runtime::SessionRuntime,
-) {
+) -> SessionKey {
     let scope = (runtime.sessions_root != runtime.profile.data_dir).then(|| {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
@@ -4026,7 +4028,8 @@ fn register_session_ledger_scope(
     // what makes the goal store isolate cwds exactly as the transcript already
     // does. The goal continuation dispatch strips this scope back to the wire
     // key when it reaches the session runtime / actor.
-    default_agent_orchestrator().set_goal_scope(&runtime.session_key, scope.clone());
+    let pinned_goal_key =
+        default_agent_orchestrator().set_goal_scope(&runtime.session_key, scope.clone());
     // Topic-suffixed sessions also emit ledger events under their BASE key:
     // the alpha-9 file/visual bridges deliberately strip the `#topic` before
     // appending so base-bucket subscribers see them (see
@@ -4037,8 +4040,9 @@ fn register_session_ledger_scope(
     let base = runtime.session_key.base_key();
     if base != runtime.session_key.0 {
         ledger.set_session_scope(&SessionKey(base.to_owned()), scope.clone());
-        default_agent_orchestrator().set_goal_scope(&SessionKey(base.to_owned()), scope);
+        let _ = default_agent_orchestrator().set_goal_scope(&SessionKey(base.to_owned()), scope);
     }
+    pinned_goal_key
 }
 
 /// Process-global event ledger.
@@ -17030,6 +17034,25 @@ async fn handle_session_open(
     let session_id_for_subscribe = params.session_id.clone();
     let live_rx = ledger.subscribe(&session_id_for_subscribe);
 
+    // codex #2065 round-3 W6.1 — retire the PREVIOUS forwarder for this
+    // session BEFORE `open_session_result` computes the replay baseline
+    // (order: subscribe new receiver → retire old lane → baseline → replay
+    // → drain → null → pump). With the old order the previous pump stayed
+    // live through the new replay window and could deliver a post-baseline
+    // event CONCURRENTLY with the replay that also carries it. abort+join
+    // fully retires the lane: every await point in the forwarder (recv,
+    // the offloaded send's capacity park) is cancellable, and an enqueue
+    // is an atomic `try_send` — there is no detached in-flight segment for
+    // the join to miss (see `send_durable_offloaded`).
+    let previous_forwarder = live_forwarders
+        .lock()
+        .await
+        .remove(&session_id_for_subscribe);
+    if let Some(previous) = previous_forwarder {
+        previous.abort();
+        let _ = previous.await;
+    }
+
     let mut outcome = match open_session_result(
         state,
         ledger,
@@ -17195,11 +17218,7 @@ async fn handle_session_open(
     //
     // Gated on the same `coding.goal_runtime.v1` capability the goal RPC
     // surface requires (codex #2065 P2): a client without goal support must
-    // never see goal frames. Built HERE (the open resolved its scope) but
-    // DELIVERED by the live-forwarder task below, which first drains the
-    // broadcast backlog that raced this handshake — the null must be the
-    // LAST goal-state frame of the open sequence (codex #2065 H3; see
-    // `spawn_live_forwarder_with_goal_null_snapshot`).
+    // never see goal frames.
     let open_goal_null: Option<UiNotification> = if features.goal_runtime_available() {
         resolve_autonomy_profile_id(
             Some(&session_id),
@@ -17229,6 +17248,30 @@ async fn handle_session_open(
     } else {
         None
     };
+    // codex #2065 round-3 PATH B — the null is delivered SYNCHRONOUSLY here,
+    // in the open sequence itself, on the same writer lane as the replay
+    // frames above: drain the broadcast backlog that raced the handshake
+    // (H3 — a stale `session/goal/updated` buffered since the subscribe
+    // must flush BEFORE the null), then emit the null with an
+    // admission-adjacent superseded re-check. The read loop dispatches
+    // commands inline-awaited, so no same-connection RPC can interleave
+    // into this section; spawned turn tasks CAN, which is exactly what the
+    // guard-lock-held re-check in `emit_open_goal_null_now` closes. The
+    // parked-retry task this replaces could abandon on frames that never
+    // reached this client and outlived every ordering argument — the
+    // synchronous emit needs neither.
+    let live_rx = drain_open_backlog_then_emit_goal_null(
+        ws,
+        ledger,
+        live_rx,
+        baseline_seq,
+        ws.connection_id,
+        features,
+        topic_scope.as_deref(),
+        &session_id,
+        open_goal_null,
+    )
+    .await;
 
     // #1594 follow-up: the SessionOpened NOTIFICATION is a documented
     // capability-discovery path (UPCR-2026-007), so an ingress connection's
@@ -17246,12 +17289,11 @@ async fn handle_session_open(
     let ledger_for_forwarder = ledger.clone();
     let _ = send_ledger_event_durable(ws, ledger, outcome.opened_event.event);
 
-    // Hand the broadcast receiver to a per-session forwarder. The previous
-    // forwarder for this session on this connection (if any) is aborted —
-    // a re-`session/open` always restarts the live pump from a fresh
-    // baseline cursor. The #2062 goal null snapshot rides along: the
-    // forwarder drains the open-raced backlog, then delivers it (H3).
-    spawn_live_forwarder_with_goal_null_snapshot(
+    // Hand the broadcast receiver to the per-session live pump. The
+    // previous forwarder was already retired BEFORE the replay baseline
+    // was computed (W6.1, top of this function); the in-spawn retire is an
+    // idempotent second line of defense for direct callers.
+    spawn_live_forwarder(
         ws.clone(),
         ledger_for_forwarder,
         session_id,
@@ -17262,7 +17304,6 @@ async fn handle_session_open(
         live_profile_scope,
         live_rx,
         live_forwarders.clone(),
-        open_goal_null,
     )
     .await;
     true
@@ -17530,42 +17571,206 @@ fn stdio_session_open_candidate_profile(
         .or_else(|| current_profile_id.map(ToOwned::to_owned))
 }
 
-/// Legacy-signature wrapper over
-/// [`spawn_live_forwarder_with_goal_null_snapshot`] (no open-time goal null
-/// snapshot). The production open path always passes the snapshot slot, so
-/// this survives for the forwarder test suite's many call sites only.
-#[cfg(test)]
+/// codex #2065 round-3 PATH B — the synchronous open-section half of the
+/// #2062 goal null snapshot: drain the live-broadcast backlog that raced the
+/// open handshake, then emit the null, both on the CALLER's task (the open
+/// handler), on the same writer lane as the replay frames that preceded it.
+/// Returns the receiver for the subsequent [`spawn_live_forwarder`] hand-off.
+///
+/// Ordering (H3): the subscription predates the replay snapshot, so a stale
+/// `session/goal/updated` that raced the handshake is sitting in `rx` now —
+/// it must flush BEFORE the null (the pump's ledger-send lane runs no
+/// generation guard and the client's `updated` reducer applies
+/// unconditionally). Everything that arrives after this drain is pumped
+/// after the open completes — genuinely newer state that may follow the
+/// null.
+///
+/// Lag honesty (codex round-3 W7): a `Lagged` HERE can drop post-baseline
+/// frames from the broadcast ring, not just pre-open history — the durable
+/// ledger still has them, so account the skips into the connection's
+/// dropped-frame counter and raise `protocol/replay_lossy`, exactly like a
+/// backpressure-dropped durable frame. The client surfaces "reconnect to
+/// rehydrate"; nothing here pretends the drain recovered the loss.
 #[allow(clippy::too_many_arguments)]
-async fn spawn_live_forwarder(
-    ws: WsConnection,
-    ledger: Arc<UiProtocolLedger>,
-    session_id: SessionKey,
+async fn drain_open_backlog_then_emit_goal_null(
+    ws: &WsConnection,
+    ledger: &Arc<UiProtocolLedger>,
+    mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
     baseline_seq: u64,
     self_connection_id: ConnectionId,
     features: ConnectionUiFeatures,
-    topic_scope: Option<String>,
-    // #2067 (H2) — the profile this SESSION resolved to at `session/open`,
-    // captured immutably for the lifetime of this forwarder exactly like
-    // `topic_scope`. Never re-read from the connection: a later
-    // `session/open` on the same connection can resolve a different profile,
-    // and a shared cell would retarget this pump mid-flight.
-    profile_scope: Option<String>,
-    mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
-    forwarders: SharedLiveForwarders,
-) {
-    spawn_live_forwarder_with_goal_null_snapshot(
-        ws,
-        ledger,
-        session_id,
-        baseline_seq,
-        self_connection_id,
-        features,
-        topic_scope,
-        rx,
-        forwarders,
-        None,
-    )
-    .await
+    topic_scope: Option<&str>,
+    session_id: &SessionKey,
+    open_goal_null: Option<UiNotification>,
+) -> tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent> {
+    use tokio::sync::broadcast::error::TryRecvError;
+    loop {
+        match rx.try_recv() {
+            Ok(event) => {
+                if matches!(
+                    forward_live_ledger_event(
+                        ws,
+                        ledger,
+                        event,
+                        baseline_seq,
+                        self_connection_id,
+                        features,
+                        topic_scope,
+                    )
+                    .await,
+                    Err(SendError::Closed | SendError::FatalClosed)
+                ) {
+                    // Writer gone: the null below fails the same way; the
+                    // caller's remaining sends surface the teardown.
+                    break;
+                }
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Lagged(skipped)) => {
+                ws.metrics
+                    .dropped_count
+                    .fetch_add(skipped, Ordering::Relaxed);
+                emit_replay_lossy_opportunistic(ws, ledger, session_id.0.as_str());
+                log_live_forwarder_lag(session_id, skipped, features);
+            }
+            Err(TryRecvError::Closed) => break,
+        }
+    }
+    if let Some(notification) = open_goal_null {
+        let _ = emit_open_goal_null_now(ws, ledger, notification, features);
+    }
+    rx
+}
+
+/// #2062 (codex #2065 rounds 1–3) — emit the open-time goal NULL snapshot,
+/// synchronously, exactly once. THE NULL IS A SNAPSHOT, NOT A COMMAND: it
+/// only needs delivering while nothing newer has been delivered, so instead
+/// of racing newer frames it yields to them.
+///
+/// - EPHEMERAL in content: never appended to the ledger — a reopen is one
+///   client's catch-up state, not session history. The frame carries no
+///   cursor, so no cursor-based recovery exists for it either.
+/// - SUPERSEDED-ABANDON, admission-adjacent (round-3 W2): the #1959 guard
+///   lock is held across the final watermark re-read AND the non-blocking
+///   enqueue. Every producer records its generation under that same lock
+///   BEFORE enqueueing, so either a newer frame's record precedes this
+///   check (→ abandon; the RPC durable path also ledgers unconditionally,
+///   so that newer frame reaches this client via the post-open pump — the
+///   abandon is sound) or its record waits on the lock until the null is
+///   already enqueued (→ wire order null-then-newer, newest wins). The
+///   only residual is an EPHEMERAL-only superseder (accountant repaint,
+///   not ledgered) admitted in this instant whose own lossy enqueue then
+///   drops — the pre-existing spec §9 ephemeral-chip lossiness class,
+///   recovered by the next reopen. There is no parked window: same-
+///   connection RPCs cannot interleave at all (the read loops dispatch
+///   inline-awaited), and spawned turn tasks are exactly what the held
+///   lock serializes against.
+/// - BACKPRESSURE couples to `protocol/replay_lossy` (round-3 PATH B(3)):
+///   a full writer here means the SAME section was already dropping replay
+///   frames. The drop is accounted into the shared dropped-frame counter
+///   and the lossy signal raised opportunistically; the client surfaces
+///   "reconnect to rehydrate" (it performs no automatic resync — verified
+///   in the octoscode reducer), and the reopen it is told to perform
+///   re-emits this snapshot (idempotent null). On the stdio lane this is a
+///   deliberate divergence from the blocking durable enqueue: the null
+///   uses the non-blocking try lane so the supersession check stays atomic
+///   — a drop there is recovered identically.
+fn emit_open_goal_null_now(
+    ws: &WsConnection,
+    ledger: &UiProtocolLedger,
+    notification: UiNotification,
+    features: ConnectionUiFeatures,
+) -> Result<(), SendError> {
+    // Entry admit: records this null's generation as the session watermark
+    // (or abandons immediately when a newer goal frame already admitted).
+    if !goal_event_passes_generation_guard(&notification) {
+        return Ok(());
+    }
+    let (watermark_session, own_generation) = match &notification {
+        UiNotification::SessionGoalCleared(event) => (event.session_id.0.clone(), event.generation),
+        UiNotification::SessionGoalUpdated(event) => (event.session_id.0.clone(), event.generation),
+        _ => (String::new(), 0),
+    };
+    let method = notification.method().to_string();
+    let filter_event = UiProtocolLedgerEvent::Notification(notification.clone());
+    let delivery_metric = ui_protocol_delivery_metric(&filter_event);
+    // Same per-connection capability filter as every other direct send,
+    // against the open's negotiated `features` (exactly like the open's
+    // replay loop), not the WsConnection snapshot.
+    if !live_event_passes_capability_filter(&filter_event, features) {
+        return Ok(());
+    }
+    let rpc = match notification.into_rpc_notification() {
+        Ok(rpc) => rpc,
+        Err(error) => {
+            tracing::warn!(
+                target: "octos::ui_protocol::ws",
+                method = %method,
+                error = %error,
+                "failed to serialize open goal null snapshot"
+            );
+            return Err(SendError::BackpressureDrop);
+        }
+    };
+    let Some(frame) = frame_for(&rpc) else {
+        return Err(SendError::BackpressureDrop);
+    };
+    // Final re-read + enqueue under ONE guard-lock acquisition. No await and
+    // no blocking call happens under the lock (`try_enqueue` is a
+    // non-blocking `try_send` on both lanes).
+    let send_outcome = {
+        let watermarks = goal_event_guard_map()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if own_generation > 0
+            && watermarks
+                .get(watermark_session.as_str())
+                .copied()
+                .unwrap_or(0)
+                > own_generation
+        {
+            tracing::debug!(
+                target: "octos::ui_protocol::ws",
+                method = %method,
+                session_id = %watermark_session,
+                "open goal null snapshot superseded by a newer goal frame; abandoned"
+            );
+            return Ok(());
+        }
+        ws.try_enqueue(frame)
+    };
+    match send_outcome {
+        Ok(()) => {
+            record_ui_protocol_delivery_metric(delivery_metric);
+            Ok(())
+        }
+        Err(SendError::BackpressureDrop) => {
+            // Account the loss into the shared dropped-frame counter (the
+            // same one every backpressure-dropped durable frame feeds) and
+            // raise the lossy signal; the client's recovery action — a
+            // reopen — re-emits this snapshot.
+            ws.metrics.dropped_count.fetch_add(1, Ordering::Relaxed);
+            metrics::counter!("ws.send.drop.backpressure", "method" => method.clone()).increment(1);
+            emit_replay_lossy_opportunistic(ws, ledger, watermark_session.as_str());
+            tracing::warn!(
+                target: "octos::ui_protocol::ws",
+                method = %method,
+                session_id = %watermark_session,
+                "open goal null snapshot dropped under backpressure; replay_lossy raised, \
+                 the next reopen re-emits it"
+            );
+            Err(SendError::BackpressureDrop)
+        }
+        Err(error) => {
+            tracing::debug!(
+                target: "octos::ui_protocol::ws",
+                method = %method,
+                error = ?error,
+                "open goal null snapshot not delivered; connection gone"
+            );
+            Err(error)
+        }
+    }
 }
 
 /// Deliver one live broadcast ledger event to `ws` through the forwarder's
@@ -17647,17 +17852,21 @@ fn log_live_forwarder_lag(session_id: &SessionKey, skipped: u64, features: Conne
 /// closes (peer gone), the broadcast sender is dropped (rare), or the
 /// connection cleanup aborts the handle.
 ///
-/// `open_goal_null` (#2062: a `SessionGoalCleared` built by
-/// `session_goal_hydrate_cleared_event_json` when the open found no goal
-/// bound) is delivered BY THE FORWARDER TASK, after it drains the broadcast
-/// backlog that accumulated during the open handshake and before it pumps
-/// any later event — see the task-body comment for why that position is
-/// the correctness argument (codex #2065 H3).
+/// codex #2065 round-3 PATH B — this is a PUMP ONLY. The #2062 goal null
+/// snapshot and the open-backlog drain both moved onto the open handler
+/// itself (`drain_open_backlog_then_emit_goal_null`), synchronous in the
+/// open sequence; by the time this task starts, the backlog is empty and
+/// the null (if any) is already on the wire. Every await point here (recv,
+/// the offloaded send's capacity park) is cancellable and every enqueue is
+/// an atomic `try_send`, so abort+join retires the lane with no detached
+/// in-flight work — the round-3 W6 hazard (an uncancellable
+/// `spawn_blocking(SyncSender::send)` outliving the abort) is gone by
+/// construction, see `send_durable_offloaded`.
 // Each parameter is an independent piece of the forwarder's runtime state
 // (connection, ledger, replay baseline, negotiated features, broadcast
 // receiver); grouping them would only obscure the per-connection wiring.
 #[allow(clippy::too_many_arguments)]
-async fn spawn_live_forwarder_with_goal_null_snapshot(
+async fn spawn_live_forwarder(
     ws: WsConnection,
     ledger: Arc<UiProtocolLedger>,
     session_id: SessionKey,
@@ -17667,9 +17876,8 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
     topic_scope: Option<String>,
     mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
     forwarders: SharedLiveForwarders,
-    open_goal_null: Option<UiNotification>,
 ) {
-    use tokio::sync::broadcast::error::{RecvError, TryRecvError};
+    use tokio::sync::broadcast::error::RecvError;
 
     // Codex #1336 round-2 BLOCKER 1: keep the per-connection feature
     // snapshot on WsConnection in lockstep with what we received. The
@@ -17686,15 +17894,14 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
     // `projection.envelope.v1` client did not negotiate to receive.
     ws.update_live_features(features);
 
-    // codex #2065 round-2 Z5-lifecycle — retire the PREVIOUS forwarder for
-    // this session BEFORE the replacement exists: abort it and await the
-    // handoff so "one live lane per (connection, session)" holds across
-    // re-opens. The old order (spawn first, abort at insert) left a window
-    // where both pumps could interleave frames onto the same writer queue.
-    // Awaiting the aborted task is bounded: it parks in `recv().await` /
-    // an offloaded send, and cancellation lands at that yield point. The
-    // map lock is NOT held across the await (the old task never touches
-    // the map, but the connection-cleanup path does take this lock).
+    // codex #2065 round-2 Z5-lifecycle — retire any PREVIOUS forwarder for
+    // this session BEFORE the replacement exists, so "one live lane per
+    // (connection, session)" holds across re-opens. The production open
+    // path already retired it even earlier — before the replay baseline
+    // was computed (round-3 W6.1, see `handle_session_open`) — so this is
+    // an idempotent second line of defense for direct callers. abort+join
+    // is a full retirement: cancellation lands at a recv/park await and
+    // enqueues are atomic, so nothing detached survives the join.
     let previous = forwarders.lock().await.remove(&session_id);
     if let Some(previous) = previous {
         previous.abort();
@@ -17703,72 +17910,6 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
 
     let session_for_log = session_id.clone();
     let task = tokio::spawn(async move {
-        // #2062 fix round (codex #2065 H3) — the open-time goal NULL
-        // snapshot must be the LAST goal-state frame of the open sequence
-        // on this connection's one ordered lane (the writer queue this task
-        // feeds). The broadcast subscription was taken BEFORE the open's
-        // replay snapshot, so a goal event that raced the handshake (e.g. a
-        // stale `session/goal/updated` — the pump's ledger-send path does
-        // not run the #1959 generation guard, and the client's `updated`
-        // reducer applies unconditionally) is sitting in `rx` right now and
-        // would otherwise be pumped AFTER a null emitted from
-        // `handle_session_open`, resurrecting the chip the null just
-        // blanked. Drain that backlog FIRST, then deliver the null, then
-        // enter the live pump: every event pumped after this point was
-        // appended after open-completion — genuinely newer state that may
-        // legitimately follow the null. The ordering is positional (by
-        // construction: one task, one writer queue); it does NOT lean on
-        // generation arithmetic, which is process-local runtime state and
-        // resets across restarts.
-        let mut writer_alive = true;
-        loop {
-            match rx.try_recv() {
-                Ok(event) => {
-                    if matches!(
-                        forward_live_ledger_event(
-                            &ws,
-                            &ledger,
-                            event,
-                            baseline_seq,
-                            self_connection_id,
-                            features,
-                            topic_scope.as_deref(),
-                        )
-                        .await,
-                        Err(SendError::Closed | SendError::FatalClosed)
-                    ) {
-                        writer_alive = false;
-                        break;
-                    }
-                }
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Lagged(skipped)) => {
-                    // codex #2065 round-2 Z5-lifecycle — a lag HERE loses
-                    // pre-open history only, and REPLAY (which already ran,
-                    // straight from the durable ledger) is the history
-                    // authority; the broadcast ring is never it. Benign for
-                    // the null's ordering guarantee too: everything the
-                    // client actually received still precedes the null.
-                    // Log for observability, don't pretend to recover.
-                    log_live_forwarder_lag(&session_for_log, skipped, features);
-                }
-                // Broadcast sender gone: still deliver the null below (the
-                // connection writer may well outlive the session bucket);
-                // the pump loop then observes Closed and exits.
-                Err(TryRecvError::Closed) => break,
-            }
-        }
-        if !writer_alive {
-            return;
-        }
-        if let Some(notification) = open_goal_null {
-            // codex #2065 P1 — delivered on the DURABLE lane with a bounded
-            // in-task retry, and the result is checked (a lossy ephemeral
-            // try-send silently dropped under a replay-filled writer queue
-            // would reproduce the exact stale chip this frame exists to
-            // clear). See `send_open_catchup_notification`.
-            let _ = send_open_catchup_notification(&ws, notification, features).await;
-        }
         loop {
             match rx.recv().await {
                 Ok(event) => {
@@ -17783,6 +17924,9 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
                             topic_scope.as_deref(),
                         )
                         .await,
+                        // #924 BLOCK 2: a closed writer OR a latched failure
+                        // both mean further pumps produce FatalClosed
+                        // forever; stop spinning.
                         Err(SendError::Closed | SendError::FatalClosed)
                     ) {
                         break;
@@ -17797,124 +17941,10 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
     });
     // #924 NIT 8: store the full JoinHandle so the connection-cleanup
     // path can `await` the aborted task before pruning idle subscribers.
-    // The previous forwarder (if any) was already retired ABOVE, before
-    // this replacement was spawned (Z5-lifecycle), so this insert never
-    // displaces a live task.
+    // Any previous forwarder was retired ABOVE (and, on the open path,
+    // before the replay baseline), so this insert never displaces a live
+    // task.
     forwarders.lock().await.insert(session_id, task);
-}
-
-/// #2062 (codex #2065 rounds 1–2) — deliver the open-time goal catch-up
-/// notification. THE NULL IS A SNAPSHOT, NOT A COMMAND: it only needs
-/// delivering while nothing newer has been delivered, so this loop never
-/// tries to win a race — it makes the null yield it.
-///
-/// - EPHEMERAL in content: never appended to the ledger — a reopen is one
-///   client's catch-up state, not session history, so reopen spam must not
-///   grow the durable ledger. The frame carries no cursor, so no
-///   `replay_lossy` recovery exists for it either.
-/// - PARK-DON'T-DROP (round-2 Z3): on writer backpressure the frame is
-///   never terminally dropped on a live connection — the loop parks on
-///   [`WsConnection::await_writer_capacity`] (the WS writer's own
-///   `reserve()` readiness; a bounded sleep-probe on stdio, whose
-///   `SyncSender` has no async readiness) and re-attempts. The enqueue
-///   itself is the non-blocking `try_enqueue` on BOTH lanes, so a full
-///   stdio queue parks THIS task, never a blocking `SyncSender::send` on
-///   an executor worker. If the connection dies, delivery is moot; if it
-///   lives, the null lands — or is superseded:
-/// - SUPERSEDED-ABANDON (round-2 Z2): before EVERY attempt the loop
-///   re-reads the session's #1959 watermark and abandons the null the
-///   moment ANY newer goal frame has been admitted (the goal RPC durable
-///   path, the accountant's ephemeral repaint — direct senders that share
-///   this writer queue but not this task, so they cannot be serialized
-///   against a parked null). An abandoned null is CORRECT: a newer
-///   authoritative frame reached the client, so the stale-chip condition
-///   the null exists to fix is already gone. Forwarder-lane frames need no
-///   watermark: the pump runs strictly AFTER this send returns (same
-///   task), so they cannot precede the null on this wire at all.
-///
-/// The entry guard RECORDS this null's generation as the watermark, which
-/// also drops an in-process stale `session/goal/updated` racing an
-/// out-of-band clear at that update's OWN send site. The stamp is
-/// process-local bookkeeping (default-only runtime state, reset across
-/// restarts) — cross-restart ordering still comes from POSITION: after the
-/// replay loop and the open-backlog drain. An unstamped (`generation == 0`)
-/// null cannot be ordered and skips the supersession check (legacy
-/// always-apply semantics, production nulls are always stamped).
-async fn send_open_catchup_notification(
-    ws: &WsConnection,
-    notification: UiNotification,
-    features: ConnectionUiFeatures,
-) -> Result<(), SendError> {
-    if !goal_event_passes_generation_guard(&notification) {
-        return Ok(());
-    }
-    // Supersession identity, captured before the notification is consumed.
-    let (watermark_session, own_generation) = match &notification {
-        UiNotification::SessionGoalCleared(event) => (event.session_id.0.clone(), event.generation),
-        UiNotification::SessionGoalUpdated(event) => (event.session_id.0.clone(), event.generation),
-        _ => (String::new(), 0),
-    };
-    let method = notification.method().to_string();
-    let filter_event = UiProtocolLedgerEvent::Notification(notification.clone());
-    let delivery_metric = ui_protocol_delivery_metric(&filter_event);
-    // Same per-connection capability filter as every other direct send,
-    // against the open's negotiated `features` (exactly like the open's
-    // replay loop does), not the WsConnection snapshot.
-    if !live_event_passes_capability_filter(&filter_event, features) {
-        return Ok(());
-    }
-    let rpc = match notification.into_rpc_notification() {
-        Ok(rpc) => rpc,
-        Err(error) => {
-            tracing::warn!(
-                target: "octos::ui_protocol::ws",
-                method = %method,
-                error = %error,
-                "failed to serialize open catch-up notification"
-            );
-            return Err(SendError::BackpressureDrop);
-        }
-    };
-    let Some(frame) = frame_for(&rpc) else {
-        return Err(SendError::BackpressureDrop);
-    };
-    const CAPACITY_RECHECK_WINDOW: std::time::Duration = std::time::Duration::from_millis(50);
-    loop {
-        if ws.is_failed() {
-            return Err(SendError::FatalClosed);
-        }
-        if own_generation > 0
-            && goal_event_generation_watermark(&watermark_session) > own_generation
-        {
-            tracing::debug!(
-                target: "octos::ui_protocol::ws",
-                method = %method,
-                session_id = %watermark_session,
-                "open catch-up notification superseded by a newer goal frame; abandoned"
-            );
-            return Ok(());
-        }
-        match ws.try_enqueue(frame.clone()) {
-            Ok(()) => {
-                record_ui_protocol_delivery_metric(delivery_metric);
-                return Ok(());
-            }
-            Err(SendError::BackpressureDrop) => {
-                ws.await_writer_capacity(CAPACITY_RECHECK_WINDOW).await;
-            }
-            Err(error) => {
-                // Closed / latched-failed: the connection is gone, delivery
-                // is moot — the next reopen re-emits the snapshot.
-                tracing::debug!(
-                    target: "octos::ui_protocol::ws",
-                    method = %method,
-                    error = ?error,
-                    "open catch-up notification not delivered; connection gone"
-                );
-                return Err(error);
-            }
-        }
-    }
 }
 
 /// Build the Stage-1 v2 projection for one already-durable source event.
@@ -18472,6 +18502,11 @@ async fn open_session_result(
     // materializes (profile-less open), which makes the snapshot fail open
     // (publish without compacting) rather than guess a window.
     let mut open_context_provider: Option<Arc<dyn octos_llm::LlmProvider>> = None;
+    // #2062 codex round-2 Z1 + round-3 W5 — THIS open's goal-store identity,
+    // pinned from INSIDE the registration's own lock when the runtime arm
+    // below registers a scope (see `register_session_ledger_scope`); the
+    // one-lock return makes a registration-to-capture flip unrepresentable.
+    let mut pinned_goal_key: Option<SessionKey> = None;
     if let Some(profile_runtime) =
         resolve_session_profile_runtime(state, active_profile_id.as_deref())
     {
@@ -18505,7 +18540,8 @@ async fn open_session_result(
                 // `replay_after_with_head` below, so this open replays (and
                 // this session's turns later append) under the per-cwd
                 // storage identity. No-op when the store wasn't relocated.
-                register_session_ledger_scope(ledger, &runtime);
+                // The returned key is this open's goal-store pin (W5).
+                pinned_goal_key = Some(register_session_ledger_scope(ledger, &runtime));
                 open_context_provider = Some(
                     peer_lane_provider_for(&params.session_id, &runtime)
                         .unwrap_or_else(|| runtime.profile.llm.clone()),
@@ -18588,16 +18624,13 @@ async fn open_session_result(
     // of event the UPCR-2026-026 surface exists for. Feature-gating is the
     // replay filter's job (`ContextCompaction*` events are dropped for
     // connections without `context_lifecycle`).
-    // #2062 codex round-2 Z1 — pin THIS open's goal-store identity NOW,
-    // immediately after (our) `register_session_ledger_scope` call above,
-    // exactly like the turn path's turn-pinned scoped key: `scoped_goal_key`
-    // resolves through the process-global last-writer-wins cwd map, so a
-    // concurrent same-wire/different-cwd `session/open` can flip it between
-    // here and the null-snapshot computation — suppression would then
-    // inspect the OTHER folder's key and emit a spurious cleared for this
-    // folder's live chip. All downstream goal-null reads use this pinned
-    // key, never a re-resolution.
-    let pinned_goal_key = default_agent_orchestrator().scoped_goal_key(&params.session_id);
+    // Legacy/profile-less opens perform NO scope registration above; there
+    // is no registration for the pin to be atomic with, so a single read of
+    // the current map value is the only meaning available (such sessions
+    // also never register cwd scopes of their own — the read is a plain
+    // wire-id fallthrough unless an earlier profiled open scoped this wire).
+    let pinned_goal_key = pinned_goal_key
+        .unwrap_or_else(|| default_agent_orchestrator().scoped_goal_key(&params.session_id));
     let Some(sessions) = resolve_sessions_for_lookup(
         state,
         connection_profile_id,
@@ -37591,29 +37624,15 @@ fn send_notification_lifecycle_forced_backpressure_fixture(
 /// #1959 process-global watermark map: wire session id → highest goal-frame
 /// generation an admitted `SessionGoalUpdated` / `SessionGoalCleared` has
 /// recorded. Module-scoped (not fn-local in the guard) so the #2062
-/// open-time null snapshot can READ it before every delivery attempt
-/// (superseded-abandon, codex #2065 round-2 Z2).
+/// open-time null snapshot can hold THIS lock across its final
+/// superseded re-check AND its non-blocking enqueue
+/// (`emit_open_goal_null_now`) — every producer records its generation
+/// here BEFORE enqueueing, which is what makes that check-and-send atomic
+/// against them (codex #2065 rounds 2–3).
 static GOAL_EVENT_GENERATION_GUARD: OnceLock<StdMutex<HashMap<String, u64>>> = OnceLock::new();
 
 fn goal_event_guard_map() -> &'static StdMutex<HashMap<String, u64>> {
     GOAL_EVENT_GENERATION_GUARD.get_or_init(|| StdMutex::new(HashMap::new()))
-}
-
-/// codex #2065 round-2 Z2 — read-only view of the #1959 watermark for
-/// `session`: the highest generation any ADMITTED goal frame has recorded
-/// (`0` = nothing recorded / legacy unstamped). The open-time null snapshot
-/// consults this before every delivery attempt and abandons itself the
-/// moment a newer goal frame has been admitted anywhere (the goal RPC
-/// durable path, the accountant's ephemeral repaint) — the null is a
-/// SNAPSHOT, not a command, so it only needs delivering while nothing
-/// newer has reached the client.
-fn goal_event_generation_watermark(session: &str) -> u64 {
-    goal_event_guard_map()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(session)
-        .copied()
-        .unwrap_or(0)
 }
 
 /// #1959 — per-session monotonic guard for goal chip events. Returns `false`

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -17117,45 +17117,52 @@ async fn handle_session_open(
     // data dir, or a serve restart that rebuilt the ledger) leaves this
     // reconnect SILENT about goal state, so a client's cached chip survives —
     // absence-of-message is indistinguishable from message-not-yet-arrived.
-    // Push the SAME `session/goal/cleared` the explicit clear RPC emits
-    // whenever no goal is bound for the resolved (session, profile): now
-    // "removed", "never existed", and "removed while you were away" are one
-    // message (codex `ThreadGoalCleared` parity). Sent EPHEMERAL like the
-    // task snapshot above (one client's catch-up state, not session history —
-    // reopen spam must not grow the durable ledger), AFTER the replay loop so
-    // a replayed stale `session/goal/updated` cannot land behind it on the
-    // wire, and stamped with a fresh #1959 generation so it also outranks one
-    // on the client's ordering rule. When a goal IS bound this emits nothing:
-    // the positive replay/live paths own the chip, and a spurious cleared
-    // would blank a live one.
-    if let Ok(goal_profile_id) = resolve_autonomy_profile_id(
-        Some(&session_id),
-        requested_profile_id.as_deref(),
-        connection_profile_id,
-    ) {
-        if let Some(cleared_json) = default_agent_orchestrator()
-            .session_goal_hydrate_cleared_event_json(&session_id, &goal_profile_id)
-        {
+    // When no goal record exists for this session's goal-store key, build the
+    // SAME `session/goal/cleared` the explicit clear RPC emits: "removed",
+    // "never existed", and "removed while you were away" become one message
+    // (codex `ThreadGoalCleared` parity). When a goal IS bound — under ANY
+    // profile (codex #2065 H1: the chip and its cleared reducer are
+    // session-keyed with no profile check, and goal RPCs may have bound it
+    // under a caller-requested profile this open does not resolve) — this
+    // stays `None`: the positive replay/live paths own the chip, and a
+    // spurious cleared would blank a live one.
+    //
+    // Gated on the same `coding.goal_runtime.v1` capability the goal RPC
+    // surface requires (codex #2065 P2): a client without goal support must
+    // never see goal frames. Built HERE (the open resolved its scope) but
+    // DELIVERED by the live-forwarder task below, which first drains the
+    // broadcast backlog that raced this handshake — the null must be the
+    // LAST goal-state frame of the open sequence (codex #2065 H3; see
+    // `spawn_live_forwarder_with_goal_null_snapshot`).
+    let open_goal_null: Option<UiNotification> = if features.goal_runtime_available() {
+        resolve_autonomy_profile_id(
+            Some(&session_id),
+            requested_profile_id.as_deref(),
+            connection_profile_id,
+        )
+        .ok()
+        .and_then(|goal_profile_id| {
+            default_agent_orchestrator()
+                .session_goal_hydrate_cleared_event_json(&session_id, &goal_profile_id)
+        })
+        .and_then(|cleared_json| {
             match serde_json::from_value::<octos_core::ui_protocol::SessionGoalClearedEvent>(
                 cleared_json,
             ) {
-                Ok(event) => {
-                    let _ = send_notification_ephemeral(
-                        ws,
-                        ledger,
-                        UiNotification::SessionGoalCleared(event),
-                    );
-                }
+                Ok(event) => Some(UiNotification::SessionGoalCleared(event)),
                 Err(error) => {
                     tracing::warn!(
                         %error,
                         session_id = %session_id,
                         "session/open no-goal snapshot produced an unparseable cleared event",
                     );
+                    None
                 }
             }
-        }
-    }
+        })
+    } else {
+        None
+    };
 
     // #1594 follow-up: the SessionOpened NOTIFICATION is a documented
     // capability-discovery path (UPCR-2026-007), so an ingress connection's
@@ -17176,8 +17183,9 @@ async fn handle_session_open(
     // Hand the broadcast receiver to a per-session forwarder. The previous
     // forwarder for this session on this connection (if any) is aborted —
     // a re-`session/open` always restarts the live pump from a fresh
-    // baseline cursor.
-    spawn_live_forwarder(
+    // baseline cursor. The #2062 goal null snapshot rides along: the
+    // forwarder drains the open-raced backlog, then delivers it (H3).
+    spawn_live_forwarder_with_goal_null_snapshot(
         ws.clone(),
         ledger_for_forwarder,
         session_id,
@@ -17188,6 +17196,7 @@ async fn handle_session_open(
         live_profile_scope,
         live_rx,
         live_forwarders.clone(),
+        open_goal_null,
     )
     .await;
     true
@@ -17455,15 +17464,11 @@ fn stdio_session_open_candidate_profile(
         .or_else(|| current_profile_id.map(ToOwned::to_owned))
 }
 
-/// Pump live ledger events for `session_id` into the connection's WS write
-/// channel. Filters out events with `cursor.seq <= baseline_seq` (which
-/// were already shipped via replay) and applies the same capability
-/// gating as the live-emit path. The task ends when the WS write channel
-/// closes (peer gone), the broadcast sender is dropped (rare), or the
-/// connection cleanup aborts the handle.
-// Each parameter is an independent piece of the forwarder's runtime state
-// (connection, ledger, replay baseline, negotiated features, broadcast
-// receiver); grouping them would only obscure the per-connection wiring.
+/// Legacy-signature wrapper over
+/// [`spawn_live_forwarder_with_goal_null_snapshot`] (no open-time goal null
+/// snapshot). The production open path always passes the snapshot slot, so
+/// this survives for the forwarder test suite's many call sites only.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 async fn spawn_live_forwarder(
     ws: WsConnection,
@@ -17482,7 +17487,121 @@ async fn spawn_live_forwarder(
     mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
     forwarders: SharedLiveForwarders,
 ) {
-    use tokio::sync::broadcast::error::RecvError;
+    spawn_live_forwarder_with_goal_null_snapshot(
+        ws,
+        ledger,
+        session_id,
+        baseline_seq,
+        self_connection_id,
+        features,
+        topic_scope,
+        rx,
+        forwarders,
+        None,
+    )
+    .await
+}
+
+/// Deliver one live broadcast ledger event to `ws` through the forwarder's
+/// full filter pipeline: baseline cursor (events `<= baseline_seq` were
+/// already shipped via replay), self-connection dedupe (Codex MUST-FIX-2 —
+/// the originating handler already direct-sent the wire frame on this
+/// connection; other connections still receive it via fan-out), topic
+/// scope, profile scope, v2 projection (before the capability gate so a v2
+/// connection evaluates `EnvelopeV2` while legacy/v1 connections keep the
+/// original event byte-for-byte), and the per-connection capability filter.
+///
+/// Shared by `spawn_live_forwarder_with_goal_null_snapshot`'s open-backlog
+/// drain and its live pump loop (#2062) so the two stay filter-for-filter
+/// identical. `Ok(())` covers "sent", "filtered", AND backpressure
+/// (`send_ledger_event_durable` already opportunistically emits
+/// `replay_lossy`; the caller keeps pumping so a recovered consumer gets
+/// caught up). `Err` is only the #924 BLOCK 2 writer-fatal pair — a closed
+/// writer OR a latched failure both mean further pumps produce FatalClosed
+/// forever, so the caller must stop spinning.
+#[allow(clippy::too_many_arguments)]
+fn forward_live_ledger_event(
+    ws: &WsConnection,
+    ledger: &Arc<UiProtocolLedger>,
+    event: LedgeredUiProtocolEvent,
+    baseline_seq: u64,
+    self_connection_id: ConnectionId,
+    features: ConnectionUiFeatures,
+    topic_scope: Option<&str>,
+) -> Result<(), SendError> {
+    if event.cursor.seq <= baseline_seq {
+        return Ok(());
+    }
+    if event.from_connection == Some(self_connection_id) {
+        return Ok(());
+    }
+    if !ledger_event_matches_topic_scope(&event.event, topic_scope) {
+        return Ok(());
+    }
+    if !ledger_event_matches_profile_scope(&event.event, &ws.snapshot_live_profile_id()) {
+        return Ok(());
+    }
+    let projected = features
+        .projection_envelope_v2
+        .then(|| project_v2_ledger_event(ledger, &event.event, &event.cursor))
+        .flatten();
+    let event_for_wire = projected.unwrap_or(event.event);
+    if !live_event_passes_capability_filter(&event_for_wire, features) {
+        return Ok(());
+    }
+    match send_ledger_event_durable(ws, ledger, event_for_wire) {
+        Err(err @ (SendError::Closed | SendError::FatalClosed)) => Err(err),
+        _ => Ok(()),
+    }
+}
+
+/// Slow consumer fell behind the broadcast ring. The ledger is durable; the
+/// client's cursor is the source of truth and a follow-up session/hydrate
+/// or reconnect with the last cursor catches them up. This is also the
+/// server-side gap detection point for v2: the live projection stream
+/// skipped durable records and the client must rehydrate from its cursor.
+fn log_live_forwarder_lag(session_id: &SessionKey, skipped: u64, features: ConnectionUiFeatures) {
+    if features.projection_envelope_v2 {
+        metrics::counter!("octos_ui_protocol_v2_replay_gap_total").increment(1);
+    }
+    tracing::warn!(
+        target: "octos::ui_protocol::ws",
+        session_id = %session_id.0,
+        skipped_events = skipped,
+        "live ledger forwarder lagged; client must rehydrate via cursor"
+    );
+}
+
+/// Pump live ledger events for `session_id` into the connection's WS write
+/// channel. Filters out events with `cursor.seq <= baseline_seq` (which
+/// were already shipped via replay) and applies the same capability
+/// gating as the live-emit path. The task ends when the WS write channel
+/// closes (peer gone), the broadcast sender is dropped (rare), or the
+/// connection cleanup aborts the handle.
+///
+/// `open_goal_null` (#2062: a `SessionGoalCleared` built by
+/// `session_goal_hydrate_cleared_event_json` when the open found no goal
+/// bound) is delivered BY THE FORWARDER TASK, after it drains the broadcast
+/// backlog that accumulated during the open handshake and before it pumps
+/// any later event — see the task-body comment for why that position is
+/// the correctness argument (codex #2065 H3).
+// Each parameter is an independent piece of the forwarder's runtime state
+// (connection, ledger, replay baseline, negotiated features, broadcast
+// receiver); grouping them would only obscure the per-connection wiring.
+#[allow(clippy::too_many_arguments)]
+async fn spawn_live_forwarder_with_goal_null_snapshot(
+    ws: WsConnection,
+    ledger: Arc<UiProtocolLedger>,
+    session_id: SessionKey,
+    baseline_seq: u64,
+    self_connection_id: ConnectionId,
+    features: ConnectionUiFeatures,
+    topic_scope: Option<String>,
+    mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
+    forwarders: SharedLiveForwarders,
+    open_goal_null: Option<UiNotification>,
+) {
+    use tokio::sync::broadcast::error::{RecvError, TryRecvError};
 
     // Codex #1336 round-2 BLOCKER 1: keep the per-connection feature
     // snapshot on WsConnection in lockstep with what we received. The
@@ -17501,67 +17620,84 @@ async fn spawn_live_forwarder(
 
     let session_for_log = session_id.clone();
     let task = tokio::spawn(async move {
+        // #2062 fix round (codex #2065 H3) — the open-time goal NULL
+        // snapshot must be the LAST goal-state frame of the open sequence
+        // on this connection's one ordered lane (the writer queue this task
+        // feeds). The broadcast subscription was taken BEFORE the open's
+        // replay snapshot, so a goal event that raced the handshake (e.g. a
+        // stale `session/goal/updated` — the pump's ledger-send path does
+        // not run the #1959 generation guard, and the client's `updated`
+        // reducer applies unconditionally) is sitting in `rx` right now and
+        // would otherwise be pumped AFTER a null emitted from
+        // `handle_session_open`, resurrecting the chip the null just
+        // blanked. Drain that backlog FIRST, then deliver the null, then
+        // enter the live pump: every event pumped after this point was
+        // appended after open-completion — genuinely newer state that may
+        // legitimately follow the null. The ordering is positional (by
+        // construction: one task, one writer queue); it does NOT lean on
+        // generation arithmetic, which is process-local runtime state and
+        // resets across restarts.
+        let mut writer_alive = true;
+        loop {
+            match rx.try_recv() {
+                Ok(event) => {
+                    if matches!(
+                        forward_live_ledger_event(
+                            &ws,
+                            &ledger,
+                            event,
+                            baseline_seq,
+                            self_connection_id,
+                            features,
+                            topic_scope.as_deref(),
+                        ),
+                        Err(SendError::Closed | SendError::FatalClosed)
+                    ) {
+                        writer_alive = false;
+                        break;
+                    }
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Lagged(skipped)) => {
+                    log_live_forwarder_lag(&session_for_log, skipped, features);
+                }
+                // Broadcast sender gone: still deliver the null below (the
+                // connection writer may well outlive the session bucket);
+                // the pump loop then observes Closed and exits.
+                Err(TryRecvError::Closed) => break,
+            }
+        }
+        if !writer_alive {
+            return;
+        }
+        if let Some(notification) = open_goal_null {
+            // codex #2065 P1 — delivered on the DURABLE lane with a bounded
+            // in-task retry, and the result is checked (a lossy ephemeral
+            // try-send silently dropped under a replay-filled writer queue
+            // would reproduce the exact stale chip this frame exists to
+            // clear). See `send_open_catchup_notification`.
+            let _ = send_open_catchup_notification(&ws, notification, features).await;
+        }
         loop {
             match rx.recv().await {
                 Ok(event) => {
-                    if event.cursor.seq <= baseline_seq {
-                        continue;
-                    }
-                    // Codex MUST-FIX-2: when the originating handler ran
-                    // on this same connection it already direct-sent the
-                    // wire frame; dropping the broadcast copy here is the
-                    // only way to keep delivery exactly-once. Other
-                    // connections still receive the event via fan-out.
-                    if event.from_connection == Some(self_connection_id) {
-                        continue;
-                    }
-                    if !ledger_event_matches_topic_scope(&event.event, topic_scope.as_deref()) {
-                        continue;
-                    }
-                    if !ledger_event_matches_profile_scope(&event.event, profile_scope.as_deref()) {
-                        continue;
-                    }
-                    // Stage 1 v2 is a wire projection of this existing
-                    // durable record. Do this before filtering so the v2
-                    // gate sees `EnvelopeV2`, while legacy/v1 connections
-                    // keep evaluating the original event byte-for-byte.
-                    let projected = features
-                        .projection_envelope_v2
-                        .then(|| project_v2_ledger_event(&ledger, &event.event, &event.cursor))
-                        .flatten();
-                    let event_for_wire = projected.unwrap_or(event.event);
-                    if !live_event_passes_capability_filter(&event_for_wire, features) {
-                        continue;
-                    }
-                    match send_ledger_event_durable(&ws, &ledger, event_for_wire) {
-                        Ok(()) => {}
-                        // #924 BLOCK 2: a closed writer OR a latched
-                        // failure both mean further pumps will produce
-                        // FatalClosed forever; stop spinning.
-                        Err(SendError::Closed | SendError::FatalClosed) => break,
-                        // BackpressureDrop: `send_ledger_event_durable`
-                        // already opportunistically emits replay_lossy; keep
-                        // pumping so a recovered consumer gets caught up.
-                        Err(_) => {}
+                    if matches!(
+                        forward_live_ledger_event(
+                            &ws,
+                            &ledger,
+                            event,
+                            baseline_seq,
+                            self_connection_id,
+                            features,
+                            topic_scope.as_deref(),
+                        ),
+                        Err(SendError::Closed | SendError::FatalClosed)
+                    ) {
+                        break;
                     }
                 }
                 Err(RecvError::Lagged(skipped)) => {
-                    // Slow consumer fell behind. The ledger is durable; the
-                    // client's cursor is the source of truth and a follow-up
-                    // session/hydrate or reconnect with the last cursor
-                    // catches them up. Log and keep pumping new events.
-                    // This is the server-side gap detection point for v2:
-                    // the live projection stream skipped durable records and
-                    // the client must rehydrate from its cursor.
-                    if features.projection_envelope_v2 {
-                        metrics::counter!("octos_ui_protocol_v2_replay_gap_total").increment(1);
-                    }
-                    tracing::warn!(
-                        target: "octos::ui_protocol::ws",
-                        session_id = %session_for_log.0,
-                        skipped_events = skipped,
-                        "live ledger forwarder lagged; client must rehydrate via cursor"
-                    );
+                    log_live_forwarder_lag(&session_for_log, skipped, features);
                 }
                 Err(RecvError::Closed) => break,
             }
@@ -17577,6 +17713,84 @@ async fn spawn_live_forwarder(
     let mut guard = forwarders.lock().await;
     if let Some(prev) = guard.insert(session_id, task) {
         prev.abort();
+    }
+}
+
+/// #2062 (codex #2065 H3 + P1) — deliver an open-time catch-up
+/// notification: EPHEMERAL in content (never appended to the ledger — a
+/// reopen is one client's catch-up state, not session history, so reopen
+/// spam must not grow the durable ledger) but DURABLE in delivery. The
+/// plain ephemeral lane is a lossy `try_enqueue`, and a writer queue filled
+/// by a large replay would silently drop exactly the no-goal snapshot this
+/// path exists to guarantee — reproducing the stale chip. `send_durable`
+/// gives the stdio transport's blocking enqueue outright; on the WS lane a
+/// full queue is retried on a short bounded backoff (the writer task drains
+/// concurrently while this task — the only sender of goal frames during
+/// the open window — is parked, so the retry cannot reorder against a
+/// newer goal frame). A queue still full after the retries is logged WARN:
+/// the frame carries no cursor, so `replay_lossy` cannot recover it — the
+/// next reopen re-emits the snapshot instead (idempotent null).
+///
+/// The #1959 generation guard still runs so this send RECORDS its
+/// watermark: an in-process stale `session/goal/updated` that races an
+/// out-of-band clear is then dropped at that update's OWN send site. The
+/// guard is process-local (the counter is default-only runtime state, not
+/// restored across restarts) — cross-restart ordering comes from POSITION
+/// (after the replay loop and the open-backlog drain), not from the stamp.
+async fn send_open_catchup_notification(
+    ws: &WsConnection,
+    notification: UiNotification,
+    features: ConnectionUiFeatures,
+) -> Result<(), SendError> {
+    if !goal_event_passes_generation_guard(&notification) {
+        return Ok(());
+    }
+    let method = notification.method().to_string();
+    let filter_event = UiProtocolLedgerEvent::Notification(notification.clone());
+    let delivery_metric = ui_protocol_delivery_metric(&filter_event);
+    // Same per-connection capability filter as every other direct send,
+    // against the open's negotiated `features` (exactly like the open's
+    // replay loop does), not the WsConnection snapshot.
+    if !live_event_passes_capability_filter(&filter_event, features) {
+        return Ok(());
+    }
+    let rpc = match notification.into_rpc_notification() {
+        Ok(rpc) => rpc,
+        Err(error) => {
+            tracing::warn!(
+                target: "octos::ui_protocol::ws",
+                method = %method,
+                error = %error,
+                "failed to serialize open catch-up notification"
+            );
+            return Err(SendError::BackpressureDrop);
+        }
+    };
+    let Some(frame) = frame_for(&rpc) else {
+        return Err(SendError::BackpressureDrop);
+    };
+    const MAX_SEND_ATTEMPTS: u32 = 4;
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        match ws.send_durable(frame.clone(), &method) {
+            Ok(()) => {
+                record_ui_protocol_delivery_metric(delivery_metric);
+                return Ok(());
+            }
+            Err(SendError::BackpressureDrop) if attempt < MAX_SEND_ATTEMPTS => {
+                tokio::time::sleep(std::time::Duration::from_millis(25 * u64::from(attempt))).await;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "octos::ui_protocol::ws",
+                    method = %method,
+                    error = ?error,
+                    "open catch-up notification not delivered; the next reopen re-emits it"
+                );
+                return Err(error);
+            }
+        }
     }
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -802,20 +802,19 @@ impl WsConnection {
         }
     }
 
-    /// codex #2065 round-2 Z3 + round-3 W6 — await-safe durable enqueue for
-    /// the live-forwarder task. The stdio durable lane
-    /// (`enqueue_durable_or_lifecycle`) is a BLOCKING `SyncSender::send`:
-    /// correct backpressure on a blocking-capable caller, an
-    /// executor-worker stall when a full stdio queue parks an async task
-    /// (round-2 Z3) — and a round-3 W6 hazard when hopped to
-    /// `spawn_blocking`, because an in-flight blocking closure survives the
+    /// #2065 — await-safe durable enqueue for the live-forwarder task. The
+    /// stdio durable lane (`enqueue_durable_or_lifecycle`) is a BLOCKING
+    /// `SyncSender::send`: correct backpressure on a blocking-capable
+    /// caller, but an executor-worker stall when a full stdio queue parks
+    /// an async task — and hopping it to `spawn_blocking` trades that for
+    /// a worse hazard, because an in-flight blocking closure survives the
     /// task's abort and can enqueue a stale frame AFTER the lane was
     /// retired. Here the stdio lane instead parks COOPERATIVELY: a
     /// non-blocking `try_send` probe with a bounded async sleep between
     /// probes. That keeps the stdio never-drop durable semantics (the frame
     /// waits for capacity, exactly like the blocking send did), never
-    /// occupies an executor worker, and — the W6 point — is cancellable at
-    /// every await with an ATOMIC enqueue: after abort+join there is no
+    /// occupies an executor worker, and is cancellable at every await with
+    /// an ATOMIC enqueue: after abort+join there is no
     /// detached in-flight work that could still enqueue. The WS lane keeps
     /// its non-blocking `try_send`+`replay_lossy` semantics via
     /// [`Self::send_durable`], byte-identical to the sync callers.
@@ -4000,15 +3999,10 @@ fn combine_typed_prompt_with_transcript(typed_prompt: &str, transcript: &str) ->
 /// MUST be called before the flow replays the session (`session/open` calls
 /// it right after the runtime cache materializes, before
 /// `replay_after_with_head`) so replay and subsequent appends agree.
-/// Returns the goal-store key this open's registration established for the
-/// session key — handed back from INSIDE `set_goal_scope`'s own lock (codex
-/// #2065 round-3 W5), so the caller's pin and the registration are one
-/// acquisition and no concurrent same-wire open can flip the
-/// last-writer-wins map in between.
 fn register_session_ledger_scope(
     ledger: &UiProtocolLedger,
     runtime: &crate::runtime::SessionRuntime,
-) -> SessionKey {
+) {
     let scope = (runtime.sessions_root != runtime.profile.data_dir).then(|| {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
@@ -4028,8 +4022,7 @@ fn register_session_ledger_scope(
     // what makes the goal store isolate cwds exactly as the transcript already
     // does. The goal continuation dispatch strips this scope back to the wire
     // key when it reaches the session runtime / actor.
-    let pinned_goal_key =
-        default_agent_orchestrator().set_goal_scope(&runtime.session_key, scope.clone());
+    let _ = default_agent_orchestrator().set_goal_scope(&runtime.session_key, scope.clone());
     // Topic-suffixed sessions also emit ledger events under their BASE key:
     // the alpha-9 file/visual bridges deliberately strip the `#topic` before
     // appending so base-bucket subscribers see them (see
@@ -4042,7 +4035,6 @@ fn register_session_ledger_scope(
         ledger.set_session_scope(&SessionKey(base.to_owned()), scope.clone());
         let _ = default_agent_orchestrator().set_goal_scope(&SessionKey(base.to_owned()), scope);
     }
-    pinned_goal_key
 }
 
 /// Process-global event ledger.
@@ -17029,20 +17021,20 @@ async fn handle_session_open(
     let session_id_for_subscribe = params.session_id.clone();
     let live_rx = ledger.subscribe(&session_id_for_subscribe);
 
-    // codex #2065 round-3 W6.1 — retire the PREVIOUS forwarder for this
-    // session BEFORE `open_session_result` computes the replay baseline
-    // (order: subscribe new receiver → retire old lane → baseline → replay
-    // → response, carrying the #2062 `goal_state` snapshot → pump). With
-    // the old order the previous pump stayed live through the new replay
-    // window and could deliver a post-baseline event CONCURRENTLY with the
-    // replay that also carries it. abort+join fully retires the lane:
+    // #2065 — retire the PREVIOUS forwarder for this session BEFORE
+    // `open_session_result` computes the replay baseline (order: subscribe
+    // new receiver → retire old lane → baseline → replay → response →
+    // pump). With the old order the previous pump stayed live through the
+    // new replay window and could deliver a post-baseline event
+    // CONCURRENTLY with the replay that also carries it. abort+join fully
+    // retires the lane:
     // every await point in the forwarder (recv, the offloaded send's
     // capacity park) is cancellable, and an enqueue is an atomic
     // `try_send` — there is no detached in-flight segment for the join to
     // miss (see `send_durable_offloaded`).
     //
     // Delivery semantics across the handover are AT-LEAST-ONCE, not
-    // exactly-once (codex #2065 round-4 S5, tracked): a durable frame the
+    // exactly-once (#2065, tracked): a durable frame the
     // old lane already delivered may be re-delivered by this open's replay
     // (the client's `after` cursor lags what was enqueued), and the client
     // merges durable frames by id/cursor — the normal reconnect-replay
@@ -17115,10 +17107,7 @@ async fn handle_session_open(
         }
     };
     // session/open reply is the lifecycle frame that the client blocks on;
-    // if it fails the connection is doomed for this command. The #2062
-    // `goal_state` snapshot rides in it, VERSIONED (round 8): its arrival
-    // position needs no guarantee — the client resolves order by version
-    // (see `SessionOpenResult::goal_state`).
+    // if it fails the connection is doomed for this command.
     if send_rpc_result(ws, id, result).is_err() {
         return false;
     }
@@ -17203,14 +17192,6 @@ async fn handle_session_open(
             }
         }
     }
-
-    // #2062 round 6 — the goal snapshot is carried IN the `session/open`
-    // RPC RESPONSE (`SessionOpenResult::goal_state`, computed in
-    // `open_session_result` against the registration-pinned scoped key):
-    // the response's fixed position in the client's own processing order
-    // makes the snapshot race-free by construction, so this handler emits
-    // NO goal frames of its own — every live goal frame the pump later
-    // delivers is by definition newer and simply overwrites the snapshot.
 
     // #1594 follow-up: the SessionOpened NOTIFICATION is a documented
     // capability-discovery path (UPCR-2026-007), so an ingress connection's
@@ -17556,7 +17537,7 @@ async fn forward_live_ledger_event(
     if !live_event_passes_capability_filter(&event_for_wire, features) {
         return Ok(());
     }
-    // codex #2065 round-2 Z3 / round-3 W6 — await-safe send: a full stdio
+    // #2065 — await-safe send: a full stdio
     // queue parks THIS task cooperatively (non-blocking probe + async
     // sleep), never a blocking `SyncSender::send` on any thread — so the
     // park is cancellable and an abort+join retires it with no detached
@@ -17591,14 +17572,12 @@ fn log_live_forwarder_lag(session_id: &SessionKey, skipped: u64, features: Conne
 /// closes (peer gone), the broadcast sender is dropped (rare), or the
 /// connection cleanup aborts the handle.
 ///
-/// #2062 round 6 — this is a PUMP ONLY: the goal snapshot rides in the
-/// `session/open` RPC response (`SessionOpenResult::goal_state`), so no
-/// goal frames originate here. Every await point (recv, the offloaded
-/// send's capacity park) is cancellable and every enqueue is an atomic
-/// `try_send`, so abort+join retires the lane with no detached in-flight
-/// work — the round-3 W6 hazard (an uncancellable
-/// `spawn_blocking(SyncSender::send)` outliving the abort) is gone by
-/// construction, see `send_durable_offloaded`.
+/// #2065 — every await point here (recv, the offloaded send's capacity
+/// park) is cancellable and every enqueue is an atomic `try_send`, so
+/// abort+join retires the lane with no detached in-flight work: an
+/// uncancellable `spawn_blocking(SyncSender::send)` used to be able to
+/// outlive the abort and enqueue a stale frame onto the replacement lane.
+/// See `send_durable_offloaded`.
 // Each parameter is an independent piece of the forwarder's runtime state
 // (connection, ledger, replay baseline, negotiated features, broadcast
 // receiver); grouping them would only obscure the per-connection wiring.
@@ -17631,11 +17610,11 @@ async fn spawn_live_forwarder(
     // `projection.envelope.v1` client did not negotiate to receive.
     ws.update_live_features(features);
 
-    // codex #2065 round-2 Z5-lifecycle — retire any PREVIOUS forwarder for
+    // #2065 — retire any PREVIOUS forwarder for
     // this session BEFORE the replacement exists, so "one live lane per
     // (connection, session)" holds across re-opens. The production open
     // path already retired it even earlier — before the replay baseline
-    // was computed (round-3 W6.1, see `handle_session_open`) — so this is
+    // was computed (see `handle_session_open`) — so this is
     // an idempotent second line of defense for direct callers. abort+join
     // is a full retirement: cancellation lands at a recv/park await and
     // enqueues are atomic, so nothing detached survives the join.
@@ -18015,14 +17994,13 @@ fn live_event_passes_capability_filter(
             return false;
         }
     }
-    // codex #2065 round-2 Z5 — goal-chip frames are gated on the SAME
+    // #2065 — goal-chip frames are gated on the SAME
     // `coding.goal_runtime.v1` capability the goal RPC surface requires
-    // (`raw_method_feature_gate`). The #2062 null snapshot already gated its
-    // CONSTRUCTION; this arm closes the remaining lanes — session/open
-    // replay, the forwarder's open-backlog drain and live pump, and the
-    // direct sends — all of which funnel through this one filter. A client
-    // that cannot call the goal surface has no chip to maintain and must
-    // see zero goal frames.
+    // (`raw_method_feature_gate`). Every lane that can deliver a
+    // `session/goal/*` frame — session/open replay, the live pump, and the
+    // direct sends — funnels through this one filter, so a client that
+    // cannot call the goal surface has no chip to maintain and sees zero
+    // goal frames instead of ones it would report as unknown.
     if !features.goal_runtime_available() {
         if let UiProtocolLedgerEvent::Notification(
             UiNotification::SessionGoalUpdated(_) | UiNotification::SessionGoalCleared(_),
@@ -18233,11 +18211,6 @@ async fn open_session_result(
     // materializes (profile-less open), which makes the snapshot fail open
     // (publish without compacting) rather than guess a window.
     let mut open_context_provider: Option<Arc<dyn octos_llm::LlmProvider>> = None;
-    // #2062 codex round-2 Z1 + round-3 W5 — THIS open's goal-store identity,
-    // pinned from INSIDE the registration's own lock when the runtime arm
-    // below registers a scope (see `register_session_ledger_scope`); the
-    // one-lock return makes a registration-to-capture flip unrepresentable.
-    let mut pinned_goal_key: Option<SessionKey> = None;
     if let Some(profile_runtime) =
         resolve_session_profile_runtime(state, active_profile_id.as_deref())
     {
@@ -18271,8 +18244,7 @@ async fn open_session_result(
                 // `replay_after_with_head` below, so this open replays (and
                 // this session's turns later append) under the per-cwd
                 // storage identity. No-op when the store wasn't relocated.
-                // The returned key is this open's goal-store pin (W5).
-                pinned_goal_key = Some(register_session_ledger_scope(ledger, &runtime));
+                register_session_ledger_scope(ledger, &runtime);
                 open_context_provider = Some(
                     peer_lane_provider_for(&params.session_id, &runtime)
                         .unwrap_or_else(|| runtime.profile.llm.clone()),
@@ -18355,25 +18327,6 @@ async fn open_session_result(
     // of event the UPCR-2026-026 surface exists for. Feature-gating is the
     // replay filter's job (`ContextCompaction*` events are dropped for
     // connections without `context_lifecycle`).
-    // Legacy/profile-less opens perform NO scope registration above; there
-    // is no registration for the pin to be atomic with, so a single read of
-    // the current map value is the only meaning available (such sessions
-    // also never register cwd scopes of their own — the read is a plain
-    // wire-id fallthrough unless an earlier profiled open scoped this wire).
-    let pinned_goal_key = pinned_goal_key
-        .unwrap_or_else(|| default_agent_orchestrator().scoped_goal_key(&params.session_id));
-    // #2062 round 8 — the goal snapshot's PROFILE resolution, captured here
-    // where `params` lives: the SAME resolution the goal RPC surface uses.
-    // A resolution error resolves to `None` and the snapshot's `goal` stays
-    // `null` (never leak, never fabricate; the open already passed
-    // `validate_session_scope`, so the error arm is effectively
-    // unreachable).
-    let goal_profile_id = resolve_autonomy_profile_id(
-        Some(&params.session_id),
-        params.profile_id.as_deref(),
-        connection_profile_id,
-    )
-    .ok();
     let Some(sessions) = resolve_sessions_for_lookup(
         state,
         connection_profile_id,
@@ -18389,23 +18342,6 @@ async fn open_session_result(
         let data_dir = sessions.data_dir();
         let session = sessions.get_or_create(&params.session_id).await;
         (data_dir, session.messages.clone())
-    };
-    // #2062 round 8 — capture the VERSIONED snapshot (state + the scope's
-    // latest #1959 generation, read under ONE state-lock acquisition so the
-    // pair cannot disagree). Its position in this function no longer
-    // matters for correctness: the version is what lets the client resolve
-    // any arrival order (codex round-7 F1 showed wire order can never carry
-    // freshness — producers release the guard and enqueue later, so
-    // admission order cannot establish enqueue order; the round-7
-    // capture-at-enqueue loop and its stale-shipping bound are deleted).
-    // It sits after the sessions-lock block only so the mid-open tests can
-    // barrier on that lock and pin the pinned-key/versioning behavior at
-    // the production callsite.
-    let goal_state = match goal_profile_id.as_deref() {
-        Some(profile_id) => {
-            default_agent_orchestrator().session_open_goal_state(&pinned_goal_key, profile_id)
-        }
-        None => json!({ "version": 0, "goal": Value::Null }),
     };
     let (context, context_state, open_compaction_events) = appui_context_open_snapshot(
         &data_dir,
@@ -18523,7 +18459,7 @@ async fn open_session_result(
         unreachable!("session/open ledger append returns session/open notification");
     };
     Ok(SessionOpenOutcome {
-        result: SessionOpenResult::new(opened).with_goal_state(goal_state),
+        result: SessionOpenResult::new(opened),
         replay,
         pending_approvals,
         pending_questions,
@@ -37382,35 +37318,31 @@ fn send_notification_lifecycle_forced_backpressure_fixture(
 
 /// #1959 process-global watermark map: SCOPED goal identity → highest
 /// goal-frame generation an admitted `SessionGoalUpdated` /
-/// `SessionGoalCleared` has recorded. Module-scoped (not fn-local in the
-/// guard) because it has TWO consumers: the send guard below, and the
-/// #2062 open-response snapshot
-/// (`send_open_result_with_goal_state_at_enqueue`), which uses the pinned
-/// scope's watermark as its freshness marker and holds THIS lock across
-/// its recheck + non-blocking response enqueue — every producer records
-/// its generation here BEFORE enqueueing, which is what slots the response
-/// into the live total order at its build position (codex #2065 round 7).
+/// `SessionGoalCleared` has recorded.
 ///
-/// codex #2065 round-4 S3 — the key is the SCOPED goal-store key resolved
-/// via [`goal_event_watermark_identity`], NOT the plain wire session id
-/// the frames carry: two cwd scopes can share one wire id, and a
-/// wire-keyed watermark advanced by scope A's clear would falsely drop
-/// scope B's later-delivered-but-earlier-built live repaint at the send
-/// guard (cross-scope suppression among real frames).
+/// #2065 — the key is the SCOPED goal-store key resolved via
+/// [`goal_event_watermark_identity`], NOT the plain wire session id the
+/// frames carry. Two cwd scopes can share one wire session id
+/// (`appui.sessions_in_cwd`), and the guard is strictly monotonic per key:
+/// wire-keyed, one scope's later-ALLOCATED clear advanced the watermark
+/// past a sibling scope's earlier-built repaint, so that repaint was
+/// dropped at the guard and the sibling's live goal chip silently stopped
+/// updating. Per-scope identities keep the two streams independent, which
+/// is what the guard's monotonicity assumption requires.
 static GOAL_EVENT_GENERATION_GUARD: OnceLock<StdMutex<HashMap<String, u64>>> = OnceLock::new();
 
 fn goal_event_guard_map() -> &'static StdMutex<HashMap<String, u64>> {
     GOAL_EVENT_GENERATION_GUARD.get_or_init(|| StdMutex::new(HashMap::new()))
 }
 
-/// codex #2065 round-4 S3 — the #1959 watermark identity for a goal frame:
-/// the SCOPED goal-store key its generation was allocated under (registered
+/// #2065 — the #1959 watermark identity for a goal frame: the SCOPED
+/// goal-store key its generation was allocated under (registered
 /// atomically with the allocation by `next_goal_event_generation` — the
 /// producer's BUILD-TIME key, never a later re-resolution of the
 /// last-writer-wins cwd map, which a concurrent open flips). Falls back to
 /// the plain wire session id for unstamped/unregistered generations
 /// (legacy events, hand-built test frames, FIFO-evicted entries) — exactly
-/// the pre-S3 behavior for exactly the events that predate the registry.
+/// the pre-fix behavior for exactly the events that predate the registry.
 ///
 /// Takes the orchestrator STATE lock briefly; callers must resolve this
 /// BEFORE taking the guard-map lock (the two never nest).
@@ -37642,7 +37574,7 @@ fn send_ledger_event_durable(
 }
 
 /// Async twin of [`send_ledger_event_durable`] for the live-forwarder task
-/// (codex #2065 round-2 Z3 / round-3 W6): identical prep, metrics, and
+/// (#2065): identical prep, metrics, and
 /// `replay_lossy` semantics — keep the two in lockstep — but the enqueue
 /// goes through [`WsConnection::send_durable_offloaded`], whose stdio lane
 /// parks THIS task cooperatively (non-blocking probe + async sleep) instead

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -802,6 +802,68 @@ impl WsConnection {
         }
     }
 
+    /// codex #2065 round-2 Z3 — park until the writer MAY have capacity
+    /// again, or `window` elapses (the caller's cadence for re-checking its
+    /// abandon conditions between attempts). WS lane: the writer channel's
+    /// own `reserve()` readiness — the permit is dropped immediately because
+    /// the caller re-runs its superseded check before actually sending, and
+    /// losing the freed slot to a concurrent sender just re-parks. stdio
+    /// lane: the bounded std `SyncSender` has no async readiness primitive —
+    /// a plain bounded sleep, with the caller's `try_enqueue` as the probe.
+    /// Never blocks an executor worker on either lane.
+    async fn await_writer_capacity(&self, window: std::time::Duration) {
+        if self.stdio_writer.is_some() {
+            tokio::time::sleep(window).await;
+            return;
+        }
+        let _ = tokio::time::timeout(window, self.writer.reserve()).await;
+    }
+
+    /// codex #2065 round-2 Z3 — await-safe durable enqueue for async tasks.
+    /// The stdio durable lane (`enqueue_durable_or_lifecycle`) is a BLOCKING
+    /// `SyncSender::send`: correct backpressure on a blocking-capable
+    /// caller, an executor-worker stall when a full stdio queue parks an
+    /// async task. Here the stdio send hops to the blocking pool instead —
+    /// the caller awaits each hop before its next send, so per-task frame
+    /// order is preserved — while the WS lane keeps its non-blocking
+    /// `try_send` semantics via [`Self::send_durable`].
+    async fn send_durable_offloaded(
+        &self,
+        frame: WsMessage,
+        method: &str,
+    ) -> Result<(), SendError> {
+        if self.stdio_writer.is_none() {
+            return self.send_durable(frame, method);
+        }
+        if self.failed.load(std::sync::atomic::Ordering::Acquire) {
+            return Err(SendError::FatalClosed);
+        }
+        let writer = self
+            .stdio_writer
+            .as_ref()
+            .expect("stdio_writer checked above")
+            .clone();
+        match tokio::task::spawn_blocking(move || writer.send(frame)).await {
+            Ok(Ok(())) => Ok(()),
+            // Disconnected writer, or the blocking pool was torn down at
+            // shutdown — either way the connection is going away; mirror
+            // `send_durable`'s Closed accounting.
+            Ok(Err(_)) | Err(_) => {
+                metrics::counter!("ws.send.drop.closed", "method" => method.to_string())
+                    .increment(1);
+                metrics::counter!("ws.send.error.durable", "method" => method.to_string())
+                    .increment(1);
+                tracing::warn!(
+                    target: "octos::ui_protocol::ws",
+                    method,
+                    reason = "closed",
+                    "durable ws send failed; client gone"
+                );
+                Err(SendError::Closed)
+            }
+        }
+    }
+
     /// Dedicated writer-task loop: drains the channel into the actual sink.
     ///
     /// Exits on the first sink error (peer gone) or once all senders drop.
@@ -17081,6 +17143,10 @@ async fn handle_session_open(
     // event that happened to land between replay and the session/open
     // append, exactly the gap codex flagged.
     let baseline_seq = outcome.replay_baseline_seq;
+    // #2062 codex round-2 Z1 — the open-registration-pinned goal-store key;
+    // the null snapshot below inspects THIS, never a re-resolution of the
+    // last-writer-wins cwd map.
+    let pinned_goal_key = outcome.pinned_goal_key.clone();
     let session_id = match &outcome.opened_event.event {
         UiProtocolLedgerEvent::Notification(UiNotification::SessionOpened(opened)) => {
             opened.session_id.clone()
@@ -17143,7 +17209,7 @@ async fn handle_session_open(
         .ok()
         .and_then(|goal_profile_id| {
             default_agent_orchestrator()
-                .session_goal_hydrate_cleared_event_json(&session_id, &goal_profile_id)
+                .session_goal_hydrate_cleared_event_json(&pinned_goal_key, &goal_profile_id)
         })
         .and_then(|cleared_json| {
             match serde_json::from_value::<octos_core::ui_protocol::SessionGoalClearedEvent>(
@@ -17520,7 +17586,7 @@ async fn spawn_live_forwarder(
 /// writer OR a latched failure both mean further pumps produce FatalClosed
 /// forever, so the caller must stop spinning.
 #[allow(clippy::too_many_arguments)]
-fn forward_live_ledger_event(
+async fn forward_live_ledger_event(
     ws: &WsConnection,
     ledger: &Arc<UiProtocolLedger>,
     event: LedgeredUiProtocolEvent,
@@ -17549,7 +17615,9 @@ fn forward_live_ledger_event(
     if !live_event_passes_capability_filter(&event_for_wire, features) {
         return Ok(());
     }
-    match send_ledger_event_durable(ws, ledger, event_for_wire) {
+    // codex #2065 round-2 Z3 — offloaded send: a full stdio queue parks a
+    // blocking-pool thread, never this async task's executor worker.
+    match send_ledger_event_durable_offloaded(ws, ledger, event_for_wire).await {
         Err(err @ (SendError::Closed | SendError::FatalClosed)) => Err(err),
         _ => Ok(()),
     }
@@ -17618,6 +17686,21 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
     // `projection.envelope.v1` client did not negotiate to receive.
     ws.update_live_features(features);
 
+    // codex #2065 round-2 Z5-lifecycle — retire the PREVIOUS forwarder for
+    // this session BEFORE the replacement exists: abort it and await the
+    // handoff so "one live lane per (connection, session)" holds across
+    // re-opens. The old order (spawn first, abort at insert) left a window
+    // where both pumps could interleave frames onto the same writer queue.
+    // Awaiting the aborted task is bounded: it parks in `recv().await` /
+    // an offloaded send, and cancellation lands at that yield point. The
+    // map lock is NOT held across the await (the old task never touches
+    // the map, but the connection-cleanup path does take this lock).
+    let previous = forwarders.lock().await.remove(&session_id);
+    if let Some(previous) = previous {
+        previous.abort();
+        let _ = previous.await;
+    }
+
     let session_for_log = session_id.clone();
     let task = tokio::spawn(async move {
         // #2062 fix round (codex #2065 H3) — the open-time goal NULL
@@ -17650,7 +17733,8 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
                             self_connection_id,
                             features,
                             topic_scope.as_deref(),
-                        ),
+                        )
+                        .await,
                         Err(SendError::Closed | SendError::FatalClosed)
                     ) {
                         writer_alive = false;
@@ -17659,6 +17743,13 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
                 }
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Lagged(skipped)) => {
+                    // codex #2065 round-2 Z5-lifecycle — a lag HERE loses
+                    // pre-open history only, and REPLAY (which already ran,
+                    // straight from the durable ledger) is the history
+                    // authority; the broadcast ring is never it. Benign for
+                    // the null's ordering guarantee too: everything the
+                    // client actually received still precedes the null.
+                    // Log for observability, don't pretend to recover.
                     log_live_forwarder_lag(&session_for_log, skipped, features);
                 }
                 // Broadcast sender gone: still deliver the null below (the
@@ -17690,7 +17781,8 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
                             self_connection_id,
                             features,
                             topic_scope.as_deref(),
-                        ),
+                        )
+                        .await,
                         Err(SendError::Closed | SendError::FatalClosed)
                     ) {
                         break;
@@ -17704,39 +17796,50 @@ async fn spawn_live_forwarder_with_goal_null_snapshot(
         }
     });
     // #924 NIT 8: store the full JoinHandle so the connection-cleanup
-    // path can `await` the aborted task before pruning idle
-    // subscribers. Replace any prior forwarder for this session on
-    // this connection — re-`session/open` restarts the live pump from
-    // a fresh baseline. The previous handle is aborted + the resulting
-    // JoinHandle dropped on the spot; we don't await here because
-    // re-open is a hot path.
-    let mut guard = forwarders.lock().await;
-    if let Some(prev) = guard.insert(session_id, task) {
-        prev.abort();
-    }
+    // path can `await` the aborted task before pruning idle subscribers.
+    // The previous forwarder (if any) was already retired ABOVE, before
+    // this replacement was spawned (Z5-lifecycle), so this insert never
+    // displaces a live task.
+    forwarders.lock().await.insert(session_id, task);
 }
 
-/// #2062 (codex #2065 H3 + P1) — deliver an open-time catch-up
-/// notification: EPHEMERAL in content (never appended to the ledger — a
-/// reopen is one client's catch-up state, not session history, so reopen
-/// spam must not grow the durable ledger) but DURABLE in delivery. The
-/// plain ephemeral lane is a lossy `try_enqueue`, and a writer queue filled
-/// by a large replay would silently drop exactly the no-goal snapshot this
-/// path exists to guarantee — reproducing the stale chip. `send_durable`
-/// gives the stdio transport's blocking enqueue outright; on the WS lane a
-/// full queue is retried on a short bounded backoff (the writer task drains
-/// concurrently while this task — the only sender of goal frames during
-/// the open window — is parked, so the retry cannot reorder against a
-/// newer goal frame). A queue still full after the retries is logged WARN:
-/// the frame carries no cursor, so `replay_lossy` cannot recover it — the
-/// next reopen re-emits the snapshot instead (idempotent null).
+/// #2062 (codex #2065 rounds 1–2) — deliver the open-time goal catch-up
+/// notification. THE NULL IS A SNAPSHOT, NOT A COMMAND: it only needs
+/// delivering while nothing newer has been delivered, so this loop never
+/// tries to win a race — it makes the null yield it.
 ///
-/// The #1959 generation guard still runs so this send RECORDS its
-/// watermark: an in-process stale `session/goal/updated` that races an
-/// out-of-band clear is then dropped at that update's OWN send site. The
-/// guard is process-local (the counter is default-only runtime state, not
-/// restored across restarts) — cross-restart ordering comes from POSITION
-/// (after the replay loop and the open-backlog drain), not from the stamp.
+/// - EPHEMERAL in content: never appended to the ledger — a reopen is one
+///   client's catch-up state, not session history, so reopen spam must not
+///   grow the durable ledger. The frame carries no cursor, so no
+///   `replay_lossy` recovery exists for it either.
+/// - PARK-DON'T-DROP (round-2 Z3): on writer backpressure the frame is
+///   never terminally dropped on a live connection — the loop parks on
+///   [`WsConnection::await_writer_capacity`] (the WS writer's own
+///   `reserve()` readiness; a bounded sleep-probe on stdio, whose
+///   `SyncSender` has no async readiness) and re-attempts. The enqueue
+///   itself is the non-blocking `try_enqueue` on BOTH lanes, so a full
+///   stdio queue parks THIS task, never a blocking `SyncSender::send` on
+///   an executor worker. If the connection dies, delivery is moot; if it
+///   lives, the null lands — or is superseded:
+/// - SUPERSEDED-ABANDON (round-2 Z2): before EVERY attempt the loop
+///   re-reads the session's #1959 watermark and abandons the null the
+///   moment ANY newer goal frame has been admitted (the goal RPC durable
+///   path, the accountant's ephemeral repaint — direct senders that share
+///   this writer queue but not this task, so they cannot be serialized
+///   against a parked null). An abandoned null is CORRECT: a newer
+///   authoritative frame reached the client, so the stale-chip condition
+///   the null exists to fix is already gone. Forwarder-lane frames need no
+///   watermark: the pump runs strictly AFTER this send returns (same
+///   task), so they cannot precede the null on this wire at all.
+///
+/// The entry guard RECORDS this null's generation as the watermark, which
+/// also drops an in-process stale `session/goal/updated` racing an
+/// out-of-band clear at that update's OWN send site. The stamp is
+/// process-local bookkeeping (default-only runtime state, reset across
+/// restarts) — cross-restart ordering still comes from POSITION: after the
+/// replay loop and the open-backlog drain. An unstamped (`generation == 0`)
+/// null cannot be ordered and skips the supersession check (legacy
+/// always-apply semantics, production nulls are always stamped).
 async fn send_open_catchup_notification(
     ws: &WsConnection,
     notification: UiNotification,
@@ -17745,6 +17848,12 @@ async fn send_open_catchup_notification(
     if !goal_event_passes_generation_guard(&notification) {
         return Ok(());
     }
+    // Supersession identity, captured before the notification is consumed.
+    let (watermark_session, own_generation) = match &notification {
+        UiNotification::SessionGoalCleared(event) => (event.session_id.0.clone(), event.generation),
+        UiNotification::SessionGoalUpdated(event) => (event.session_id.0.clone(), event.generation),
+        _ => (String::new(), 0),
+    };
     let method = notification.method().to_string();
     let filter_event = UiProtocolLedgerEvent::Notification(notification.clone());
     let delivery_metric = ui_protocol_delivery_metric(&filter_event);
@@ -17769,24 +17878,38 @@ async fn send_open_catchup_notification(
     let Some(frame) = frame_for(&rpc) else {
         return Err(SendError::BackpressureDrop);
     };
-    const MAX_SEND_ATTEMPTS: u32 = 4;
-    let mut attempt = 0;
+    const CAPACITY_RECHECK_WINDOW: std::time::Duration = std::time::Duration::from_millis(50);
     loop {
-        attempt += 1;
-        match ws.send_durable(frame.clone(), &method) {
+        if ws.is_failed() {
+            return Err(SendError::FatalClosed);
+        }
+        if own_generation > 0
+            && goal_event_generation_watermark(&watermark_session) > own_generation
+        {
+            tracing::debug!(
+                target: "octos::ui_protocol::ws",
+                method = %method,
+                session_id = %watermark_session,
+                "open catch-up notification superseded by a newer goal frame; abandoned"
+            );
+            return Ok(());
+        }
+        match ws.try_enqueue(frame.clone()) {
             Ok(()) => {
                 record_ui_protocol_delivery_metric(delivery_metric);
                 return Ok(());
             }
-            Err(SendError::BackpressureDrop) if attempt < MAX_SEND_ATTEMPTS => {
-                tokio::time::sleep(std::time::Duration::from_millis(25 * u64::from(attempt))).await;
+            Err(SendError::BackpressureDrop) => {
+                ws.await_writer_capacity(CAPACITY_RECHECK_WINDOW).await;
             }
             Err(error) => {
-                tracing::warn!(
+                // Closed / latched-failed: the connection is gone, delivery
+                // is moot — the next reopen re-emits the snapshot.
+                tracing::debug!(
                     target: "octos::ui_protocol::ws",
                     method = %method,
                     error = ?error,
-                    "open catch-up notification not delivered; the next reopen re-emits it"
+                    "open catch-up notification not delivered; connection gone"
                 );
                 return Err(error);
             }
@@ -18125,6 +18248,22 @@ fn live_event_passes_capability_filter(
             return false;
         }
     }
+    // codex #2065 round-2 Z5 — goal-chip frames are gated on the SAME
+    // `coding.goal_runtime.v1` capability the goal RPC surface requires
+    // (`raw_method_feature_gate`). The #2062 null snapshot already gated its
+    // CONSTRUCTION; this arm closes the remaining lanes — session/open
+    // replay, the forwarder's open-backlog drain and live pump, and the
+    // direct sends — all of which funnel through this one filter. A client
+    // that cannot call the goal surface has no chip to maintain and must
+    // see zero goal frames.
+    if !features.goal_runtime_available() {
+        if let UiProtocolLedgerEvent::Notification(
+            UiNotification::SessionGoalUpdated(_) | UiNotification::SessionGoalCleared(_),
+        ) = event
+        {
+            return false;
+        }
+    }
     // #2019 `event.background_activity.v1` gate. The human sink is a NEW
     // notification shape; a client that did not negotiate it cannot render it
     // and would report "unknown UI protocol notification" — the exact
@@ -18233,6 +18372,13 @@ struct SessionOpenOutcome {
     /// or `None` when its scope is not a tenant boundary and filtering it
     /// would starve it. See `connection_filterable_profile_scope`.
     profile_scope: Option<String>,
+    profile_id: String,
+    /// #2062 codex round-2 Z1 — THIS open's goal-store identity, pinned at
+    /// open-registration time (right after `register_session_ledger_scope`).
+    /// The goal null snapshot inspects THIS key, never a re-resolution of
+    /// the last-writer-wins cwd map that a concurrent same-wire open could
+    /// flip mid-open. Mirrors the turn path's turn-pinned scoped key.
+    pinned_goal_key: SessionKey,
 }
 
 // Threading both the approval store and the (UPCR-2026-023) question store
@@ -18442,6 +18588,16 @@ async fn open_session_result(
     // of event the UPCR-2026-026 surface exists for. Feature-gating is the
     // replay filter's job (`ContextCompaction*` events are dropped for
     // connections without `context_lifecycle`).
+    // #2062 codex round-2 Z1 — pin THIS open's goal-store identity NOW,
+    // immediately after (our) `register_session_ledger_scope` call above,
+    // exactly like the turn path's turn-pinned scoped key: `scoped_goal_key`
+    // resolves through the process-global last-writer-wins cwd map, so a
+    // concurrent same-wire/different-cwd `session/open` can flip it between
+    // here and the null-snapshot computation — suppression would then
+    // inspect the OTHER folder's key and emit a spurious cleared for this
+    // folder's live chip. All downstream goal-null reads use this pinned
+    // key, never a re-resolution.
+    let pinned_goal_key = default_agent_orchestrator().scoped_goal_key(&params.session_id);
     let Some(sessions) = resolve_sessions_for_lookup(
         state,
         connection_profile_id,
@@ -18581,6 +18737,8 @@ async fn open_session_result(
         opened_event,
         replay_baseline_seq,
         profile_scope,
+        profile_id: ledger_profile_id,
+        pinned_goal_key,
     })
 }
 
@@ -37430,6 +37588,34 @@ fn send_notification_lifecycle_forced_backpressure_fixture(
     Err(SendError::LifecycleFailure(reason.into()))
 }
 
+/// #1959 process-global watermark map: wire session id → highest goal-frame
+/// generation an admitted `SessionGoalUpdated` / `SessionGoalCleared` has
+/// recorded. Module-scoped (not fn-local in the guard) so the #2062
+/// open-time null snapshot can READ it before every delivery attempt
+/// (superseded-abandon, codex #2065 round-2 Z2).
+static GOAL_EVENT_GENERATION_GUARD: OnceLock<StdMutex<HashMap<String, u64>>> = OnceLock::new();
+
+fn goal_event_guard_map() -> &'static StdMutex<HashMap<String, u64>> {
+    GOAL_EVENT_GENERATION_GUARD.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+/// codex #2065 round-2 Z2 — read-only view of the #1959 watermark for
+/// `session`: the highest generation any ADMITTED goal frame has recorded
+/// (`0` = nothing recorded / legacy unstamped). The open-time null snapshot
+/// consults this before every delivery attempt and abandons itself the
+/// moment a newer goal frame has been admitted anywhere (the goal RPC
+/// durable path, the accountant's ephemeral repaint) — the null is a
+/// SNAPSHOT, not a command, so it only needs delivering while nothing
+/// newer has reached the client.
+fn goal_event_generation_watermark(session: &str) -> u64 {
+    goal_event_guard_map()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(session)
+        .copied()
+        .unwrap_or(0)
+}
+
 /// #1959 — per-session monotonic guard for goal chip events. Returns `false`
 /// (DROP) when a `SessionGoalUpdated` / `SessionGoalCleared` carries a
 /// `generation` that is not greater than the last goal event already emitted
@@ -37441,15 +37627,14 @@ fn send_notification_lifecycle_forced_backpressure_fixture(
 /// `send_notification_ephemeral` for the interactive update) funnel through
 /// here, so ordering holds regardless of which path an event takes.
 fn goal_event_passes_generation_guard(notification: &UiNotification) -> bool {
-    // fn-local process-global: wire session id -> last emitted goal generation.
-    static GUARD: OnceLock<StdMutex<HashMap<String, u64>>> = OnceLock::new();
     let (session, generation) = match notification {
         UiNotification::SessionGoalUpdated(e) => (e.session_id.0.as_str(), e.generation),
         UiNotification::SessionGoalCleared(e) => (e.session_id.0.as_str(), e.generation),
         _ => return true,
     };
-    let map = GUARD.get_or_init(|| StdMutex::new(HashMap::new()));
-    let mut guard = map.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut guard = goal_event_guard_map()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     goal_event_generation_admits(&mut guard, session, generation)
 }
 
@@ -37630,6 +37815,41 @@ fn send_ledger_event_durable(
         None => return Err(SendError::BackpressureDrop),
     };
     match ws.send_durable(frame, &method) {
+        Ok(()) => {
+            record_ui_protocol_delivery_metric(delivery_metric);
+            if let Some(cursor) = cursor {
+                ws.metrics.record_durable_cursor(&cursor);
+            }
+            Ok(())
+        }
+        Err(SendError::BackpressureDrop) => {
+            if let Some(cursor) = cursor.as_ref() {
+                emit_replay_lossy_opportunistic(ws, ledger, &cursor.stream);
+            }
+            Err(SendError::BackpressureDrop)
+        }
+        Err(other) => Err(other),
+    }
+}
+
+/// Async twin of [`send_ledger_event_durable`] for the live-forwarder task
+/// (codex #2065 round-2 Z3): identical prep, metrics, and `replay_lossy`
+/// semantics — keep the two in lockstep — but the enqueue goes through
+/// [`WsConnection::send_durable_offloaded`], so a full stdio queue parks a
+/// blocking-pool thread instead of stalling an async executor worker.
+async fn send_ledger_event_durable_offloaded(
+    ws: &WsConnection,
+    ledger: &UiProtocolLedger,
+    event: UiProtocolLedgerEvent,
+) -> Result<(), SendError> {
+    let method = ledger_event_method(&event).to_string();
+    let delivery_metric = ui_protocol_delivery_metric(&event);
+    let cursor = ledger_event_cursor(&event);
+    let frame = match frame_from_ledger(event) {
+        Some(frame) => frame,
+        None => return Err(SendError::BackpressureDrop),
+    };
+    match ws.send_durable_offloaded(frame, &method).await {
         Ok(()) => {
             record_ui_protocol_delivery_metric(delivery_metric);
             if let Some(cursor) = cursor {

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -17044,6 +17044,15 @@ async fn handle_session_open(
     // the offloaded send's capacity park) is cancellable, and an enqueue
     // is an atomic `try_send` — there is no detached in-flight segment for
     // the join to miss (see `send_durable_offloaded`).
+    //
+    // Delivery semantics across the handover are AT-LEAST-ONCE, not
+    // exactly-once (codex #2065 round-4 S5, tracked): a durable frame the
+    // old lane already delivered may be re-delivered by this open's replay
+    // (the client's `after` cursor lags what was enqueued), and the client
+    // merges durable frames by id/cursor — the normal reconnect-replay
+    // overlap every reopen already has. What the retire-before-baseline
+    // order guarantees is the absence of CONCURRENT old-pump/new-replay
+    // delivery, not global dedupe.
     let previous_forwarder = live_forwarders
         .lock()
         .await
@@ -17650,47 +17659,78 @@ async fn drain_open_backlog_then_emit_goal_null(
 /// - EPHEMERAL in content: never appended to the ledger — a reopen is one
 ///   client's catch-up state, not session history. The frame carries no
 ///   cursor, so no cursor-based recovery exists for it either.
-/// - SUPERSEDED-ABANDON, admission-adjacent (round-3 W2): the #1959 guard
-///   lock is held across the final watermark re-read AND the non-blocking
-///   enqueue. Every producer records its generation under that same lock
-///   BEFORE enqueueing, so either a newer frame's record precedes this
-///   check (→ abandon; the RPC durable path also ledgers unconditionally,
-///   so that newer frame reaches this client via the post-open pump — the
-///   abandon is sound) or its record waits on the lock until the null is
+/// - SUPERSEDED-ABANDON, admission-adjacent (round-3 W2, round-4 S3): the
+///   #1959 guard lock is held across the final watermark re-read AND the
+///   non-blocking enqueue, and the watermark is keyed by the SCOPED goal
+///   identity (`goal_event_watermark_identity`) — another cwd scope's
+///   frames on the same wire session move a DIFFERENT watermark and can
+///   never abandon this null (cross-scope pollution, the round-4 S3 bug).
+///   Every producer records its generation under that same lock BEFORE
+///   enqueueing, so either a same-scope newer frame's record precedes this
+///   check (→ abandon — sound per-scope: a same-scope superseder implies
+///   the goal now EXISTS under this scope, and RPC-created goals ledger
+///   their positive state durably (`session/goal/set` appends before any
+///   per-connection filtering), so it reaches this client via the
+///   post-open pump) or its record waits on the lock until the null is
 ///   already enqueued (→ wire order null-then-newer, newest wins). The
-///   only residual is an EPHEMERAL-only superseder (accountant repaint,
-///   not ledgered) admitted in this instant whose own lossy enqueue then
-///   drops — the pre-existing spec §9 ephemeral-chip lossiness class,
-///   recovered by the next reopen. There is no parked window: same-
+///   honest residual: a goal created by the model's tool DURING a turn has
+///   ephemeral-only positive frames — if its repaint is admitted in this
+///   instant and then dropped by its own lossy enqueue, the chip stays
+///   empty until the next repaint/reopen — the pre-existing spec §9
+///   ephemeral-chip lossiness class. There is no parked window: same-
 ///   connection RPCs cannot interleave at all (the read loops dispatch
 ///   inline-awaited), and spawned turn tasks are exactly what the held
 ///   lock serializes against.
 /// - BACKPRESSURE couples to `protocol/replay_lossy` (round-3 PATH B(3)):
 ///   a full writer here means the SAME section was already dropping replay
 ///   frames. The drop is accounted into the shared dropped-frame counter
-///   and the lossy signal raised opportunistically; the client surfaces
-///   "reconnect to rehydrate" (it performs no automatic resync — verified
-///   in the octoscode reducer), and the reopen it is told to perform
-///   re-emits this snapshot (idempotent null). On the stdio lane this is a
-///   deliberate divergence from the blocking durable enqueue: the null
-///   uses the non-blocking try lane so the supersession check stays atomic
-///   — a drop there is recovered identically.
+///   and the lossy signal raised opportunistically — and if that emit ALSO
+///   fails on the still-full queue, the debt survives and the live pump's
+///   FIRST action flushes it through the capacity-aware lane (round-4 S2,
+///   `flush_replay_lossy_debt_cooperatively`), so the client always gets
+///   the "reconnect to rehydrate" prompt (it performs no automatic resync
+///   — verified in the octoscode reducer), and the reopen it is told to
+///   perform re-emits this snapshot (idempotent null). On the stdio lane
+///   this is a deliberate divergence from the blocking durable enqueue:
+///   the null uses the non-blocking try lane so the supersession check
+///   stays atomic — a drop there is recovered identically.
 fn emit_open_goal_null_now(
     ws: &WsConnection,
     ledger: &UiProtocolLedger,
     notification: UiNotification,
     features: ConnectionUiFeatures,
 ) -> Result<(), SendError> {
-    // Entry admit: records this null's generation as the session watermark
+    emit_open_goal_null_with_pre_lock_hook(ws, ledger, notification, features, None)
+}
+
+/// Body of [`emit_open_goal_null_now`] with a test seam (codex #2065
+/// round-4 S7): `pre_lock_hook` runs after the entry guard admitted this
+/// null but before the final in-lock recheck — the exact window a spawned
+/// turn task can occupy — so a test can deliver a REAL newer frame there
+/// and pin that the in-lock recheck (not the entry guard) abandons the
+/// null. Production always passes `None`.
+fn emit_open_goal_null_with_pre_lock_hook(
+    ws: &WsConnection,
+    ledger: &UiProtocolLedger,
+    notification: UiNotification,
+    features: ConnectionUiFeatures,
+    pre_lock_hook: Option<&dyn Fn()>,
+) -> Result<(), SendError> {
+    // Entry admit: records this null's generation as its scope's watermark
     // (or abandons immediately when a newer goal frame already admitted).
     if !goal_event_passes_generation_guard(&notification) {
         return Ok(());
     }
-    let (watermark_session, own_generation) = match &notification {
+    let (wire_session, own_generation) = match &notification {
         UiNotification::SessionGoalCleared(event) => (event.session_id.0.clone(), event.generation),
         UiNotification::SessionGoalUpdated(event) => (event.session_id.0.clone(), event.generation),
         _ => (String::new(), 0),
     };
+    // S3: the recheck below compares against the SCOPED watermark identity
+    // (resolved before the guard lock; the orchestrator-state and guard
+    // locks never nest). The wire session id stays for logs + the client-
+    // facing lossy signal.
+    let watermark_identity = goal_event_watermark_identity(&wire_session, own_generation);
     let method = notification.method().to_string();
     let filter_event = UiProtocolLedgerEvent::Notification(notification.clone());
     let delivery_metric = ui_protocol_delivery_metric(&filter_event);
@@ -17715,6 +17755,9 @@ fn emit_open_goal_null_now(
     let Some(frame) = frame_for(&rpc) else {
         return Err(SendError::BackpressureDrop);
     };
+    if let Some(hook) = pre_lock_hook {
+        hook();
+    }
     // Final re-read + enqueue under ONE guard-lock acquisition. No await and
     // no blocking call happens under the lock (`try_enqueue` is a
     // non-blocking `try_send` on both lanes).
@@ -17724,7 +17767,7 @@ fn emit_open_goal_null_now(
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if own_generation > 0
             && watermarks
-                .get(watermark_session.as_str())
+                .get(watermark_identity.as_str())
                 .copied()
                 .unwrap_or(0)
                 > own_generation
@@ -17732,7 +17775,7 @@ fn emit_open_goal_null_now(
             tracing::debug!(
                 target: "octos::ui_protocol::ws",
                 method = %method,
-                session_id = %watermark_session,
+                session_id = %wire_session,
                 "open goal null snapshot superseded by a newer goal frame; abandoned"
             );
             return Ok(());
@@ -17751,11 +17794,11 @@ fn emit_open_goal_null_now(
             // reopen — re-emits this snapshot.
             ws.metrics.dropped_count.fetch_add(1, Ordering::Relaxed);
             metrics::counter!("ws.send.drop.backpressure", "method" => method.clone()).increment(1);
-            emit_replay_lossy_opportunistic(ws, ledger, watermark_session.as_str());
+            emit_replay_lossy_opportunistic(ws, ledger, wire_session.as_str());
             tracing::warn!(
                 target: "octos::ui_protocol::ws",
                 method = %method,
-                session_id = %watermark_session,
+                session_id = %wire_session,
                 "open goal null snapshot dropped under backpressure; replay_lossy raised, \
                  the next reopen re-emits it"
             );
@@ -17820,8 +17863,11 @@ async fn forward_live_ledger_event(
     if !live_event_passes_capability_filter(&event_for_wire, features) {
         return Ok(());
     }
-    // codex #2065 round-2 Z3 — offloaded send: a full stdio queue parks a
-    // blocking-pool thread, never this async task's executor worker.
+    // codex #2065 round-2 Z3 / round-3 W6 — await-safe send: a full stdio
+    // queue parks THIS task cooperatively (non-blocking probe + async
+    // sleep), never a blocking `SyncSender::send` on any thread — so the
+    // park is cancellable and an abort+join retires it with no detached
+    // in-flight work.
     match send_ledger_event_durable_offloaded(ws, ledger, event_for_wire).await {
         Err(err @ (SendError::Closed | SendError::FatalClosed)) => Err(err),
         _ => Ok(()),
@@ -17843,6 +17889,62 @@ fn log_live_forwarder_lag(session_id: &SessionKey, skipped: u64, features: Conne
         skipped_events = skipped,
         "live ledger forwarder lagged; client must rehydrate via cursor"
     );
+}
+
+/// codex #2065 round-4 S2 — deliver any accumulated replay-lossy debt
+/// through a capacity-aware park before the pump forwards its first event.
+///
+/// The debt can otherwise exist with NO delivered signal: the open-section
+/// null (cursorless — no cursor-based recovery exists for it) and even the
+/// `SessionOpened` frame can drop on a full writer, and the opportunistic
+/// lossy emit fails on that same full queue and restores the count; the
+/// ledgered lossy row's broadcast copy is self-connection-deduped, and no
+/// later send was guaranteed to happen. The chain then dead-ended: the
+/// client never saw the "reconnect to rehydrate" prompt, so the dropped
+/// null was never re-emitted. The pump — which already parks cooperatively
+/// on capacity — is the natural retry lane: one ledgered lossy row per
+/// accumulated batch, the frame parked (non-blocking probe + async sleep,
+/// cancellable at every await, atomic enqueue) until delivered. Debt that
+/// accumulates while parked is taken by the next loop pass; a dead
+/// connection makes delivery moot.
+async fn flush_replay_lossy_debt_cooperatively(
+    ws: &WsConnection,
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+) {
+    const CAPACITY_PROBE_WINDOW: std::time::Duration = std::time::Duration::from_millis(15);
+    loop {
+        let dropped = ws.metrics.dropped_count.swap(0, Ordering::Relaxed);
+        if dropped == 0 {
+            return;
+        }
+        let last_cursor = ws.metrics.snapshot_last_cursor();
+        let lossy = UiNotification::ReplayLossy(ReplayLossyEvent {
+            session_id: session_id.clone(),
+            dropped_count: dropped,
+            last_durable_cursor: last_cursor,
+        });
+        // One durable row per batch (same as the opportunistic emitter);
+        // tagged with our connection id so this pump's own broadcast copy
+        // is self-deduped.
+        let event = ledger.append_notification_from(lossy, ws.connection_id);
+        let Some(frame) = frame_from_ledger(event.event) else {
+            return;
+        };
+        loop {
+            if ws.is_failed() {
+                return;
+            }
+            match ws.try_enqueue(frame.clone()) {
+                Ok(()) => break,
+                Err(SendError::BackpressureDrop) => {
+                    tokio::time::sleep(CAPACITY_PROBE_WINDOW).await;
+                }
+                // Closed / latched: the connection is gone, delivery moot.
+                Err(_) => return,
+            }
+        }
+    }
 }
 
 /// Pump live ledger events for `session_id` into the connection's WS write
@@ -17910,6 +18012,16 @@ async fn spawn_live_forwarder(
 
     let session_for_log = session_id.clone();
     let task = tokio::spawn(async move {
+        // codex #2065 round-4 S2 — FIRST action, before forwarding any
+        // event: deliver any pending replay-lossy debt. The open section
+        // can leave debt with NO delivered signal — the null (and even the
+        // SessionOpened frame) dropped on a full writer, and the
+        // opportunistic lossy emit failing on that same full queue and
+        // restoring the count. The pump is the natural retry lane: it
+        // parks cooperatively on capacity, so the "reconnect to rehydrate"
+        // prompt reaches the client as soon as the queue frees, and the
+        // reopen it prompts re-emits the dropped null. Zero new tasks.
+        flush_replay_lossy_debt_cooperatively(&ws, &ledger, &session_for_log).await;
         loop {
             match rx.recv().await {
                 Ok(event) => {
@@ -37621,25 +37733,52 @@ fn send_notification_lifecycle_forced_backpressure_fixture(
     Err(SendError::LifecycleFailure(reason.into()))
 }
 
-/// #1959 process-global watermark map: wire session id → highest goal-frame
-/// generation an admitted `SessionGoalUpdated` / `SessionGoalCleared` has
-/// recorded. Module-scoped (not fn-local in the guard) so the #2062
-/// open-time null snapshot can hold THIS lock across its final
-/// superseded re-check AND its non-blocking enqueue
+/// #1959 process-global watermark map: SCOPED goal identity → highest
+/// goal-frame generation an admitted `SessionGoalUpdated` /
+/// `SessionGoalCleared` has recorded. Module-scoped (not fn-local in the
+/// guard) so the #2062 open-time null snapshot can hold THIS lock across
+/// its final superseded re-check AND its non-blocking enqueue
 /// (`emit_open_goal_null_now`) — every producer records its generation
 /// here BEFORE enqueueing, which is what makes that check-and-send atomic
 /// against them (codex #2065 rounds 2–3).
+///
+/// codex #2065 round-4 S3 — the key is the SCOPED goal-store key resolved
+/// via [`goal_event_watermark_identity`], NOT the plain wire session id
+/// the frames carry: two cwd scopes can share one wire id, and wire-keyed
+/// watermarks let connection B's scope-B repaint (delivered only to B)
+/// advance the watermark that connection A's scope-A null checks — the
+/// null would abandon with A receiving nothing, #2062 surviving through
+/// cross-scope watermark pollution.
 static GOAL_EVENT_GENERATION_GUARD: OnceLock<StdMutex<HashMap<String, u64>>> = OnceLock::new();
 
 fn goal_event_guard_map() -> &'static StdMutex<HashMap<String, u64>> {
     GOAL_EVENT_GENERATION_GUARD.get_or_init(|| StdMutex::new(HashMap::new()))
 }
 
-/// #1959 — per-session monotonic guard for goal chip events. Returns `false`
+/// codex #2065 round-4 S3 — the #1959 watermark identity for a goal frame:
+/// the SCOPED goal-store key its generation was allocated under (registered
+/// atomically with the allocation by `next_goal_event_generation` — the
+/// producer's BUILD-TIME key, never a later re-resolution of the
+/// last-writer-wins cwd map, which a concurrent open flips). Falls back to
+/// the plain wire session id for unstamped/unregistered generations
+/// (legacy events, hand-built test frames, FIFO-evicted entries) — exactly
+/// the pre-S3 behavior for exactly the events that predate the registry.
+///
+/// Takes the orchestrator STATE lock briefly; callers must resolve this
+/// BEFORE taking the guard-map lock (the two never nest).
+fn goal_event_watermark_identity(wire_session: &str, generation: u64) -> String {
+    default_agent_orchestrator()
+        .goal_event_watermark_key(generation)
+        .map(|key| key.0)
+        .unwrap_or_else(|| wire_session.to_owned())
+}
+
+/// #1959 — per-scope monotonic guard for goal chip events. Returns `false`
 /// (DROP) when a `SessionGoalUpdated` / `SessionGoalCleared` carries a
 /// `generation` that is not greater than the last goal event already emitted
-/// for the same wire session — so a stale update that races behind a clear can
-/// never be delivered after it (the client would otherwise resurrect the
+/// for the same SCOPED goal identity (S3; wire-session fallback for
+/// unregistered generations) — so a stale update that races behind a clear
+/// can never be delivered after it (the client would otherwise resurrect the
 /// cleared chip). Non-goal notifications and legacy `generation == 0` events
 /// (older backend, or events built before #1959) always pass. Both direct-send
 /// boundaries (`send_notification_durable` for the RPC-derived clear,
@@ -37651,10 +37790,13 @@ fn goal_event_passes_generation_guard(notification: &UiNotification) -> bool {
         UiNotification::SessionGoalCleared(e) => (e.session_id.0.as_str(), e.generation),
         _ => return true,
     };
+    // S3: resolve the scoped identity FIRST (orchestrator state lock,
+    // released) — then take the guard lock. The two never nest.
+    let identity = goal_event_watermark_identity(session, generation);
     let mut guard = goal_event_guard_map()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    goal_event_generation_admits(&mut guard, session, generation)
+    goal_event_generation_admits(&mut guard, &identity, generation)
 }
 
 /// Pure core of [`goal_event_passes_generation_guard`] (extracted for testing:
@@ -37852,10 +37994,13 @@ fn send_ledger_event_durable(
 }
 
 /// Async twin of [`send_ledger_event_durable`] for the live-forwarder task
-/// (codex #2065 round-2 Z3): identical prep, metrics, and `replay_lossy`
-/// semantics — keep the two in lockstep — but the enqueue goes through
-/// [`WsConnection::send_durable_offloaded`], so a full stdio queue parks a
-/// blocking-pool thread instead of stalling an async executor worker.
+/// (codex #2065 round-2 Z3 / round-3 W6): identical prep, metrics, and
+/// `replay_lossy` semantics — keep the two in lockstep — but the enqueue
+/// goes through [`WsConnection::send_durable_offloaded`], whose stdio lane
+/// parks THIS task cooperatively (non-blocking probe + async sleep) instead
+/// of a blocking `SyncSender::send` — never an executor-worker stall, and
+/// cancellable with an atomic enqueue so abort+join leaves nothing
+/// detached in flight.
 async fn send_ledger_event_durable_offloaded(
     ws: &WsConnection,
     ledger: &UiProtocolLedger,

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -17101,8 +17101,6 @@ async fn handle_session_open(
     if session_ingress {
         filter_capabilities_for_session_ingress(&mut outcome.result.opened.capabilities);
     }
-    let pinned_goal_key = outcome.pinned_goal_key.clone();
-    let goal_profile_id = outcome.goal_profile_id.clone();
     let result = match serde_json::to_value(outcome.result) {
         Ok(result) => result,
         Err(error) => {
@@ -17118,19 +17116,10 @@ async fn handle_session_open(
     };
     // session/open reply is the lifecycle frame that the client blocks on;
     // if it fails the connection is doomed for this command. The #2062
-    // `goal_state` snapshot is captured AT this enqueue (codex
-    // R6-OPEN-SNAPSHOT-ORDER) — see the sender for the two-direction
-    // total-order argument.
-    if send_open_result_with_goal_state_at_enqueue(
-        ws,
-        id,
-        result,
-        &pinned_goal_key,
-        goal_profile_id.as_deref(),
-    )
-    .await
-    .is_err()
-    {
+    // `goal_state` snapshot rides in it, VERSIONED (round 8): its arrival
+    // position needs no guarantee — the client resolves order by version
+    // (see `SessionOpenResult::goal_state`).
+    if send_rpc_result(ws, id, result).is_err() {
         return false;
     }
     // Replay frames are durable: drops surface as `protocol/replay_lossy`
@@ -18151,16 +18140,6 @@ struct SessionOpenOutcome {
     /// would starve it. See `connection_filterable_profile_scope`.
     profile_scope: Option<String>,
     profile_id: String,
-    /// #2062 round 7 — THIS open's goal-store identity, pinned at
-    /// open-registration (the key `set_goal_scope` returns from inside its
-    /// own lock; legacy fallback: one map read). The response's
-    /// `goal_state` is captured against THIS key at enqueue time by
-    /// `send_open_result_with_goal_state_at_enqueue`.
-    pinned_goal_key: SessionKey,
-    /// The open's resolved goal profile (same resolver as the goal RPC
-    /// surface); `None` (resolution error, effectively unreachable) keeps
-    /// the snapshot at `null`.
-    goal_profile_id: Option<String>,
 }
 
 // Threading both the approval store and the (UPCR-2026-023) question store
@@ -18383,19 +18362,12 @@ async fn open_session_result(
     // wire-id fallthrough unless an earlier profiled open scoped this wire).
     let pinned_goal_key = pinned_goal_key
         .unwrap_or_else(|| default_agent_orchestrator().scoped_goal_key(&params.session_id));
-    // #2062 rounds 6–7 — the goal snapshot rides IN this open's RPC
-    // response, but it is CAPTURED AT ENQUEUE, not here (codex
-    // R6-OPEN-SNAPSHOT-ORDER: several awaits separate this point from the
-    // response enqueue, and an already-spawned turn's repaint landing in
-    // that window would make an early-captured snapshot overwrite the
-    // fresher frame backwards on the client). Only the PROFILE RESOLUTION
-    // is captured here, where `params` lives — the SAME resolution the
-    // goal RPC surface uses; a resolution error resolves to `None` and the
-    // snapshot stays `null` (never leak, never fabricate; the open already
-    // passed `validate_session_scope`, so the error arm is effectively
-    // unreachable). The snapshot itself is computed by
-    // `send_open_result_with_goal_state_at_enqueue` against the pinned key
-    // above at the moment the response joins the writer queue.
+    // #2062 round 8 — the goal snapshot's PROFILE resolution, captured here
+    // where `params` lives: the SAME resolution the goal RPC surface uses.
+    // A resolution error resolves to `None` and the snapshot's `goal` stays
+    // `null` (never leak, never fabricate; the open already passed
+    // `validate_session_scope`, so the error arm is effectively
+    // unreachable).
     let goal_profile_id = resolve_autonomy_profile_id(
         Some(&params.session_id),
         params.profile_id.as_deref(),
@@ -18417,6 +18389,23 @@ async fn open_session_result(
         let data_dir = sessions.data_dir();
         let session = sessions.get_or_create(&params.session_id).await;
         (data_dir, session.messages.clone())
+    };
+    // #2062 round 8 — capture the VERSIONED snapshot (state + the scope's
+    // latest #1959 generation, read under ONE state-lock acquisition so the
+    // pair cannot disagree). Its position in this function no longer
+    // matters for correctness: the version is what lets the client resolve
+    // any arrival order (codex round-7 F1 showed wire order can never carry
+    // freshness — producers release the guard and enqueue later, so
+    // admission order cannot establish enqueue order; the round-7
+    // capture-at-enqueue loop and its stale-shipping bound are deleted).
+    // It sits after the sessions-lock block only so the mid-open tests can
+    // barrier on that lock and pin the pinned-key/versioning behavior at
+    // the production callsite.
+    let goal_state = match goal_profile_id.as_deref() {
+        Some(profile_id) => {
+            default_agent_orchestrator().session_open_goal_state(&pinned_goal_key, profile_id)
+        }
+        None => json!({ "version": 0, "goal": Value::Null }),
     };
     let (context, context_state, open_compaction_events) = appui_context_open_snapshot(
         &data_dir,
@@ -18534,7 +18523,7 @@ async fn open_session_result(
         unreachable!("session/open ledger append returns session/open notification");
     };
     Ok(SessionOpenOutcome {
-        result: SessionOpenResult::new(opened),
+        result: SessionOpenResult::new(opened).with_goal_state(goal_state),
         replay,
         pending_approvals,
         pending_questions,
@@ -18542,8 +18531,6 @@ async fn open_session_result(
         replay_baseline_seq,
         profile_scope,
         profile_id: ledger_profile_id,
-        pinned_goal_key,
-        goal_profile_id,
     })
 }
 
@@ -37194,168 +37181,6 @@ fn send_rpc_result(ws: &WsConnection, id: String, result: Value) -> Result<(), S
     match frame_for(&RpcResponse::success(id.clone(), result)) {
         Some(frame) => ws.send_lifecycle(frame),
         None => send_minimal_rpc_error_fallback(ws, Some(id)),
-    }
-}
-
-/// #2062 round 7 (codex R6-OPEN-SNAPSHOT-ORDER) — enqueue the
-/// `session/open` RPC result with its `goal_state` snapshot captured AT
-/// ENQUEUE, not at the round-6 early site several awaits upstream (where an
-/// already-spawned turn's goal repaint could land in the window and the
-/// stale unversioned response would then overwrite the fresher frame
-/// backwards on the client). Response position alone is not snapshot
-/// freshness — the capture must join the writer queue at its build
-/// position.
-///
-/// Per attempt: read the pinned scope's #1959 watermark (guard lock,
-/// released) → snapshot the goal state (orchestrator state lock, released)
-/// → build the frame → under ONE guard-lock acquisition, re-read the
-/// watermark and, if unmoved, `try_enqueue` in-section. Watermark-first
-/// ordering is deliberate: a producer landing between the watermark read
-/// and the snapshot moves the watermark while its mutation is already IN
-/// the snapshot, so the recheck retries with an already-fresh capture —
-/// conservative, never stale.
-///
-/// The two-direction total-order argument (replacing round 6's
-/// fixed-position claim): every goal producer records its generation under
-/// the guard lock BEFORE enqueueing, so a live goal frame either
-/// (a) admitted before this in-section enqueue — the watermark moved, this
-/// loop recaptures, and the response carries state ≥ that frame (client
-/// order frame → response: a fresher-or-equal overwrite, correct); or
-/// (b) admits after — its own enqueue then follows this one on the FIFO
-/// per-connection writer (client order response → frame: newer overwrites,
-/// correct). Out-of-order builds among the frames themselves are already
-/// collapsed by the #1959 send guard. The response therefore slots into
-/// the LIVE total order at its build position. (Replayed HISTORICAL goal
-/// frames ride the client's cursor semantics — snapshot-vs-replay
-/// precedence is the pairing client change's domain.)
-///
-/// Why capture-then-recheck instead of holding a lock across the enqueue:
-/// the lifecycle lane's stdio enqueue is a BLOCKING `SyncSender::send`
-/// (`enqueue_durable_or_lifecycle`), and holding the orchestrator state
-/// lock or the guard lock across a blocking channel send would stall every
-/// goal producer process-wide behind one slow stdio consumer.
-/// `try_enqueue` is non-blocking on both lanes, so the guard-lock section
-/// spans exactly [recheck + try_enqueue].
-///
-/// Lifecycle semantics are preserved per lane: WS backpressure/closed
-/// latch the connection failed exactly like `send_lifecycle`; a full stdio
-/// queue parks cooperatively (the stdio lifecycle lane never drops) and
-/// each retry re-verifies freshness. The recapture loop is bounded: after
-/// `MAX_GOAL_STATE_RECAPTURES` consecutive stale detections (a sustained
-/// same-scope goal-frame storm inside microsecond windows — unreachable in
-/// practice, goal frames are RPC/turn-scale), the freshest capture is
-/// enqueued anyway and the residual at-most-one-frame staleness is logged.
-async fn send_open_result_with_goal_state_at_enqueue(
-    ws: &WsConnection,
-    id: String,
-    mut result: Value,
-    pinned_goal_key: &SessionKey,
-    goal_profile_id: Option<&str>,
-) -> Result<(), SendError> {
-    const MAX_GOAL_STATE_RECAPTURES: u32 = 16;
-    const STDIO_CAPACITY_PROBE_WINDOW: std::time::Duration = std::time::Duration::from_millis(15);
-    enum EnqueueOutcome {
-        Sent,
-        Stale,
-        Full,
-        Failed(SendError),
-    }
-    let mut recaptures: u32 = 0;
-    loop {
-        let expected_watermark = {
-            let watermarks = goal_event_guard_map()
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            watermarks
-                .get(pinned_goal_key.0.as_str())
-                .copied()
-                .unwrap_or(0)
-        };
-        let goal_state = match goal_profile_id {
-            Some(profile_id) => {
-                default_agent_orchestrator().session_open_goal_state(pinned_goal_key, profile_id)
-            }
-            None => Value::Null,
-        };
-        result["goal_state"] = goal_state;
-        let Some(frame) = frame_for(&RpcResponse::success(id.clone(), result.clone())) else {
-            // Oversized result: same fallback as `send_rpc_result`.
-            return send_minimal_rpc_error_fallback(ws, Some(id));
-        };
-        let outcome = {
-            let watermarks = goal_event_guard_map()
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let current = watermarks
-                .get(pinned_goal_key.0.as_str())
-                .copied()
-                .unwrap_or(0);
-            if current != expected_watermark && recaptures < MAX_GOAL_STATE_RECAPTURES {
-                EnqueueOutcome::Stale
-            } else {
-                if current != expected_watermark {
-                    tracing::debug!(
-                        target: "octos::ui_protocol::ws",
-                        session = %pinned_goal_key.0,
-                        recaptures,
-                        "goal_state recapture bound hit; enqueueing the freshest capture"
-                    );
-                }
-                match ws.try_enqueue(frame) {
-                    Ok(()) => EnqueueOutcome::Sent,
-                    Err(SendError::BackpressureDrop) => EnqueueOutcome::Full,
-                    Err(error) => EnqueueOutcome::Failed(error),
-                }
-            }
-        };
-        match outcome {
-            EnqueueOutcome::Sent => return Ok(()),
-            EnqueueOutcome::Stale => {
-                recaptures += 1;
-                continue;
-            }
-            EnqueueOutcome::Full => {
-                if ws.stdio_writer.is_some() {
-                    // The stdio lifecycle lane never drops: park
-                    // cooperatively and retry — the retry re-verifies
-                    // freshness before enqueueing.
-                    tokio::time::sleep(STDIO_CAPACITY_PROBE_WINDOW).await;
-                    continue;
-                }
-                // WS lifecycle backpressure is a connection failure —
-                // mirror `send_lifecycle`'s arm (#922.2).
-                metrics::counter!("ws.send.error.lifecycle").increment(1);
-                tracing::warn!(
-                    target: "octos::ui_protocol::ws",
-                    reason = "backpressure",
-                    "lifecycle ws send failed; aborting connection"
-                );
-                ws.mark_failed();
-                return Err(SendError::LifecycleFailure(
-                    "writer channel full for lifecycle frame".into(),
-                ));
-            }
-            EnqueueOutcome::Failed(SendError::Closed) => {
-                metrics::counter!("ws.send.error.lifecycle").increment(1);
-                tracing::warn!(
-                    target: "octos::ui_protocol::ws",
-                    reason = "closed",
-                    "lifecycle ws send failed; aborting connection"
-                );
-                ws.mark_failed();
-                return Err(SendError::LifecycleFailure(
-                    "writer channel closed for lifecycle frame".into(),
-                ));
-            }
-            EnqueueOutcome::Failed(SendError::FatalClosed) => {
-                // #924 BLOCK 2: a prior lifecycle send already latched the
-                // connection failed; surface the lifecycle-shape error.
-                return Err(SendError::LifecycleFailure(
-                    "connection already latched as failed".into(),
-                ));
-            }
-            EnqueueOutcome::Failed(error) => return Err(error),
-        }
     }
 }
 

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -4597,75 +4597,57 @@ impl InProcessAgentOrchestrator {
         }))
     }
 
-    /// #2062 — `SessionGoalCleared`-shaped NULL snapshot for the session
-    /// (re)open path: `Some(event JSON)` when NO goal record exists for
-    /// `session_id`'s goal-store key, `None` when one IS bound (the positive
-    /// chip state is owned by the durable replay + live update pushes,
-    /// untouched here). Silence is not a goal state: without this, a client
-    /// that cached a chip and reconnects after the goal was cleared
-    /// elsewhere (a second connection, another process on the same data
-    /// dir, or a serve restart that rebuilt the ledger) keeps rendering it.
-    /// "Removed", "never existed", and "removed while you were away" must
-    /// be ONE message — the same payload shape as the explicit
-    /// `session/goal/clear` result (`cleared: true` is what the client's
-    /// single null-the-chip reducer keys on).
+    /// #2062 round 6 — the goal snapshot carried IN the `session/open`
+    /// RESPONSE (the codex-CLI design: its ThreadGoal null snapshot rides
+    /// adjacent to the thread-resume response, ordered by the response
+    /// channel). Returns the goal object (same shape as
+    /// `SessionGoalUpdated`'s `goal` field) when a goal is bound under the
+    /// caller's open-registration-PINNED scoped key AND the open's resolved
+    /// profile; EXPLICIT `Value::Null` otherwise — "no goal", "cleared
+    /// while you were away", and "never existed" are one statement.
     ///
-    /// Suppression is existence-under-ANY-profile, deliberately NOT a
-    /// profile match (codex #2065 H1): goal RPCs can bind under a
-    /// caller-REQUESTED profile while `session/open` resolves the
-    /// connection/auth profile (a bare open resolves `_main`), and the
-    /// client's chip — and its cleared reducer — are SESSION-keyed with no
-    /// profile check. A profile-mismatched "absent" verdict here would
-    /// therefore blank a LIVE chip. The server-side null must be at least
-    /// as conservative as the client-side clearing it triggers. Likewise
-    /// ANY stored status suppresses (a `budget_limited`/`paused` goal is
-    /// frozen for scheduling, not for display).
+    /// WHY THIS IS SOUND where five rounds of ordered-notification delivery
+    /// were not: the response occupies a FIXED position in the client's own
+    /// processing order — the client applies this snapshot while handling
+    /// the open result, BEFORE it processes any subsequently delivered
+    /// frame, and every later goal frame (update or cleared, from ANY
+    /// connection or path) is by definition newer and simply overwrites it.
+    /// There is no race to win, no supersession to detect, and no delivery
+    /// to guarantee beyond the RPC result itself (whose failure fails the
+    /// whole open — already handled). Same-connection ordering is the read
+    /// loops' inline-await dispatch. A snapshot carried this way needs no
+    /// generation, no watermark, and no enqueue — it is a plain
+    /// profile-filtered read under the goal-state lock, and it never
+    /// participates in the #1959 generation space (the round-5 design fell
+    /// to exactly that: nulls consuming generations suppressed each other
+    /// across connections).
     ///
-    /// Emit-only: no goal state is read-modified. The #1959 generation
-    /// bump is process-local bookkeeping with two jobs: (a) recorded as the
-    /// session watermark by `goal_event_passes_generation_guard`, it drops
-    /// an in-process stale update racing an out-of-band clear at that
-    /// update's OWN send site, and (b) the emit site re-reads the watermark
-    /// once more, admission-adjacent under the guard's own lock, and
-    /// ABANDONS this null if any newer goal frame was admitted since it was
-    /// built (superseded-abandon — the null is a snapshot, not a command).
-    /// It is NOT an ordering guarantee: the counter is default-only runtime
-    /// state and resets across restarts, so the caller must order the null
-    /// POSITIONALLY — synchronously in the open sequence, after the replay
-    /// loop and the live-broadcast backlog drain (see
-    /// `drain_open_backlog_then_emit_goal_null`).
+    /// Profile filtering is the leak gate: a goal bound under a DIFFERENT
+    /// profile than this open resolves reads as `null` — the snapshot
+    /// carries objective text, and it goes only to THIS connection, whose
+    /// own `goal/get` equally reports "none". (The round-1 "blank a live
+    /// chip" hazard was a broadcast-channel artifact: this snapshot reaches
+    /// only the connection that opened, so its null describes exactly that
+    /// connection's own view.)
     ///
-    /// codex #2065 round-2 Z1 + round-3 W5 — takes the goal-store key the
-    /// caller PINNED at open-registration time: the key
-    /// [`Self::set_goal_scope`] RETURNS from inside its own lock, so
-    /// registration and capture are one acquisition and a concurrent
-    /// same-wire/different-cwd `session/open` can never flip the
-    /// last-writer-wins map between them. Re-resolving here (or capturing
-    /// via a second `scoped_goal_key` read) would let suppression inspect
-    /// the OTHER folder's key and emit a spurious cleared for this folder's
-    /// live chip. Same discipline as the turn path's turn-pinned scoped
-    /// key. The wire id the client keys the chip by is recovered via
-    /// [`wire_key_from_goal_key`] (a pinned key is the wire id itself, or
-    /// wire id + `\u{0}~cwd-` suffix).
-    pub(crate) fn session_goal_hydrate_cleared_event_json(
+    /// The pinned key is the one [`Self::set_goal_scope`] RETURNS from
+    /// inside its own lock at open-registration (codex round-3 W5) — never
+    /// a later re-resolution of the last-writer-wins cwd map, which a
+    /// concurrent same-wire/different-cwd open can flip.
+    pub(crate) fn session_open_goal_state(
         &self,
         pinned_goal_key: &SessionKey,
         profile_id: &str,
-    ) -> Option<Value> {
-        let mut state = self.state();
-        if state.goals.contains_key(pinned_goal_key) {
-            return None;
+    ) -> Value {
+        let state = self.state();
+        match state
+            .goals
+            .get(pinned_goal_key)
+            .filter(|goal| goal.profile_id == profile_id)
+        {
+            Some(goal) => autonomy_goal_json(goal),
+            None => Value::Null,
         }
-        // S3: watermark identity = the pinned scoped key this null describes.
-        let generation = next_goal_event_generation(&mut state, pinned_goal_key);
-        Some(json!({
-            "session_id": wire_key_from_goal_key(pinned_goal_key),
-            "profile_id": profile_id,
-            "cleared": true,
-            "goal": Value::Null,
-            "generation": generation,
-            "transition_actor": "backend",
-        }))
     }
 
     /// codex #2065 round-4 S3 — the SCOPED goal-store key event
@@ -4674,8 +4656,12 @@ impl InProcessAgentOrchestrator {
     /// its map by this identity (falling back to the plain wire session id
     /// for unstamped/unregistered generations — legacy events, hand-built
     /// test frames, FIFO-evicted entries), so two cwd scopes sharing one
-    /// wire session id keep independent watermarks: scope B's repaint can
-    /// no longer falsely supersede scope A's open-time null snapshot.
+    /// wire session id keep independently monotonic guard streams: scope
+    /// A's clear can no longer falsely drop scope B's
+    /// later-delivered-but-earlier-built live repaint at the send guard.
+    /// (Round 6 note: the open-response goal snapshot does NOT participate
+    /// in this generation space at all — the registry serves the four
+    /// remaining REAL producers: set, clear, token-charge, turn repaint.)
     pub(crate) fn goal_event_watermark_key(&self, generation: u64) -> Option<SessionKey> {
         if generation == 0 {
             return None;

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -12663,10 +12663,7 @@ fn enqueue_agent_terminal_continuations(
     // check skips re-observation, restart-safe); a genuinely re-expanded
     // group gets a new epoch at spawn admission and joins again.
     let join_group_key = agent_continuation_group_id(agent);
-    let join_state = state
-        .scatter_join_state
-        .entry(join_group_key)
-        .or_default();
+    let join_state = state.scatter_join_state.entry(join_group_key).or_default();
     let mut cwd_hasher = std::collections::hash_map::DefaultHasher::new();
     std::hash::Hash::hash(&agent.cwd, &mut cwd_hasher);
     let cwd_hash = std::hash::Hasher::finish(&cwd_hasher);
@@ -12706,10 +12703,7 @@ fn enqueue_agent_terminal_continuations(
     };
     enqueue_and_persist_continuation(state, scatter);
     let join_group_key = agent_continuation_group_id(agent);
-    let join_state = state
-        .scatter_join_state
-        .entry(join_group_key)
-        .or_default();
+    let join_state = state.scatter_join_state.entry(join_group_key).or_default();
     join_state.last_joined_key = Some(join_key);
 }
 

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -1497,7 +1497,20 @@ impl InProcessAgentOrchestrator {
     /// `ledger.set_session_scope` so the goal store and the ledger agree on
     /// each session's cwd scope. Mirrors
     /// [`UiProtocolLedger::set_session_scope`].
-    pub(crate) fn set_goal_scope(&self, session_id: &SessionKey, scope: Option<String>) {
+    /// Returns the goal-store key this registration establishes for
+    /// `session_id`, computed INSIDE the same `goal_scopes` lock acquisition
+    /// (codex #2065 round-3 W5): registration and capture used to be two
+    /// separate lock acquisitions (`set_goal_scope` then `scoped_goal_key`),
+    /// a TOCTOU on a multi-thread runtime — a concurrent same-wire open
+    /// could flip the last-writer-wins map between them and the caller
+    /// would pin the OTHER open's key. A caller that pins the RETURNED key
+    /// cannot observe an interleaved flip; the race is unrepresentable at
+    /// this capture site.
+    pub(crate) fn set_goal_scope(
+        &self,
+        session_id: &SessionKey,
+        scope: Option<String>,
+    ) -> SessionKey {
         // #1973 fix-round 4b — GC snapshot: the scoped-goal keys currently in
         // the store, taken (and the state lock RELEASED) BEFORE the
         // goal_scopes lock — the two locks must never nest in that order
@@ -1508,6 +1521,12 @@ impl InProcessAgentOrchestrator {
             .goal_scopes
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Same injective encoding as `scoped_goal_key`, evaluated under THIS
+        // lock so it reflects exactly the registration below.
+        let registered_key = match scope.as_deref() {
+            Some(scope) => SessionKey(format!("{}\u{0}~cwd-{scope}", session_id.0)),
+            None => session_id.clone(),
+        };
         let changed = match scope {
             Some(scope) => {
                 self.mark_scope_wire_live(session_id);
@@ -1522,6 +1541,7 @@ impl InProcessAgentOrchestrator {
         if changed {
             self.persist_goal_scopes_locked(&scopes, Some(&gc_live_goal_keys));
         }
+        registered_key
     }
 
     /// PR 4b — register `scope` for `session_id` ONLY when no scope is registered
@@ -4602,20 +4622,23 @@ impl InProcessAgentOrchestrator {
     /// bump is process-local bookkeeping with two jobs: (a) recorded as the
     /// session watermark by `goal_event_passes_generation_guard`, it drops
     /// an in-process stale update racing an out-of-band clear at that
-    /// update's OWN send site, and (b) the delivery loop re-reads the
-    /// watermark before every attempt and ABANDONS this null once any newer
-    /// goal frame was admitted (superseded-abandon — the null is a
-    /// snapshot, not a command). It is NOT an ordering guarantee: the
-    /// counter is default-only runtime state and resets across restarts, so
-    /// the caller must order the null POSITIONALLY — after the open's
-    /// replay loop and after the live-broadcast backlog drain (see
-    /// `spawn_live_forwarder_with_goal_null_snapshot`).
+    /// update's OWN send site, and (b) the emit site re-reads the watermark
+    /// once more, admission-adjacent under the guard's own lock, and
+    /// ABANDONS this null if any newer goal frame was admitted since it was
+    /// built (superseded-abandon — the null is a snapshot, not a command).
+    /// It is NOT an ordering guarantee: the counter is default-only runtime
+    /// state and resets across restarts, so the caller must order the null
+    /// POSITIONALLY — synchronously in the open sequence, after the replay
+    /// loop and the live-broadcast backlog drain (see
+    /// `drain_open_backlog_then_emit_goal_null`).
     ///
-    /// codex #2065 round-2 Z1 — takes the goal-store key the caller PINNED
-    /// at open-registration time instead of a wire id this fn would
-    /// re-resolve: `scoped_goal_key` reads the process-global
-    /// last-writer-wins cwd map, which a concurrent same-wire/different-cwd
-    /// `session/open` can flip mid-open — suppression would then inspect
+    /// codex #2065 round-2 Z1 + round-3 W5 — takes the goal-store key the
+    /// caller PINNED at open-registration time: the key
+    /// [`Self::set_goal_scope`] RETURNS from inside its own lock, so
+    /// registration and capture are one acquisition and a concurrent
+    /// same-wire/different-cwd `session/open` can never flip the
+    /// last-writer-wins map between them. Re-resolving here (or capturing
+    /// via a second `scoped_goal_key` read) would let suppression inspect
     /// the OTHER folder's key and emit a spurious cleared for this folder's
     /// live chip. Same discipline as the turn path's turn-pinned scoped
     /// key. The wire id the client keys the chip by is recovered via

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -4597,38 +4597,37 @@ impl InProcessAgentOrchestrator {
         }))
     }
 
-    /// #2062 round 6 — the goal snapshot carried IN the `session/open`
-    /// RESPONSE (the codex-CLI design: its ThreadGoal null snapshot rides
-    /// adjacent to the thread-resume response, ordered by the response
-    /// channel). Returns the goal object (same shape as
-    /// `SessionGoalUpdated`'s `goal` field) when a goal is bound under the
-    /// caller's open-registration-PINNED scoped key AND the open's resolved
-    /// profile; EXPLICIT `Value::Null` otherwise — "no goal", "cleared
-    /// while you were away", and "never existed" are one statement.
+    /// #2062 rounds 6–8 — the VERSIONED goal snapshot carried IN the
+    /// `session/open` RESPONSE: `{ "version": u64, "goal": object|null }`.
+    /// `goal` is the goal object (same shape as `SessionGoalUpdated`'s
+    /// `goal` field) when one is bound under the caller's
+    /// open-registration-PINNED scoped key AND the open's resolved profile,
+    /// else `null` — "no goal", "cleared while you were away", and "never
+    /// existed" are one statement. `version` is the scope's LATEST #1959
+    /// generation (`goal_scope_versions`, recorded atomically with every
+    /// allocation) — the SAME number space stamped on outgoing
+    /// `SessionGoalUpdated`/`SessionGoalCleared` frames, so the client can
+    /// compare snapshot and frames apples-to-apples.
     ///
-    /// WHY THIS IS SOUND where five rounds of ordered-notification delivery
-    /// were not: the response occupies a FIXED position in the client's own
-    /// processing order — the client applies this snapshot while handling
-    /// the open result, BEFORE it processes any subsequently delivered
-    /// frame, and every later goal frame (update or cleared, from ANY
-    /// connection or path) is by definition newer and simply overwrites it.
-    /// There is no race to win, no supersession to detect, and no delivery
-    /// to guarantee beyond the RPC result itself (whose failure fails the
-    /// whole open — already handled). Same-connection ordering is the read
-    /// loops' inline-await dispatch. A snapshot carried this way needs no
-    /// generation, no watermark, and no enqueue — it is a plain
-    /// profile-filtered read under the goal-state lock, and it never
-    /// participates in the #1959 generation space (the round-5 design fell
-    /// to exactly that: nulls consuming generations suppressed each other
-    /// across connections).
+    /// WHY VERSIONING, not wire ordering (codex round-7 F1 terminated the
+    /// ordering family): producers release the #1959 guard and enqueue
+    /// LATER, after ledger/filter/serialization work — admission order can
+    /// never establish enqueue order, so NO server-side scheme (five
+    /// notification rounds, response position, capture-at-enqueue) can make
+    /// wire order carry freshness without holding a lock across a blocking
+    /// stdio send, which stalls every goal producer. So the wire stops
+    /// carrying order: the DATA carries it. State and version are read
+    /// under ONE state-lock acquisition (the pair cannot disagree), the
+    /// response is enqueued wherever convenient, and the client resolves
+    /// any arrival order by version — see `SessionOpenResult::goal_state`
+    /// in octos-core for the client-side contract.
     ///
     /// Profile filtering is the leak gate: a goal bound under a DIFFERENT
-    /// profile than this open resolves reads as `null` — the snapshot
+    /// profile than this open resolves reads as `goal: null` — the snapshot
     /// carries objective text, and it goes only to THIS connection, whose
-    /// own `goal/get` equally reports "none". (The round-1 "blank a live
-    /// chip" hazard was a broadcast-channel artifact: this snapshot reaches
-    /// only the connection that opened, so its null describes exactly that
-    /// connection's own view.)
+    /// own `goal/get` equally reports "none". (The version still reflects
+    /// the scope's latest allocation: the null is versioned exactly like a
+    /// cleared state, so a stale pre-clear frame can never beat it.)
     ///
     /// The pinned key is the one [`Self::set_goal_scope`] RETURNS from
     /// inside its own lock at open-registration (codex round-3 W5) — never
@@ -4639,15 +4638,25 @@ impl InProcessAgentOrchestrator {
         pinned_goal_key: &SessionKey,
         profile_id: &str,
     ) -> Value {
+        // ONE lock acquisition for BOTH reads: the (version, state) pair is
+        // internally consistent by construction — a producer cannot
+        // interleave between them (every mutation + its version allocation
+        // happen under this same lock).
         let state = self.state();
-        match state
+        let version = state
+            .goal_scope_versions
+            .get(pinned_goal_key)
+            .copied()
+            .unwrap_or(0);
+        let goal = match state
             .goals
             .get(pinned_goal_key)
             .filter(|goal| goal.profile_id == profile_id)
         {
             Some(goal) => autonomy_goal_json(goal),
             None => Value::Null,
-        }
+        };
+        json!({ "version": version, "goal": goal })
     }
 
     /// codex #2065 round-4 S3 — the SCOPED goal-store key event
@@ -4659,9 +4668,10 @@ impl InProcessAgentOrchestrator {
     /// wire session id keep independently monotonic guard streams: scope
     /// A's clear can no longer falsely drop scope B's
     /// later-delivered-but-earlier-built live repaint at the send guard.
-    /// (Round 6 note: the open-response goal snapshot does NOT participate
-    /// in this generation space at all — the registry serves the four
-    /// remaining REAL producers: set, clear, token-charge, turn repaint.)
+    /// (Round 8 note: the open-response goal snapshot never ALLOCATES in
+    /// this generation space — the four real producers do: set, clear,
+    /// token-charge, turn repaint. The snapshot only READS the scope's
+    /// latest allocation as its `version`, via `goal_scope_versions`.)
     pub(crate) fn goal_event_watermark_key(&self, generation: u64) -> Option<SessionKey> {
         if generation == 0 {
             return None;
@@ -11175,12 +11185,26 @@ struct AutonomyRuntimeState {
     /// event was built from, registered atomically with the allocation (same
     /// state lock). The transport's #1959 watermark is keyed by THIS
     /// identity, not the plain wire session id: two cwd scopes can share a
-    /// wire id, and wire-keyed watermarks let one folder's repaint falsely
-    /// abandon the other folder's open-time null snapshot (cross-scope
-    /// pollution). Bounded FIFO — see `next_goal_event_generation`.
+    /// wire id, and a wire-keyed watermark advanced by one scope's clear
+    /// would falsely drop the sibling scope's later-delivered live repaint
+    /// at the send guard. Bounded FIFO — see `next_goal_event_generation`.
     goal_event_scope_index: HashMap<u64, SessionKey>,
     /// FIFO eviction order for [`Self::goal_event_scope_index`].
     goal_event_scope_fifo: std::collections::VecDeque<u64>,
+    /// #2062 round 8 — SCOPED goal-store key → the LATEST #1959 generation
+    /// allocated for that scope, recorded atomically with the allocation
+    /// (same state lock). This is the VERSION the `session/open` response's
+    /// `goal_state` snapshot pairs with its state: allocation-time
+    /// bookkeeping covers out-of-band mutations that never emit a frame
+    /// (an orchestrator-direct clear still allocates), which
+    /// admission-time bookkeeping (the transport guard's watermark) does
+    /// not. Same number space as the `generation` stamped on outgoing
+    /// `SessionGoalUpdated`/`SessionGoalCleared` frames, so client-side
+    /// version comparison is apples-to-apples. Bounded like the #1959
+    /// guard map: when huge, cleared wholesale (an evicted scope reads 0 —
+    /// pre-versioning behavior for scopes idle across thousands of
+    /// allocations).
+    goal_scope_versions: HashMap<SessionKey, u64>,
     /// #991 / M15-B — per-agent cancellation handles registered by
     /// `run_native_specialist` (and future specialist runners) so that
     /// `interrupt_agent` / `close_agent` can signal a *real* abort to
@@ -13603,6 +13627,20 @@ fn next_goal_event_generation(state: &mut AutonomyRuntimeState, watermark_key: &
             state.goal_event_scope_index.remove(&evicted);
         }
     }
+    // #2062 round 8 — record this allocation as the scope's LATEST version,
+    // in the same state-lock hold, so the open-response snapshot can pair
+    // its state with the exact version it was read at (see
+    // `goal_scope_versions`). Bounded like the #1959 guard map: reset when
+    // huge rather than leak (an evicted scope reads 0 until it allocates
+    // again).
+    if state.goal_scope_versions.len() >= GOAL_EVENT_SCOPE_INDEX_CAP
+        && !state.goal_scope_versions.contains_key(watermark_key)
+    {
+        state.goal_scope_versions.clear();
+    }
+    state
+        .goal_scope_versions
+        .insert(watermark_key.clone(), generation);
     generation
 }
 

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -4575,21 +4575,38 @@ impl InProcessAgentOrchestrator {
     }
 
     /// #2062 — `SessionGoalCleared`-shaped NULL snapshot for the session
-    /// (re)open path: `Some(event JSON)` when NO goal is bound to
-    /// `session_id` for `profile_id`, `None` when a goal IS bound (the
-    /// positive chip state is owned by the durable replay + live update
-    /// pushes, untouched here). Silence is not a goal state: without this,
-    /// a client that cached a chip and reconnects after the goal was
-    /// cleared elsewhere (a second connection, another process on the same
-    /// data dir, or a serve restart that rebuilt the ledger) keeps
-    /// rendering it. "Removed", "never existed", and "removed while you
-    /// were away" must be ONE message — the same payload shape as the
-    /// explicit `session/goal/clear` result (`cleared: true` is what the
-    /// client's single null-the-chip reducer keys on).
+    /// (re)open path: `Some(event JSON)` when NO goal record exists for
+    /// `session_id`'s goal-store key, `None` when one IS bound (the positive
+    /// chip state is owned by the durable replay + live update pushes,
+    /// untouched here). Silence is not a goal state: without this, a client
+    /// that cached a chip and reconnects after the goal was cleared
+    /// elsewhere (a second connection, another process on the same data
+    /// dir, or a serve restart that rebuilt the ledger) keeps rendering it.
+    /// "Removed", "never existed", and "removed while you were away" must
+    /// be ONE message — the same payload shape as the explicit
+    /// `session/goal/clear` result (`cleared: true` is what the client's
+    /// single null-the-chip reducer keys on).
+    ///
+    /// Suppression is existence-under-ANY-profile, deliberately NOT a
+    /// profile match (codex #2065 H1): goal RPCs can bind under a
+    /// caller-REQUESTED profile while `session/open` resolves the
+    /// connection/auth profile (a bare open resolves `_main`), and the
+    /// client's chip — and its cleared reducer — are SESSION-keyed with no
+    /// profile check. A profile-mismatched "absent" verdict here would
+    /// therefore blank a LIVE chip. The server-side null must be at least
+    /// as conservative as the client-side clearing it triggers. Likewise
+    /// ANY stored status suppresses (a `budget_limited`/`paused` goal is
+    /// frozen for scheduling, not for display).
     ///
     /// Emit-only: no goal state is read-modified. The #1959 generation
-    /// bump is the shared ordering stamp EVERY goal chip event must carry —
-    /// an unstamped `0` would let a replayed stale update outrank the null.
+    /// bump is the process-local watermark stamp every goal chip event
+    /// carries so `goal_event_passes_generation_guard` can drop an
+    /// in-process stale update that races an out-of-band clear at that
+    /// update's OWN send site. It is NOT an ordering guarantee: the counter
+    /// is default-only runtime state and resets across restarts, so the
+    /// caller must order the null POSITIONALLY — after the open's replay
+    /// loop and after the live-broadcast backlog drain (see
+    /// `spawn_live_forwarder_with_goal_null_snapshot`).
     pub(crate) fn session_goal_hydrate_cleared_event_json(
         &self,
         session_id: &SessionKey,
@@ -4597,16 +4614,10 @@ impl InProcessAgentOrchestrator {
     ) -> Option<Value> {
         // #1666 residue — same scoped-store lookup as `clear_goal_impl`, so
         // folder A's bound goal never reads as "unbound" through folder B's
-        // reuse of the wire id. A goal bound under a DIFFERENT profile also
-        // renders as unbound: this connection's profile can never see that
-        // goal, so its null is truthful (and keeps the chip tenant-scoped).
+        // reuse of the wire id.
         let key = self.scoped_goal_key(session_id);
         let mut state = self.state();
-        if state
-            .goals
-            .get(&key)
-            .is_some_and(|goal| goal.profile_id == profile_id)
-        {
+        if state.goals.contains_key(&key) {
             return None;
         }
         let generation = next_goal_event_generation(&mut state);

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -4599,30 +4599,40 @@ impl InProcessAgentOrchestrator {
     /// frozen for scheduling, not for display).
     ///
     /// Emit-only: no goal state is read-modified. The #1959 generation
-    /// bump is the process-local watermark stamp every goal chip event
-    /// carries so `goal_event_passes_generation_guard` can drop an
-    /// in-process stale update that races an out-of-band clear at that
-    /// update's OWN send site. It is NOT an ordering guarantee: the counter
-    /// is default-only runtime state and resets across restarts, so the
-    /// caller must order the null POSITIONALLY — after the open's replay
-    /// loop and after the live-broadcast backlog drain (see
+    /// bump is process-local bookkeeping with two jobs: (a) recorded as the
+    /// session watermark by `goal_event_passes_generation_guard`, it drops
+    /// an in-process stale update racing an out-of-band clear at that
+    /// update's OWN send site, and (b) the delivery loop re-reads the
+    /// watermark before every attempt and ABANDONS this null once any newer
+    /// goal frame was admitted (superseded-abandon — the null is a
+    /// snapshot, not a command). It is NOT an ordering guarantee: the
+    /// counter is default-only runtime state and resets across restarts, so
+    /// the caller must order the null POSITIONALLY — after the open's
+    /// replay loop and after the live-broadcast backlog drain (see
     /// `spawn_live_forwarder_with_goal_null_snapshot`).
+    ///
+    /// codex #2065 round-2 Z1 — takes the goal-store key the caller PINNED
+    /// at open-registration time instead of a wire id this fn would
+    /// re-resolve: `scoped_goal_key` reads the process-global
+    /// last-writer-wins cwd map, which a concurrent same-wire/different-cwd
+    /// `session/open` can flip mid-open — suppression would then inspect
+    /// the OTHER folder's key and emit a spurious cleared for this folder's
+    /// live chip. Same discipline as the turn path's turn-pinned scoped
+    /// key. The wire id the client keys the chip by is recovered via
+    /// [`wire_key_from_goal_key`] (a pinned key is the wire id itself, or
+    /// wire id + `\u{0}~cwd-` suffix).
     pub(crate) fn session_goal_hydrate_cleared_event_json(
         &self,
-        session_id: &SessionKey,
+        pinned_goal_key: &SessionKey,
         profile_id: &str,
     ) -> Option<Value> {
-        // #1666 residue — same scoped-store lookup as `clear_goal_impl`, so
-        // folder A's bound goal never reads as "unbound" through folder B's
-        // reuse of the wire id.
-        let key = self.scoped_goal_key(session_id);
         let mut state = self.state();
-        if state.goals.contains_key(&key) {
+        if state.goals.contains_key(pinned_goal_key) {
             return None;
         }
         let generation = next_goal_event_generation(&mut state);
         Some(json!({
-            "session_id": session_id,
+            "session_id": wire_key_from_goal_key(pinned_goal_key),
             "profile_id": profile_id,
             "cleared": true,
             "goal": Value::Null,

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -4574,6 +4574,52 @@ impl InProcessAgentOrchestrator {
         }))
     }
 
+    /// #2062 — `SessionGoalCleared`-shaped NULL snapshot for the session
+    /// (re)open path: `Some(event JSON)` when NO goal is bound to
+    /// `session_id` for `profile_id`, `None` when a goal IS bound (the
+    /// positive chip state is owned by the durable replay + live update
+    /// pushes, untouched here). Silence is not a goal state: without this,
+    /// a client that cached a chip and reconnects after the goal was
+    /// cleared elsewhere (a second connection, another process on the same
+    /// data dir, or a serve restart that rebuilt the ledger) keeps
+    /// rendering it. "Removed", "never existed", and "removed while you
+    /// were away" must be ONE message — the same payload shape as the
+    /// explicit `session/goal/clear` result (`cleared: true` is what the
+    /// client's single null-the-chip reducer keys on).
+    ///
+    /// Emit-only: no goal state is read-modified. The #1959 generation
+    /// bump is the shared ordering stamp EVERY goal chip event must carry —
+    /// an unstamped `0` would let a replayed stale update outrank the null.
+    pub(crate) fn session_goal_hydrate_cleared_event_json(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+    ) -> Option<Value> {
+        // #1666 residue — same scoped-store lookup as `clear_goal_impl`, so
+        // folder A's bound goal never reads as "unbound" through folder B's
+        // reuse of the wire id. A goal bound under a DIFFERENT profile also
+        // renders as unbound: this connection's profile can never see that
+        // goal, so its null is truthful (and keeps the chip tenant-scoped).
+        let key = self.scoped_goal_key(session_id);
+        let mut state = self.state();
+        if state
+            .goals
+            .get(&key)
+            .is_some_and(|goal| goal.profile_id == profile_id)
+        {
+            return None;
+        }
+        let generation = next_goal_event_generation(&mut state);
+        Some(json!({
+            "session_id": session_id,
+            "profile_id": profile_id,
+            "cleared": true,
+            "goal": Value::Null,
+            "generation": generation,
+            "transition_actor": "backend",
+        }))
+    }
+
     /// #1696 — read-only goal snapshot for the model's `goal_get` tool.
     /// Never errors: no goal (or a goal outside the profile scope) renders
     /// as `status: "none"` so the model gets a stable shape either way.

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -3845,7 +3845,8 @@ impl InProcessAgentOrchestrator {
         }
         // #1959 (codex #1) — stamp the generation like every other goal-event
         // producer so the send guard can order this token-charge update.
-        let generation = next_goal_event_generation(&mut state);
+        // S3: watermark identity = the scoped key this charge mutated under.
+        let generation = next_goal_event_generation(&mut state, &key);
         // #1966 — the event carries the WIRE key: clients key goal chips by
         // the wire session id, never the internal scoped storage form.
         Some(json!({
@@ -4584,7 +4585,9 @@ impl InProcessAgentOrchestrator {
         let wire_id = wire_key_from_goal_key(session_id);
         // #1959 — stamp a monotonic generation so a stale update can't
         // resurrect a cleared goal on the client (see the field's doc comment).
-        let generation = next_goal_event_generation(&mut state);
+        // S3: the watermark identity is the SCOPED key this fn looked up
+        // under (the caller's turn-pinned key), not the wire id emitted.
+        let generation = next_goal_event_generation(&mut state, session_id);
         Some(json!({
             "session_id": wire_id,
             "profile_id": profile_id,
@@ -4653,7 +4656,8 @@ impl InProcessAgentOrchestrator {
         if state.goals.contains_key(pinned_goal_key) {
             return None;
         }
-        let generation = next_goal_event_generation(&mut state);
+        // S3: watermark identity = the pinned scoped key this null describes.
+        let generation = next_goal_event_generation(&mut state, pinned_goal_key);
         Some(json!({
             "session_id": wire_key_from_goal_key(pinned_goal_key),
             "profile_id": profile_id,
@@ -4662,6 +4666,24 @@ impl InProcessAgentOrchestrator {
             "generation": generation,
             "transition_actor": "backend",
         }))
+    }
+
+    /// codex #2065 round-4 S3 — the SCOPED goal-store key event
+    /// `generation` was built from, registered at allocation time by
+    /// `next_goal_event_generation`. The transport's #1959 watermark keys
+    /// its map by this identity (falling back to the plain wire session id
+    /// for unstamped/unregistered generations — legacy events, hand-built
+    /// test frames, FIFO-evicted entries), so two cwd scopes sharing one
+    /// wire session id keep independent watermarks: scope B's repaint can
+    /// no longer falsely supersede scope A's open-time null snapshot.
+    pub(crate) fn goal_event_watermark_key(&self, generation: u64) -> Option<SessionKey> {
+        if generation == 0 {
+            return None;
+        }
+        self.state()
+            .goal_event_scope_index
+            .get(&generation)
+            .cloned()
     }
 
     /// #1696 — read-only goal snapshot for the model's `goal_get` tool.
@@ -5651,8 +5673,9 @@ impl InProcessAgentOrchestrator {
             // `SessionGoalUpdated` so the client can order a clear against a
             // racing stale update. A stale update always bumps before this
             // clear (its goal read preceded the removal above), so
-            // `update.generation < clear.generation`.
-            let generation = next_goal_event_generation(&mut state);
+            // `update.generation < clear.generation`. S3: watermark identity
+            // = the scoped key this clear resolved and removed under.
+            let generation = next_goal_event_generation(&mut state, &key);
             let fleet_store = state.fleet_store.clone();
             (removed, generation, fleet_store)
         };
@@ -9518,7 +9541,8 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
         // #1959 (codex #1) — stamp the generation so a user-set goal update
         // participates in the send guard's ordering (it is durable, so an
         // unstamped one could persist a clear->stale-update inversion).
-        let generation = next_goal_event_generation(&mut state);
+        // S3: watermark identity = the scoped key this set stored under.
+        let generation = next_goal_event_generation(&mut state, &key);
         Ok(json!({
             "session_id": request.session_id,
             "profile_id": request.profile_id,
@@ -11161,6 +11185,16 @@ struct AutonomyRuntimeState {
     /// emit no event), so `stale_update.generation < clear.generation` always
     /// holds and the client keeps the newer clear.
     goal_event_generation: u64,
+    /// codex #2065 round-4 S3 — generation → the SCOPED goal-store key the
+    /// event was built from, registered atomically with the allocation (same
+    /// state lock). The transport's #1959 watermark is keyed by THIS
+    /// identity, not the plain wire session id: two cwd scopes can share a
+    /// wire id, and wire-keyed watermarks let one folder's repaint falsely
+    /// abandon the other folder's open-time null snapshot (cross-scope
+    /// pollution). Bounded FIFO — see `next_goal_event_generation`.
+    goal_event_scope_index: HashMap<u64, SessionKey>,
+    /// FIFO eviction order for [`Self::goal_event_scope_index`].
+    goal_event_scope_fifo: std::collections::VecDeque<u64>,
     /// #991 / M15-B — per-agent cancellation handles registered by
     /// `run_native_specialist` (and future specialist runners) so that
     /// `interrupt_agent` / `close_agent` can signal a *real* abort to
@@ -13557,9 +13591,33 @@ fn restored_agent_artifact(artifact: &SupervisorArtifactRecord) -> AgentArtifact
 /// An unstamped (`0`) event is always admitted by the guard and would reopen
 /// the stale-update-overtakes-clear race (codex #1 caught `set_goal` /
 /// `charge_active_goal_tokens` shipping unstamped).
-fn next_goal_event_generation(state: &mut AutonomyRuntimeState) -> u64 {
+///
+/// codex #2065 round-4 S3 — the allocation also registers `watermark_key`,
+/// the SCOPED goal-store key the event is being built from (the compiler
+/// forces every producer to supply its build-time key — never a later
+/// re-resolution of the last-writer-wins cwd map). The transport's #1959
+/// watermark is keyed by this identity via
+/// [`InProcessAgentOrchestrator::goal_event_watermark_key`], so two cwd
+/// scopes sharing one wire session id keep independent watermarks —
+/// scope B's repaint can no longer falsely supersede scope A's open-time
+/// null snapshot. The registry is a bounded FIFO: at 4096 live entries the
+/// oldest is evicted, and an evicted generation falls back to wire-keyed
+/// watermarking at the guard (strictly the pre-S3 behavior, and only for
+/// events ~4096 generations stale).
+fn next_goal_event_generation(state: &mut AutonomyRuntimeState, watermark_key: &SessionKey) -> u64 {
+    const GOAL_EVENT_SCOPE_INDEX_CAP: usize = 4096;
     state.goal_event_generation += 1;
-    state.goal_event_generation
+    let generation = state.goal_event_generation;
+    state
+        .goal_event_scope_index
+        .insert(generation, watermark_key.clone());
+    state.goal_event_scope_fifo.push_back(generation);
+    while state.goal_event_scope_fifo.len() > GOAL_EVENT_SCOPE_INDEX_CAP {
+        if let Some(evicted) = state.goal_event_scope_fifo.pop_front() {
+            state.goal_event_scope_index.remove(&evicted);
+        }
+    }
+    generation
 }
 
 fn persist_goal_state(

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -1499,7 +1499,7 @@ impl InProcessAgentOrchestrator {
     /// [`UiProtocolLedger::set_session_scope`].
     /// Returns the goal-store key this registration establishes for
     /// `session_id`, computed INSIDE the same `goal_scopes` lock acquisition
-    /// (codex #2065 round-3 W5): registration and capture used to be two
+    /// (#2065): registration and capture used to be two
     /// separate lock acquisitions (`set_goal_scope` then `scoped_goal_key`),
     /// a TOCTOU on a multi-thread runtime — a concurrent same-wire open
     /// could flip the last-writer-wins map between them and the caller
@@ -3845,7 +3845,8 @@ impl InProcessAgentOrchestrator {
         }
         // #1959 (codex #1) — stamp the generation like every other goal-event
         // producer so the send guard can order this token-charge update.
-        // S3: watermark identity = the scoped key this charge mutated under.
+        // #2065: watermark identity = the scoped key this charge mutated
+        // under (per-scope guard streams).
         let generation = next_goal_event_generation(&mut state, &key);
         // #1966 — the event carries the WIRE key: clients key goal chips by
         // the wire session id, never the internal scoped storage form.
@@ -4585,7 +4586,7 @@ impl InProcessAgentOrchestrator {
         let wire_id = wire_key_from_goal_key(session_id);
         // #1959 — stamp a monotonic generation so a stale update can't
         // resurrect a cleared goal on the client (see the field's doc comment).
-        // S3: the watermark identity is the SCOPED key this fn looked up
+        // #2065: the watermark identity is the SCOPED key this fn looked up
         // under (the caller's turn-pinned key), not the wire id emitted.
         let generation = next_goal_event_generation(&mut state, session_id);
         Some(json!({
@@ -4597,81 +4598,24 @@ impl InProcessAgentOrchestrator {
         }))
     }
 
-    /// #2062 rounds 6–8 — the VERSIONED goal snapshot carried IN the
-    /// `session/open` RESPONSE: `{ "version": u64, "goal": object|null }`.
-    /// `goal` is the goal object (same shape as `SessionGoalUpdated`'s
-    /// `goal` field) when one is bound under the caller's
-    /// open-registration-PINNED scoped key AND the open's resolved profile,
-    /// else `null` — "no goal", "cleared while you were away", and "never
-    /// existed" are one statement. `version` is the scope's LATEST #1959
-    /// generation (`goal_scope_versions`, recorded atomically with every
-    /// allocation) — the SAME number space stamped on outgoing
-    /// `SessionGoalUpdated`/`SessionGoalCleared` frames, so the client can
-    /// compare snapshot and frames apples-to-apples.
+    /// #2065 — the SCOPED goal-store key a goal event's `generation` was
+    /// built from, registered at allocation time by
+    /// [`next_goal_event_generation`]. The transport's #1959 send guard
+    /// keys its watermark map by THIS identity rather than the plain wire
+    /// session id the frames carry (falling back to the wire id for
+    /// unstamped/unregistered generations — legacy events, hand-built test
+    /// frames, FIFO-evicted entries).
     ///
-    /// WHY VERSIONING, not wire ordering (codex round-7 F1 terminated the
-    /// ordering family): producers release the #1959 guard and enqueue
-    /// LATER, after ledger/filter/serialization work — admission order can
-    /// never establish enqueue order, so NO server-side scheme (five
-    /// notification rounds, response position, capture-at-enqueue) can make
-    /// wire order carry freshness without holding a lock across a blocking
-    /// stdio send, which stalls every goal producer. So the wire stops
-    /// carrying order: the DATA carries it. State and version are read
-    /// under ONE state-lock acquisition (the pair cannot disagree), the
-    /// response is enqueued wherever convenient, and the client resolves
-    /// any arrival order by version — see `SessionOpenResult::goal_state`
-    /// in octos-core for the client-side contract.
-    ///
-    /// Profile filtering is the leak gate: a goal bound under a DIFFERENT
-    /// profile than this open resolves reads as `goal: null` — the snapshot
-    /// carries objective text, and it goes only to THIS connection, whose
-    /// own `goal/get` equally reports "none". (The version still reflects
-    /// the scope's latest allocation: the null is versioned exactly like a
-    /// cleared state, so a stale pre-clear frame can never beat it.)
-    ///
-    /// The pinned key is the one [`Self::set_goal_scope`] RETURNS from
-    /// inside its own lock at open-registration (codex round-3 W5) — never
-    /// a later re-resolution of the last-writer-wins cwd map, which a
-    /// concurrent same-wire/different-cwd open can flip.
-    pub(crate) fn session_open_goal_state(
-        &self,
-        pinned_goal_key: &SessionKey,
-        profile_id: &str,
-    ) -> Value {
-        // ONE lock acquisition for BOTH reads: the (version, state) pair is
-        // internally consistent by construction — a producer cannot
-        // interleave between them (every mutation + its version allocation
-        // happen under this same lock).
-        let state = self.state();
-        let version = state
-            .goal_scope_versions
-            .get(pinned_goal_key)
-            .copied()
-            .unwrap_or(0);
-        let goal = match state
-            .goals
-            .get(pinned_goal_key)
-            .filter(|goal| goal.profile_id == profile_id)
-        {
-            Some(goal) => autonomy_goal_json(goal),
-            None => Value::Null,
-        };
-        json!({ "version": version, "goal": goal })
-    }
-
-    /// codex #2065 round-4 S3 — the SCOPED goal-store key event
-    /// `generation` was built from, registered at allocation time by
-    /// `next_goal_event_generation`. The transport's #1959 watermark keys
-    /// its map by this identity (falling back to the plain wire session id
-    /// for unstamped/unregistered generations — legacy events, hand-built
-    /// test frames, FIFO-evicted entries), so two cwd scopes sharing one
-    /// wire session id keep independently monotonic guard streams: scope
-    /// A's clear can no longer falsely drop scope B's
-    /// later-delivered-but-earlier-built live repaint at the send guard.
-    /// (Round 8 note: the open-response goal snapshot never ALLOCATES in
-    /// this generation space — the four real producers do: set, clear,
-    /// token-charge, turn repaint. The snapshot only READS the scope's
-    /// latest allocation as its `version`, via `goal_scope_versions`.)
+    /// Two cwd scopes can share one wire session id (`appui.sessions_in_cwd`
+    /// — the same session key opened from two folders), and the guard is
+    /// strictly monotonic per key. Wire-keyed, the two scopes shared one
+    /// watermark, so scope A's later-ALLOCATED clear suppressed scope B's
+    /// earlier-built repaint when B's frame reached the guard second: B's
+    /// live goal chip silently stopped repainting. Per-scope identities
+    /// keep the two streams independent, which is what the guard's
+    /// monotonicity assumption requires. The four goal-event producers
+    /// (set / clear / token-charge / turn repaint) all allocate through
+    /// [`next_goal_event_generation`], so every stamped frame is covered.
     pub(crate) fn goal_event_watermark_key(&self, generation: u64) -> Option<SessionKey> {
         if generation == 0 {
             return None;
@@ -5669,8 +5613,8 @@ impl InProcessAgentOrchestrator {
             // `SessionGoalUpdated` so the client can order a clear against a
             // racing stale update. A stale update always bumps before this
             // clear (its goal read preceded the removal above), so
-            // `update.generation < clear.generation`. S3: watermark identity
-            // = the scoped key this clear resolved and removed under.
+            // `update.generation < clear.generation`. #2065: watermark
+            // identity = the scoped key this clear resolved and removed under.
             let generation = next_goal_event_generation(&mut state, &key);
             let fleet_store = state.fleet_store.clone();
             (removed, generation, fleet_store)
@@ -9537,7 +9481,7 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
         // #1959 (codex #1) — stamp the generation so a user-set goal update
         // participates in the send guard's ordering (it is durable, so an
         // unstamped one could persist a clear->stale-update inversion).
-        // S3: watermark identity = the scoped key this set stored under.
+        // #2065: watermark identity = the scoped key this set stored under.
         let generation = next_goal_event_generation(&mut state, &key);
         Ok(json!({
             "session_id": request.session_id,
@@ -11181,30 +11125,17 @@ struct AutonomyRuntimeState {
     /// emit no event), so `stale_update.generation < clear.generation` always
     /// holds and the client keeps the newer clear.
     goal_event_generation: u64,
-    /// codex #2065 round-4 S3 — generation → the SCOPED goal-store key the
-    /// event was built from, registered atomically with the allocation (same
-    /// state lock). The transport's #1959 watermark is keyed by THIS
+    /// #2065 — generation → the SCOPED goal-store key the event was built
+    /// from, registered atomically with the allocation (same state lock).
+    /// The transport's #1959 send guard keys its watermark by THIS
     /// identity, not the plain wire session id: two cwd scopes can share a
-    /// wire id, and a wire-keyed watermark advanced by one scope's clear
-    /// would falsely drop the sibling scope's later-delivered live repaint
-    /// at the send guard. Bounded FIFO — see `next_goal_event_generation`.
+    /// wire id, and a wire-keyed watermark advanced by one scope's
+    /// later-allocated clear falsely dropped the sibling scope's
+    /// earlier-built repaint at the guard. Bounded FIFO — see
+    /// [`next_goal_event_generation`].
     goal_event_scope_index: HashMap<u64, SessionKey>,
     /// FIFO eviction order for [`Self::goal_event_scope_index`].
     goal_event_scope_fifo: std::collections::VecDeque<u64>,
-    /// #2062 round 8 — SCOPED goal-store key → the LATEST #1959 generation
-    /// allocated for that scope, recorded atomically with the allocation
-    /// (same state lock). This is the VERSION the `session/open` response's
-    /// `goal_state` snapshot pairs with its state: allocation-time
-    /// bookkeeping covers out-of-band mutations that never emit a frame
-    /// (an orchestrator-direct clear still allocates), which
-    /// admission-time bookkeeping (the transport guard's watermark) does
-    /// not. Same number space as the `generation` stamped on outgoing
-    /// `SessionGoalUpdated`/`SessionGoalCleared` frames, so client-side
-    /// version comparison is apples-to-apples. Bounded like the #1959
-    /// guard map: when huge, cleared wholesale (an evicted scope reads 0 —
-    /// pre-versioning behavior for scopes idle across thousands of
-    /// allocations).
-    goal_scope_versions: HashMap<SessionKey, u64>,
     /// #991 / M15-B — per-agent cancellation handles registered by
     /// `run_native_specialist` (and future specialist runners) so that
     /// `interrupt_agent` / `close_agent` can signal a *real* abort to
@@ -13602,18 +13533,19 @@ fn restored_agent_artifact(artifact: &SupervisorArtifactRecord) -> AgentArtifact
 /// the stale-update-overtakes-clear race (codex #1 caught `set_goal` /
 /// `charge_active_goal_tokens` shipping unstamped).
 ///
-/// codex #2065 round-4 S3 — the allocation also registers `watermark_key`,
-/// the SCOPED goal-store key the event is being built from (the compiler
-/// forces every producer to supply its build-time key — never a later
-/// re-resolution of the last-writer-wins cwd map). The transport's #1959
-/// watermark is keyed by this identity via
+/// #2065 — the allocation also registers `watermark_key`, the SCOPED
+/// goal-store key the event is being built from (the compiler forces every
+/// producer to supply its build-time key — never a later re-resolution of
+/// the last-writer-wins cwd map, which a concurrent same-wire open flips).
+/// The transport's #1959 send guard keys its watermark by this identity via
 /// [`InProcessAgentOrchestrator::goal_event_watermark_key`], so two cwd
-/// scopes sharing one wire session id keep independent watermarks —
-/// scope B's repaint can no longer falsely supersede scope A's open-time
-/// null snapshot. The registry is a bounded FIFO: at 4096 live entries the
-/// oldest is evicted, and an evicted generation falls back to wire-keyed
-/// watermarking at the guard (strictly the pre-S3 behavior, and only for
-/// events ~4096 generations stale).
+/// scopes sharing one wire session id keep independent, independently
+/// monotonic guard streams — without it, one scope's later-allocated clear
+/// suppressed the sibling scope's earlier-built repaint at the guard. The
+/// registry is a bounded FIFO: at 4096 live entries the oldest is evicted,
+/// and an evicted generation falls back to wire-keyed watermarking at the
+/// guard (strictly the pre-fix behavior, and only for events ~4096
+/// generations stale).
 fn next_goal_event_generation(state: &mut AutonomyRuntimeState, watermark_key: &SessionKey) -> u64 {
     const GOAL_EVENT_SCOPE_INDEX_CAP: usize = 4096;
     state.goal_event_generation += 1;
@@ -13627,20 +13559,6 @@ fn next_goal_event_generation(state: &mut AutonomyRuntimeState, watermark_key: &
             state.goal_event_scope_index.remove(&evicted);
         }
     }
-    // #2062 round 8 — record this allocation as the scope's LATEST version,
-    // in the same state-lock hold, so the open-response snapshot can pair
-    // its state with the exact version it was read at (see
-    // `goal_scope_versions`). Bounded like the #1959 guard map: reset when
-    // huge rather than leak (an evicted scope reads 0 until it allocates
-    // again).
-    if state.goal_scope_versions.len() >= GOAL_EVENT_SCOPE_INDEX_CAP
-        && !state.goal_scope_versions.contains_key(watermark_key)
-    {
-        state.goal_scope_versions.clear();
-    }
-    state
-        .goal_scope_versions
-        .insert(watermark_key.clone(), generation);
     generation
 }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -4631,11 +4631,35 @@ pub struct SessionOpened {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SessionOpenResult {
     pub opened: SessionOpened,
+    /// #2062 — the session's goal state for the opener's resolved (pinned
+    /// cwd scope, profile), carried IN the open response: either the goal
+    /// object (same shape as `SessionGoalUpdated`'s `goal` field) or
+    /// EXPLICIT `null` meaning "no goal bound" — `null` is a statement,
+    /// not an omission, so new servers ALWAYS serialize this field.
+    ///
+    /// Compatibility needs no capability negotiation: an old client
+    /// ignores the unknown field; a new client treats an ABSENT field as
+    /// "old server, no snapshot" (legacy no-op) and `null`/object as
+    /// authoritative. The response's fixed position in the client's own
+    /// processing order is what makes the snapshot race-free — see
+    /// `session_open_goal_state` on the server for the full argument.
+    #[serde(default)]
+    pub goal_state: Value,
 }
 
 impl SessionOpenResult {
     pub fn new(opened: SessionOpened) -> Self {
-        Self { opened }
+        Self {
+            opened,
+            goal_state: Value::Null,
+        }
+    }
+
+    /// Attach the #2062 open-response goal snapshot (goal object, or
+    /// `Value::Null` for "no goal bound").
+    pub fn with_goal_state(mut self, goal_state: Value) -> Self {
+        self.goal_state = goal_state;
+        self
     }
 }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -4631,56 +4631,11 @@ pub struct SessionOpened {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SessionOpenResult {
     pub opened: SessionOpened,
-    /// #2062 — the session's VERSIONED goal snapshot for the opener's
-    /// resolved (pinned cwd scope, profile), carried IN the open response:
-    ///
-    /// ```json
-    /// "goal_state": { "version": 42, "goal": { ...goal object... } }
-    /// "goal_state": { "version": 42, "goal": null }
-    /// ```
-    ///
-    /// `goal` is the same shape as `SessionGoalUpdated`'s `goal` field, or
-    /// `null` meaning "no goal bound" — a statement, not an omission, so
-    /// new servers ALWAYS serialize this field. `version` is the goal
-    /// scope's latest #1959 generation — the SAME monotonic number space
-    /// stamped as `generation` on `SessionGoalUpdated` /
-    /// `SessionGoalCleared` frames — captured together with the state
-    /// under one server-side lock acquisition, so the pair is internally
-    /// consistent.
-    ///
-    /// CLIENT RULE (the wire contract, written down once): apply a goal
-    /// state — this snapshot or any goal frame — only if its
-    /// version/`generation` is `>=` the last version applied for the
-    /// session's chip; drop older. Both the snapshot and every frame carry
-    /// versions, so arrival order never matters: a stale snapshot cannot
-    /// overwrite a fresher frame, and a stale frame cannot overwrite the
-    /// snapshot. Versions are comparable only WITHIN one connection to one
-    /// server process (the generation counter is process-local): on a new
-    /// connection the client clears its last-applied tracking and this
-    /// snapshot re-establishes it. Legacy `generation: 0` frames (pre-#1959
-    /// producers) apply unconditionally, as before.
-    ///
-    /// Compatibility needs no capability negotiation: an old client
-    /// ignores the unknown field; a new client treats an ABSENT field as
-    /// "old server, no snapshot" (legacy no-op).
-    #[serde(default)]
-    pub goal_state: Value,
 }
 
 impl SessionOpenResult {
     pub fn new(opened: SessionOpened) -> Self {
-        Self {
-            opened,
-            goal_state: Value::Null,
-        }
-    }
-
-    /// Attach the #2062 open-response goal snapshot: the versioned
-    /// `{ "version": u64, "goal": object|null }` object (see the field
-    /// doc for the client-side contract).
-    pub fn with_goal_state(mut self, goal_state: Value) -> Self {
-        self.goal_state = goal_state;
-        self
+        Self { opened }
     }
 }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -4631,18 +4631,38 @@ pub struct SessionOpened {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SessionOpenResult {
     pub opened: SessionOpened,
-    /// #2062 — the session's goal state for the opener's resolved (pinned
-    /// cwd scope, profile), carried IN the open response: either the goal
-    /// object (same shape as `SessionGoalUpdated`'s `goal` field) or
-    /// EXPLICIT `null` meaning "no goal bound" — `null` is a statement,
-    /// not an omission, so new servers ALWAYS serialize this field.
+    /// #2062 — the session's VERSIONED goal snapshot for the opener's
+    /// resolved (pinned cwd scope, profile), carried IN the open response:
+    ///
+    /// ```json
+    /// "goal_state": { "version": 42, "goal": { ...goal object... } }
+    /// "goal_state": { "version": 42, "goal": null }
+    /// ```
+    ///
+    /// `goal` is the same shape as `SessionGoalUpdated`'s `goal` field, or
+    /// `null` meaning "no goal bound" — a statement, not an omission, so
+    /// new servers ALWAYS serialize this field. `version` is the goal
+    /// scope's latest #1959 generation — the SAME monotonic number space
+    /// stamped as `generation` on `SessionGoalUpdated` /
+    /// `SessionGoalCleared` frames — captured together with the state
+    /// under one server-side lock acquisition, so the pair is internally
+    /// consistent.
+    ///
+    /// CLIENT RULE (the wire contract, written down once): apply a goal
+    /// state — this snapshot or any goal frame — only if its
+    /// version/`generation` is `>=` the last version applied for the
+    /// session's chip; drop older. Both the snapshot and every frame carry
+    /// versions, so arrival order never matters: a stale snapshot cannot
+    /// overwrite a fresher frame, and a stale frame cannot overwrite the
+    /// snapshot. Versions are comparable only WITHIN one connection to one
+    /// server process (the generation counter is process-local): on a new
+    /// connection the client clears its last-applied tracking and this
+    /// snapshot re-establishes it. Legacy `generation: 0` frames (pre-#1959
+    /// producers) apply unconditionally, as before.
     ///
     /// Compatibility needs no capability negotiation: an old client
     /// ignores the unknown field; a new client treats an ABSENT field as
-    /// "old server, no snapshot" (legacy no-op) and `null`/object as
-    /// authoritative. The response's fixed position in the client's own
-    /// processing order is what makes the snapshot race-free — see
-    /// `session_open_goal_state` on the server for the full argument.
+    /// "old server, no snapshot" (legacy no-op).
     #[serde(default)]
     pub goal_state: Value,
 }
@@ -4655,8 +4675,9 @@ impl SessionOpenResult {
         }
     }
 
-    /// Attach the #2062 open-response goal snapshot (goal object, or
-    /// `Value::Null` for "no goal bound").
+    /// Attach the #2062 open-response goal snapshot: the versioned
+    /// `{ "version": u64, "goal": object|null }` object (see the field
+    /// doc for the client-side contract).
     pub fn with_goal_state(mut self, goal_state: Value) -> Self {
         self.goal_state = goal_state;
         self


### PR DESCRIPTION
Rebased successor of #2065 (head branch history rewritten; original branch cannot be force-pushed under the no-push ruleset).

## What changed vs #2065

- Rebased onto current main (9 commits), resolving conflicts:
  - `ui_protocol_tests.rs`: kept both the main-side usage-status tests (#2102) and the #2062 goal-snapshot tests
  - `ui_protocol_transport.rs`: reconciled with #2067's `profile_scope` — the forwarder now receives the captured profile scope (capture-at-open semantics) instead of re-reading `ws.snapshot_live_profile_id()`
- Dropped the dead `profile_id` field from `SessionOpenOutcome` (superseded by #2067's `profile_scope`)
- Test call sites updated for `pinned_profile_id` / `profile_scope` parameters
- Also fixes #2103's `Message` import regression (see #2119, which lands the same fix on main first)

Verified: `cargo check --features api --tests` clean, rustfmt clean, 187 goal tests + 3 session_open_goal tests pass.