### PR TITLE
feat(agent): measure whether request history is append-only

### DIFF
--- a/crates/octos-agent/src/agent/append_only_audit.rs
+++ b/crates/octos-agent/src/agent/append_only_audit.rs
@@ -1,0 +1,364 @@
+//! Append-only context audit: does a turn's request history only ever GROW?
+//!
+//! ## Why this exists
+//!
+//! The messages handed to the model and the messages written to the durable
+//! session are two different objects. Nothing compares them, so they drift —
+//! and the drift is silent at the moment it happens, surfacing later as a
+//! resumed session the model never had, a context gauge over 100%, or a cost
+//! figure computed from a request nobody can reconstruct.
+//!
+//! The `pi` harness avoids the whole family by never rewriting history: the
+//! request prefix only grows, and output is bounded where it is PRODUCED
+//! rather than trimmed after the fact. `deepseek-harness` enforces the same
+//! property structurally, asserting that every loop-built request equals the
+//! projection of its durable log.
+//!
+//! Adopting either is a large change. This module is the cheap precursor that
+//! tells us whether it is warranted: it MEASURES how append-only we actually
+//! are today, without changing what is sent.
+//!
+//! ## What it checks
+//!
+//! Within one turn, successive requests must be prefix-extensions of each
+//! other: iteration N's message list must be an exact prefix of iteration
+//! N+1's. Any index that changes content, or a list that shrinks, is a
+//! REWRITE — the sent history at that point is no longer reconstructable by
+//! replaying what came before.
+//!
+//! ## What it deliberately does NOT do
+//!
+//! - It never mutates, blocks, or fails a request. Findings are reported.
+//! - It does not compare against the durable session. That lives in another
+//!   crate; this is the in-turn half, which needs no new plumbing and which
+//!   catches the known rewrite path (`truncate_old_tool_results`).
+//! - It hashes content rather than retaining it: an audit that copies every
+//!   request would be a memory regression on long turns.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+#[cfg(test)]
+use std::sync::Mutex;
+
+use octos_core::{Message, MessageRole};
+
+/// Process-global findings collector.
+///
+/// The audit also logs through `tracing`, but a log line is not a measurement
+/// you can verify: octos-agent's lib tests install no subscriber, so `warn!`
+/// output goes nowhere and an empty run is indistinguishable from a clean one.
+/// This gives the measurement a channel whose silence can be checked — drain
+/// it and you know whether the audit ran at all.
+///
+/// Bounded so an armed long-running process cannot grow it without limit.
+#[cfg(test)]
+static FINDINGS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+/// Retained-findings ceiling; further findings still log, and still count.
+#[cfg(test)]
+const MAX_RETAINED_FINDINGS: usize = 512;
+
+/// Number of findings recorded since the process started, retained or not.
+#[cfg(test)]
+static FINDING_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Record one finding for later inspection.
+///
+/// Test-only on purpose. In production the channel is `tracing`, whose
+/// subscriber the operator installs and can therefore verify; in tests no
+/// subscriber exists, so the audit needs somewhere its silence can be checked.
+#[cfg(test)]
+pub(crate) fn record_finding(description: String) {
+    FINDING_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut findings = FINDINGS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if findings.len() < MAX_RETAINED_FINDINGS {
+        findings.push(description);
+    }
+}
+
+/// Test-only arming override, so a test never has to mutate the environment
+/// (`set_var` is `unsafe` under edition 2024, and this workspace denies unsafe).
+#[cfg(test)]
+static FORCED_ON: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the audit is armed.
+///
+/// Opt-in because it is a measurement, not a guard: it exists to establish how
+/// far octos already is from the append-only prefix `pi` keeps and
+/// `deepseek-harness` enforces, before committing to either.
+pub(crate) fn enabled() -> bool {
+    #[cfg(test)]
+    if FORCED_ON.load(std::sync::atomic::Ordering::Relaxed) {
+        return true;
+    }
+    std::env::var("OCTOS_APPEND_ONLY_AUDIT").is_ok_and(|value| value == "1")
+}
+
+/// Arm the audit for one test.
+#[cfg(test)]
+pub(crate) fn arm_for_test() {
+    FORCED_ON.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Disarm after a test.
+#[cfg(test)]
+pub(crate) fn disarm_for_test() {
+    FORCED_ON.store(false, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Total findings recorded, including any past the retention ceiling.
+#[cfg(test)]
+pub(crate) fn finding_count() -> usize {
+    FINDING_COUNT.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Drain retained findings, leaving the counter intact.
+#[cfg(test)]
+pub(crate) fn drain_findings() -> Vec<String> {
+    let mut findings = FINDINGS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::take(&mut *findings)
+}
+
+/// Cheap positional fingerprint of one message.
+///
+/// Content is hashed rather than kept so the audit's footprint stays flat on
+/// long turns; `len` rides along because a length delta is the single most
+/// useful thing in a report ("4,812 chars became 800" names the mechanism).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct MessageFingerprint {
+    role: MessageRole,
+    len: usize,
+    hash: u64,
+}
+
+impl MessageFingerprint {
+    fn of(message: &Message) -> Self {
+        let mut hasher = DefaultHasher::new();
+        message.content.hash(&mut hasher);
+        message.tool_call_id.hash(&mut hasher);
+        // Tool calls are part of what the model saw; a rewritten argument list
+        // is as much a divergence as rewritten prose.
+        if let Some(calls) = &message.tool_calls {
+            for call in calls {
+                call.id.hash(&mut hasher);
+                call.name.hash(&mut hasher);
+                call.arguments.to_string().hash(&mut hasher);
+            }
+        }
+        Self {
+            role: message.role,
+            len: message.content.len(),
+            hash: hasher.finish(),
+        }
+    }
+}
+
+/// One way a turn's history stopped being append-only.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Rewrite {
+    /// A message that had already been sent came back with different content.
+    Modified {
+        index: usize,
+        role: MessageRole,
+        previous_len: usize,
+        current_len: usize,
+    },
+    /// The history got SHORTER: messages already shown to the model are gone.
+    Shrunk {
+        previous_len: usize,
+        current_len: usize,
+    },
+}
+
+impl Rewrite {
+    /// One-line report for a log line.
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Self::Modified {
+                index,
+                role,
+                previous_len,
+                current_len,
+            } => format!(
+                "message[{index}] ({role}) rewritten in place: {previous_len} -> {current_len} chars"
+            ),
+            Self::Shrunk {
+                previous_len,
+                current_len,
+            } => format!("history shrank: {previous_len} -> {current_len} messages"),
+        }
+    }
+}
+
+/// Per-turn append-only auditor.
+///
+/// Holds only the previous request's fingerprints, so its cost is one small
+/// vector per live turn regardless of how long the conversation runs.
+#[derive(Default, Clone, Debug)]
+pub(crate) struct AppendOnlyAudit {
+    previous: Option<Vec<MessageFingerprint>>,
+}
+
+impl AppendOnlyAudit {
+    /// Record this iteration's request and report how it broke append-only.
+    ///
+    /// The first call of a turn establishes the baseline and can report
+    /// nothing — there is no earlier request to have diverged from.
+    pub(crate) fn observe(&mut self, messages: &[Message]) -> Vec<Rewrite> {
+        let current: Vec<MessageFingerprint> =
+            messages.iter().map(MessageFingerprint::of).collect();
+        let Some(previous) = self.previous.replace(current.clone()) else {
+            return Vec::new();
+        };
+
+        let mut rewrites = Vec::new();
+        if current.len() < previous.len() {
+            rewrites.push(Rewrite::Shrunk {
+                previous_len: previous.len(),
+                current_len: current.len(),
+            });
+        }
+
+        // Compare only the overlap: everything past it is legitimate growth.
+        for (index, (before, after)) in previous.iter().zip(current.iter()).enumerate() {
+            if before != after {
+                rewrites.push(Rewrite::Modified {
+                    index,
+                    role: after.role,
+                    previous_len: before.len,
+                    current_len: after.len,
+                });
+            }
+        }
+        rewrites
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::message_repair::truncate_old_tool_results;
+
+    fn tool_result(id: &str, content: &str) -> Message {
+        let mut message = Message::user(content);
+        message.role = MessageRole::Tool;
+        message.tool_call_id = Some(id.to_string());
+        message
+    }
+
+    #[test]
+    fn should_report_nothing_when_the_turn_only_appends() {
+        let mut audit = AppendOnlyAudit::default();
+        let mut messages = vec![Message::system("prompt"), Message::user("do the thing")];
+        assert!(
+            audit.observe(&messages).is_empty(),
+            "the baseline cannot diverge"
+        );
+
+        messages.push(Message::assistant("calling a tool"));
+        messages.push(tool_result("call-1", "a result"));
+        assert!(
+            audit.observe(&messages).is_empty(),
+            "appending to the end is exactly what an append-only turn does"
+        );
+    }
+
+    #[test]
+    fn should_report_a_rewrite_when_an_earlier_message_changes_in_place() {
+        let mut audit = AppendOnlyAudit::default();
+        let messages = vec![Message::system("prompt"), Message::user("first")];
+        audit.observe(&messages);
+
+        let mut rewritten = messages.clone();
+        rewritten[1].content = "first, edited".into();
+        rewritten.push(Message::assistant("reply"));
+
+        let rewrites = audit.observe(&rewritten);
+        assert_eq!(
+            rewrites,
+            vec![Rewrite::Modified {
+                index: 1,
+                role: MessageRole::User,
+                previous_len: 5,
+                current_len: 13,
+            }],
+            "an edit under an index the model already saw is not an append"
+        );
+    }
+
+    #[test]
+    fn should_report_a_shrink_when_history_is_dropped() {
+        let mut audit = AppendOnlyAudit::default();
+        let messages = vec![
+            Message::system("prompt"),
+            Message::user("first"),
+            Message::assistant("reply"),
+        ];
+        audit.observe(&messages);
+
+        let rewrites = audit.observe(&messages[..2]);
+        assert!(
+            rewrites.contains(&Rewrite::Shrunk {
+                previous_len: 3,
+                current_len: 2,
+            }),
+            "messages the model already saw disappearing is the loudest possible divergence; got {rewrites:?}"
+        );
+    }
+
+    /// The measurement this module was built to take.
+    ///
+    /// `truncate_old_tool_results` collapses tool results older than the last
+    /// user message to 800 chars, in place, on the vector that is about to be
+    /// sent — while the durable session keeps the full text. If the audit
+    /// cannot see THAT, it cannot see anything that matters.
+    #[test]
+    fn should_report_the_real_in_place_truncation_octos_performs_today() {
+        let mut audit = AppendOnlyAudit::default();
+        let mut messages = vec![
+            Message::system("prompt"),
+            Message::user("first question"),
+            Message::assistant("looking it up"),
+            tool_result("call-1", &"x".repeat(4_000)),
+            Message::user("second question"),
+        ];
+        audit.observe(&messages);
+
+        let changed = truncate_old_tool_results(&mut messages);
+        assert!(
+            changed,
+            "fixture must actually trip the production truncation"
+        );
+
+        let rewrites = audit.observe(&messages);
+        let modified: Vec<_> = rewrites
+            .iter()
+            .filter(|r| matches!(r, Rewrite::Modified { .. }))
+            .collect();
+        assert_eq!(
+            modified.len(),
+            1,
+            "exactly the collapsed tool result should be reported; got {rewrites:?}"
+        );
+        let Rewrite::Modified {
+            index,
+            role,
+            previous_len,
+            current_len,
+        } = modified[0]
+        else {
+            unreachable!("filtered above")
+        };
+        assert_eq!(*index, 3);
+        assert_eq!(*role, MessageRole::Tool);
+        assert_eq!(*previous_len, 4_000);
+        assert!(
+            *current_len < *previous_len,
+            "the production path collapses the result, so the length must fall"
+        );
+    }
+}

--- a/crates/octos-agent/src/agent/llm_call.rs
+++ b/crates/octos-agent/src/agent/llm_call.rs
@@ -35,6 +35,36 @@ impl Agent {
         // so callers must record it instead of re-pricing the merged total at
         // the winner's rate (codex #1632 P2). `None` = no attempt was priced.
     ) -> Result<(ChatResponse, bool, Option<f64>)> {
+        // Measurement only (#pi/dsh append-only study): report whether this
+        // turn's request history is still a prefix-extension of the last one.
+        // Off unless OCTOS_APPEND_ONLY_AUDIT=1, and never alters the request —
+        // a rewrite here means the sent history stopped being reconstructable
+        // from what came before, which is the drift that makes a resumed
+        // session differ from the one the model actually had.
+        if crate::agent::append_only_audit::enabled() {
+            let rewrites = {
+                let mut audit = self
+                    .append_only_audit
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                audit.observe(messages)
+            };
+            for rewrite in rewrites {
+                let description = rewrite.describe();
+                warn!(
+                    iteration,
+                    model = %self.llm.model_id(),
+                    "append-only audit: {description}"
+                );
+                // Also recorded out-of-band under test: a `tracing` line with
+                // no subscriber installed is not a measurement you can verify.
+                #[cfg(test)]
+                crate::agent::append_only_audit::record_finding(format!(
+                    "iteration {iteration}: {description}"
+                ));
+            }
+        }
+
         let ctx = self.hook_ctx();
         if let Some(ref hooks) = self.hooks {
             let payload = HookPayload::before_llm(

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6190,3 +6190,65 @@ fn repeated_identical_failing_command_still_trips_the_retry_limit() {
         recover_shell_retry(&messages, 4).expect("the same command failing repeatedly is a spiral");
     assert!(matches!(recovery.kind, ShellRetryRecoveryKind::RetryLimit));
 }
+
+/// Append-only measurement, end to end through the real loop.
+///
+/// The point of the audit is to answer one question with evidence rather than
+/// argument: does octos already rewrite request history in place? This drives
+/// two real turns on one agent — the second carrying the first's oversized
+/// tool result as history — which is the shape `truncate_old_tool_results`
+/// acts on, and asserts the audit both RAN and reported it.
+///
+/// The `RAN` half matters as much as the finding. An earlier version of this
+/// measurement reported nothing, and the nothing meant only that octos-agent's
+/// lib tests install no `tracing` subscriber, so every `warn!` went nowhere.
+/// A measurement whose silence cannot be distinguished from absence is not a
+/// measurement, so findings are recorded out-of-band and asserted here.
+#[tokio::test]
+async fn append_only_audit_observes_the_in_place_truncation_across_turns() {
+    crate::agent::append_only_audit::arm_for_test();
+    let _ = crate::agent::append_only_audit::drain_findings();
+    let before = crate::agent::append_only_audit::finding_count();
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut tools = ToolRegistry::with_builtins(dir.path());
+    // Comfortably past the 800-char collapse threshold.
+    tools.register(NamedEchoTool {
+        name: "alpha",
+        output: BIG_TOOL_OUTPUT,
+    });
+
+    let provider: Arc<dyn LlmProvider> = Arc::new(MultiToolThenEndProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("append-only-audit"), provider, tools, memory);
+
+    let first = agent.process_message("do work", &[], vec![]).await.unwrap();
+    // Second turn carries the first turn's tool results as history, which is
+    // what puts them BEFORE the newest user message.
+    let _second = agent
+        .process_message("and now the next thing", &first.messages, vec![])
+        .await
+        .unwrap();
+
+    let after = crate::agent::append_only_audit::finding_count();
+    let findings = crate::agent::append_only_audit::drain_findings();
+    crate::agent::append_only_audit::disarm_for_test();
+
+    assert!(
+        after > before,
+        "the audit must have RUN; a silent result here means the wiring is dead, \
+         not that octos is append-only (findings: {findings:?})"
+    );
+    assert!(
+        findings.iter().any(|f| f.contains("rewritten in place")),
+        "expected an in-place rewrite across turns; got {findings:?}"
+    );
+}
+
+/// Large enough that `truncate_old_tool_results` collapses it.
+const BIG_TOOL_OUTPUT: &str = concat!(
+    "BEGIN-LARGE-TOOL-RESULT ",
+    include_str!("append_only_audit.rs"),
+);

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -1,6 +1,7 @@
 //! Agent implementation.
 
 mod activity;
+mod append_only_audit;
 mod budget;
 mod compaction;
 mod detection;
@@ -377,6 +378,13 @@ pub struct Agent {
     /// [`crate::compaction::CompactionRunner`] wrapped as a
     /// [`crate::compaction_tiered::FullCompactor`].
     pub(super) tiered_compaction: Option<Arc<crate::compaction_tiered::TieredCompactionRunner>>,
+    /// Measurement only (`OCTOS_APPEND_ONLY_AUDIT=1`). Held here rather than
+    /// on the per-turn state because the rewrite path we know about —
+    /// `truncate_old_tool_results` — only collapses tool results BEFORE the
+    /// last user message, so it fires ACROSS turns and a per-turn auditor
+    /// would never observe it.
+    pub(super) append_only_audit:
+        std::sync::Mutex<crate::agent::append_only_audit::AppendOnlyAudit>,
     /// M8.7 sub-agent output router. When configured, the spawn_only
     /// background branch in `execution.rs` calls
     /// [`crate::SubAgentOutputRouter::mark_terminal`] when a task ends so
@@ -556,6 +564,7 @@ impl Agent {
             file_state_cache: None,
             profile: None,
             tiered_compaction: None,
+            append_only_audit: Default::default(),
             subagent_output_router: None,
             subagent_summary_generator: None,
             cost_accountant: None,
@@ -637,6 +646,7 @@ impl Agent {
             file_state_cache: None,
             profile: None,
             tiered_compaction: None,
+            append_only_audit: Default::default(),
             subagent_output_router: None,
             subagent_summary_generator: None,
             cost_accountant: None,


### PR DESCRIPTION
Measurement, not a guard. Off unless `OCTOS_APPEND_ONLY_AUDIT=1`, and it never alters, blocks, or fails a request.

## Why

The messages handed to the model and the messages written to the durable session are two different objects, and **nothing compares them**. They drift, and the drift is silent when it happens — surfacing later as a resumed session the model never had, a context gauge over 100%, or a cost figure computed from a request nobody can reconstruct.

`pi` avoids that whole family by never rewriting history: the prefix only grows, and output is bounded where it is *produced* rather than trimmed after the fact (`docs/harness-context-efficiency.md`, #1638). `deepseek-harness` enforces the same property structurally — it asserts at runtime that every loop-built request equals the projection of its durable log.

Adopting either is a multi-week change to the hottest code we have (`execution.rs` alone is 4,456 lines, and 45 sites mutate the message vector). **This is the cheap precursor that says whether it's warranted**, by measuring how append-only we already are.

## What it found

We are not — verified end to end through the real loop, across two turns.

`truncate_old_tool_results` (`message_repair.rs:513`, called from `loop_compaction.rs:54`) collapses tool results older than the last user message to 800 chars **in place**, on the vector about to be sent, while the durable session keeps the full text.

The July prefix audit cleared this for *caching* because it's idempotent — collapse once, stays collapsed — and that reasoning still holds. But idempotent is not the same as reconstructable, and nobody was asking that question then.

## Two things worth knowing about the build

**Scope.** The auditor lives on `Agent`, not on `LoopTurnState`. Per-turn was the obvious placement and was wrong: the rewrite only touches tool results *before* the last user message, so it fires **across** turns and a per-turn auditor would never observe it. The end-to-end test drives two real turns for exactly that reason.

**Channel.** Findings are recorded out-of-band under `#[cfg(test)]`, not just logged. The first version of this reported nothing — and the nothing meant only that octos-agent's lib tests install no `tracing` subscriber, so every `warn!` went nowhere. A measurement whose silence can't be distinguished from absence isn't a measurement. In production the channel is `tracing`, whose subscriber the operator installs and can verify.

## Verification

```
cargo test -p octos-agent --lib append_only              => ok. 5 passed; 0 failed
cargo clippy -p octos-agent --all-targets -- -D warnings => no warnings
cargo fmt --all -- --check                               => clean
cargo test -p octos-agent --lib                          => 2597 passed; 2 failed
```

The two failures are this host's DNS resolver hijacking NXDOMAIN for `*.invalid` (`tools::ssrf`, `tools::web_fetch`). Neither file is in this diff and CI passes both.

## What this does not do

- It does not compare against the **durable session** — that lives in another crate and needs plumbing this deliberately avoids. This is the in-turn/in-session half, which needs no new wiring and catches the known path.
- It does not fix anything. The next step, if the finding holds up in real sessions, is the `pi` work we deferred in July: caps in the tool, recovery in the result, spool-and-grep for large output. That's the prerequisite for stopping the rewrite, and it pays for itself in tokens regardless.

Refs #1638