### PR TITLE
feat(tools): tell the model how to recover output the harness truncated

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -2358,9 +2358,32 @@ impl Agent {
                 let _ = hooks.run(HookEvent::AfterToolCall, &payload).await;
             }
 
-            // Per-tool output truncation with head/tail split
+            // Per-tool output truncation with head/tail split.
+            //
+            // The cut is a BACKSTOP: it is the one point every tool's output
+            // funnels through, which is also the point that knows the least —
+            // `truncate_head_tail` receives a string and a number. On its own it
+            // leaves the model with `... [N bytes omitted] ...` and no way to
+            // reach what it lost, so the only recovery is re-running the call,
+            // which returns the same output cut the same way and spends the
+            // tokens the cap was meant to save.
+            //
+            // `Tool::truncation_recovery` is the missing half: the tool still
+            // knows its own arguments and whether it paginates, so it can name a
+            // concrete next call. Tools with no resume path return None and get
+            // no invented advice.
             let limit = octos_core::tool_output_limit(&tc_name);
-            let content = octos_core::truncate_head_tail(&content, limit, 0.7);
+            let untruncated_len = content.len();
+            let mut content = octos_core::truncate_head_tail(&content, limit, 0.7);
+            if content.len() < untruncated_len {
+                if let Some(recovery) = tools.get(&tc_name).and_then(|tool| {
+                    tool.truncation_recovery(&effective_args, untruncated_len - content.len())
+                }) {
+                    content.push('\n');
+                    content.push_str(&recovery);
+                }
+            }
+            let content = content;
             let content = crate::sanitize::sanitize_tool_output(&content);
 
             // Pair the structured side-channel with the originating tool's

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6252,3 +6252,134 @@ const BIG_TOOL_OUTPUT: &str = concat!(
     "BEGIN-LARGE-TOOL-RESULT ",
     include_str!("append_only_audit.rs"),
 );
+
+/// A tool whose output overflows the cap and which knows how to resume.
+struct OverflowingPagedTool;
+
+#[async_trait]
+impl Tool for OverflowingPagedTool {
+    fn name(&self) -> &str {
+        "overflowing_paged"
+    }
+
+    fn description(&self) -> &str {
+        "Return more output than the per-tool cap allows"
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({ "type": "object", "properties": {} })
+    }
+
+    async fn execute(&self, _args: &serde_json::Value) -> Result<ToolResult> {
+        Ok(ToolResult {
+            // Comfortably past the 50_000-byte default cap.
+            output: "y".repeat(120_000),
+            success: true,
+            ..Default::default()
+        })
+    }
+
+    fn truncation_recovery(
+        &self,
+        args: &serde_json::Value,
+        omitted_bytes: usize,
+    ) -> Option<String> {
+        let page = args
+            .get("page")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        Some(format!(
+            "[{omitted_bytes} bytes omitted] Continue with page: {}.",
+            page + 1
+        ))
+    }
+}
+
+struct CallsOverflowingToolThenEnds {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl LlmProvider for CallsOverflowingToolThenEnds {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> Result<ChatResponse> {
+        let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        Ok(if call == 0 {
+            ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![ToolCall {
+                    id: "call_overflow".to_string(),
+                    name: "overflowing_paged".to_string(),
+                    arguments: serde_json::json!({ "page": 0 }),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: LlmTokenUsage::default(),
+                provider_index: None,
+            }
+        } else {
+            ChatResponse {
+                content: Some("done".to_string()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: LlmTokenUsage::default(),
+                provider_index: None,
+            }
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "test-model"
+    }
+
+    fn provider_name(&self) -> &str {
+        "test-provider"
+    }
+}
+
+/// The wiring test: a truncated tool result must reach the model carrying its
+/// recovery advice.
+///
+/// The unit tests prove `truncation_recovery` returns good text. They prove
+/// nothing about whether the execution loop ever CALLS it — and an unwired
+/// hook that returns perfect advice into the void is the failure mode this
+/// whole change exists to remove. So this drives the real loop and inspects
+/// the tool message the model actually received.
+#[tokio::test]
+async fn truncated_tool_output_reaches_the_model_with_its_recovery_advice() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut tools = ToolRegistry::with_builtins(dir.path());
+    tools.register(OverflowingPagedTool);
+
+    let provider: Arc<dyn LlmProvider> = Arc::new(CallsOverflowingToolThenEnds {
+        calls: AtomicUsize::new(0),
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("truncation-recovery"), provider, tools, memory);
+
+    let result = agent.process_message("go", &[], vec![]).await.unwrap();
+
+    let tool_message = result
+        .messages
+        .iter()
+        .find(|m| m.role == MessageRole::Tool)
+        .expect("the turn must contain the tool result");
+
+    assert!(
+        tool_message.content.len() < 120_000,
+        "the cap must still apply: got {} bytes",
+        tool_message.content.len()
+    );
+    assert!(
+        tool_message.content.contains("Continue with page: 1."),
+        "the truncated result must carry the tool's recovery advice, otherwise the model is \
+         left at a dead end and can only re-run the same call; tail was: {:?}",
+        &tool_message.content[tool_message.content.len().saturating_sub(200)..]
+    );
+}

--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -119,6 +119,36 @@ impl Tool for GrepTool {
         })
     }
 
+    /// `grep` does not paginate, so the recovery is to NARROW, and the advice
+    /// says which lever is still unused rather than offering a generic hint.
+    fn truncation_recovery(
+        &self,
+        args: &serde_json::Value,
+        omitted_bytes: usize,
+    ) -> Option<String> {
+        let mut levers = Vec::new();
+        if args
+            .get("path")
+            .and_then(serde_json::Value::as_str)
+            .is_none()
+        {
+            levers.push("scope it with path");
+        }
+        if args
+            .get("file_pattern")
+            .and_then(serde_json::Value::as_str)
+            .is_none()
+        {
+            levers.push("filter files with file_pattern (for example \"*.rs\")");
+        }
+        levers.push("tighten the pattern");
+        levers.push("lower limit and re-run");
+        Some(format!(
+            "[{omitted_bytes} bytes omitted] Too many matches to return. Narrow the search: {}.",
+            levers.join(", ")
+        ))
+    }
+
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
         // PR-B: legacy entry point routes through the typed path with a
         // zero-value context so out-of-band callers still get the same
@@ -849,5 +879,35 @@ mod tests {
             .unwrap();
         assert!(result.success);
         assert!(result.output.contains("hello"));
+    }
+
+    /// grep cannot paginate, so its recovery is narrowing — and the advice
+    /// should name the levers still UNUSED rather than listing all of them.
+    #[test]
+    fn should_offer_the_unused_narrowing_levers_when_matches_overflow() {
+        let tool = GrepTool::new(std::path::Path::new("."));
+        let advice = tool
+            .truncation_recovery(&serde_json::json!({ "pattern": "fn " }), 9_000)
+            .expect("grep always has narrowing available");
+        assert!(advice.contains("9000 bytes omitted"), "{advice}");
+        assert!(
+            advice.contains("path"),
+            "unused path filter should be offered: {advice}"
+        );
+        assert!(
+            advice.contains("file_pattern"),
+            "unused file_pattern filter should be offered: {advice}"
+        );
+
+        let already_scoped = tool
+            .truncation_recovery(
+                &serde_json::json!({ "pattern": "fn ", "path": "crates", "file_pattern": "*.rs" }),
+                9_000,
+            )
+            .expect("still recoverable by tightening the pattern");
+        assert!(
+            !already_scoped.contains("scope it with path"),
+            "a lever already in use must not be suggested again: {already_scoped}"
+        );
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -630,6 +630,43 @@ pub trait Tool: Send + Sync {
 
     /// Execute the tool with typed execution context.
     ///
+    /// How the model can retrieve output the harness had to truncate.
+    ///
+    /// Returns the advice to append when this tool's result exceeded
+    /// [`octos_core::tool_output_limit`] and was cut. `None` (the default)
+    /// means the tool has no resume path, so no advice is offered rather than
+    /// inventing one.
+    ///
+    /// ## Why this lives on the tool
+    ///
+    /// Truncation happens in the execution loop, at the one point every tool's
+    /// output funnels through — which is also the point that knows the least.
+    /// By then the result is a plain `String`: the helper doing the cutting
+    /// (`truncate_head_tail(s, max_len, head_ratio)`) receives a string and a
+    /// number and cannot know which tool produced it, whether that tool paginates,
+    /// or what the parameter is called.
+    ///
+    /// So the loop knows it truncated but not how to resume; the tool knows how
+    /// to resume but not that it was truncated. This hook is the missing half.
+    ///
+    /// Without it the model is told only `... [47000 bytes omitted] ...` — a
+    /// dead end whose only recovery is re-running the call, which returns the
+    /// same output cut the same way and spends the tokens the cap was meant to
+    /// save.
+    ///
+    /// # Arguments
+    /// * `args` - the arguments this call was made with, so advice can name a
+    ///   concrete next call rather than a generic one.
+    /// * `omitted_bytes` - how much was dropped.
+    fn truncation_recovery(
+        &self,
+        args: &serde_json::Value,
+        omitted_bytes: usize,
+    ) -> Option<String> {
+        let _ = (args, omitted_bytes);
+        None
+    }
+
     /// The default implementation delegates to [`Tool::execute`], discarding
     /// the context. Tools that want to read [`ToolContext`] fields override
     /// this and ignore `execute`'s default path. See the module-level doc

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -118,6 +118,41 @@ impl Tool for ReadFileTool {
         })
     }
 
+    /// `read_file` paginates, so a truncated read has a real next call.
+    ///
+    /// The advice names `offset`/`limit` explicitly and echoes the range that
+    /// was just read, because "output was truncated" alone leaves the model
+    /// re-issuing the identical call.
+    fn truncation_recovery(
+        &self,
+        args: &serde_json::Value,
+        omitted_bytes: usize,
+    ) -> Option<String> {
+        let start = args
+            .get("offset")
+            .or_else(|| args.get("start_line"))
+            .and_then(serde_json::Value::as_u64);
+        let limit = args.get("limit").and_then(serde_json::Value::as_u64);
+        Some(match (start, limit) {
+            (Some(start), Some(limit)) => format!(
+                "[{omitted_bytes} bytes omitted] This read started at line {start} with limit \
+                 {limit}. Continue with offset: {} to read on, or lower limit to read less per \
+                 call.",
+                start + limit
+            ),
+            (Some(start), None) => format!(
+                "[{omitted_bytes} bytes omitted] This read started at line {start}. Re-read a \
+                 bounded range with offset and limit (for example limit: 200) instead of the \
+                 whole file."
+            ),
+            _ => format!(
+                "[{omitted_bytes} bytes omitted] Read a bounded range instead: pass offset \
+                 (1-indexed start line) and limit (for example offset: 1, limit: 200), then page \
+                 forward."
+            ),
+        })
+    }
+
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
         // M8.1: legacy entry point routes through the typed path with a
         // zero-value context so out-of-band callers still exercise the same
@@ -1134,5 +1169,33 @@ mod tests {
             second.output
         );
         assert!(second.output.contains("line 7"));
+    }
+
+    /// A truncated read must name the call that continues it.
+    ///
+    /// Without this the model sees only "N bytes omitted" and its sole
+    /// recovery is re-issuing the identical call, which returns the identical
+    /// truncation — spending the tokens the cap existed to save.
+    #[test]
+    fn should_name_the_next_offset_when_a_bounded_read_is_truncated() {
+        let tool = ReadFileTool::new(std::path::Path::new("."));
+        let advice = tool
+            .truncation_recovery(&serde_json::json!({ "offset": 1, "limit": 200 }), 47_000)
+            .expect("read_file paginates, so it always has a resume path");
+        assert!(advice.contains("47000 bytes omitted"), "{advice}");
+        assert!(
+            advice.contains("offset: 201"),
+            "the advice must name the CONCRETE next call, not just mention offset: {advice}"
+        );
+    }
+
+    #[test]
+    fn should_suggest_bounding_the_read_when_no_range_was_given() {
+        let tool = ReadFileTool::new(std::path::Path::new("."));
+        let advice = tool
+            .truncation_recovery(&serde_json::json!({ "path": "big.txt" }), 12_345)
+            .expect("still recoverable: the tool takes offset/limit");
+        assert!(advice.contains("offset"), "{advice}");
+        assert!(advice.contains("limit"), "{advice}");
     }
 }


### PR DESCRIPTION
## The bug

Truncation happens in the execution loop, at the one point every tool's output funnels through — which is also the point that knows the least. The helper doing the cutting takes a string and a number:

```rust
truncate_head_tail(s: &str, max_len: usize, head_ratio: f32) -> String
```

It cannot know which tool produced the text, whether that tool paginates, or what the parameter is called. So the model was told only:

```
... [47000 bytes omitted] ...
```

…with no way to reach what it lost. Its only recovery was **re-running the call**, which returns the same output cut the same way — spending the tokens the cap existed to save, sometimes twice more before giving up.

The loop knew it truncated but not how to resume. The tool knew how to resume but not that it had been truncated. **Neither half had both pieces.**

## The fix

`Tool::truncation_recovery(args, omitted_bytes)` is the missing half. It runs where the tool's own arguments are still in scope, so it can name a **concrete** next call. It defaults to `None` — a tool with no resume path gets no invented advice, and no existing tool changes behaviour.

Implemented where a real recovery exists:

- **`read_file`** already had `offset`/`limit`. The machinery was there and the model was simply never told. It now echoes the range just read and names the next one — `offset: 201` after `offset: 1, limit: 200`.
- **`grep`** cannot paginate, so its recovery is narrowing — and it offers only the levers still **unused**, rather than suggesting a `path` filter to a call that already has one.

`truncate_head_tail` is unchanged. It stays the generic backstop for everything that funnels through, including plugin tools that don't exist yet. **The bug was never that the backstop was wrong — it's that nothing stood in front of it.**

## Verification

```
3 unit tests (read_file × 2, grep × 1)   => ok. 3 passed; 0 failed
1 end-to-end wiring test                 => ok. 1 passed; 0 failed
cargo clippy -p octos-agent --all-targets -- -D warnings => no warnings
cargo fmt --all -- --check               => clean
cargo test -p octos-agent --lib          => 2600 passed; 3 failed
```

**The end-to-end test is mutation-proved.** Deleting the loop wiring makes it fail, with the tool result's tail showing raw truncated output and no advice:

```
the truncated result must carry the tool's recovery advice ... tail was:
"yyyyyyyyyyyyyyyyyyyyyyyyyy..."
```

That check matters here specifically: unit tests prove the hook returns good text, and prove nothing about whether the loop ever **calls** it. An unwired hook returning perfect advice into the void is exactly the failure mode this change exists to remove.

The 3 suite failures are pre-existing and unrelated: two are this host's DNS resolver hijacking NXDOMAIN for `*.invalid` (`tools::ssrf`, `tools::web_fetch`), and one is #2093, which passed 3/3 on re-run.

## What this does not do

- **`shell` still gets no advice.** Its real recovery is spooling full output to a temp file and returning head + tail + path so the model can `grep` it. That's a bigger change and wants its own PR.
- **The caps themselves are untouched.** `search`/`deep_search`/`news_fetch` remain at 200,000 chars — roughly 50K tokens from a single call. Lowering them is the next lever, and it's *safe to pull now* in a way it wasn't before: a smaller cap with a recovery path costs a cheap follow-up call, where previously it cost a full re-run.

Refs #1638