### PR TITLE
feat(llm): probe local servers for their real context window

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -2215,6 +2215,10 @@ impl Agent {
                 // benefit from the same cheap shrinkage before their LLM call.
                 let protected_ids = collect_protected_tool_call_ids(&messages);
                 self.run_tier1_compaction(&mut messages, &protected_ids, tier1_pass(iteration));
+                // #2135 re-review P1: task mode (delegated workers, MCP task
+                // runs) sizes its prompt here too — resolve a lazily-probed
+                // window before the trim reads context_window().
+                self.llm.ensure_ready().await;
                 prepare_task_messages(self, &mut messages, &mut turn);
                 self.prepare_prompt_with_context_manager(
                     &mut messages,

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1205,6 +1205,13 @@ impl Agent {
                     // tier 3 considers whether to summarise).
                     let protected_ids = collect_protected_tool_call_ids(&messages);
                     self.run_tier1_compaction(&mut messages, &protected_ids, tier1_pass(iteration));
+                    // #2135 review P1: a provider that learns its true
+                    // context window asynchronously (the local probe) must
+                    // resolve BEFORE the trim below reads context_window() —
+                    // otherwise a resumed long transcript is compacted
+                    // against the stale catalog value. No-op (immediate) for
+                    // every other provider and once resolved.
+                    self.llm.ensure_ready().await;
                     prepare_conversation_messages(self, &mut messages, &mut turn);
                     // Harness M6.3: post-prep compaction pass so the declarative
                     // runner sees the final shape of the conversation (after

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -30520,9 +30520,10 @@ async fn run_standalone_turn(
     // #2135 review P1: resolve a lazily-probed context window BEFORE the
     // threshold compaction inside appui_context_history_for_agent reads it —
     // a resumed transcript compacted against the stale catalog value is
-    // exactly the failure the probe exists to prevent. Immediate no-op for
-    // non-probing providers and once resolved.
-    session_runtime.llm.ensure_ready().await;
+    // exactly the failure the probe exists to prevent. Uses the turn's
+    // already-selected provider (peer-lane routing preserved). Immediate
+    // no-op for non-probing providers and once resolved.
+    llm_provider.ensure_ready().await;
     let (history, context_manager, context_lifecycle_notifications) =
         appui_context_history_for_agent(
             // Root the context ledger at the session's TRANSCRIPT root, not the

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -30517,6 +30517,12 @@ async fn run_standalone_turn(
         let session = sessions.get_or_create(&session_id).await;
         session.get_history(50).to_vec()
     };
+    // #2135 review P1: resolve a lazily-probed context window BEFORE the
+    // threshold compaction inside appui_context_history_for_agent reads it —
+    // a resumed transcript compacted against the stale catalog value is
+    // exactly the failure the probe exists to prevent. Immediate no-op for
+    // non-probing providers and once resolved.
+    session_runtime.llm.ensure_ready().await;
     let (history, context_manager, context_lifecycle_notifications) =
         appui_context_history_for_agent(
             // Root the context ledger at the session's TRANSCRIPT root, not the

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -7473,6 +7473,11 @@ impl SessionActor {
         // M16-D2: capture ContextManager-derived prompt history before
         // persisting this turn's user message, because the agent appends the
         // current user message internally.
+        // #2135 round-3 P1: resolve a lazily-probed context window before
+        // the ContextManager threshold below reads it — a resumed gateway
+        // session must not PERSIST a compaction sized by the stale catalog
+        // value. Immediate no-op for non-probing providers, once resolved.
+        self.agent.llm_provider().ensure_ready().await;
         let history_for_agent: Vec<Message> =
             self.context_history_for_agent("pre_turn_speculative");
 
@@ -9297,6 +9302,9 @@ impl SessionActor {
         // ContextManager. If the active context is over threshold this installs
         // a compacted generation before the model call; raw session history
         // remains durable and unchanged.
+        // #2135 round-3 P1: same readiness requirement as the speculative
+        // path above — the threshold derives from context_window().
+        self.agent.llm_provider().ensure_ready().await;
         let history: Vec<Message> = self.context_history_for_agent("pre_turn");
 
         // Token tracker for status indicator

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -1704,22 +1704,6 @@ impl AdaptiveRouter {
         }
     }
 
-    /// The slot the router would pick with NO stochastic exploration: the
-    /// best-scored non-circuit-open slot, falling back to slot 0. Used by
-    /// the identity/readiness accessors (#2135 round-6 P1) so metadata and
-    /// preloading are stable across calls, while `select_provider` keeps
-    /// its exploration for actual request routing.
-    fn preferred_slot_index(&self) -> usize {
-        self.slots
-            .iter()
-            .enumerate()
-            .filter(|(_, s)| !s.metrics.is_circuit_open(self.config.failure_threshold))
-            .map(|(i, s)| (i, self.score(s)))
-            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
-            .map(|(i, _)| i)
-            .unwrap_or(0)
-    }
-
     /// Score a provider. Lower is better.
     ///
     /// Four factors:
@@ -1882,7 +1866,12 @@ impl AdaptiveRouter {
         Some(matched)
     }
 
-    /// Select provider index and whether this is a probe request.
+    /// The DETERMINISTIC selection — everything `select_provider` does
+    /// except the stochastic probe redirect (#2135 round-7 P1: the
+    /// identity/readiness accessors need the same mode/lane rules and the
+    /// same ASCENDING score order as real routing, not a parallel
+    /// reimplementation; an earlier cut used max_by against a
+    /// lower-is-better score and preferred the worst lane).
     ///
     /// - Off / Hedge: priority order, skip circuit-broken only.
     ///   (Hedge mode uses this to pick the primary for racing.)
@@ -1893,7 +1882,7 @@ impl AdaptiveRouter {
     /// in the lane's candidate list. When the lane filter yields
     /// zero matches we fall through to the full slot list so the
     /// router never starves (see [`Self::lane_filtered_slot_indices`]).
-    fn select_provider(&self) -> (usize, bool) {
+    fn select_provider_deterministic(&self) -> usize {
         let mode = self.mode();
         // RFC-3: lane-filtered eligible set, if any. None ⇒ no
         // filter; behave identically to pre-RFC-3.
@@ -1923,7 +1912,7 @@ impl AdaptiveRouter {
                                 "provider failover (lane filter, lane changing disabled)"
                             );
                         }
-                        return (i, false);
+                        return i;
                     }
                 }
                 // All lane candidates circuit-broken → fall through
@@ -1943,7 +1932,7 @@ impl AdaptiveRouter {
                             "provider failover (circuit breaker, lane changing disabled)"
                         );
                     }
-                    return (i, false);
+                    return i;
                 }
             }
             // All circuit-broken — fall through to least-failed logic below
@@ -1996,19 +1985,42 @@ impl AdaptiveRouter {
                 "all providers circuit-broken, using least-failed"
             );
             self.last_selected.store(best as u32, Ordering::Relaxed);
-            return (best, false);
+            return best;
         }
 
         scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
         let best_idx = scored[0].0;
 
+        // Detect lane change. (This now runs before any probe redirect in
+        // `select_provider` — a probe is a measurement detour, not a lane
+        // change, so logging the deterministic selection is the accurate
+        // record.)
+        let prev = self.last_selected.swap(best_idx as u32, Ordering::Relaxed);
+        if prev != best_idx as u32 && prev < self.slots.len() as u32 {
+            info!(
+                from = self.slots[prev as usize].provider.provider_name(),
+                to = self.slots[best_idx].provider.provider_name(),
+                from_score = format!("{:.3}", self.score(&self.slots[prev as usize])),
+                to_score = format!("{:.3}", self.score(&self.slots[best_idx])),
+                "adaptive lane change"
+            );
+        }
+
+        best_idx
+    }
+
+    /// Select provider index and whether this is a probe request: the
+    /// deterministic selection above, plus the stochastic stale-provider
+    /// probe redirect used for actual request routing only.
+    fn select_provider(&self) -> (usize, bool) {
+        let best_idx = self.select_provider_deterministic();
         // Probe: with some probability, redirect to a stale non-primary provider.
         // RFC-3 (#1292) — codex P2: when a lane filter is active,
         // restrict probe targets to the lane's eligible slots so a
         // probe under `slides:*`/`code:*` can never route the user
         // turn to an out-of-lane model.
         if self.slots.len() > 1 && self.should_probe() {
-            // Find a stale provider that isn't the best
+            let lane_eligible = self.lane_filtered_slot_indices();
             for (i, slot) in self.slots.iter().enumerate() {
                 if i != best_idx
                     && slot.metrics.is_stale(self.config.probe_interval_secs)
@@ -2027,19 +2039,6 @@ impl AdaptiveRouter {
                 }
             }
         }
-
-        // Detect lane change
-        let prev = self.last_selected.swap(best_idx as u32, Ordering::Relaxed);
-        if prev != best_idx as u32 && prev < self.slots.len() as u32 {
-            info!(
-                from = self.slots[prev as usize].provider.provider_name(),
-                to = self.slots[best_idx].provider.provider_name(),
-                from_score = format!("{:.3}", self.score(&self.slots[prev as usize])),
-                to_score = format!("{:.3}", self.score(&self.slots[best_idx])),
-                "adaptive lane change"
-            );
-        }
-
         (best_idx, false)
     }
 
@@ -2503,22 +2502,24 @@ impl LlmProvider for AdaptiveRouter {
         // prefer (best score, no stochastic exploration — #2135 round-6
         // P1): readiness may preload, and a coin-flipped lane must not
         // decide which model gets loaded into memory.
-        let idx = self.preferred_slot_index();
+        let idx = self.select_provider_deterministic();
         self.slots[idx].provider.ensure_ready().await;
     }
 
     fn model_id(&self) -> &str {
-        self.slots[self.preferred_slot_index()].provider.model_id()
+        self.slots[self.select_provider_deterministic()]
+            .provider
+            .model_id()
     }
 
     fn provider_name(&self) -> &str {
-        self.slots[self.preferred_slot_index()]
+        self.slots[self.select_provider_deterministic()]
             .provider
             .provider_name()
     }
 
     fn provider_metadata(&self) -> ProviderMetadata {
-        self.slots[self.preferred_slot_index()]
+        self.slots[self.select_provider_deterministic()]
             .provider
             .provider_metadata()
     }

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -2181,6 +2181,20 @@ impl AdaptiveRouter {
         tools: &[ToolSpec],
         config: &ChatConfig,
     ) -> Result<ChatResponse> {
+        // #2135 round-8 P1: every adaptive dispatch — primary selection,
+        // stochastic probe, hedge racer, failover candidate — funnels
+        // through here, so this is the ONE place the route-fit guard
+        // covers them all. An unfit route errors WITHOUT touching the
+        // slot's metrics (not the provider's fault; the circuit breaker
+        // must not open over prompt size) — failover treats it like any
+        // other error and moves to a lane that fits.
+        if !crate::context::route_fits_request(&self.slots[idx].provider, messages, tools).await {
+            return Err(eyre::eyre!(
+                "route {} skipped: request does not fit its context window ({} tokens)",
+                self.slots[idx].provider.provider_name(),
+                self.slots[idx].provider.context_window()
+            ));
+        }
         let start = Instant::now();
         let result = self.slots[idx].provider.chat(messages, tools, config).await;
         let elapsed_us = start.elapsed().as_micros() as u64;
@@ -2262,6 +2276,20 @@ impl AdaptiveRouter {
         tools: &[ToolSpec],
         config: &ChatConfig,
     ) -> Result<ChatStream> {
+        // #2135 round-8 P1: every adaptive dispatch — primary selection,
+        // stochastic probe, hedge racer, failover candidate — funnels
+        // through here, so this is the ONE place the route-fit guard
+        // covers them all. An unfit route errors WITHOUT touching the
+        // slot's metrics (not the provider's fault; the circuit breaker
+        // must not open over prompt size) — failover treats it like any
+        // other error and moves to a lane that fits.
+        if !crate::context::route_fits_request(&self.slots[idx].provider, messages, tools).await {
+            return Err(eyre::eyre!(
+                "route {} skipped: request does not fit its context window ({} tokens)",
+                self.slots[idx].provider.provider_name(),
+                self.slots[idx].provider.context_window()
+            ));
+        }
         let start = Instant::now();
         let result = self.slots[idx]
             .provider

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -1704,6 +1704,22 @@ impl AdaptiveRouter {
         }
     }
 
+    /// The slot the router would pick with NO stochastic exploration: the
+    /// best-scored non-circuit-open slot, falling back to slot 0. Used by
+    /// the identity/readiness accessors (#2135 round-6 P1) so metadata and
+    /// preloading are stable across calls, while `select_provider` keeps
+    /// its exploration for actual request routing.
+    fn preferred_slot_index(&self) -> usize {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| !s.metrics.is_circuit_open(self.config.failure_threshold))
+            .map(|(i, s)| (i, self.score(s)))
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    }
+
     /// Score a provider. Lower is better.
     ///
     /// Four factors:
@@ -2459,37 +2475,52 @@ impl LlmProvider for AdaptiveRouter {
         }
     }
 
-    // #2135 review P1: same slot selection as model_id — the router must
-    // report the window of the provider it would actually route to, not
-    // the static catalog default.
+    // #2135 round-6 P1: the sizing accessors take the MINIMUM across all
+    // slots — selection-INDEPENDENT and safe for every route this router
+    // can take (Lane-mode stochastic probes, hedged sends, failover): a
+    // prompt sized for a probed 256K local primary must not reach a 32K
+    // lane. Per-route resizing at dispatch is the precise fix and belongs
+    // to the router itself; until then the conservative envelope is the
+    // pre-probe catalog behavior restored, minus its staleness.
     fn context_window(&self) -> u32 {
-        let (idx, _) = self.select_provider();
-        self.slots[idx].provider.context_window()
+        self.slots
+            .iter()
+            .map(|slot| slot.provider.context_window())
+            .min()
+            .unwrap_or(32_768)
     }
 
     fn max_output_tokens(&self) -> u32 {
-        let (idx, _) = self.select_provider();
-        self.slots[idx].provider.max_output_tokens()
+        self.slots
+            .iter()
+            .map(|slot| slot.provider.max_output_tokens())
+            .min()
+            .unwrap_or(4096)
     }
 
     async fn ensure_ready(&self) {
-        let (idx, _) = self.select_provider();
+        // Readiness preps the lane the router would DETERMINISTICALLY
+        // prefer (best score, no stochastic exploration — #2135 round-6
+        // P1): readiness may preload, and a coin-flipped lane must not
+        // decide which model gets loaded into memory.
+        let idx = self.preferred_slot_index();
         self.slots[idx].provider.ensure_ready().await;
     }
 
     fn model_id(&self) -> &str {
-        let (idx, _) = self.select_provider();
-        self.slots[idx].provider.model_id()
+        self.slots[self.preferred_slot_index()].provider.model_id()
     }
 
     fn provider_name(&self) -> &str {
-        let (idx, _) = self.select_provider();
-        self.slots[idx].provider.provider_name()
+        self.slots[self.preferred_slot_index()]
+            .provider
+            .provider_name()
     }
 
     fn provider_metadata(&self) -> ProviderMetadata {
-        let (idx, _) = self.select_provider();
-        self.slots[idx].provider.provider_metadata()
+        self.slots[self.preferred_slot_index()]
+            .provider
+            .provider_metadata()
     }
 
     fn provider_metadata_for_index(&self, provider_index: Option<usize>) -> ProviderMetadata {

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -2459,6 +2459,24 @@ impl LlmProvider for AdaptiveRouter {
         }
     }
 
+    // #2135 review P1: same slot selection as model_id — the router must
+    // report the window of the provider it would actually route to, not
+    // the static catalog default.
+    fn context_window(&self) -> u32 {
+        let (idx, _) = self.select_provider();
+        self.slots[idx].provider.context_window()
+    }
+
+    fn max_output_tokens(&self) -> u32 {
+        let (idx, _) = self.select_provider();
+        self.slots[idx].provider.max_output_tokens()
+    }
+
+    async fn ensure_ready(&self) {
+        let (idx, _) = self.select_provider();
+        self.slots[idx].provider.ensure_ready().await;
+    }
+
     fn model_id(&self) -> &str {
         let (idx, _) = self.select_provider();
         self.slots[idx].provider.model_id()

--- a/crates/octos-llm/src/adaptive_tests.rs
+++ b/crates/octos-llm/src/adaptive_tests.rs
@@ -2500,4 +2500,10 @@ async fn test_sizing_is_min_across_slots_and_identity_is_deterministic() {
             "identity must not flip stochastically"
         );
     }
+    // #2135 round-7 P1: the deterministic selection must pick the BEST
+    // slot (ascending score, same rules as routing) — an earlier cut used
+    // max_by over a lower-is-better score and preferred the worst lane.
+    // With identical cold providers, priority ordering makes the PRIMARY
+    // the correct choice.
+    assert_eq!(first, "m1", "cold identical slots must select the primary");
 }

--- a/crates/octos-llm/src/adaptive_tests.rs
+++ b/crates/octos-llm/src/adaptive_tests.rs
@@ -2455,3 +2455,49 @@ async fn should_not_failover_when_failfast_and_primary_fails() {
         "FailFast must NOT call fallback provider"
     );
 }
+
+/// #2135 round-6 P1: sizing accessors take the minimum across slots
+/// (selection-independent — safe for hedge/probe/failover routing), and
+/// the identity accessors are DETERMINISTIC (best-scored slot, no
+/// stochastic exploration).
+#[tokio::test]
+async fn test_sizing_is_min_across_slots_and_identity_is_deterministic() {
+    let big: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+        Arc::new(MockProvider {
+            name: "primary",
+            model: "m1",
+            latency_ms: 0,
+            fail: false,
+            error_msg: "",
+        }),
+        262_144,
+    ));
+    let small: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+        Arc::new(MockProvider {
+            name: "fallback",
+            model: "m2",
+            latency_ms: 0,
+            fail: false,
+            error_msg: "",
+        }),
+        32_768,
+    ));
+    let router = AdaptiveRouter::new(
+        vec![big, small],
+        &[],
+        AdaptiveConfig {
+            // Exploration ON: identity must be stable regardless.
+            probe_probability: 0.5,
+            ..Default::default()
+        },
+    );
+    assert_eq!(router.context_window(), 32_768, "min across slots");
+    let first = router.model_id().to_string();
+    for _ in 0..50 {
+        assert_eq!(
+            router.model_id(),
+            first,
+            "identity must not flip stochastically"
+        );
+    }
+}

--- a/crates/octos-llm/src/adaptive_tests.rs
+++ b/crates/octos-llm/src/adaptive_tests.rs
@@ -2507,3 +2507,101 @@ async fn test_sizing_is_min_across_slots_and_identity_is_deterministic() {
     // the correct choice.
     assert_eq!(first, "m1", "cold identical slots must select the primary");
 }
+
+/// #2135 round-8 P1: every adaptive dispatch passes the route-fit guard —
+/// a lane that resolves too small at dispatch is skipped (its chat never
+/// invoked), failover serves from a fitting lane, and the skip must NOT
+/// poison the skipped lane's circuit breaker.
+#[tokio::test]
+async fn test_unfit_lane_is_skipped_without_breaker_pollution() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct LateSmall {
+        resolved: AtomicBool,
+        calls: Arc<AtomicUsize>,
+    }
+    #[async_trait::async_trait]
+    impl LlmProvider for LateSmall {
+        async fn chat(
+            &self,
+            _m: &[Message],
+            _t: &[ToolSpec],
+            _c: &ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ChatResponse {
+                content: Some("from-small".into()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: crate::StopReason::EndTurn,
+                usage: TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "m-small"
+        }
+        fn provider_name(&self) -> &str {
+            "local"
+        }
+        fn context_window(&self) -> u32 {
+            if self.resolved.load(Ordering::SeqCst) {
+                1_024
+            } else {
+                131_072
+            }
+        }
+        async fn ensure_ready(&self) {
+            self.resolved.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let small_calls = Arc::new(AtomicUsize::new(0));
+    let router = AdaptiveRouter::new(
+        vec![
+            Arc::new(LateSmall {
+                resolved: AtomicBool::new(false),
+                calls: small_calls.clone(),
+            }),
+            Arc::new(MockProvider {
+                name: "fallback",
+                model: "m2",
+                latency_ms: 0,
+                fail: false,
+                error_msg: "",
+            }),
+        ],
+        &[],
+        AdaptiveConfig {
+            probe_probability: 0.0,
+            ..Default::default()
+        },
+    );
+    let big = Message::user("x ".repeat(20_000));
+    for _ in 0..4 {
+        let resp = router
+            .chat(std::slice::from_ref(&big), &[], &ChatConfig::default())
+            .await
+            .expect("the fitting lane must serve the request");
+        assert_eq!(resp.content.unwrap(), "from-fallback");
+    }
+    assert_eq!(
+        small_calls.load(Ordering::SeqCst),
+        0,
+        "unfit lane must never be dispatched for oversized prompts"
+    );
+    // Breaker not poisoned: for a SMALL prompt the lane fits again and —
+    // being the deterministic primary — must serve it. Four unfit skips
+    // above exceed the default failure threshold, so if skips recorded
+    // failures the breaker would be open and this would route to the
+    // fallback instead.
+    let resp = router
+        .chat(&[Message::user("hi")], &[], &ChatConfig::default())
+        .await
+        .expect("small prompt must succeed");
+    assert_eq!(
+        resp.content.unwrap(),
+        "from-small",
+        "skips must not open the unfit lane's breaker"
+    );
+}

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -217,7 +217,6 @@ pub fn estimate_message_tokens(msg: &Message) -> u32 {
     tokens + 4
 }
 
-#[cfg(test)]
 /// Route-fit guard for failover/fallback dispatch (#2135 round-7 P1):
 /// before re-sending an UNCHANGED request to an alternate route, resolve
 /// that route's readiness (a lazily-probed local provider may still be
@@ -239,6 +238,7 @@ pub(crate) async fn route_fits_request(
     estimated <= window.saturating_sub(margin)
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -217,23 +217,40 @@ pub fn estimate_message_tokens(msg: &Message) -> u32 {
     tokens + 4
 }
 
-/// Route-fit guard for failover/fallback dispatch (#2135 round-7 P1):
+/// Rough token cost of ONE tool declaration in the request: providers
+/// serialize every name, description, and full input schema (#2135
+/// round-8 P1 — a guard that only totals messages passes a tiny prompt
+/// whose tool schemas alone overflow a small window).
+pub(crate) fn estimate_tool_tokens(tool: &crate::types::ToolSpec) -> u32 {
+    estimate_tokens(&tool.name)
+        + estimate_tokens(&tool.description)
+        + estimate_tokens(&tool.input_schema.to_string())
+        + 8 // serialization scaffolding per tool
+}
+
+/// Route-fit guard for failover/fallback dispatch (#2135 rounds 7-8, P1):
 /// before re-sending an UNCHANGED request to an alternate route, resolve
 /// that route's readiness (a lazily-probed local provider may still be
-/// reporting its catalog guess) and check the prompt plausibly fits its
-/// window. The min-across-routes sizing accessors bound the envelope at
-/// PROMPT-BUILD time with whatever was resolved then; this guard is the
-/// dispatch-time recheck for routes that resolved smaller afterwards. A
-/// route that cannot fit is SKIPPED like a failed route — an oversized
-/// request would be truncated or rejected server-side anyway, with worse
-/// failure modes than trying the next lane.
+/// reporting its catalog guess) and check the ACTUAL request — messages
+/// plus serialized tool declarations — plausibly fits its window. The
+/// min-across-routes sizing accessors bound the envelope at PROMPT-BUILD
+/// time with whatever was resolved then; this guard is the dispatch-time
+/// recheck for routes that resolved smaller afterwards. A route that
+/// cannot fit is SKIPPED like a failed route — an oversized request would
+/// be truncated or rejected server-side anyway, with worse failure modes
+/// than trying the next lane.
 pub(crate) async fn route_fits_request(
     provider: &std::sync::Arc<dyn crate::provider::LlmProvider>,
     messages: &[octos_core::Message],
+    tools: &[crate::types::ToolSpec],
 ) -> bool {
     provider.ensure_ready().await;
     let window = provider.context_window();
-    let estimated: u32 = messages.iter().map(estimate_message_tokens).sum();
+    let estimated: u32 = messages
+        .iter()
+        .map(estimate_message_tokens)
+        .chain(tools.iter().map(estimate_tool_tokens))
+        .sum();
     let margin = (window / 8).clamp(64, 1024);
     estimated <= window.saturating_sub(margin)
 }
@@ -241,6 +258,47 @@ pub(crate) async fn route_fits_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #2135 round-8 P1: the fit guard measures the ACTUAL request — a
+    /// tiny message with a large tool schema must fail a small window.
+    #[tokio::test]
+    async fn should_count_tool_schemas_in_route_fit() {
+        use std::sync::Arc;
+        struct Tiny;
+        #[async_trait::async_trait]
+        impl crate::provider::LlmProvider for Tiny {
+            async fn chat(
+                &self,
+                _m: &[octos_core::Message],
+                _t: &[crate::types::ToolSpec],
+                _c: &crate::config::ChatConfig,
+            ) -> eyre::Result<crate::types::ChatResponse> {
+                unreachable!()
+            }
+            fn model_id(&self) -> &str {
+                "tiny"
+            }
+            fn provider_name(&self) -> &str {
+                "local"
+            }
+        }
+        let provider: Arc<dyn crate::provider::LlmProvider> =
+            Arc::new(crate::ContextWindowOverride::new(Arc::new(Tiny), 2_000));
+        let msg = [octos_core::Message::user("hi")];
+        let fat_tool = crate::types::ToolSpec {
+            name: "big".into(),
+            description: "d".into(),
+            input_schema: serde_json::json!({"properties": {"x": "y".repeat(20_000)}}),
+        };
+        assert!(
+            route_fits_request(&provider, &msg, &[]).await,
+            "message alone fits"
+        );
+        assert!(
+            !route_fits_request(&provider, &msg, &[fat_tool]).await,
+            "tool schema must count against the window"
+        );
+    }
 
     #[test]
     fn test_context_window_default() {

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -218,6 +218,27 @@ pub fn estimate_message_tokens(msg: &Message) -> u32 {
 }
 
 #[cfg(test)]
+/// Route-fit guard for failover/fallback dispatch (#2135 round-7 P1):
+/// before re-sending an UNCHANGED request to an alternate route, resolve
+/// that route's readiness (a lazily-probed local provider may still be
+/// reporting its catalog guess) and check the prompt plausibly fits its
+/// window. The min-across-routes sizing accessors bound the envelope at
+/// PROMPT-BUILD time with whatever was resolved then; this guard is the
+/// dispatch-time recheck for routes that resolved smaller afterwards. A
+/// route that cannot fit is SKIPPED like a failed route — an oversized
+/// request would be truncated or rejected server-side anyway, with worse
+/// failure modes than trying the next lane.
+pub(crate) async fn route_fits_request(
+    provider: &std::sync::Arc<dyn crate::provider::LlmProvider>,
+    messages: &[octos_core::Message],
+) -> bool {
+    provider.ensure_ready().await;
+    let window = provider.context_window();
+    let estimated: u32 = messages.iter().map(estimate_message_tokens).sum();
+    let margin = (window / 8).clamp(64, 1024);
+    estimated <= window.saturating_sub(margin)
+}
+
 mod tests {
     use super::*;
 
@@ -482,25 +503,4 @@ mod tests {
         let tokens = estimate_message_tokens(&msg);
         assert_eq!(tokens, estimate_tokens("Hello, how are you today?") + 4);
     }
-}
-
-/// Route-fit guard for failover/fallback dispatch (#2135 round-7 P1):
-/// before re-sending an UNCHANGED request to an alternate route, resolve
-/// that route's readiness (a lazily-probed local provider may still be
-/// reporting its catalog guess) and check the prompt plausibly fits its
-/// window. The min-across-routes sizing accessors bound the envelope at
-/// PROMPT-BUILD time with whatever was resolved then; this guard is the
-/// dispatch-time recheck for routes that resolved smaller afterwards. A
-/// route that cannot fit is SKIPPED like a failed route — an oversized
-/// request would be truncated or rejected server-side anyway, with worse
-/// failure modes than trying the next lane.
-pub(crate) async fn route_fits_request(
-    provider: &std::sync::Arc<dyn crate::provider::LlmProvider>,
-    messages: &[octos_core::Message],
-) -> bool {
-    provider.ensure_ready().await;
-    let window = provider.context_window();
-    let estimated: u32 = messages.iter().map(estimate_message_tokens).sum();
-    let margin = (window / 8).clamp(64, 1024);
-    estimated <= window.saturating_sub(margin)
 }

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -483,3 +483,24 @@ mod tests {
         assert_eq!(tokens, estimate_tokens("Hello, how are you today?") + 4);
     }
 }
+
+/// Route-fit guard for failover/fallback dispatch (#2135 round-7 P1):
+/// before re-sending an UNCHANGED request to an alternate route, resolve
+/// that route's readiness (a lazily-probed local provider may still be
+/// reporting its catalog guess) and check the prompt plausibly fits its
+/// window. The min-across-routes sizing accessors bound the envelope at
+/// PROMPT-BUILD time with whatever was resolved then; this guard is the
+/// dispatch-time recheck for routes that resolved smaller afterwards. A
+/// route that cannot fit is SKIPPED like a failed route — an oversized
+/// request would be truncated or rejected server-side anyway, with worse
+/// failure modes than trying the next lane.
+pub(crate) async fn route_fits_request(
+    provider: &std::sync::Arc<dyn crate::provider::LlmProvider>,
+    messages: &[octos_core::Message],
+) -> bool {
+    provider.ensure_ready().await;
+    let window = provider.context_window();
+    let estimated: u32 = messages.iter().map(estimate_message_tokens).sum();
+    let margin = (window / 8).clamp(64, 1024);
+    estimated <= window.saturating_sub(margin)
+}

--- a/crates/octos-llm/src/context_override.rs
+++ b/crates/octos-llm/src/context_override.rs
@@ -44,6 +44,10 @@ impl LlmProvider for ContextWindowOverride {
         self.inner.chat_stream(messages, tools, config).await
     }
 
+    async fn ensure_ready(&self) {
+        self.inner.ensure_ready().await;
+    }
+
     fn context_window(&self) -> u32 {
         self.window
     }

--- a/crates/octos-llm/src/failover.rs
+++ b/crates/octos-llm/src/failover.rs
@@ -165,6 +165,19 @@ impl ProviderChain {
                 continue;
             }
 
+            // #2135 round-7 P1: an ALTERNATE lane receives the unchanged
+            // request, so resolve its readiness and skip it when the prompt
+            // cannot plausibly fit its (possibly just-resolved) window — an
+            // oversized send would truncate or be rejected server-side.
+            if offset > 0 && !crate::context::route_fits_request(&slot.provider, messages).await {
+                tracing::warn!(
+                    provider = slot.provider.provider_name(),
+                    window = slot.provider.context_window(),
+                    "skipping failover lane: prompt does not fit its context window"
+                );
+                continue;
+            }
+
             let result = self
                 .with_lane_timeout(
                     slot.provider.provider_name(),
@@ -249,6 +262,19 @@ impl LlmProvider for ProviderChain {
             let slot = &self.slots[idx];
 
             if offset > 0 && slot.failures.load(Ordering::Relaxed) >= self.failure_threshold {
+                continue;
+            }
+
+            // #2135 round-7 P1: an ALTERNATE lane receives the unchanged
+            // request, so resolve its readiness and skip it when the prompt
+            // cannot plausibly fit its (possibly just-resolved) window — an
+            // oversized send would truncate or be rejected server-side.
+            if offset > 0 && !crate::context::route_fits_request(&slot.provider, messages).await {
+                tracing::warn!(
+                    provider = slot.provider.provider_name(),
+                    window = slot.provider.context_window(),
+                    "skipping failover lane: prompt does not fit its context window"
+                );
                 continue;
             }
 

--- a/crates/octos-llm/src/failover.rs
+++ b/crates/octos-llm/src/failover.rs
@@ -165,28 +165,35 @@ impl ProviderChain {
                 continue;
             }
 
-            // #2135 round-7 P1: an ALTERNATE lane receives the unchanged
-            // request, so resolve its readiness and skip it when the prompt
-            // cannot plausibly fit its (possibly just-resolved) window — an
-            // oversized send would truncate or be rejected server-side.
-            if offset > 0 && !crate::context::route_fits_request(&slot.provider, messages).await {
-                tracing::warn!(
-                    provider = slot.provider.provider_name(),
-                    window = slot.provider.context_window(),
-                    "skipping failover lane: prompt does not fit its context window"
-                );
-                continue;
-            }
-
             let result = self
-                .with_lane_timeout(
-                    slot.provider.provider_name(),
-                    slot.provider.chat(messages, tools, config),
-                )
+                .with_lane_timeout(slot.provider.provider_name(), async {
+                    // #2135 rounds 7-8: an ALTERNATE lane receives the
+                    // unchanged request — resolve its readiness and skip it
+                    // when the request cannot fit its window. The guard
+                    // runs INSIDE the lane timeout so a slow local
+                    // readiness counts against the SAME deadline as the
+                    // request and cannot delay failover (round-8 P2).
+                    // Ok(None) = unfit skip, distinct from a lane failure.
+                    if offset > 0
+                        && !crate::context::route_fits_request(&slot.provider, messages, tools)
+                            .await
+                    {
+                        return Ok(None);
+                    }
+                    slot.provider.chat(messages, tools, config).await.map(Some)
+                })
                 .await;
 
             match result {
-                Ok(mut response) => {
+                Ok(None) => {
+                    tracing::warn!(
+                        provider = slot.provider.provider_name(),
+                        window = slot.provider.context_window(),
+                        "skipping failover lane: request does not fit its context window"
+                    );
+                    continue;
+                }
+                Ok(Some(mut response)) => {
                     self.record_success(idx);
                     response.provider_index = Some(idx);
                     return Ok(response);
@@ -265,31 +272,36 @@ impl LlmProvider for ProviderChain {
                 continue;
             }
 
-            // #2135 round-7 P1: an ALTERNATE lane receives the unchanged
-            // request, so resolve its readiness and skip it when the prompt
-            // cannot plausibly fit its (possibly just-resolved) window — an
-            // oversized send would truncate or be rejected server-side.
-            if offset > 0 && !crate::context::route_fits_request(&slot.provider, messages).await {
-                tracing::warn!(
-                    provider = slot.provider.provider_name(),
-                    window = slot.provider.context_window(),
-                    "skipping failover lane: prompt does not fit its context window"
-                );
-                continue;
-            }
-
             // Cap stream *initialization* per lane; consuming the returned
             // stream is unaffected. A hung init is recorded below and the
-            // chain fails over like any other retriable error.
+            // chain fails over like any other retriable error. The fit
+            // guard runs INSIDE the cap (#2135 round-8 P2), and Ok(None)
+            // means an unfit skip, distinct from a lane failure.
             let result = self
-                .with_lane_timeout(
-                    slot.provider.provider_name(),
-                    slot.provider.chat_stream(messages, tools, config),
-                )
+                .with_lane_timeout(slot.provider.provider_name(), async {
+                    if offset > 0
+                        && !crate::context::route_fits_request(&slot.provider, messages, tools)
+                            .await
+                    {
+                        return Ok(None);
+                    }
+                    slot.provider
+                        .chat_stream(messages, tools, config)
+                        .await
+                        .map(Some)
+                })
                 .await;
 
             match result {
-                Ok(stream) => {
+                Ok(None) => {
+                    tracing::warn!(
+                        provider = slot.provider.provider_name(),
+                        window = slot.provider.context_window(),
+                        "skipping failover lane: request does not fit its context window"
+                    );
+                    continue;
+                }
+                Ok(Some(stream)) => {
                     self.record_success(idx);
                     return Ok(self.stream_with_provider_index(idx, stream));
                 }
@@ -764,5 +776,49 @@ mod tests {
         ));
         let chain = ProviderChain::new(vec![big, small]);
         assert_eq!(chain.context_window(), 32_768);
+    }
+
+    /// #2135 round-8 P2: the fit guard's readiness runs INSIDE the lane
+    /// timeout — a lane whose local readiness hangs must be abandoned at
+    /// the configured deadline, not delay failover for a probe budget.
+    #[tokio::test]
+    async fn should_cap_readiness_inside_the_lane_timeout() {
+        struct SlowReadyProvider;
+        #[async_trait]
+        impl LlmProvider for SlowReadyProvider {
+            async fn chat(
+                &self,
+                _m: &[Message],
+                _t: &[ToolSpec],
+                _c: &ChatConfig,
+            ) -> Result<ChatResponse> {
+                unreachable!("never dispatched");
+            }
+            fn model_id(&self) -> &str {
+                "slow-ready"
+            }
+            fn provider_name(&self) -> &str {
+                "local"
+            }
+            async fn ensure_ready(&self) {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            }
+        }
+        let failing: Arc<dyn LlmProvider> = Arc::new(FailingProvider {
+            name: "primary",
+            error: "boom",
+        });
+        let slow: Arc<dyn LlmProvider> = Arc::new(SlowReadyProvider);
+        let chain = ProviderChain::new(vec![failing, slow])
+            .with_max_request_duration(Some(std::time::Duration::from_millis(100)));
+        let start = std::time::Instant::now();
+        let _ = chain
+            .chat(&[Message::user("hi")], &[], &ChatConfig::default())
+            .await;
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "slow readiness must be capped by the lane deadline; took {:?}",
+            start.elapsed()
+        );
     }
 }

--- a/crates/octos-llm/src/failover.rs
+++ b/crates/octos-llm/src/failover.rs
@@ -290,6 +290,24 @@ impl LlmProvider for ProviderChain {
         Err(last_error.unwrap_or_else(|| eyre::eyre!("all providers exhausted")))
     }
 
+    // #2135 review P1: same slot selection as model_id — the chain must
+    // report the window of the provider it would actually use, not the
+    // static catalog default.
+    fn context_window(&self) -> u32 {
+        let idx = self.pick_start();
+        self.slots[idx].provider.context_window()
+    }
+
+    fn max_output_tokens(&self) -> u32 {
+        let idx = self.pick_start();
+        self.slots[idx].provider.max_output_tokens()
+    }
+
+    async fn ensure_ready(&self) {
+        let idx = self.pick_start();
+        self.slots[idx].provider.ensure_ready().await;
+    }
+
     fn model_id(&self) -> &str {
         let idx = self.pick_start();
         self.slots[idx].provider.model_id()

--- a/crates/octos-llm/src/failover.rs
+++ b/crates/octos-llm/src/failover.rs
@@ -290,17 +290,23 @@ impl LlmProvider for ProviderChain {
         Err(last_error.unwrap_or_else(|| eyre::eyre!("all providers exhausted")))
     }
 
-    // #2135 review P1: same slot selection as model_id — the chain must
-    // report the window of the provider it would actually use, not the
-    // static catalog default.
+    // #2135 round-6 P1: the MINIMUM across every slot — the chain fails
+    // over with the SAME request, so the prompt must fit the smallest lane
+    // it can land on, not just the preferred one.
     fn context_window(&self) -> u32 {
-        let idx = self.pick_start();
-        self.slots[idx].provider.context_window()
+        self.slots
+            .iter()
+            .map(|slot| slot.provider.context_window())
+            .min()
+            .unwrap_or(32_768)
     }
 
     fn max_output_tokens(&self) -> u32 {
-        let idx = self.pick_start();
-        self.slots[idx].provider.max_output_tokens()
+        self.slots
+            .iter()
+            .map(|slot| slot.provider.max_output_tokens())
+            .min()
+            .unwrap_or(4096)
     }
 
     async fn ensure_ready(&self) {
@@ -716,5 +722,21 @@ mod tests {
             Some(StreamEvent::ProviderIndex(idx)) => assert_eq!(idx, 1),
             other => panic!("expected ProviderIndex(1) first, got {other:?}"),
         }
+    }
+
+    /// #2135 round-6 P1: the chain fails over with the same request, so
+    /// the reported window is the minimum across slots.
+    #[test]
+    fn should_report_minimum_window_across_slots() {
+        let big: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+            Arc::new(SuccessProvider { name: "big" }),
+            262_144,
+        ));
+        let small: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+            Arc::new(SuccessProvider { name: "small" }),
+            32_768,
+        ));
+        let chain = ProviderChain::new(vec![big, small]);
+        assert_eq!(chain.context_window(), 32_768);
     }
 }

--- a/crates/octos-llm/src/fallback.rs
+++ b/crates/octos-llm/src/fallback.rs
@@ -101,7 +101,7 @@ impl LlmProvider for FallbackProvider {
                     // #2135 round-7 P1: the fallback receives the unchanged
                     // request — resolve its readiness and skip it when the
                     // prompt cannot fit its (possibly just-resolved) window.
-                    if !crate::context::route_fits_request(fb, messages).await {
+                    if !crate::context::route_fits_request(fb, messages, tools).await {
                         warn!(
                             fallback = fb.model_id(),
                             window = fb.context_window(),
@@ -157,7 +157,7 @@ impl LlmProvider for FallbackProvider {
                 );
                 for fb in &self.fallbacks {
                     // #2135 round-7 P1: same fit guard as the chat path.
-                    if !crate::context::route_fits_request(fb, messages).await {
+                    if !crate::context::route_fits_request(fb, messages, tools).await {
                         warn!(
                             fallback = fb.model_id(),
                             window = fb.context_window(),

--- a/crates/octos-llm/src/fallback.rs
+++ b/crates/octos-llm/src/fallback.rs
@@ -98,6 +98,17 @@ impl LlmProvider for FallbackProvider {
                     "primary provider failed, trying fallbacks"
                 );
                 for (i, fb) in self.fallbacks.iter().enumerate() {
+                    // #2135 round-7 P1: the fallback receives the unchanged
+                    // request — resolve its readiness and skip it when the
+                    // prompt cannot fit its (possibly just-resolved) window.
+                    if !crate::context::route_fits_request(fb, messages).await {
+                        warn!(
+                            fallback = fb.model_id(),
+                            window = fb.context_window(),
+                            "skipping fallback: prompt does not fit its context window"
+                        );
+                        continue;
+                    }
                     match fb.chat(messages, tools, config).await {
                         Ok(resp) => {
                             warn!(
@@ -145,6 +156,15 @@ impl LlmProvider for FallbackProvider {
                     "primary stream failed, trying fallbacks"
                 );
                 for fb in &self.fallbacks {
+                    // #2135 round-7 P1: same fit guard as the chat path.
+                    if !crate::context::route_fits_request(fb, messages).await {
+                        warn!(
+                            fallback = fb.model_id(),
+                            window = fb.context_window(),
+                            "skipping fallback: prompt does not fit its context window"
+                        );
+                        continue;
+                    }
                     match fb.chat_stream(messages, tools, config).await {
                         Ok(stream) => return Ok(stream),
                         Err(e) => {
@@ -363,6 +383,82 @@ mod tests {
             fb_calls.load(Ordering::SeqCst),
             1,
             "fallback must be called once"
+        );
+    }
+
+    /// #2135 round-7 P1: a fallback whose window resolves SMALL only at
+    /// dispatch time (its probe was unresolved when the prompt was sized)
+    /// must be skipped, not sent an oversized request. The mock reports a
+    /// huge window until ensure_ready(), then the truth: tiny.
+    struct LateSmallProvider {
+        resolved: std::sync::atomic::AtomicBool,
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for LateSmallProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ChatResponse {
+                content: Some("from-late-small".into()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "late-small"
+        }
+
+        fn provider_name(&self) -> &str {
+            "local"
+        }
+
+        fn context_window(&self) -> u32 {
+            if self.resolved.load(Ordering::SeqCst) {
+                1_024
+            } else {
+                131_072
+            }
+        }
+
+        async fn ensure_ready(&self) {
+            self.resolved.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn should_skip_fallback_that_resolves_too_small_at_dispatch() {
+        let failing_primary: Arc<dyn LlmProvider> = Arc::new(CountingProvider::always_err_500());
+        let small_calls = Arc::new(AtomicUsize::new(0));
+        let late_small: Arc<dyn LlmProvider> = Arc::new(LateSmallProvider {
+            resolved: std::sync::atomic::AtomicBool::new(false),
+            calls: small_calls.clone(),
+        });
+        let big_ok: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+            Arc::new(CountingProvider::ok()),
+            131_072,
+        ));
+        let provider = FallbackProvider::new(failing_primary, vec![late_small, big_ok]);
+        // A prompt far larger than the late-resolving 1K window.
+        let big_message = Message::user("x ".repeat(20_000));
+        let response = provider
+            .chat(&[big_message], &[], &ChatConfig::default())
+            .await
+            .expect("second fallback must serve the request");
+        assert_eq!(response.content.unwrap(), "ok");
+        assert_eq!(
+            small_calls.load(Ordering::SeqCst),
+            0,
+            "the too-small fallback must be skipped at dispatch"
         );
     }
 

--- a/crates/octos-llm/src/fallback.rs
+++ b/crates/octos-llm/src/fallback.rs
@@ -170,6 +170,10 @@ impl LlmProvider for FallbackProvider {
         self.primary.context_window()
     }
 
+    async fn ensure_ready(&self) {
+        self.primary.ensure_ready().await;
+    }
+
     fn max_output_tokens(&self) -> u32 {
         self.primary.max_output_tokens()
     }

--- a/crates/octos-llm/src/fallback.rs
+++ b/crates/octos-llm/src/fallback.rs
@@ -166,8 +166,17 @@ impl LlmProvider for FallbackProvider {
         self.primary.provider_name()
     }
 
+    // #2135 round-6 P1: the MINIMUM across primary and every fallback —
+    // this wrapper re-sends the SAME messages to a fallback on failure, so
+    // a prompt sized for a probed 256K primary must fit the smallest route
+    // it can take. (The pre-probe catalog value was accidentally safe this
+    // way; per-route resizing before each fallback send is the precise
+    // fix, tracked with the router follow-ups.)
     fn context_window(&self) -> u32 {
-        self.primary.context_window()
+        std::iter::once(self.primary.context_window())
+            .chain(self.fallbacks.iter().map(|fb| fb.context_window()))
+            .min()
+            .unwrap_or_else(|| self.primary.context_window())
     }
 
     async fn ensure_ready(&self) {
@@ -175,7 +184,10 @@ impl LlmProvider for FallbackProvider {
     }
 
     fn max_output_tokens(&self) -> u32 {
-        self.primary.max_output_tokens()
+        std::iter::once(self.primary.max_output_tokens())
+            .chain(self.fallbacks.iter().map(|fb| fb.max_output_tokens()))
+            .min()
+            .unwrap_or_else(|| self.primary.max_output_tokens())
     }
 
     fn report_stream_metrics(&self, output_tokens: u32, stream_duration_us: u64) {
@@ -352,5 +364,22 @@ mod tests {
             1,
             "fallback must be called once"
         );
+    }
+
+    /// #2135 round-6 P1: the same messages are re-sent to a fallback on
+    /// failure, so the reported window must fit the SMALLEST possible
+    /// route — a probed 256K primary over a 32K fallback budgets as 32K.
+    #[test]
+    fn should_report_minimum_window_across_routes() {
+        let primary: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+            Arc::new(CountingProvider::ok()),
+            262_144,
+        ));
+        let small_fallback: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+            Arc::new(CountingProvider::ok()),
+            32_768,
+        ));
+        let provider = FallbackProvider::new(primary, vec![small_fallback]);
+        assert_eq!(provider.context_window(), 32_768);
     }
 }

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -17,6 +17,7 @@ pub mod embedding;
 mod failover;
 mod fallback;
 pub mod lane;
+mod local_context_probe;
 pub mod local_discovery;
 pub mod pricing;
 mod provider;
@@ -59,6 +60,7 @@ pub use content_classifier::{
     RoutingConfig,
 };
 pub use context_override::ContextWindowOverride;
+pub use local_context_probe::LocalContextProbe;
 pub use credential_pool::{
     CREDENTIAL_POOL_SCHEMA_VERSION, Credential, CredentialPool, CredentialRotationEvent,
     CredentialState, DEFAULT_COOLDOWN_US, DEFAULT_CREDENTIAL_POOL_DB_FILENAME, ErrorId,

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -60,7 +60,6 @@ pub use content_classifier::{
     RoutingConfig,
 };
 pub use context_override::ContextWindowOverride;
-pub use local_context_probe::LocalContextProbe;
 pub use credential_pool::{
     CREDENTIAL_POOL_SCHEMA_VERSION, Credential, CredentialPool, CredentialRotationEvent,
     CredentialState, DEFAULT_COOLDOWN_US, DEFAULT_CREDENTIAL_POOL_DB_FILENAME, ErrorId,
@@ -77,6 +76,7 @@ pub use lane::{
     LANE_CONTEXT, Lane, LaneContext, LaneRoutingConfig, current_lane_context,
     default_lane_candidates, resolve_lane_for_topic, topic_prefix, with_lane_context,
 };
+pub use local_context_probe::LocalContextProbe;
 pub use middleware::{LlmMiddleware, MiddlewareStack};
 pub use ominix::{OminixClient, PlatformModels};
 pub use provider::{

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -86,6 +86,13 @@ fn ollama_show_url(base_url: &str) -> String {
     format!("{}/api/show", ollama_root(base_url))
 }
 
+/// Ollama's native generate endpoint — an empty request is the OFFICIAL
+/// preload mechanism (Ollama FAQ): it loads the model and returns, after
+/// which `/api/ps` reports the real allocation.
+fn ollama_generate_url(base_url: &str) -> String {
+    format!("{}/api/generate", ollama_root(base_url))
+}
+
 fn ollama_root(base_url: &str) -> String {
     let trimmed = base_url.trim_end_matches('/');
     trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
@@ -112,9 +119,15 @@ enum ProbeEndpoints {
         models_url: String,
     },
     /// Ollama: `GET /api/ps` (running models' allocated context), with
-    /// `POST /api/show` as the COLD-model fallback (Modelfile num_ctx —
-    /// runtime configuration, safe to pin before the model loads).
-    OllamaNative { ps_url: String, show_url: String },
+    /// `POST /api/show` (Modelfile num_ctx) and — when neither answers —
+    /// an official empty-request PRELOAD via `POST /api/generate`, after
+    /// which `/api/ps` reports the real allocation. Sequential by nature;
+    /// one attempt is bounded by a few request timeouts.
+    OllamaNative {
+        ps_url: String,
+        show_url: String,
+        generate_url: String,
+    },
 }
 
 /// Wraps a local-family provider; overrides `context_window()` with the
@@ -179,6 +192,7 @@ impl LocalContextProbe {
             ProbeEndpoints::OllamaNative {
                 ps_url: ollama_ps_url(base_url),
                 show_url: ollama_show_url(base_url),
+                generate_url: ollama_generate_url(base_url),
             },
             None,
             timeouts,
@@ -231,8 +245,17 @@ impl LocalContextProbe {
         if self.window.get().is_some() {
             return;
         }
-        let guard = self.in_flight.lock().await;
-        self.run_probe_attempt(&guard).await;
+        match self.in_flight.try_lock() {
+            // No attempt active: run exactly one ourselves.
+            Ok(guard) => self.run_probe_attempt(&guard).await,
+            // An attempt is ACTIVE: await its completion and take its
+            // outcome — do NOT stack a second attempt on top. The readiness
+            // bound is ONE attempt's requests (#2135 round-3 P2); if the
+            // active attempt resolves transient, the next request retries.
+            Err(_) => {
+                let _guard = self.in_flight.lock().await;
+            }
+        }
     }
 
     /// One probe attempt. Caller holds the `in_flight` guard.
@@ -280,11 +303,16 @@ impl LocalContextProbe {
                     && matches!(models, FetchOutcome::Answered(_));
                 (window, all_answered)
             }
-            ProbeEndpoints::OllamaNative { ps_url, show_url } => {
+            ProbeEndpoints::OllamaNative {
+                ps_url,
+                show_url,
+                generate_url,
+            } => {
+                let model = self.inner.model_id();
                 let ps = fetch(&client, ps_url, None).await;
                 let mut window = match &ps {
                     FetchOutcome::Answered(Some(body)) => {
-                        parse_ollama_ps_context_window(body, self.inner.model_id())
+                        parse_ollama_ps_context_window(body, model)
                     }
                     _ => None,
                 };
@@ -293,16 +321,35 @@ impl LocalContextProbe {
                 // prompt from the catalog. /api/show answers from the
                 // registry, and a Modelfile num_ctx is runtime
                 // configuration — safe to pin now.
-                if window.is_none() && matches!(&ps, FetchOutcome::Answered(Some(_))) {
-                    let body = serde_json::json!({ "model": self.inner.model_id() });
+                let server_up = matches!(&ps, FetchOutcome::Answered(Some(_)));
+                if window.is_none() && server_up {
+                    let body = serde_json::json!({ "model": model });
                     if let FetchOutcome::Answered(Some(show)) =
                         fetch_post_json(&client, show_url, &body).await
                     {
                         window = parse_ollama_show_num_ctx(&show);
+                        // No Modelfile num_ctx either (#2135 round-3 P2):
+                        // the effective window is decided at LOAD time
+                        // (OLLAMA_CONTEXT_LENGTH / server default — often
+                        // 4K, far from catalog maxima). Use Ollama's
+                        // OFFICIAL preload — an empty /api/generate request
+                        // — then re-read /api/ps for the real allocation. A
+                        // big model that cannot load within the probe
+                        // timeout keeps loading server-side and the next
+                        // attempt reads the allocation; the first chat was
+                        // going to trigger this exact load anyway.
+                        if window.is_none() {
+                            let _ = fetch_post_json(&client, generate_url, &body).await;
+                            if let FetchOutcome::Answered(Some(ps_after)) =
+                                fetch(&client, ps_url, None).await
+                            {
+                                window = parse_ollama_ps_context_window(&ps_after, model);
+                            }
+                        }
                     }
                 }
-                // Still unknown (model cold with no Modelfile num_ctx, or
-                // server unreachable): stay unresolved so a later request
+                // Still unknown (server unreachable, or the preload is
+                // still loading): stay unresolved so a later request
                 // retries once the model is running.
                 let resolved = window.is_some();
                 (window, resolved)
@@ -349,8 +396,18 @@ impl LocalContextProbe {
     }
 }
 
-/// One best-effort POST with a JSON body (Ollama /api/show). Same outcome
-/// semantics as [`fetch`].
+/// Whether a failed HTTP status is worth retrying later. 5xx (server not
+/// ready), 408 (request timeout), 425 (too early), and 429 (rate limited)
+/// are TRANSIENT — pinning "no window" on a rate-limited probe would
+/// permanently keep the catalog value with no recovery (#2135 round-3
+/// P2). Other client errors (401, 403, 404) are decisive: re-asking will
+/// not change them.
+fn status_is_transient(status: reqwest::StatusCode) -> bool {
+    status.is_server_error() || matches!(status.as_u16(), 408 | 425 | 429)
+}
+
+/// One best-effort POST with a JSON body (Ollama /api/show, /api/generate).
+/// Same outcome semantics as [`fetch`].
 async fn fetch_post_json(
     client: &reqwest::Client,
     url: &str,
@@ -364,7 +421,7 @@ async fn fetch_post_json(
                     Ok(text) => FetchOutcome::Answered(Some(text)),
                     Err(_) => FetchOutcome::Transient,
                 }
-            } else if status.is_server_error() {
+            } else if status_is_transient(status) {
                 FetchOutcome::Transient
             } else {
                 FetchOutcome::Answered(None)
@@ -374,9 +431,10 @@ async fn fetch_post_json(
     }
 }
 
-/// One best-effort GET. Statuses below 500 are decisive answers (2xx carries
-/// a body; 401/404 tell us re-asking is pointless); 5xx and transport
-/// failures are transient. The probe must never fail a chat request.
+/// One best-effort GET. 2xx carries a body; retryable statuses (see
+/// [`status_is_transient`]) and transport failures are transient; other
+/// client errors (401/404) are decisive answers. The probe must never fail
+/// a chat request.
 async fn fetch(client: &reqwest::Client, url: &str, api_key: Option<&str>) -> FetchOutcome {
     let mut request = client.get(url);
     if let Some(key) = api_key {
@@ -390,7 +448,7 @@ async fn fetch(client: &reqwest::Client, url: &str, api_key: Option<&str>) -> Fe
                     Ok(body) => FetchOutcome::Answered(Some(body)),
                     Err(_) => FetchOutcome::Transient,
                 }
-            } else if status.is_server_error() {
+            } else if status_is_transient(status) {
                 FetchOutcome::Transient
             } else {
                 FetchOutcome::Answered(None)
@@ -552,6 +610,27 @@ mod tests {
         probe.window.set(Some(262_144)).unwrap();
         let wrapped = crate::RetryProvider::new(probe);
         assert_eq!(wrapped.context_window(), 262_144);
+    }
+
+    /// #2135 round-3 P2: retryable client statuses must classify as
+    /// transient — the reviewer's scenario was /props 404 (decisive) plus
+    /// /models 429 (rate limited): with 429 marked decisive, all_answered
+    /// pinned "no window" permanently and later recovery was impossible.
+    #[test]
+    fn should_treat_retryable_statuses_as_transient() {
+        use reqwest::StatusCode;
+        for code in [408u16, 425, 429, 500, 502, 503] {
+            assert!(
+                status_is_transient(StatusCode::from_u16(code).unwrap()),
+                "{code} must be transient"
+            );
+        }
+        for code in [400u16, 401, 403, 404, 410] {
+            assert!(
+                !status_is_transient(StatusCode::from_u16(code).unwrap()),
+                "{code} is decisive"
+            );
+        }
     }
 
     /// #2135 re-review P1 regression (delayed server): ensure_ready must

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -61,6 +61,23 @@ const MAX_PROBE_TIMEOUT_SECS: u64 = 15;
 /// forever.
 const MAX_PROBE_ATTEMPTS: u32 = 5;
 
+/// Overall wall-clock budget for ONE probe attempt, whatever it does
+/// inside (#2135 round-4 P2): the per-request timeout applies to each
+/// request independently, and the Ollama branch is sequential (ps, show,
+/// preload, ps) — without an outer deadline one attempt could block
+/// readiness for ~4x the request timeout. Derived from the request
+/// timeout, clamped to a human-tolerable range.
+fn attempt_deadline_secs(request_timeout_secs: u64) -> u64 {
+    (request_timeout_secs * 2).clamp(4, 20)
+}
+
+/// Safe fallback window pinned PROVISIONALLY when a cold Ollama model
+/// cannot finish loading inside the attempt budget (#2135 round-4 P1):
+/// Ollama's stock allocation is 4K (FAQ), so compacting against 4096 is
+/// conservative in the only direction that cannot overflow the server. A
+/// later resolved probe replaces it with the real allocation.
+const OLLAMA_PROVISIONAL_WINDOW: u32 = 4096;
+
 /// llama.cpp serves `/props` at the server root, not under `/v1`.
 /// Single-suffix strip: a proxy mounting the API under `/v1/v1` keeps its
 /// first `/v1` as the server root (`trim_end_matches` would strip every
@@ -141,6 +158,12 @@ pub struct LocalContextProbe {
     /// window; `None` = the server answered but names none (or the attempt
     /// cap was spent) — the catalog value stands either way.
     window: OnceLock<Option<u32>>,
+    /// Non-zero = a SAFE conservative window in force while the real one is
+    /// still unknown (cold Ollama model that could not finish loading
+    /// inside the attempt budget). Consulted by `context_window()` after
+    /// the pin and before the catalog; replaced by the pin when a later
+    /// attempt resolves.
+    provisional: AtomicU32,
     attempts: AtomicU32,
     in_flight: tokio::sync::Mutex<()>,
 }
@@ -211,6 +234,7 @@ impl LocalContextProbe {
             api_key: api_key.filter(|k| !k.is_empty() && k != "no-key"),
             timeouts,
             window: OnceLock::new(),
+            provisional: AtomicU32::new(0),
             attempts: AtomicU32::new(0),
             in_flight: tokio::sync::Mutex::new(()),
         });
@@ -231,7 +255,12 @@ impl LocalContextProbe {
         let Ok(guard) = self.in_flight.try_lock() else {
             return;
         };
-        self.run_probe_attempt(&guard).await;
+        // PASSIVE (#2135 round-4 P1): background/request-path probes never
+        // preload — construction probes every configured provider,
+        // including fallback lanes the user may never select, and an eager
+        // /api/generate would load all of their models into memory. Only
+        // explicit readiness for a route about to be USED may preload.
+        self.run_probe_attempt(&guard, false).await;
     }
 
     /// Readiness: unlike the request path above, AWAIT an active probe
@@ -246,8 +275,10 @@ impl LocalContextProbe {
             return;
         }
         match self.in_flight.try_lock() {
-            // No attempt active: run exactly one ourselves.
-            Ok(guard) => self.run_probe_attempt(&guard).await,
+            // No attempt active: run exactly one ourselves. Readiness is
+            // the one caller allowed to PRELOAD (the route is about to be
+            // used; the first chat would trigger the same load).
+            Ok(guard) => self.run_probe_attempt(&guard, true).await,
             // An attempt is ACTIVE: await its completion and take its
             // outcome — do NOT stack a second attempt on top. The readiness
             // bound is ONE attempt's requests (#2135 round-3 P2); if the
@@ -258,8 +289,15 @@ impl LocalContextProbe {
         }
     }
 
-    /// One probe attempt. Caller holds the `in_flight` guard.
-    async fn run_probe_attempt(&self, _guard: &tokio::sync::MutexGuard<'_, ()>) {
+    /// One probe attempt, bounded by [`attempt_deadline_secs`] overall
+    /// (#2135 round-4 P2) regardless of how many sequential requests the
+    /// branch makes. Caller holds the `in_flight` guard; `allow_preload`
+    /// is granted only by readiness (see `probe_if_unresolved`).
+    async fn run_probe_attempt(
+        &self,
+        _guard: &tokio::sync::MutexGuard<'_, ()>,
+        allow_preload: bool,
+    ) {
         if self.window.get().is_some() {
             return;
         }
@@ -270,7 +308,20 @@ impl LocalContextProbe {
             let _ = self.window.set(None);
             return;
         }
+        let budget = std::time::Duration::from_secs(attempt_deadline_secs(self.timeouts.0));
+        if tokio::time::timeout(budget, self.attempt_body(attempt, allow_preload))
+            .await
+            .is_err()
+        {
+            tracing::debug!(
+                attempt,
+                budget_secs = budget.as_secs(),
+                "context probe attempt exceeded its overall deadline; will retry"
+            );
+        }
+    }
 
+    async fn attempt_body(&self, attempt: u32, allow_preload: bool) {
         let client = build_http_client(self.timeouts.0, self.timeouts.1);
         let (window, all_answered) = match &self.endpoints {
             ProbeEndpoints::OpenAiCompatible {
@@ -328,29 +379,71 @@ impl LocalContextProbe {
                         fetch_post_json(&client, show_url, &body).await
                     {
                         window = parse_ollama_show_num_ctx(&show);
-                        // No Modelfile num_ctx either (#2135 round-3 P2):
-                        // the effective window is decided at LOAD time
-                        // (OLLAMA_CONTEXT_LENGTH / server default — often
-                        // 4K, far from catalog maxima). Use Ollama's
-                        // OFFICIAL preload — an empty /api/generate request
-                        // — then re-read /api/ps for the real allocation. A
-                        // big model that cannot load within the probe
-                        // timeout keeps loading server-side and the next
-                        // attempt reads the allocation; the first chat was
-                        // going to trigger this exact load anyway.
+                        // No Modelfile num_ctx: the effective window is
+                        // decided at LOAD time (OLLAMA_CONTEXT_LENGTH /
+                        // server default). Put the SAFE conservative floor
+                        // in force IMMEDIATELY — before any preload — so
+                        // that whatever happens next (passive probe stops
+                        // here; a preload outlives the attempt deadline and
+                        // is cancelled mid-poll, routine for large models),
+                        // the first turn compacts against a window the
+                        // server cannot overflow instead of catalog maxima
+                        // (#2135 round-4 P1). Replaced by the real
+                        // allocation the moment any attempt reads it.
                         if window.is_none() {
-                            let _ = fetch_post_json(&client, generate_url, &body).await;
-                            if let FetchOutcome::Answered(Some(ps_after)) =
-                                fetch(&client, ps_url, None).await
-                            {
-                                window = parse_ollama_ps_context_window(&ps_after, model);
+                            self.provisional
+                                .store(OLLAMA_PROVISIONAL_WINDOW, Ordering::SeqCst);
+                            tracing::info!(
+                                model,
+                                provisional = OLLAMA_PROVISIONAL_WINDOW,
+                                "cold Ollama model: conservative provisional window in \
+                                 force until the load reports its allocation"
+                            );
+                        }
+                        // PRELOAD — Ollama's official empty /api/generate
+                        // request — ONLY when readiness granted it (#2135
+                        // round-4 P1: a passive background probe must never
+                        // load models on lanes the user did not select).
+                        // The generate future and a 1s poll interval are
+                        // driven together; the outer attempt deadline
+                        // cancels the whole body if the load is slow.
+                        if window.is_none() && allow_preload {
+                            let preload = fetch_post_json(&client, generate_url, &body);
+                            tokio::pin!(preload);
+                            let mut preload_done = false;
+                            loop {
+                                // Drive the preload and the poll interval
+                                // together (never re-polling the completed
+                                // preload future); either way, re-read the
+                                // allocation each second. The OUTER attempt
+                                // deadline cancels this whole body when the
+                                // load is slow — the provisional floor set
+                                // above is already in force for that case.
+                                if preload_done {
+                                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                                } else {
+                                    tokio::select! {
+                                        _ = &mut preload => preload_done = true,
+                                        _ = tokio::time::sleep(
+                                            std::time::Duration::from_secs(1),
+                                        ) => {}
+                                    }
+                                }
+                                if let FetchOutcome::Answered(Some(ps_after)) =
+                                    fetch(&client, ps_url, None).await
+                                {
+                                    window = parse_ollama_ps_context_window(&ps_after, model);
+                                }
+                                if window.is_some() {
+                                    break;
+                                }
                             }
                         }
                     }
                 }
-                // Still unknown (server unreachable, or the preload is
-                // still loading): stay unresolved so a later request
-                // retries once the model is running.
+                // Still unknown (server unreachable, or the load is still
+                // in progress): stay unresolved so a later request retries
+                // once the model is running.
                 let resolved = window.is_some();
                 (window, resolved)
             }
@@ -358,6 +451,7 @@ impl LocalContextProbe {
 
         match window {
             Some(w) => {
+                self.provisional.store(0, Ordering::SeqCst);
                 let catalog = self.inner.context_window();
                 if w != catalog {
                     tracing::info!(
@@ -490,10 +584,17 @@ impl LlmProvider for LocalContextProbe {
     }
 
     fn context_window(&self) -> u32 {
-        self.window
-            .get()
-            .and_then(|probed| *probed)
-            .unwrap_or_else(|| self.inner.context_window())
+        if let Some(Some(window)) = self.window.get() {
+            return *window;
+        }
+        // A provisional floor (cold Ollama, load still in progress) beats
+        // the catalog: it is conservative in the only direction that
+        // cannot overflow the server.
+        let provisional = self.provisional.load(Ordering::SeqCst);
+        if provisional != 0 {
+            return provisional;
+        }
+        self.inner.context_window()
     }
 
     fn max_output_tokens(&self) -> u32 {
@@ -610,6 +711,131 @@ mod tests {
         probe.window.set(Some(262_144)).unwrap();
         let wrapped = crate::RetryProvider::new(probe);
         assert_eq!(wrapped.context_window(), 262_144);
+    }
+
+    /// Minimal Ollama-shaped HTTP stub: records request paths, serves
+    /// /api/ps (allocation only once "loaded"), /api/show (no Modelfile
+    /// num_ctx), and /api/generate (sets "loaded" after `generate_delay`).
+    async fn spawn_ollama_stub(
+        generate_delay: std::time::Duration,
+    ) -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}/v1", listener.local_addr().unwrap());
+        let hits: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
+        let loaded = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let hits_srv = hits.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let hits = hits_srv.clone();
+                let loaded = loaded.clone();
+                let delay = generate_delay;
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let head = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let path = head.split_whitespace().nth(1).unwrap_or("").to_string();
+                    hits.lock().unwrap().push(path.clone());
+                    let body = match path.as_str() {
+                        "/api/ps" => {
+                            if loaded.load(std::sync::atomic::Ordering::SeqCst) {
+                                r#"{"models":[{"name":"local-default","context_length":32768}]}"#
+                                    .to_string()
+                            } else {
+                                r#"{"models":[]}"#.to_string()
+                            }
+                        }
+                        "/api/show" => r#"{"parameters":"stop "x""}"#.to_string(),
+                        "/api/generate" => {
+                            tokio::time::sleep(delay).await;
+                            loaded.store(true, std::sync::atomic::Ordering::SeqCst);
+                            "{}".to_string()
+                        }
+                        _ => "{}".to_string(),
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        (base, hits)
+    }
+
+    /// #2135 round-4 P1 regression: construction and the request path are
+    /// PASSIVE — they must never hit /api/generate (an eager preload would
+    /// load every configured Ollama lane's model into memory) — but they DO
+    /// put the conservative provisional floor in force for a cold model.
+    #[tokio::test]
+    async fn should_not_preload_from_construction_or_request_path() {
+        let (base, hits) = spawn_ollama_stub(std::time::Duration::ZERO).await;
+        let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((2, 1)));
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        probe.probe_if_unresolved().await;
+        let paths = hits.lock().unwrap().clone();
+        assert!(
+            !paths.iter().any(|p| p == "/api/generate"),
+            "passive probes must never preload; hits: {paths:?}"
+        );
+        assert!(paths.iter().any(|p| p == "/api/ps"), "hits: {paths:?}");
+        assert!(probe.window.get().is_none(), "cold model stays unresolved");
+        assert_eq!(
+            probe.context_window(),
+            OLLAMA_PROVISIONAL_WINDOW,
+            "conservative floor must be in force"
+        );
+    }
+
+    /// #2135 round-4 P1 regression (delayed preload): readiness preloads
+    /// the SELECTED route, polls /api/ps, and adopts the real allocation
+    /// once the (slow) load completes within the attempt budget.
+    #[tokio::test]
+    async fn should_preload_and_adopt_allocation_on_readiness() {
+        let (base, hits) = spawn_ollama_stub(std::time::Duration::from_millis(300)).await;
+        let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((2, 1)));
+        probe.ensure_ready().await;
+        assert_eq!(probe.window.get(), Some(&Some(32_768)));
+        assert_eq!(probe.context_window(), 32_768);
+        assert_eq!(
+            probe.provisional.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "provisional floor is cleared once the real allocation pins"
+        );
+        let generates = hits
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|p| p.as_str() == "/api/generate")
+            .count();
+        assert_eq!(generates, 1, "readiness preloads exactly once");
+    }
+
+    /// #2135 round-4 P1+P2 regression: a load that outlives the attempt
+    /// deadline leaves readiness bounded (single overall deadline, not a
+    /// per-request multiple) with the provisional floor in force.
+    #[tokio::test]
+    async fn should_bound_readiness_and_keep_floor_when_load_outlives_deadline() {
+        let (base, _hits) = spawn_ollama_stub(std::time::Duration::from_secs(60)).await;
+        let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((1, 1)));
+        let start = std::time::Instant::now();
+        probe.ensure_ready().await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(attempt_deadline_secs(1) + 3),
+            "readiness must respect the overall attempt deadline; took {elapsed:?}"
+        );
+        assert!(probe.window.get().is_none(), "still unresolved for retry");
+        assert_eq!(
+            probe.context_window(),
+            OLLAMA_PROVISIONAL_WINDOW,
+            "floor stays in force while the load continues server-side"
+        );
     }
 
     /// #2135 round-3 P2: retryable client statuses must classify as

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -42,7 +42,9 @@ use eyre::Result;
 use octos_core::Message;
 
 use crate::config::ChatConfig;
-use crate::local_discovery::{parse_models_context_window, parse_props_context_window};
+use crate::local_discovery::{
+    parse_models_context_window, parse_ollama_ps_context_window, parse_props_context_window,
+};
 use crate::provider::{LlmProvider, build_http_client};
 use crate::types::{ChatResponse, ChatStream, ProviderMetadata, ToolSpec};
 
@@ -73,6 +75,13 @@ fn models_url(base_url: &str) -> String {
     format!("{}/models", base_url.trim_end_matches('/'))
 }
 
+/// Ollama's native process-status endpoint, at the server root.
+fn ollama_ps_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    let root = trimmed.strip_suffix("/v1").unwrap_or(trimmed);
+    format!("{root}/api/ps")
+}
+
 /// What one probe GET established — the distinction the retry logic runs on.
 enum FetchOutcome {
     /// The server answered decisively: 2xx with a body, or a definitive
@@ -83,12 +92,26 @@ enum FetchOutcome {
     Transient,
 }
 
+/// Which endpoints the probe asks — the engines disagree (#2135 review:
+/// Ollama serves no `/props`, and its OpenAI-compatible model list carries
+/// no context length; its allocated window lives on the native `/api/ps`).
+enum ProbeEndpoints {
+    /// llama.cpp / vLLM / LM Studio: `/props` (authoritative) then
+    /// `{base}/models`.
+    OpenAiCompatible {
+        props_url: String,
+        models_url: String,
+    },
+    /// Ollama: `GET /api/ps` — the RUNNING models with their allocated
+    /// `context_length`.
+    OllamaNative { ps_url: String },
+}
+
 /// Wraps a local-family provider; overrides `context_window()` with the
 /// server-reported value once the probe has resolved.
 pub struct LocalContextProbe {
     inner: Arc<dyn LlmProvider>,
-    props_url: String,
-    models_url: String,
+    endpoints: ProbeEndpoints,
     api_key: Option<String>,
     timeouts: (u64, u64),
     /// Set ONLY on a definitive outcome: `Some(w)` = the server named its
@@ -117,10 +140,49 @@ impl LocalContextProbe {
                 DEFAULT_PROBE_TIMEOUT_SECS,
                 DEFAULT_PROBE_CONNECT_TIMEOUT_SECS,
             ));
+        Self::with_endpoints(
+            inner,
+            ProbeEndpoints::OpenAiCompatible {
+                props_url: props_url(base_url),
+                models_url: models_url(base_url),
+            },
+            api_key,
+            timeouts,
+        )
+    }
+
+    /// Ollama-native probing: `GET /api/ps` (allocated context of the
+    /// running models). Ollama takes no API key.
+    pub fn new_ollama(
+        inner: Arc<dyn LlmProvider>,
+        base_url: &str,
+        http_timeout: Option<(u64, u64)>,
+    ) -> Arc<Self> {
+        let timeouts = http_timeout
+            .map(|(t, c)| (t.min(MAX_PROBE_TIMEOUT_SECS), c))
+            .unwrap_or((
+                DEFAULT_PROBE_TIMEOUT_SECS,
+                DEFAULT_PROBE_CONNECT_TIMEOUT_SECS,
+            ));
+        Self::with_endpoints(
+            inner,
+            ProbeEndpoints::OllamaNative {
+                ps_url: ollama_ps_url(base_url),
+            },
+            None,
+            timeouts,
+        )
+    }
+
+    fn with_endpoints(
+        inner: Arc<dyn LlmProvider>,
+        endpoints: ProbeEndpoints,
+        api_key: Option<String>,
+        timeouts: (u64, u64),
+    ) -> Arc<Self> {
         let probe = Arc::new(Self {
             inner,
-            props_url: props_url(base_url),
-            models_url: models_url(base_url),
+            endpoints,
             api_key: api_key.filter(|k| !k.is_empty() && k != "no-key"),
             timeouts,
             window: OnceLock::new(),
@@ -156,28 +218,51 @@ impl LocalContextProbe {
         }
 
         let client = build_http_client(self.timeouts.0, self.timeouts.1);
-        // Both GETs concurrently — the probe may be riding in front of a
-        // user-visible request, so the failure worst-case must be one
-        // timeout, not two in sequence.
-        let (props, models) = tokio::join!(
-            fetch(&client, &self.props_url, self.api_key.as_deref()),
-            fetch(&client, &self.models_url, self.api_key.as_deref()),
-        );
-
-        // `/props` wins when it names a window: it reports the value the
-        // server was LAUNCHED with, which caps whatever the per-model
-        // metadata claims (a model trained for 256K served with -c 32768
-        // really has 32K).
-        let window = match (&props, &models) {
-            (FetchOutcome::Answered(Some(body)), _)
-                if parse_props_context_window(body).is_some() =>
-            {
-                parse_props_context_window(body)
+        let (window, all_answered) = match &self.endpoints {
+            ProbeEndpoints::OpenAiCompatible {
+                props_url,
+                models_url,
+            } => {
+                // Both GETs concurrently — the probe may be riding in front
+                // of a user-visible request, so the failure worst-case must
+                // be one timeout, not two in sequence.
+                let (props, models) = tokio::join!(
+                    fetch(&client, props_url, self.api_key.as_deref()),
+                    fetch(&client, models_url, self.api_key.as_deref()),
+                );
+                // `/props` wins when it names a window: it reports the value
+                // the server was LAUNCHED with, which caps whatever the
+                // per-model metadata claims (a model trained for 256K served
+                // with -c 32768 really has 32K).
+                let window = match (&props, &models) {
+                    (FetchOutcome::Answered(Some(body)), _)
+                        if parse_props_context_window(body).is_some() =>
+                    {
+                        parse_props_context_window(body)
+                    }
+                    (_, FetchOutcome::Answered(Some(body))) => {
+                        parse_models_context_window(body, self.inner.model_id())
+                    }
+                    _ => None,
+                };
+                let all_answered = matches!(props, FetchOutcome::Answered(_))
+                    && matches!(models, FetchOutcome::Answered(_));
+                (window, all_answered)
             }
-            (_, FetchOutcome::Answered(Some(body))) => {
-                parse_models_context_window(body, self.inner.model_id())
+            ProbeEndpoints::OllamaNative { ps_url } => {
+                let ps = fetch(&client, ps_url, None).await;
+                let window = match &ps {
+                    FetchOutcome::Answered(Some(body)) => {
+                        parse_ollama_ps_context_window(body, self.inner.model_id())
+                    }
+                    _ => None,
+                };
+                // A model not yet loaded answers with an empty models list;
+                // treat as transient so a later request retries once the
+                // model is running.
+                let answered_with_window_chance = matches!(&ps, FetchOutcome::Answered(Some(_)));
+                (window, answered_with_window_chance && window.is_some())
             }
-            _ => None,
         };
 
         match window {
@@ -194,15 +279,13 @@ impl LocalContextProbe {
                 let _ = self.window.set(Some(w));
             }
             None => {
-                let both_answered = matches!(props, FetchOutcome::Answered(_))
-                    && matches!(models, FetchOutcome::Answered(_));
-                if both_answered {
+                if all_answered {
                     // Definitive: the server is up and simply does not name
                     // a window. Asking again will not change that.
-                    tracing::debug!(
-                        props_url = %self.props_url,
-                        models_url = %self.models_url,
-                        "local server answered but named no context window; keeping catalog value"
+                    tracing::info!(
+                        catalog = self.inner.context_window(),
+                        model = self.inner.model_id(),
+                        "local server answered but named no context window; catalog value stands"
                     );
                     let _ = self.window.set(None);
                 } else {
@@ -268,6 +351,14 @@ impl LlmProvider for LocalContextProbe {
     ) -> Result<ChatStream> {
         self.probe_if_unresolved().await;
         self.inner.chat_stream(messages, tools, config).await
+    }
+
+    async fn ensure_ready(&self) {
+        // Bounded: one probe attempt (a few seconds worst case) while
+        // unresolved and attempts remain; immediate once pinned. This is
+        // the hook that lets a RESUMED session get the corrected window
+        // before its first compaction pass instead of after its first chat.
+        self.probe_if_unresolved().await;
     }
 
     fn context_window(&self) -> u32 {
@@ -375,6 +466,34 @@ mod tests {
             props_url("http://gpu-box:9000"),
             "http://gpu-box:9000/props"
         );
+        assert_eq!(
+            ollama_ps_url("http://localhost:11434/v1"),
+            "http://localhost:11434/api/ps"
+        );
+    }
+
+    /// #2135 review P1 regression: the probed window must survive the
+    /// STANDARD runtime wrapper (every session wraps the base provider in
+    /// RetryProvider) — the trait default would re-read the static catalog
+    /// and discard the probe.
+    #[test]
+    fn should_keep_probed_window_through_retry_wrapper() {
+        let probe = unprobed("http://127.0.0.1:8080/v1");
+        probe.window.set(Some(262_144)).unwrap();
+        let wrapped = crate::RetryProvider::new(probe);
+        assert_eq!(wrapped.context_window(), 262_144);
+    }
+
+    /// ensure_ready delegates through wrappers and drives the probe: on an
+    /// unreachable server it performs a bounded attempt (leaving the window
+    /// unresolved for retry), never hanging or panicking.
+    #[tokio::test]
+    async fn should_drive_probe_through_wrapper_ensure_ready() {
+        let probe = unprobed("http://127.0.0.1:9/v1");
+        let wrapped = crate::RetryProvider::new(probe.clone());
+        wrapped.ensure_ready().await;
+        assert!(probe.attempts.load(std::sync::atomic::Ordering::SeqCst) >= 1);
+        assert!(probe.window.get().is_none(), "transient must not pin");
     }
 
     /// Before the probe resolves, the wrapper reports the inner (catalog)

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -43,7 +43,8 @@ use octos_core::Message;
 
 use crate::config::ChatConfig;
 use crate::local_discovery::{
-    parse_models_context_window, parse_ollama_ps_context_window, parse_props_context_window,
+    parse_models_context_window, parse_ollama_ps_context_window, parse_ollama_show_num_ctx,
+    parse_props_context_window,
 };
 use crate::provider::{LlmProvider, build_http_client};
 use crate::types::{ChatResponse, ChatStream, ProviderMetadata, ToolSpec};
@@ -77,9 +78,17 @@ fn models_url(base_url: &str) -> String {
 
 /// Ollama's native process-status endpoint, at the server root.
 fn ollama_ps_url(base_url: &str) -> String {
+    format!("{}/api/ps", ollama_root(base_url))
+}
+
+/// Ollama's native model-metadata endpoint, at the server root.
+fn ollama_show_url(base_url: &str) -> String {
+    format!("{}/api/show", ollama_root(base_url))
+}
+
+fn ollama_root(base_url: &str) -> String {
     let trimmed = base_url.trim_end_matches('/');
-    let root = trimmed.strip_suffix("/v1").unwrap_or(trimmed);
-    format!("{root}/api/ps")
+    trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
 }
 
 /// What one probe GET established — the distinction the retry logic runs on.
@@ -102,9 +111,10 @@ enum ProbeEndpoints {
         props_url: String,
         models_url: String,
     },
-    /// Ollama: `GET /api/ps` — the RUNNING models with their allocated
-    /// `context_length`.
-    OllamaNative { ps_url: String },
+    /// Ollama: `GET /api/ps` (running models' allocated context), with
+    /// `POST /api/show` as the COLD-model fallback (Modelfile num_ctx —
+    /// runtime configuration, safe to pin before the model loads).
+    OllamaNative { ps_url: String, show_url: String },
 }
 
 /// Wraps a local-family provider; overrides `context_window()` with the
@@ -168,6 +178,7 @@ impl LocalContextProbe {
             inner,
             ProbeEndpoints::OllamaNative {
                 ps_url: ollama_ps_url(base_url),
+                show_url: ollama_show_url(base_url),
             },
             None,
             timeouts,
@@ -203,9 +214,29 @@ impl LocalContextProbe {
         if self.window.get().is_some() {
             return;
         }
-        let Ok(_guard) = self.in_flight.try_lock() else {
+        let Ok(guard) = self.in_flight.try_lock() else {
             return;
         };
+        self.run_probe_attempt(&guard).await;
+    }
+
+    /// Readiness: unlike the request path above, AWAIT an active probe
+    /// (lock, don't try_lock) so a caller that is about to make a
+    /// window-dependent decision sees the outcome of the in-flight attempt
+    /// rather than racing past it (#2135 re-review, P1) — construction
+    /// spawns the probe in the background, and returning while it is still
+    /// running would hand compaction the stale catalog value one more time.
+    /// Still bounded: one attempt's timeouts at most, immediate once pinned.
+    async fn await_readiness(&self) {
+        if self.window.get().is_some() {
+            return;
+        }
+        let guard = self.in_flight.lock().await;
+        self.run_probe_attempt(&guard).await;
+    }
+
+    /// One probe attempt. Caller holds the `in_flight` guard.
+    async fn run_probe_attempt(&self, _guard: &tokio::sync::MutexGuard<'_, ()>) {
         if self.window.get().is_some() {
             return;
         }
@@ -249,19 +280,32 @@ impl LocalContextProbe {
                     && matches!(models, FetchOutcome::Answered(_));
                 (window, all_answered)
             }
-            ProbeEndpoints::OllamaNative { ps_url } => {
+            ProbeEndpoints::OllamaNative { ps_url, show_url } => {
                 let ps = fetch(&client, ps_url, None).await;
-                let window = match &ps {
+                let mut window = match &ps {
                     FetchOutcome::Answered(Some(body)) => {
                         parse_ollama_ps_context_window(body, self.inner.model_id())
                     }
                     _ => None,
                 };
-                // A model not yet loaded answers with an empty models list;
-                // treat as transient so a later request retries once the
-                // model is running.
-                let answered_with_window_chance = matches!(&ps, FetchOutcome::Answered(Some(_)));
-                (window, answered_with_window_chance && window.is_some())
+                // COLD model (#2135 re-review, P2): before the model loads,
+                // /api/ps lists nothing and the FIRST turn would size its
+                // prompt from the catalog. /api/show answers from the
+                // registry, and a Modelfile num_ctx is runtime
+                // configuration — safe to pin now.
+                if window.is_none() && matches!(&ps, FetchOutcome::Answered(Some(_))) {
+                    let body = serde_json::json!({ "model": self.inner.model_id() });
+                    if let FetchOutcome::Answered(Some(show)) =
+                        fetch_post_json(&client, show_url, &body).await
+                    {
+                        window = parse_ollama_show_num_ctx(&show);
+                    }
+                }
+                // Still unknown (model cold with no Modelfile num_ctx, or
+                // server unreachable): stay unresolved so a later request
+                // retries once the model is running.
+                let resolved = window.is_some();
+                (window, resolved)
             }
         };
 
@@ -302,6 +346,31 @@ impl LocalContextProbe {
                 }
             }
         }
+    }
+}
+
+/// One best-effort POST with a JSON body (Ollama /api/show). Same outcome
+/// semantics as [`fetch`].
+async fn fetch_post_json(
+    client: &reqwest::Client,
+    url: &str,
+    body: &serde_json::Value,
+) -> FetchOutcome {
+    match client.post(url).json(body).send().await {
+        Ok(response) => {
+            let status = response.status();
+            if status.is_success() {
+                match response.text().await {
+                    Ok(text) => FetchOutcome::Answered(Some(text)),
+                    Err(_) => FetchOutcome::Transient,
+                }
+            } else if status.is_server_error() {
+                FetchOutcome::Transient
+            } else {
+                FetchOutcome::Answered(None)
+            }
+        }
+        Err(_) => FetchOutcome::Transient,
     }
 }
 
@@ -354,11 +423,12 @@ impl LlmProvider for LocalContextProbe {
     }
 
     async fn ensure_ready(&self) {
-        // Bounded: one probe attempt (a few seconds worst case) while
-        // unresolved and attempts remain; immediate once pinned. This is
-        // the hook that lets a RESUMED session get the corrected window
-        // before its first compaction pass instead of after its first chat.
-        self.probe_if_unresolved().await;
+        // Bounded: waits for an ACTIVE probe to finish (or runs one
+        // attempt itself), a few seconds worst case; immediate once
+        // pinned. This is the hook that lets a RESUMED session get the
+        // corrected window before its first compaction pass instead of
+        // after its first chat.
+        self.await_readiness().await;
     }
 
     fn context_window(&self) -> u32 {
@@ -482,6 +552,33 @@ mod tests {
         probe.window.set(Some(262_144)).unwrap();
         let wrapped = crate::RetryProvider::new(probe);
         assert_eq!(wrapped.context_window(), 262_144);
+    }
+
+    /// #2135 re-review P1 regression (delayed server): ensure_ready must
+    /// AWAIT an active probe, not race past it — a background attempt still
+    /// in flight used to make readiness return with the window unknown, and
+    /// compaction read the catalog value anyway.
+    #[tokio::test]
+    async fn should_await_active_probe_completion_in_ensure_ready() {
+        let probe = unprobed("http://127.0.0.1:9/v1");
+        // Simulate a slow background probe: hold the in-flight guard.
+        let guard = probe.in_flight.lock().await;
+        let waiter = {
+            let probe = probe.clone();
+            tokio::spawn(async move {
+                probe.ensure_ready().await;
+                probe.context_window()
+            })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            !waiter.is_finished(),
+            "readiness must block while a probe attempt is active"
+        );
+        // The "background probe" resolves, then releases the guard.
+        probe.window.set(Some(262_144)).unwrap();
+        drop(guard);
+        assert_eq!(waiter.await.unwrap(), 262_144);
     }
 
     /// ensure_ready delegates through wrappers and drives the probe: on an

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -89,6 +89,11 @@ const OLLAMA_PROVISIONAL_WINDOW: u32 = 1024;
 const PRELOAD_IDLE: u32 = 0;
 const PRELOAD_RUNNING: u32 = 1;
 const PRELOAD_ANSWERED: u32 = 2;
+/// Definitive client-error answer (404/401...) from /api/generate: the
+/// load will never start this way — no retry, no polling (#2135 round-7
+/// P1: mapping these to ANSWERED made every future readiness call poll a
+/// full deadline for a load that never existed).
+const PRELOAD_FAILED: u32 = 3;
 
 /// llama.cpp serves `/props` at the server root, not under `/v1`.
 /// Single-suffix strip: a proxy mounting the API under `/v1/v1` keeps its
@@ -312,8 +317,13 @@ impl LocalContextProbe {
         tracing::info!(model, "preloading cold Ollama model (detached)");
         tokio::spawn(async move {
             match fetch_post_json(&client, &url, &body).await {
-                FetchOutcome::Answered(_) => {
+                FetchOutcome::Answered(Some(_)) => {
                     state.store(PRELOAD_ANSWERED, Ordering::SeqCst);
+                }
+                FetchOutcome::Answered(None) => {
+                    // Definitive 4xx: the load will never start this way.
+                    tracing::warn!(model, "cold-model preload rejected definitively");
+                    state.store(PRELOAD_FAILED, Ordering::SeqCst);
                 }
                 FetchOutcome::Transient => {
                     // 429/503/transport: reset so a later readiness attempt
@@ -496,15 +506,39 @@ impl LocalContextProbe {
                         self.start_preload(generate_url, model);
                         // Poll only while a load is actually in flight or
                         // reached the server; a transient preload failure
-                        // resets the state to idle and this loop stops
-                        // instead of burning the attempt deadline
-                        // (#2135 round-6 P1).
-                        while self.preload_state.load(Ordering::SeqCst) != PRELOAD_IDLE {
+                        // resets to idle and a definitive one parks at
+                        // FAILED — either way this loop stops instead of
+                        // burning the attempt deadline (#2135 rounds 6-7).
+                        loop {
+                            let state = self.preload_state.load(Ordering::SeqCst);
+                            if state != PRELOAD_RUNNING && state != PRELOAD_ANSWERED {
+                                break;
+                            }
                             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                             if let FetchOutcome::Answered(Some(ps_after)) =
                                 fetch(&client, ps_url, None).await
                             {
                                 window = parse_ollama_ps_context_window(&ps_after, model);
+                                // Load COMPLETE (generate answered) and the
+                                // server's process view still names no
+                                // usable window — an old Ollama without
+                                // context_length, or an entry we cannot
+                                // match. That view will not improve: pin
+                                // "no window" so later turns stop paying a
+                                // poll deadline; the conservative floor
+                                // stays in force permanently (#2135
+                                // round-7 P1).
+                                if window.is_none()
+                                    && self.preload_state.load(Ordering::SeqCst) == PRELOAD_ANSWERED
+                                {
+                                    tracing::info!(
+                                        model,
+                                        "loaded model reports no usable allocation; \
+                                         keeping the conservative floor permanently"
+                                    );
+                                    let _ = self.window.set(None);
+                                    break;
+                                }
                             }
                             if window.is_some() {
                                 break;
@@ -544,12 +578,14 @@ impl LocalContextProbe {
                         "local server answered but named no context window; catalog value stands"
                     );
                     let _ = self.window.set(None);
-                } else {
+                } else if self.window.get().is_none() {
                     // Transient (refused / timeout / 5xx — e.g. the model is
                     // still loading): leave unresolved so a later request
                     // retries. THIS is the session that needs the correction
                     // most — pinning the failure would reproduce the exact
-                    // phantom-32K bug this module exists to fix.
+                    // phantom-32K bug this module exists to fix. (Already-
+                    // pinned outcomes — e.g. the loaded-but-unreadable
+                    // Ollama case pinned inside the poll loop — skip this.)
                     tracing::debug!(
                         attempt,
                         max = MAX_PROBE_ATTEMPTS,
@@ -807,6 +843,22 @@ mod tests {
         Arc<std::sync::Mutex<Vec<String>>>,
         Arc<std::sync::atomic::AtomicBool>,
     ) {
+        spawn_ollama_stub_configured(generate_delay, generate_failures, true, false).await
+    }
+
+    /// Full-fidelity stub: `ps_with_context` = whether /api/ps includes
+    /// context_length once loaded (old Ollama does not);
+    /// `generate_definitive_fail` = answer every /api/generate with 404.
+    async fn spawn_ollama_stub_configured(
+        generate_delay: std::time::Duration,
+        generate_failures: u32,
+        ps_with_context: bool,
+        generate_definitive_fail: bool,
+    ) -> (
+        String,
+        Arc<std::sync::Mutex<Vec<String>>>,
+        Arc<std::sync::atomic::AtomicBool>,
+    ) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let base = format!("http://{}/v1", listener.local_addr().unwrap());
@@ -824,6 +876,8 @@ mod tests {
                 let loaded = loaded.clone();
                 let failures_left = failures_left.clone();
                 let delay = generate_delay;
+                let ps_with_context = ps_with_context;
+                let generate_definitive_fail = generate_definitive_fail;
                 tokio::spawn(async move {
                     let mut buf = vec![0u8; 4096];
                     let n = stream.read(&mut buf).await.unwrap_or(0);
@@ -833,14 +887,24 @@ mod tests {
                     let body = match path.as_str() {
                         "/api/ps" => {
                             if loaded.load(std::sync::atomic::Ordering::SeqCst) {
-                                r#"{"models":[{"name":"local-default","context_length":32768}]}"#
-                                    .to_string()
+                                if ps_with_context {
+                                    r#"{"models":[{"name":"local-default","context_length":32768}]}"#
+                                        .to_string()
+                                } else {
+                                    // Old Ollama: process entry without the field.
+                                    r#"{"models":[{"name":"local-default"}]}"#.to_string()
+                                }
                             } else {
                                 r#"{"models":[]}"#.to_string()
                             }
                         }
                         "/api/show" => r#"{"parameters":"stop "x""}"#.to_string(),
                         "/api/generate" => {
+                            if generate_definitive_fail {
+                                let response = "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+                                let _ = stream.write_all(response.as_bytes()).await;
+                                return;
+                            }
                             if failures_left
                                 .fetch_update(
                                     std::sync::atomic::Ordering::SeqCst,
@@ -1042,6 +1106,72 @@ mod tests {
             .filter(|p| p.as_str() == "/api/generate")
             .count();
         assert_eq!(generates, 2, "one failed + one successful preload");
+    }
+
+    /// #2135 round-7 P1 regression (old Ollama): once the load completes
+    /// but /api/ps names no usable allocation, the outcome pins as "no
+    /// window" — the floor stays permanently and LATER readiness calls
+    /// return immediately instead of polling a full deadline every turn.
+    #[tokio::test]
+    async fn should_pin_and_stop_polling_when_loaded_model_reports_no_allocation() {
+        let (base, hits, _loaded) = spawn_ollama_stub_configured(
+            std::time::Duration::from_millis(100),
+            0,
+            false, // old Ollama: no context_length on /api/ps
+            false,
+        )
+        .await;
+        let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((2, 1)));
+        probe.ensure_ready().await;
+        assert_eq!(probe.window.get(), Some(&None), "definitively pinned");
+        assert_eq!(probe.context_window(), OLLAMA_PROVISIONAL_WINDOW);
+        let start = std::time::Instant::now();
+        probe.ensure_ready().await;
+        assert!(
+            start.elapsed() < std::time::Duration::from_millis(500),
+            "pinned outcome must return immediately"
+        );
+        let generates = hits
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|p| p.as_str() == "/api/generate")
+            .count();
+        assert_eq!(generates, 1);
+    }
+
+    /// #2135 round-7 P1 regression (definitive preload failure): a 404 on
+    /// /api/generate parks the preload at FAILED — no polling, no retry,
+    /// readiness returns fast on every call with the floor in force.
+    #[tokio::test]
+    async fn should_not_poll_after_definitive_preload_failure() {
+        let (base, hits, _loaded) = spawn_ollama_stub_configured(
+            std::time::Duration::ZERO,
+            0,
+            true,
+            true, // /api/generate always 404
+        )
+        .await;
+        let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((2, 1)));
+        for _ in 0..2 {
+            let start = std::time::Instant::now();
+            probe.ensure_ready().await;
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(2),
+                "failed preload must not burn poll deadlines"
+            );
+        }
+        assert_eq!(probe.context_window(), OLLAMA_PROVISIONAL_WINDOW);
+        let generates = hits
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|p| p.as_str() == "/api/generate")
+            .count();
+        assert_eq!(
+            generates, 1,
+            "definitive failure must not retry the preload"
+        );
     }
 
     /// #2135 round-3 P2: retryable client statuses must classify as

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -1,0 +1,261 @@
+//! Probe a local server for its actual context window.
+//!
+//! The catalog row for `local/local-default` carries a deliberately modest
+//! `context_window` (32K) because at registration time nothing knows what the
+//! operator launched. But the running server DOES know: llama.cpp's `/props`
+//! reports the `-c` value it was started with, and every OpenAI-compatible
+//! engine exposes some spelling of the window on `GET /v1/models` (see
+//! [`crate::local_discovery`]). Budgeting a 256K server as 32K is not a safe
+//! under-estimate — the compaction loop shreds the working set to fit the
+//! phantom limit, and long tasks degrade into re-read thrash (observed: a
+//! 1,182-line source file read 66 times in one session while the live context
+//! sat at ~19K of an actual 256K).
+//!
+//! [`LocalContextProbe`] wraps a local provider and asks the server once, on
+//! the first request, in the async context that request already provides. The
+//! probe is best-effort with a short timeout: a server that answers neither
+//! endpoint costs one round of two quick failed GETs and the catalog value
+//! stands. `context_window()` is sync and never blocks — before the first
+//! request completes it reports the inner (catalog) value, after that the
+//! probed one. The first request is the system prompt plus one user turn, far
+//! below any plausible budget, so correcting the window from the second
+//! request onward is safe.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_core::Message;
+use tokio::sync::OnceCell;
+
+use crate::config::ChatConfig;
+use crate::local_discovery::{parse_models_context_window, parse_props_context_window};
+use crate::provider::{LlmProvider, build_http_client};
+use crate::types::{ChatResponse, ChatStream, ToolSpec};
+
+/// Probe timeouts: a local server answers these endpoints in milliseconds;
+/// anything slower is a server that is not going to answer at all, and the
+/// user is watching this latency on their first message.
+const PROBE_TIMEOUT_SECS: u64 = 3;
+const PROBE_CONNECT_TIMEOUT_SECS: u64 = 2;
+
+/// llama.cpp serves `/props` at the server root, not under `/v1`.
+fn props_url(base_url: &str) -> String {
+    let root = base_url
+        .trim_end_matches('/')
+        .trim_end_matches("/v1")
+        .trim_end_matches('/');
+    format!("{root}/props")
+}
+
+/// The OpenAI list-models endpoint, relative to the configured base.
+fn models_url(base_url: &str) -> String {
+    format!("{}/models", base_url.trim_end_matches('/'))
+}
+
+/// Wraps a local-family provider; overrides `context_window()` with the
+/// server-reported value once the first request has triggered the probe.
+pub struct LocalContextProbe {
+    inner: Arc<dyn LlmProvider>,
+    props_url: String,
+    models_url: String,
+    probed: OnceCell<Option<u32>>,
+}
+
+impl LocalContextProbe {
+    pub fn new(inner: Arc<dyn LlmProvider>, base_url: &str) -> Self {
+        Self {
+            inner,
+            props_url: props_url(base_url),
+            models_url: models_url(base_url),
+            probed: OnceCell::new(),
+        }
+    }
+
+    /// Run the probe exactly once; concurrent first requests coalesce on the
+    /// same `OnceCell` initialization.
+    async fn ensure_probed(&self) {
+        self.probed
+            .get_or_init(|| async {
+                let client = build_http_client(PROBE_TIMEOUT_SECS, PROBE_CONNECT_TIMEOUT_SECS);
+                // `/props` first: it reports the window the server was
+                // LAUNCHED with, which caps whatever the model metadata says.
+                let from_props = fetch(&client, &self.props_url)
+                    .await
+                    .as_deref()
+                    .and_then(parse_props_context_window);
+                let window = match from_props {
+                    Some(w) => Some(w),
+                    None => fetch(&client, &self.models_url)
+                        .await
+                        .as_deref()
+                        .and_then(parse_models_context_window),
+                };
+                match window {
+                    Some(w) => {
+                        let catalog = self.inner.context_window();
+                        if w != catalog {
+                            tracing::info!(
+                                probed = w,
+                                catalog,
+                                "local server reported its context window; overriding catalog value"
+                            );
+                        }
+                    }
+                    None => tracing::debug!(
+                        props_url = %self.props_url,
+                        models_url = %self.models_url,
+                        "local server did not report a context window; keeping catalog value"
+                    ),
+                }
+                window
+            })
+            .await;
+    }
+}
+
+/// One best-effort GET; any failure (refused, timeout, non-2xx, body read
+/// error) collapses to `None` — the probe must never fail a chat request.
+async fn fetch(client: &reqwest::Client, url: &str) -> Option<String> {
+    let response = client.get(url).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    response.text().await.ok()
+}
+
+#[async_trait]
+impl LlmProvider for LocalContextProbe {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSpec],
+        config: &ChatConfig,
+    ) -> Result<ChatResponse> {
+        self.ensure_probed().await;
+        self.inner.chat(messages, tools, config).await
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSpec],
+        config: &ChatConfig,
+    ) -> Result<ChatStream> {
+        self.ensure_probed().await;
+        self.inner.chat_stream(messages, tools, config).await
+    }
+
+    fn context_window(&self) -> u32 {
+        self.probed
+            .get()
+            .and_then(|probed| *probed)
+            .unwrap_or_else(|| self.inner.context_window())
+    }
+
+    fn max_output_tokens(&self) -> u32 {
+        self.inner.max_output_tokens()
+    }
+
+    fn model_id(&self) -> &str {
+        self.inner.model_id()
+    }
+
+    fn provider_name(&self) -> &str {
+        self.inner.provider_name()
+    }
+
+    fn report_late_failure(&self) {
+        self.inner.report_late_failure();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::TokenUsage;
+
+    struct DummyProvider;
+
+    #[async_trait]
+    impl LlmProvider for DummyProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            Ok(ChatResponse {
+                content: Some("ok".into()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: crate::StopReason::EndTurn,
+                usage: TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "local-default"
+        }
+
+        fn provider_name(&self) -> &str {
+            "local"
+        }
+    }
+
+    /// llama.cpp default base: `/props` lives at the root, `/models` under
+    /// the base. Bases without a `/v1` suffix keep their root.
+    #[test]
+    fn should_derive_probe_urls_from_base() {
+        assert_eq!(
+            props_url("http://127.0.0.1:8080/v1"),
+            "http://127.0.0.1:8080/props"
+        );
+        assert_eq!(
+            models_url("http://127.0.0.1:8080/v1"),
+            "http://127.0.0.1:8080/v1/models"
+        );
+        assert_eq!(
+            props_url("http://127.0.0.1:11434/v1/"),
+            "http://127.0.0.1:11434/props"
+        );
+        assert_eq!(
+            props_url("http://gpu-box:9000"),
+            "http://gpu-box:9000/props"
+        );
+    }
+
+    /// Before any request has run the probe, the wrapper reports the inner
+    /// (catalog) window — `context_window()` must never block.
+    #[test]
+    fn should_fall_back_to_inner_window_before_probe() {
+        let inner: Arc<dyn LlmProvider> = Arc::new(DummyProvider);
+        let expected = inner.context_window();
+        let probe = LocalContextProbe::new(inner, "http://127.0.0.1:8080/v1");
+        assert_eq!(probe.context_window(), expected);
+        assert_eq!(probe.model_id(), "local-default");
+        assert_eq!(probe.provider_name(), "local");
+    }
+
+    /// A probe that found nothing (server answered neither endpoint) pins
+    /// `None` and the catalog value continues to stand — permanently, not
+    /// retried per request.
+    #[tokio::test]
+    async fn should_keep_catalog_window_when_probe_found_nothing() {
+        let inner: Arc<dyn LlmProvider> = Arc::new(DummyProvider);
+        let expected = inner.context_window();
+        let probe = LocalContextProbe::new(inner, "http://127.0.0.1:8080/v1");
+        probe.probed.set(None).unwrap();
+        assert_eq!(probe.context_window(), expected);
+    }
+
+    /// After a successful probe the server-reported window wins.
+    #[tokio::test]
+    async fn should_report_probed_window_once_known() {
+        let inner: Arc<dyn LlmProvider> = Arc::new(DummyProvider);
+        let probe = LocalContextProbe::new(inner, "http://127.0.0.1:8080/v1");
+        probe.probed.set(Some(262_144)).unwrap();
+        assert_eq!(probe.context_window(), 262_144);
+    }
+}

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -72,17 +72,23 @@ fn attempt_deadline_secs(request_timeout_secs: u64) -> u64 {
 }
 
 /// Conservative window in force PROVISIONALLY while a cold Ollama model's
-/// real allocation is unknown (#2135 round-4/5 P1): 2048 — the smallest
-/// window Ollama's scheduler treats as practically usable (its documented
-/// vision minimum; the stock allocation is 4096 and configured contexts
-/// are usually larger). Smaller is safer here: over-budgeting a small
-/// allocation truncates server-side, under-budgeting only compacts more
-/// aggressively. Explicitly configured sub-2048 `num_ctx` values are out
-/// of scope for the floor (no non-trivial constant is safe against
-/// `num_ctx 4`); the floor is replaced by the REAL allocation as soon as
-/// any attempt reads it from /api/ps — including cheap post-cap refreshes,
-/// see `run_probe_attempt`.
-const OLLAMA_PROVISIONAL_WINDOW: u32 = 2048;
+/// real allocation is unknown (#2135 rounds 4-6, P1/P2): 1024 — the SAME
+/// lower bound this probe's own parsers accept as a plausible window
+/// (`sane_context_window`), and below every allocation Ollama's env
+/// config will produce in practice (`OLLAMA_CONTEXT_LENGTH=1024` is the
+/// smallest configuration the reviewer's audit of envconfig surfaced as
+/// realistic; the stock allocation is 4096). Smaller is safer: over-
+/// budgeting truncates server-side, under-budgeting only compacts more
+/// aggressively. Sub-1024 `num_ctx` values are below the probe's own
+/// plausibility threshold everywhere and are out of scope by design; the
+/// floor is replaced by the REAL allocation as soon as any attempt reads
+/// it from /api/ps — including cheap post-cap refreshes.
+const OLLAMA_PROVISIONAL_WINDOW: u32 = 1024;
+
+/// `preload_state` values — see the field doc.
+const PRELOAD_IDLE: u32 = 0;
+const PRELOAD_RUNNING: u32 = 1;
+const PRELOAD_ANSWERED: u32 = 2;
 
 /// llama.cpp serves `/props` at the server root, not under `/v1`.
 /// Single-suffix strip: a proxy mounting the API under `/v1/v1` keeps its
@@ -164,9 +170,13 @@ pub struct LocalContextProbe {
     /// window; `None` = the server answered but names none (or the attempt
     /// cap was spent) — the catalog value stands either way.
     window: OnceLock<Option<u32>>,
-    /// One preload per probe lifetime: the detached /api/generate task is
-    /// spawned at most once, however many readiness attempts run.
-    preload_started: std::sync::atomic::AtomicBool,
+    /// Preload lifecycle (#2135 round-6 P1): 0 = idle (may start), 1 =
+    /// running (poll /api/ps), 2 = request answered (load reached the
+    /// server; keep polling). A TRANSIENT preload failure (429/503,
+    /// transport) resets to idle so a later readiness attempt can retry —
+    /// the round-5 boolean latched such failures into "never preload
+    /// again, but keep burning the poll deadline anyway".
+    preload_state: Arc<AtomicU32>,
     /// Non-zero = a SAFE conservative window in force while the real one is
     /// still unknown (cold Ollama model that could not finish loading
     /// inside the attempt budget). Consulted by `context_window()` after
@@ -243,7 +253,7 @@ impl LocalContextProbe {
             api_key: api_key.filter(|k| !k.is_empty() && k != "no-key"),
             timeouts,
             window: OnceLock::new(),
-            preload_started: std::sync::atomic::AtomicBool::new(false),
+            preload_state: Arc::new(AtomicU32::new(PRELOAD_IDLE)),
             provisional: AtomicU32::new(0),
             attempts: AtomicU32::new(0),
             in_flight: tokio::sync::Mutex::new(()),
@@ -280,20 +290,39 @@ impl LocalContextProbe {
     /// the probe's short per-request timeout may own this future. Bounded
     /// by its own generous timeout; fire-and-forget outcome (the /api/ps
     /// polls observe the result).
-    fn start_preload_once(&self, generate_url: &str, model: &str) {
+    fn start_preload(&self, generate_url: &str, model: &str) {
         if self
-            .preload_started
-            .swap(true, std::sync::atomic::Ordering::SeqCst)
+            .preload_state
+            .compare_exchange(
+                PRELOAD_IDLE,
+                PRELOAD_RUNNING,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_err()
         {
-            return;
+            return; // already running or answered
         }
         const PRELOAD_TIMEOUT_SECS: u64 = 900;
         let client = build_http_client(PRELOAD_TIMEOUT_SECS, self.timeouts.1);
         let url = generate_url.to_string();
         let body = serde_json::json!({ "model": model });
+        let state = Arc::clone(&self.preload_state);
+        let model = model.to_string();
         tracing::info!(model, "preloading cold Ollama model (detached)");
         tokio::spawn(async move {
-            let _ = fetch_post_json(&client, &url, &body).await;
+            match fetch_post_json(&client, &url, &body).await {
+                FetchOutcome::Answered(_) => {
+                    state.store(PRELOAD_ANSWERED, Ordering::SeqCst);
+                }
+                FetchOutcome::Transient => {
+                    // 429/503/transport: reset so a later readiness attempt
+                    // retries the load instead of polling a load that never
+                    // started (#2135 round-6 P1).
+                    tracing::debug!(model, "cold-model preload failed transiently; will retry");
+                    state.store(PRELOAD_IDLE, Ordering::SeqCst);
+                }
+            }
         });
     }
 
@@ -464,8 +493,13 @@ impl LocalContextProbe {
                     // loop the model cold forever. The deadline cancels
                     // only the POLLING below; the load itself runs on.
                     if window.is_none() && allow_preload {
-                        self.start_preload_once(generate_url, model);
-                        loop {
+                        self.start_preload(generate_url, model);
+                        // Poll only while a load is actually in flight or
+                        // reached the server; a transient preload failure
+                        // resets the state to idle and this loop stops
+                        // instead of burning the attempt deadline
+                        // (#2135 round-6 P1).
+                        while self.preload_state.load(Ordering::SeqCst) != PRELOAD_IDLE {
                             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                             if let FetchOutcome::Answered(Some(ps_after)) =
                                 fetch(&client, ps_url, None).await
@@ -760,12 +794,26 @@ mod tests {
         Arc<std::sync::Mutex<Vec<String>>>,
         Arc<std::sync::atomic::AtomicBool>,
     ) {
+        spawn_ollama_stub_failing(generate_delay, 0).await
+    }
+
+    /// Like [`spawn_ollama_stub`], with the first `generate_failures`
+    /// /api/generate requests answered 503 (transient) without loading.
+    async fn spawn_ollama_stub_failing(
+        generate_delay: std::time::Duration,
+        generate_failures: u32,
+    ) -> (
+        String,
+        Arc<std::sync::Mutex<Vec<String>>>,
+        Arc<std::sync::atomic::AtomicBool>,
+    ) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let base = format!("http://{}/v1", listener.local_addr().unwrap());
         let hits: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
         let loaded = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let loaded_out = loaded.clone();
+        let failures_left = Arc::new(std::sync::atomic::AtomicU32::new(generate_failures));
         let hits_srv = hits.clone();
         tokio::spawn(async move {
             loop {
@@ -774,6 +822,7 @@ mod tests {
                 };
                 let hits = hits_srv.clone();
                 let loaded = loaded.clone();
+                let failures_left = failures_left.clone();
                 let delay = generate_delay;
                 tokio::spawn(async move {
                     let mut buf = vec![0u8; 4096];
@@ -792,6 +841,18 @@ mod tests {
                         }
                         "/api/show" => r#"{"parameters":"stop "x""}"#.to_string(),
                         "/api/generate" => {
+                            if failures_left
+                                .fetch_update(
+                                    std::sync::atomic::Ordering::SeqCst,
+                                    std::sync::atomic::Ordering::SeqCst,
+                                    |n| n.checked_sub(1),
+                                )
+                                .is_ok()
+                            {
+                                let response = "HTTP/1.1 503 Service Unavailable\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+                                let _ = stream.write_all(response.as_bytes()).await;
+                                return;
+                            }
                             tokio::time::sleep(delay).await;
                             loaded.store(true, std::sync::atomic::Ordering::SeqCst);
                             "{}".to_string()
@@ -949,6 +1010,38 @@ mod tests {
             0,
             "floor cleared once the real allocation pins"
         );
+    }
+
+    /// #2135 round-6 P1 regression: a TRANSIENT preload failure (503)
+    /// resets the preload state — the poll loop stops early instead of
+    /// burning the deadline, and the NEXT readiness attempt retries the
+    /// load and adopts the allocation. The round-5 boolean latched the
+    /// failure forever.
+    #[tokio::test]
+    async fn should_retry_preload_after_transient_failure() {
+        let (base, hits, _loaded) =
+            spawn_ollama_stub_failing(std::time::Duration::from_millis(100), 1).await;
+        let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((2, 1)));
+        // Attempt 1: preload 503s; state resets; readiness returns with the
+        // floor, well before the deadline (poll loop must stop early).
+        let start = std::time::Instant::now();
+        probe.ensure_ready().await;
+        assert!(probe.window.get().is_none());
+        assert_eq!(probe.context_window(), OLLAMA_PROVISIONAL_WINDOW);
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(attempt_deadline_secs(2)),
+            "failed preload must not burn the full deadline"
+        );
+        // Attempt 2: preload retries and the allocation is adopted.
+        probe.ensure_ready().await;
+        assert_eq!(probe.window.get(), Some(&Some(32_768)));
+        let generates = hits
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|p| p.as_str() == "/api/generate")
+            .count();
+        assert_eq!(generates, 2, "one failed + one successful preload");
     }
 
     /// #2135 round-3 P2: retryable client statuses must classify as

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -1,50 +1,70 @@
 //! Probe a local server for its actual context window.
 //!
-//! The catalog row for `local/local-default` carries a deliberately modest
-//! `context_window` (32K) because at registration time nothing knows what the
-//! operator launched. But the running server DOES know: llama.cpp's `/props`
-//! reports the `-c` value it was started with, and every OpenAI-compatible
-//! engine exposes some spelling of the window on `GET /v1/models` (see
+//! The catalog rows for local families carry deliberately modest
+//! `context_window` guesses (32K for `local`, similar for `ollama`/`vllm`)
+//! because at registration time nothing knows what the operator launched.
+//! But the running server DOES know: llama.cpp's `/props` reports the `-c`
+//! value it was started with, and every OpenAI-compatible engine exposes
+//! some spelling of the window on `GET /v1/models` (see
 //! [`crate::local_discovery`]). Budgeting a 256K server as 32K is not a safe
 //! under-estimate — the compaction loop shreds the working set to fit the
 //! phantom limit, and long tasks degrade into re-read thrash (observed: a
-//! 1,182-line source file read 66 times in one session while the live context
-//! sat at ~19K of an actual 256K).
+//! 1,182-line source file read 66 times in one session while the live
+//! context sat at ~19K of an actual 256K).
 //!
-//! [`LocalContextProbe`] wraps a local provider and asks the server once, on
-//! the first request, in the async context that request already provides. The
-//! probe is best-effort with a short timeout: a server that answers neither
-//! endpoint costs one round of two quick failed GETs and the catalog value
-//! stands. `context_window()` is sync and never blocks — before the first
-//! request completes it reports the inner (catalog) value, after that the
-//! probed one. The first request is the system prompt plus one user turn, far
-//! below any plausible budget, so correcting the window from the second
-//! request onward is safe.
+//! [`LocalContextProbe`] wraps a local-family provider. The probe runs in
+//! the background, spawned at construction when a runtime is available (so
+//! a resumed long session gets the corrected window before its first
+//! compaction pass, not after its first send), and re-attempted from the
+//! request path otherwise. Outcomes are handled by kind, not collapsed:
+//!
+//! - the server ANSWERED and named a window → pinned;
+//! - the server ANSWERED both endpoints without naming one → pinned as
+//!   "no window", the catalog value stands (re-asking will not change it);
+//! - the server was UNREACHABLE or mid-load (5xx, timeout) → NOT pinned:
+//!   the next request retries, up to [`MAX_PROBE_ATTEMPTS`], because "the
+//!   model was still loading during the first message" is precisely the
+//!   session that needs the correction later.
+//!
+//! `context_window()` is sync and never blocks: the inner (catalog) value
+//! before the probe lands, the server's truth after. Probe requests carry
+//! the configured API key (llama-server / vLLM `--api-key` deployments are
+//! exactly the ones that would otherwise 401) and honor the configured HTTP
+//! connect timeout (a GPU box over a slow tunnel is exactly the deployment
+//! most likely to run a large `-c`).
 
 use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use async_trait::async_trait;
 use eyre::Result;
 use octos_core::Message;
-use tokio::sync::OnceCell;
 
 use crate::config::ChatConfig;
 use crate::local_discovery::{parse_models_context_window, parse_props_context_window};
 use crate::provider::{LlmProvider, build_http_client};
-use crate::types::{ChatResponse, ChatStream, ToolSpec};
+use crate::types::{ChatResponse, ChatStream, ProviderMetadata, ToolSpec};
 
-/// Probe timeouts: a local server answers these endpoints in milliseconds;
-/// anything slower is a server that is not going to answer at all, and the
-/// user is watching this latency on their first message.
-const PROBE_TIMEOUT_SECS: u64 = 3;
-const PROBE_CONNECT_TIMEOUT_SECS: u64 = 2;
+/// Default probe timeouts: a local server answers these endpoints in
+/// milliseconds; these apply only when no HTTP timeout was configured.
+const DEFAULT_PROBE_TIMEOUT_SECS: u64 = 3;
+const DEFAULT_PROBE_CONNECT_TIMEOUT_SECS: u64 = 2;
+/// The probe can ride in front of a user request when it runs inline, so
+/// even a generous configured request timeout is capped here.
+const MAX_PROBE_TIMEOUT_SECS: u64 = 15;
+/// Transient failures retry on later requests, but a server that never
+/// answers the probe endpoints must not cost failed GETs per request
+/// forever.
+const MAX_PROBE_ATTEMPTS: u32 = 5;
 
 /// llama.cpp serves `/props` at the server root, not under `/v1`.
+/// Single-suffix strip: a proxy mounting the API under `/v1/v1` keeps its
+/// first `/v1` as the server root (`trim_end_matches` would strip every
+/// repetition and 404 the probe).
 fn props_url(base_url: &str) -> String {
-    let root = base_url
-        .trim_end_matches('/')
-        .trim_end_matches("/v1")
-        .trim_end_matches('/');
+    let trimmed = base_url.trim_end_matches('/');
+    let root = trimmed.strip_suffix("/v1").unwrap_or(trimmed);
     format!("{root}/props")
 }
 
@@ -53,75 +73,179 @@ fn models_url(base_url: &str) -> String {
     format!("{}/models", base_url.trim_end_matches('/'))
 }
 
+/// What one probe GET established — the distinction the retry logic runs on.
+enum FetchOutcome {
+    /// The server answered decisively: 2xx with a body, or a definitive
+    /// client-side status (404, 401) that re-asking will not change.
+    Answered(Option<String>),
+    /// Transport error, timeout, or 5xx: the server may simply not be up
+    /// yet (a large model still loading answers exactly like this).
+    Transient,
+}
+
 /// Wraps a local-family provider; overrides `context_window()` with the
-/// server-reported value once the first request has triggered the probe.
+/// server-reported value once the probe has resolved.
 pub struct LocalContextProbe {
     inner: Arc<dyn LlmProvider>,
     props_url: String,
     models_url: String,
-    probed: OnceCell<Option<u32>>,
+    api_key: Option<String>,
+    timeouts: (u64, u64),
+    /// Set ONLY on a definitive outcome: `Some(w)` = the server named its
+    /// window; `None` = the server answered but names none (or the attempt
+    /// cap was spent) — the catalog value stands either way.
+    window: OnceLock<Option<u32>>,
+    attempts: AtomicU32,
+    in_flight: tokio::sync::Mutex<()>,
 }
 
 impl LocalContextProbe {
-    pub fn new(inner: Arc<dyn LlmProvider>, base_url: &str) -> Self {
-        Self {
+    /// Wrap `inner` and start probing in the background if a runtime is
+    /// available (gateway construction runs inside one; the fallback is the
+    /// request path). `api_key` is the key the wrapped provider itself
+    /// authenticates with; `http_timeout` is the configured
+    /// `(request, connect)` override, if any.
+    pub fn new(
+        inner: Arc<dyn LlmProvider>,
+        base_url: &str,
+        api_key: Option<String>,
+        http_timeout: Option<(u64, u64)>,
+    ) -> Arc<Self> {
+        let timeouts = http_timeout
+            .map(|(t, c)| (t.min(MAX_PROBE_TIMEOUT_SECS), c))
+            .unwrap_or((
+                DEFAULT_PROBE_TIMEOUT_SECS,
+                DEFAULT_PROBE_CONNECT_TIMEOUT_SECS,
+            ));
+        let probe = Arc::new(Self {
             inner,
             props_url: props_url(base_url),
             models_url: models_url(base_url),
-            probed: OnceCell::new(),
+            api_key: api_key.filter(|k| !k.is_empty() && k != "no-key"),
+            timeouts,
+            window: OnceLock::new(),
+            attempts: AtomicU32::new(0),
+            in_flight: tokio::sync::Mutex::new(()),
+        });
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let background = probe.clone();
+            handle.spawn(async move { background.probe_if_unresolved().await });
         }
+        probe
     }
 
-    /// Run the probe exactly once; concurrent first requests coalesce on the
-    /// same `OnceCell` initialization.
-    async fn ensure_probed(&self) {
-        self.probed
-            .get_or_init(|| async {
-                let client = build_http_client(PROBE_TIMEOUT_SECS, PROBE_CONNECT_TIMEOUT_SECS);
-                // `/props` first: it reports the window the server was
-                // LAUNCHED with, which caps whatever the model metadata says.
-                let from_props = fetch(&client, &self.props_url)
-                    .await
-                    .as_deref()
-                    .and_then(parse_props_context_window);
-                let window = match from_props {
-                    Some(w) => Some(w),
-                    None => fetch(&client, &self.models_url)
-                        .await
-                        .as_deref()
-                        .and_then(parse_models_context_window),
-                };
-                match window {
-                    Some(w) => {
-                        let catalog = self.inner.context_window();
-                        if w != catalog {
-                            tracing::info!(
-                                probed = w,
-                                catalog,
-                                "local server reported its context window; overriding catalog value"
-                            );
-                        }
-                    }
-                    None => tracing::debug!(
+    /// Run one probe attempt unless the outcome is already pinned, another
+    /// attempt is in flight (skip, don't queue — the request path must not
+    /// stack behind a slow probe), or the attempt cap is spent.
+    async fn probe_if_unresolved(&self) {
+        if self.window.get().is_some() {
+            return;
+        }
+        let Ok(_guard) = self.in_flight.try_lock() else {
+            return;
+        };
+        if self.window.get().is_some() {
+            return;
+        }
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        if attempt > MAX_PROBE_ATTEMPTS {
+            // Spent: stop paying failed GETs on every request. Pinning "no
+            // window" keeps the catalog value without further probing.
+            let _ = self.window.set(None);
+            return;
+        }
+
+        let client = build_http_client(self.timeouts.0, self.timeouts.1);
+        // Both GETs concurrently — the probe may be riding in front of a
+        // user-visible request, so the failure worst-case must be one
+        // timeout, not two in sequence.
+        let (props, models) = tokio::join!(
+            fetch(&client, &self.props_url, self.api_key.as_deref()),
+            fetch(&client, &self.models_url, self.api_key.as_deref()),
+        );
+
+        // `/props` wins when it names a window: it reports the value the
+        // server was LAUNCHED with, which caps whatever the per-model
+        // metadata claims (a model trained for 256K served with -c 32768
+        // really has 32K).
+        let window = match (&props, &models) {
+            (FetchOutcome::Answered(Some(body)), _)
+                if parse_props_context_window(body).is_some() =>
+            {
+                parse_props_context_window(body)
+            }
+            (_, FetchOutcome::Answered(Some(body))) => {
+                parse_models_context_window(body, self.inner.model_id())
+            }
+            _ => None,
+        };
+
+        match window {
+            Some(w) => {
+                let catalog = self.inner.context_window();
+                if w != catalog {
+                    tracing::info!(
+                        probed = w,
+                        catalog,
+                        model = self.inner.model_id(),
+                        "local server reported its context window; overriding catalog value"
+                    );
+                }
+                let _ = self.window.set(Some(w));
+            }
+            None => {
+                let both_answered = matches!(props, FetchOutcome::Answered(_))
+                    && matches!(models, FetchOutcome::Answered(_));
+                if both_answered {
+                    // Definitive: the server is up and simply does not name
+                    // a window. Asking again will not change that.
+                    tracing::debug!(
                         props_url = %self.props_url,
                         models_url = %self.models_url,
-                        "local server did not report a context window; keeping catalog value"
-                    ),
+                        "local server answered but named no context window; keeping catalog value"
+                    );
+                    let _ = self.window.set(None);
+                } else {
+                    // Transient (refused / timeout / 5xx — e.g. the model is
+                    // still loading): leave unresolved so a later request
+                    // retries. THIS is the session that needs the correction
+                    // most — pinning the failure would reproduce the exact
+                    // phantom-32K bug this module exists to fix.
+                    tracing::debug!(
+                        attempt,
+                        max = MAX_PROBE_ATTEMPTS,
+                        "local context probe could not reach the server; will retry"
+                    );
                 }
-                window
-            })
-            .await;
+            }
+        }
     }
 }
 
-/// One best-effort GET; any failure (refused, timeout, non-2xx, body read
-/// error) collapses to `None` — the probe must never fail a chat request.
-async fn fetch(client: &reqwest::Client, url: &str) -> Option<String> {
-    let response = client.get(url).send().await.ok()?;
-    if !response.status().is_success() {
-        return None;
+/// One best-effort GET. Statuses below 500 are decisive answers (2xx carries
+/// a body; 401/404 tell us re-asking is pointless); 5xx and transport
+/// failures are transient. The probe must never fail a chat request.
+async fn fetch(client: &reqwest::Client, url: &str, api_key: Option<&str>) -> FetchOutcome {
+    let mut request = client.get(url);
+    if let Some(key) = api_key {
+        request = request.bearer_auth(key);
     }
-    response.text().await.ok()
+    match request.send().await {
+        Ok(response) => {
+            let status = response.status();
+            if status.is_success() {
+                match response.text().await {
+                    Ok(body) => FetchOutcome::Answered(Some(body)),
+                    Err(_) => FetchOutcome::Transient,
+                }
+            } else if status.is_server_error() {
+                FetchOutcome::Transient
+            } else {
+                FetchOutcome::Answered(None)
+            }
+        }
+        Err(_) => FetchOutcome::Transient,
+    }
 }
 
 #[async_trait]
@@ -132,7 +256,7 @@ impl LlmProvider for LocalContextProbe {
         tools: &[ToolSpec],
         config: &ChatConfig,
     ) -> Result<ChatResponse> {
-        self.ensure_probed().await;
+        self.probe_if_unresolved().await;
         self.inner.chat(messages, tools, config).await
     }
 
@@ -142,12 +266,12 @@ impl LlmProvider for LocalContextProbe {
         tools: &[ToolSpec],
         config: &ChatConfig,
     ) -> Result<ChatStream> {
-        self.ensure_probed().await;
+        self.probe_if_unresolved().await;
         self.inner.chat_stream(messages, tools, config).await
     }
 
     fn context_window(&self) -> u32 {
-        self.probed
+        self.window
             .get()
             .and_then(|probed| *probed)
             .unwrap_or_else(|| self.inner.context_window())
@@ -165,8 +289,29 @@ impl LlmProvider for LocalContextProbe {
         self.inner.provider_name()
     }
 
+    // Full passthrough below (mirrors `ThrottledProvider`): the wrapped
+    // OpenAIProvider overrides the metadata methods to split its
+    // "label@endpoint" tag — falling back to the trait defaults here would
+    // ship the mangled label into usage events and the UI footer.
+    fn provider_metadata(&self) -> ProviderMetadata {
+        self.inner.provider_metadata()
+    }
+
+    fn provider_metadata_for_index(&self, provider_index: Option<usize>) -> ProviderMetadata {
+        self.inner.provider_metadata_for_index(provider_index)
+    }
+
+    fn export_metrics(&self) -> Option<serde_json::Value> {
+        self.inner.export_metrics()
+    }
+
     fn report_late_failure(&self) {
         self.inner.report_late_failure();
+    }
+
+    fn report_stream_metrics(&self, output_tokens: u32, stream_duration_us: u64) {
+        self.inner
+            .report_stream_metrics(output_tokens, stream_duration_us);
     }
 }
 
@@ -204,8 +349,13 @@ mod tests {
         }
     }
 
+    fn unprobed(base: &str) -> Arc<LocalContextProbe> {
+        LocalContextProbe::new(Arc::new(DummyProvider), base, None, None)
+    }
+
     /// llama.cpp default base: `/props` lives at the root, `/models` under
-    /// the base. Bases without a `/v1` suffix keep their root.
+    /// the base. A proxy mounting the API under `/v1/v1` keeps its first
+    /// `/v1` (single-suffix strip).
     #[test]
     fn should_derive_probe_urls_from_base() {
         assert_eq!(
@@ -220,42 +370,64 @@ mod tests {
             props_url("http://127.0.0.1:11434/v1/"),
             "http://127.0.0.1:11434/props"
         );
+        assert_eq!(props_url("http://gw/v1/v1"), "http://gw/v1/props");
         assert_eq!(
             props_url("http://gpu-box:9000"),
             "http://gpu-box:9000/props"
         );
     }
 
-    /// Before any request has run the probe, the wrapper reports the inner
-    /// (catalog) window — `context_window()` must never block.
+    /// Before the probe resolves, the wrapper reports the inner (catalog)
+    /// window — `context_window()` must never block. Constructed outside a
+    /// runtime here, so no background task races the assertion.
     #[test]
     fn should_fall_back_to_inner_window_before_probe() {
         let inner: Arc<dyn LlmProvider> = Arc::new(DummyProvider);
         let expected = inner.context_window();
-        let probe = LocalContextProbe::new(inner, "http://127.0.0.1:8080/v1");
+        let probe = unprobed("http://127.0.0.1:8080/v1");
         assert_eq!(probe.context_window(), expected);
         assert_eq!(probe.model_id(), "local-default");
         assert_eq!(probe.provider_name(), "local");
     }
 
-    /// A probe that found nothing (server answered neither endpoint) pins
-    /// `None` and the catalog value continues to stand — permanently, not
-    /// retried per request.
-    #[tokio::test]
-    async fn should_keep_catalog_window_when_probe_found_nothing() {
+    /// A server that ANSWERED both endpoints without naming a window pins
+    /// "no window" — the catalog stands and no further probes run.
+    #[test]
+    fn should_keep_catalog_window_when_server_names_none() {
         let inner: Arc<dyn LlmProvider> = Arc::new(DummyProvider);
         let expected = inner.context_window();
-        let probe = LocalContextProbe::new(inner, "http://127.0.0.1:8080/v1");
-        probe.probed.set(None).unwrap();
+        let probe = unprobed("http://127.0.0.1:8080/v1");
+        probe.window.set(None).unwrap();
         assert_eq!(probe.context_window(), expected);
     }
 
     /// After a successful probe the server-reported window wins.
-    #[tokio::test]
-    async fn should_report_probed_window_once_known() {
-        let inner: Arc<dyn LlmProvider> = Arc::new(DummyProvider);
-        let probe = LocalContextProbe::new(inner, "http://127.0.0.1:8080/v1");
-        probe.probed.set(Some(262_144)).unwrap();
+    #[test]
+    fn should_report_probed_window_once_known() {
+        let probe = unprobed("http://127.0.0.1:8080/v1");
+        probe.window.set(Some(262_144)).unwrap();
         assert_eq!(probe.context_window(), 262_144);
+    }
+
+    /// Transient failures do NOT pin: each attempt against an unreachable
+    /// server leaves the window unresolved (so a later request retries),
+    /// until the attempt cap pins "no window" and requests stop paying for
+    /// dead probes.
+    #[tokio::test]
+    async fn should_retry_transient_failures_then_give_up_at_cap() {
+        // Port 9 (discard) refuses connections — every fetch is Transient.
+        // Constructed INSIDE the runtime, so one background attempt may
+        // also have run; the loop plus the final call always crosses the
+        // cap either way.
+        let probe = unprobed("http://127.0.0.1:9/v1");
+        for _ in 0..MAX_PROBE_ATTEMPTS {
+            probe.probe_if_unresolved().await;
+        }
+        probe.probe_if_unresolved().await; // crosses the cap
+        assert_eq!(
+            probe.window.get(),
+            Some(&None),
+            "cap must pin no-window; transient failures alone must not pin a value"
+        );
     }
 }

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -71,12 +71,18 @@ fn attempt_deadline_secs(request_timeout_secs: u64) -> u64 {
     (request_timeout_secs * 2).clamp(4, 20)
 }
 
-/// Safe fallback window pinned PROVISIONALLY when a cold Ollama model
-/// cannot finish loading inside the attempt budget (#2135 round-4 P1):
-/// Ollama's stock allocation is 4K (FAQ), so compacting against 4096 is
-/// conservative in the only direction that cannot overflow the server. A
-/// later resolved probe replaces it with the real allocation.
-const OLLAMA_PROVISIONAL_WINDOW: u32 = 4096;
+/// Conservative window in force PROVISIONALLY while a cold Ollama model's
+/// real allocation is unknown (#2135 round-4/5 P1): 2048 — the smallest
+/// window Ollama's scheduler treats as practically usable (its documented
+/// vision minimum; the stock allocation is 4096 and configured contexts
+/// are usually larger). Smaller is safer here: over-budgeting a small
+/// allocation truncates server-side, under-budgeting only compacts more
+/// aggressively. Explicitly configured sub-2048 `num_ctx` values are out
+/// of scope for the floor (no non-trivial constant is safe against
+/// `num_ctx 4`); the floor is replaced by the REAL allocation as soon as
+/// any attempt reads it from /api/ps — including cheap post-cap refreshes,
+/// see `run_probe_attempt`.
+const OLLAMA_PROVISIONAL_WINDOW: u32 = 2048;
 
 /// llama.cpp serves `/props` at the server root, not under `/v1`.
 /// Single-suffix strip: a proxy mounting the API under `/v1/v1` keeps its
@@ -158,6 +164,9 @@ pub struct LocalContextProbe {
     /// window; `None` = the server answered but names none (or the attempt
     /// cap was spent) — the catalog value stands either way.
     window: OnceLock<Option<u32>>,
+    /// One preload per probe lifetime: the detached /api/generate task is
+    /// spawned at most once, however many readiness attempts run.
+    preload_started: std::sync::atomic::AtomicBool,
     /// Non-zero = a SAFE conservative window in force while the real one is
     /// still unknown (cold Ollama model that could not finish loading
     /// inside the attempt budget). Consulted by `context_window()` after
@@ -234,6 +243,7 @@ impl LocalContextProbe {
             api_key: api_key.filter(|k| !k.is_empty() && k != "no-key"),
             timeouts,
             window: OnceLock::new(),
+            preload_started: std::sync::atomic::AtomicBool::new(false),
             provisional: AtomicU32::new(0),
             attempts: AtomicU32::new(0),
             in_flight: tokio::sync::Mutex::new(()),
@@ -263,6 +273,30 @@ impl LocalContextProbe {
         self.run_probe_attempt(&guard, false).await;
     }
 
+    /// Spawn the one-and-only detached preload for this probe: an empty
+    /// `POST /api/generate`, Ollama's official load trigger. Detached and
+    /// LONG-timeout on purpose (#2135 round-5 P1): the load is tied to the
+    /// request's lifetime server-side, so neither the attempt deadline nor
+    /// the probe's short per-request timeout may own this future. Bounded
+    /// by its own generous timeout; fire-and-forget outcome (the /api/ps
+    /// polls observe the result).
+    fn start_preload_once(&self, generate_url: &str, model: &str) {
+        if self
+            .preload_started
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            return;
+        }
+        const PRELOAD_TIMEOUT_SECS: u64 = 900;
+        let client = build_http_client(PRELOAD_TIMEOUT_SECS, self.timeouts.1);
+        let url = generate_url.to_string();
+        let body = serde_json::json!({ "model": model });
+        tracing::info!(model, "preloading cold Ollama model (detached)");
+        tokio::spawn(async move {
+            let _ = fetch_post_json(&client, &url, &body).await;
+        });
+    }
+
     /// Readiness: unlike the request path above, AWAIT an active probe
     /// (lock, don't try_lock) so a caller that is about to make a
     /// window-dependent decision sees the outcome of the in-flight attempt
@@ -279,12 +313,19 @@ impl LocalContextProbe {
             // the one caller allowed to PRELOAD (the route is about to be
             // used; the first chat would trigger the same load).
             Ok(guard) => self.run_probe_attempt(&guard, true).await,
-            // An attempt is ACTIVE: await its completion and take its
-            // outcome — do NOT stack a second attempt on top. The readiness
-            // bound is ONE attempt's requests (#2135 round-3 P2); if the
-            // active attempt resolves transient, the next request retries.
+            // An attempt is ACTIVE: await its completion. If it resolved
+            // the window, done. If not, that attempt may have been the
+            // constructor's PASSIVE probe — which never preloads — so
+            // returning here would leave readiness stuck on the floor
+            // (#2135 round-5 P1). Run one ACTIVE attempt of our own.
+            // Readiness is therefore bounded by at most TWO attempt
+            // budgets (the awaited one plus ours), each capped by
+            // `attempt_deadline_secs`.
             Err(_) => {
-                let _guard = self.in_flight.lock().await;
+                let guard = self.in_flight.lock().await;
+                if self.window.get().is_none() {
+                    self.run_probe_attempt(&guard, true).await;
+                }
             }
         }
     }
@@ -302,9 +343,16 @@ impl LocalContextProbe {
             return;
         }
         let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
-        if attempt > MAX_PROBE_ATTEMPTS {
+        if attempt > MAX_PROBE_ATTEMPTS && self.provisional.load(Ordering::SeqCst) == 0 {
             // Spent: stop paying failed GETs on every request. Pinning "no
             // window" keeps the catalog value without further probing.
+            //
+            // EXCEPT while a provisional floor is in force (#2135 round-5
+            // P2): pinning would freeze the floor forever even after the
+            // real chat loads the model. Post-cap attempts continue in the
+            // Ollama branch as ONE cheap /api/ps read each (the floor
+            // being set skips the show/preload path), so the real
+            // allocation is adopted whenever the model comes up.
             let _ = self.window.set(None);
             return;
         }
@@ -374,69 +422,58 @@ impl LocalContextProbe {
                 // configuration — safe to pin now.
                 let server_up = matches!(&ps, FetchOutcome::Answered(Some(_)));
                 if window.is_none() && server_up {
-                    let body = serde_json::json!({ "model": model });
-                    if let FetchOutcome::Answered(Some(show)) =
-                        fetch_post_json(&client, show_url, &body).await
-                    {
-                        window = parse_ollama_show_num_ctx(&show);
-                        // No Modelfile num_ctx: the effective window is
-                        // decided at LOAD time (OLLAMA_CONTEXT_LENGTH /
-                        // server default). Put the SAFE conservative floor
-                        // in force IMMEDIATELY — before any preload — so
-                        // that whatever happens next (passive probe stops
-                        // here; a preload outlives the attempt deadline and
-                        // is cancelled mid-poll, routine for large models),
-                        // the first turn compacts against a window the
-                        // server cannot overflow instead of catalog maxima
-                        // (#2135 round-4 P1). Replaced by the real
-                        // allocation the moment any attempt reads it.
-                        if window.is_none() {
-                            self.provisional
-                                .store(OLLAMA_PROVISIONAL_WINDOW, Ordering::SeqCst);
-                            tracing::info!(
-                                model,
-                                provisional = OLLAMA_PROVISIONAL_WINDOW,
-                                "cold Ollama model: conservative provisional window in \
-                                 force until the load reports its allocation"
-                            );
+                    // Once the floor is in force, later attempts skip the
+                    // show/preload path entirely: each is ONE cheap /api/ps
+                    // read (this is what keeps post-cap refreshes nearly
+                    // free — see the attempt-cap comment).
+                    if self.provisional.load(Ordering::SeqCst) == 0 {
+                        let body = serde_json::json!({ "model": model });
+                        if let FetchOutcome::Answered(Some(show)) =
+                            fetch_post_json(&client, show_url, &body).await
+                        {
+                            window = parse_ollama_show_num_ctx(&show);
+                            // No Modelfile num_ctx: the effective window is
+                            // decided at LOAD time. Put the conservative
+                            // floor in force IMMEDIATELY — before any
+                            // preload — so whatever happens next (passive
+                            // probe stops here; a slow load outlives the
+                            // attempt deadline), the first turn compacts
+                            // against a window the server is very unlikely
+                            // to undercut, instead of catalog maxima
+                            // (#2135 round-4/5 P1).
+                            if window.is_none() {
+                                self.provisional
+                                    .store(OLLAMA_PROVISIONAL_WINDOW, Ordering::SeqCst);
+                                tracing::info!(
+                                    model,
+                                    provisional = OLLAMA_PROVISIONAL_WINDOW,
+                                    "cold Ollama model: conservative provisional window in \
+                                     force until the load reports its allocation"
+                                );
+                            }
                         }
-                        // PRELOAD — Ollama's official empty /api/generate
-                        // request — ONLY when readiness granted it (#2135
-                        // round-4 P1: a passive background probe must never
-                        // load models on lanes the user did not select).
-                        // The generate future and a 1s poll interval are
-                        // driven together; the outer attempt deadline
-                        // cancels the whole body if the load is slow.
-                        if window.is_none() && allow_preload {
-                            let preload = fetch_post_json(&client, generate_url, &body);
-                            tokio::pin!(preload);
-                            let mut preload_done = false;
-                            loop {
-                                // Drive the preload and the poll interval
-                                // together (never re-polling the completed
-                                // preload future); either way, re-read the
-                                // allocation each second. The OUTER attempt
-                                // deadline cancels this whole body when the
-                                // load is slow — the provisional floor set
-                                // above is already in force for that case.
-                                if preload_done {
-                                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                                } else {
-                                    tokio::select! {
-                                        _ = &mut preload => preload_done = true,
-                                        _ = tokio::time::sleep(
-                                            std::time::Duration::from_secs(1),
-                                        ) => {}
-                                    }
-                                }
-                                if let FetchOutcome::Answered(Some(ps_after)) =
-                                    fetch(&client, ps_url, None).await
-                                {
-                                    window = parse_ollama_ps_context_window(&ps_after, model);
-                                }
-                                if window.is_some() {
-                                    break;
-                                }
+                    }
+                    // PRELOAD — Ollama's official empty /api/generate
+                    // request — ONLY when readiness granted it (#2135
+                    // round-4 P1: passive probes must never load models on
+                    // lanes the user did not select). The request runs as a
+                    // DETACHED task with a long-timeout client (#2135
+                    // round-5 P1): Ollama ties scheduling of the load to
+                    // the live request context, so the attempt deadline
+                    // cancelling the request could abandon the load and
+                    // loop the model cold forever. The deadline cancels
+                    // only the POLLING below; the load itself runs on.
+                    if window.is_none() && allow_preload {
+                        self.start_preload_once(generate_url, model);
+                        loop {
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                            if let FetchOutcome::Answered(Some(ps_after)) =
+                                fetch(&client, ps_url, None).await
+                            {
+                                window = parse_ollama_ps_context_window(&ps_after, model);
+                            }
+                            if window.is_some() {
+                                break;
                             }
                         }
                     }
@@ -718,12 +755,17 @@ mod tests {
     /// num_ctx), and /api/generate (sets "loaded" after `generate_delay`).
     async fn spawn_ollama_stub(
         generate_delay: std::time::Duration,
-    ) -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
+    ) -> (
+        String,
+        Arc<std::sync::Mutex<Vec<String>>>,
+        Arc<std::sync::atomic::AtomicBool>,
+    ) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let base = format!("http://{}/v1", listener.local_addr().unwrap());
         let hits: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
         let loaded = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let loaded_out = loaded.clone();
         let hits_srv = hits.clone();
         tokio::spawn(async move {
             loop {
@@ -765,7 +807,7 @@ mod tests {
                 });
             }
         });
-        (base, hits)
+        (base, hits, loaded_out)
     }
 
     /// #2135 round-4 P1 regression: construction and the request path are
@@ -774,7 +816,7 @@ mod tests {
     /// put the conservative provisional floor in force for a cold model.
     #[tokio::test]
     async fn should_not_preload_from_construction_or_request_path() {
-        let (base, hits) = spawn_ollama_stub(std::time::Duration::ZERO).await;
+        let (base, hits, _loaded) = spawn_ollama_stub(std::time::Duration::ZERO).await;
         let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((2, 1)));
         tokio::time::sleep(std::time::Duration::from_millis(400)).await;
         probe.probe_if_unresolved().await;
@@ -797,7 +839,7 @@ mod tests {
     /// once the (slow) load completes within the attempt budget.
     #[tokio::test]
     async fn should_preload_and_adopt_allocation_on_readiness() {
-        let (base, hits) = spawn_ollama_stub(std::time::Duration::from_millis(300)).await;
+        let (base, hits, _loaded) = spawn_ollama_stub(std::time::Duration::from_millis(300)).await;
         let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((2, 1)));
         probe.ensure_ready().await;
         assert_eq!(probe.window.get(), Some(&Some(32_768)));
@@ -821,7 +863,7 @@ mod tests {
     /// per-request multiple) with the provisional floor in force.
     #[tokio::test]
     async fn should_bound_readiness_and_keep_floor_when_load_outlives_deadline() {
-        let (base, _hits) = spawn_ollama_stub(std::time::Duration::from_secs(60)).await;
+        let (base, _hits, _loaded) = spawn_ollama_stub(std::time::Duration::from_secs(60)).await;
         let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((1, 1)));
         let start = std::time::Instant::now();
         probe.ensure_ready().await;
@@ -835,6 +877,77 @@ mod tests {
             probe.context_window(),
             OLLAMA_PROVISIONAL_WINDOW,
             "floor stays in force while the load continues server-side"
+        );
+    }
+
+    /// #2135 round-5 P1 regression: when readiness had to WAIT for an
+    /// in-flight PASSIVE attempt that left the window unresolved, it must
+    /// run one ACTIVE attempt of its own — returning at the floor without
+    /// ever preloading was the bug.
+    #[tokio::test]
+    async fn should_run_active_attempt_when_awaited_passive_left_unresolved() {
+        let (base, hits, _loaded) = spawn_ollama_stub(std::time::Duration::from_millis(200)).await;
+        let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((2, 1)));
+        // Simulate the constructor's passive probe holding the lock and
+        // finishing WITHOUT resolving (it never preloads).
+        let guard = probe.in_flight.lock().await;
+        let waiter = {
+            let probe = probe.clone();
+            tokio::spawn(async move {
+                probe.ensure_ready().await;
+                probe.context_window()
+            })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        drop(guard); // passive attempt "completed", window still unresolved
+        assert_eq!(
+            waiter.await.unwrap(),
+            32_768,
+            "readiness must preload itself"
+        );
+        assert!(
+            hits.lock().unwrap().iter().any(|p| p == "/api/generate"),
+            "the active readiness attempt must have preloaded"
+        );
+    }
+
+    /// #2135 round-5 P1+P2 regression: the detached preload survives the
+    /// attempt deadline (the deadline cancels only the polling), and the
+    /// real allocation is adopted EVEN AFTER the retry cap — a provisional
+    /// floor must never be frozen by the cap.
+    #[tokio::test]
+    async fn should_adopt_allocation_after_deadline_and_after_retry_cap() {
+        // Load takes 6s; timeouts (1,1) give a 4s attempt deadline.
+        let (base, _hits, loaded) = spawn_ollama_stub(std::time::Duration::from_secs(6)).await;
+        let probe = LocalContextProbe::new_ollama(Arc::new(DummyProvider), &base, Some((1, 1)));
+        probe.ensure_ready().await;
+        assert!(probe.window.get().is_none(), "load outlives the deadline");
+        assert_eq!(probe.context_window(), OLLAMA_PROVISIONAL_WINDOW);
+
+        // Burn past the retry cap while the model is still loading: with a
+        // floor in force the cap must NOT pin None.
+        for _ in 0..(MAX_PROBE_ATTEMPTS + 2) {
+            probe.probe_if_unresolved().await;
+        }
+        assert!(
+            probe.window.get().is_none(),
+            "cap must not pin over a floor"
+        );
+
+        // The DETACHED preload finishes server-side (it was not cancelled
+        // with the attempt); the next cheap refresh adopts the allocation.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !loaded.load(std::sync::atomic::Ordering::SeqCst) {
+            assert!(std::time::Instant::now() < deadline, "stub never loaded");
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+        probe.probe_if_unresolved().await;
+        assert_eq!(probe.window.get(), Some(&Some(32_768)));
+        assert_eq!(probe.context_window(), 32_768);
+        assert_eq!(
+            probe.provisional.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "floor cleared once the real allocation pins"
         );
     }
 

--- a/crates/octos-llm/src/local_discovery.rs
+++ b/crates/octos-llm/src/local_discovery.rs
@@ -41,7 +41,9 @@ pub const CANDIDATE_BASE_URLS: &[&str] = &[
 /// byte count or a typo'd value into the compaction budget, where an
 /// absurd window would disable compaction entirely.
 fn sane_context_window(value: u64) -> Option<u32> {
-    (1_024..=16_777_216).contains(&value).then_some(value as u32)
+    (1_024..=16_777_216)
+        .contains(&value)
+        .then_some(value as u32)
 }
 
 /// Context window from a llama.cpp `GET /props` response body.
@@ -61,20 +63,34 @@ pub fn parse_props_context_window(body: &str) -> Option<u32> {
     sane_context_window(n_ctx)
 }
 
-/// Context window from an OpenAI-compatible `GET /v1/models` response body.
+/// Context window from an OpenAI-compatible `GET /v1/models` response body,
+/// for the entry that IS `model_id` — never another model's.
 ///
-/// The engines disagree on where they put it, so this checks every known
-/// spelling on each model entry and takes the first plausible value:
-/// llama.cpp exposes `meta.n_ctx` (runtime) and `meta.n_ctx_train`
-/// (model's trained maximum), vLLM exposes `max_model_len`, LM Studio
-/// exposes `max_context_length` / `loaded_context_length`. Runtime values
-/// are preferred over trained maxima within an entry. `None` means no
-/// entry carried a plausible window — callers should fall back to the
-/// catalog, not error.
-pub fn parse_models_context_window(body: &str) -> Option<u32> {
+/// A multi-model server (LM Studio, llama.cpp router mode, a LiteLLM
+/// proxy) lists every loaded model; taking "the first entry with a window"
+/// would budget the session against whatever happens to be listed first —
+/// an embedding model's 8K, say. Entry selection therefore mirrors how
+/// these servers themselves resolve the request's `model` field:
+///
+/// 1. the entry whose id equals `model_id`;
+/// 2. else a case-insensitive substring match in either direction (llama.cpp
+///    reports GGUF paths as ids, so the configured short name is usually a
+///    substring of the served id);
+/// 3. else, when the list has exactly ONE entry or `model_id` is the
+///    [`PLACEHOLDER_MODEL`], that sole/first entry — single-model servers
+///    ignore the `model` field entirely;
+/// 4. else `None`: guessing a window across models is worse than the
+///    catalog fallback.
+///
+/// Within the chosen entry, every known spelling is checked, runtime values
+/// before trained maxima: llama.cpp `meta.n_ctx` / `meta.n_ctx_train`,
+/// vLLM `max_model_len`, LM Studio `loaded_context_length` /
+/// `max_context_length`. `None` means the chosen entry carried no plausible
+/// window — callers should fall back to the catalog, not error.
+pub fn parse_models_context_window(body: &str, model_id: &str) -> Option<u32> {
     let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
     let data = value.get("data")?.as_array()?;
-    for model in data {
+    let window_of = |model: &serde_json::Value| -> Option<u32> {
         let meta = model.get("meta");
         let candidates = [
             meta.and_then(|m| m.get("n_ctx")),
@@ -84,11 +100,39 @@ pub fn parse_models_context_window(body: &str) -> Option<u32> {
             model.get("max_context_length"),
             meta.and_then(|m| m.get("n_ctx_train")),
         ];
-        for candidate in candidates.into_iter().flatten() {
-            if let Some(window) = candidate.as_u64().and_then(sane_context_window) {
-                return Some(window);
-            }
+        candidates
+            .into_iter()
+            .flatten()
+            .find_map(|candidate| candidate.as_u64().and_then(sane_context_window))
+    };
+    let id_of = |model: &serde_json::Value| -> Option<String> {
+        model
+            .get("id")
+            .and_then(|id| id.as_str())
+            .map(str::to_owned)
+    };
+    // Pass 1: exact id.
+    if let Some(entry) = data.iter().find(|m| id_of(m).as_deref() == Some(model_id)) {
+        return window_of(entry);
+    }
+    // Pass 2: substring either direction, case-insensitive (skipped for the
+    // placeholder — it is not a real id and "default" would collide).
+    if model_id != PLACEHOLDER_MODEL {
+        let needle = model_id.to_lowercase();
+        if let Some(entry) = data.iter().find(|m| {
+            id_of(m).is_some_and(|id| {
+                let id = id.to_lowercase();
+                id.contains(&needle) || needle.contains(&id)
+            })
+        }) {
+            return window_of(entry);
         }
+    }
+    // Pass 3: a single-model server ignores the `model` field, so its sole
+    // entry is the one serving this session regardless of configured id;
+    // the placeholder id means the config never named a model at all.
+    if data.len() == 1 || model_id == PLACEHOLDER_MODEL {
+        return data.first().and_then(window_of);
     }
     None
 }
@@ -168,7 +212,8 @@ mod tests {
     /// window.
     #[test]
     fn should_read_n_ctx_from_props_shape() {
-        let body = r#"{"default_generation_settings":{"n_ctx":262144,"n_predict":-1},"total_slots":1}"#;
+        let body =
+            r#"{"default_generation_settings":{"n_ctx":262144,"n_predict":-1},"total_slots":1}"#;
         assert_eq!(parse_props_context_window(body), Some(262_144));
     }
 
@@ -189,27 +234,66 @@ mod tests {
     #[test]
     fn should_prefer_runtime_n_ctx_over_trained_maximum() {
         let body = r#"{"data":[{"id":"qwen","meta":{"n_ctx":65536,"n_ctx_train":262144}}]}"#;
-        assert_eq!(parse_models_context_window(body), Some(65_536));
+        assert_eq!(parse_models_context_window(body, "qwen"), Some(65_536));
         // Only the trained maximum present: better than nothing.
         let body = r#"{"data":[{"id":"qwen","meta":{"n_ctx_train":262144}}]}"#;
-        assert_eq!(parse_models_context_window(body), Some(262_144));
+        assert_eq!(parse_models_context_window(body, "qwen"), Some(262_144));
     }
 
     /// vLLM (`max_model_len`) and LM Studio (`max_context_length`) spellings.
     #[test]
     fn should_read_vllm_and_lmstudio_spellings() {
         let body = r#"{"data":[{"id":"m","max_model_len":131072}]}"#;
-        assert_eq!(parse_models_context_window(body), Some(131_072));
-        let body = r#"{"data":[{"id":"m","max_context_length":32768,"loaded_context_length":8192}]}"#;
-        assert_eq!(parse_models_context_window(body), Some(8_192));
+        assert_eq!(parse_models_context_window(body, "m"), Some(131_072));
+        let body =
+            r#"{"data":[{"id":"m","max_context_length":32768,"loaded_context_length":8192}]}"#;
+        assert_eq!(parse_models_context_window(body, "m"), Some(8_192));
     }
 
     /// No known field → None (catalog fallback), not a guess.
     #[test]
     fn should_return_none_when_models_carry_no_window() {
-        assert_eq!(parse_models_context_window(r#"{"data":[{"id":"m"}]}"#), None);
-        assert_eq!(parse_models_context_window(r#"{"data":[]}"#), None);
-        assert_eq!(parse_models_context_window("<html></html>"), None);
+        assert_eq!(
+            parse_models_context_window(r#"{"data":[{"id":"m"}]}"#, "m"),
+            None
+        );
+        assert_eq!(parse_models_context_window(r#"{"data":[]}"#, "m"), None);
+        assert_eq!(parse_models_context_window("<html></html>", "m"), None);
+    }
+
+    /// Multi-model servers: the window must come from the CONFIGURED
+    /// model's entry, never whichever model is listed first. Exact id wins;
+    /// substring matches llama.cpp's GGUF-path ids; the placeholder (or a
+    /// single-entry list) falls back to the sole/first entry; an unmatched
+    /// id on a multi-model list yields None rather than a guess.
+    #[test]
+    fn should_match_configured_model_in_multi_model_list() {
+        let body = r#"{"data":[
+            {"id":"small-embed","meta":{"n_ctx":8192}},
+            {"id":"/models/Qwen3-Coder-Q8.gguf","meta":{"n_ctx":131072}}
+        ]}"#;
+        assert_eq!(
+            parse_models_context_window(body, "small-embed"),
+            Some(8_192)
+        );
+        // Substring, either direction, case-insensitive.
+        assert_eq!(
+            parse_models_context_window(body, "qwen3-coder-q8"),
+            Some(131_072)
+        );
+        // Placeholder: first entry (single-model-server assumption).
+        assert_eq!(
+            parse_models_context_window(body, PLACEHOLDER_MODEL),
+            Some(8_192)
+        );
+        // Unmatched real id against a multi-model list: no guess.
+        assert_eq!(parse_models_context_window(body, "unrelated-model"), None);
+        // Single-entry list serves whatever was configured.
+        let single = r#"{"data":[{"id":"whatever","meta":{"n_ctx":65536}}]}"#;
+        assert_eq!(
+            parse_models_context_window(single, "my-alias"),
+            Some(65_536)
+        );
     }
 
     /// The placeholder stays namespaced — a generic id would become a broad

--- a/crates/octos-llm/src/local_discovery.rs
+++ b/crates/octos-llm/src/local_discovery.rs
@@ -82,11 +82,16 @@ pub fn parse_props_context_window(body: &str) -> Option<u32> {
 /// 4. else `None`: guessing a window across models is worse than the
 ///    catalog fallback.
 ///
-/// Within the chosen entry, every known spelling is checked, runtime values
-/// before trained maxima: llama.cpp `meta.n_ctx` / `meta.n_ctx_train`,
-/// vLLM `max_model_len`, LM Studio `loaded_context_length` /
-/// `max_context_length`. `None` means the chosen entry carried no plausible
-/// window — callers should fall back to the catalog, not error.
+/// Within the chosen entry, only RUNTIME/allocated spellings are accepted:
+/// llama.cpp `meta.n_ctx` (the launched `-c`), LM Studio
+/// `loaded_context_length`, vLLM `max_model_len` (the serving limit).
+/// Trained maxima (`meta.n_ctx_train`, `max_context_length`,
+/// `context_length`) are deliberately NOT candidates: a model trained for
+/// 256K but launched at 32K would be pinned as 256K — an over-estimate
+/// that lets the transcript grow past the server's real window until
+/// requests fail (#2135 review, P2). `None` means the chosen entry carried
+/// no plausible runtime window — callers should fall back to the catalog,
+/// not error.
 pub fn parse_models_context_window(body: &str, model_id: &str) -> Option<u32> {
     let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
     let data = value.get("data")?.as_array()?;
@@ -96,9 +101,6 @@ pub fn parse_models_context_window(body: &str, model_id: &str) -> Option<u32> {
             meta.and_then(|m| m.get("n_ctx")),
             model.get("loaded_context_length"),
             model.get("max_model_len"),
-            model.get("context_length"),
-            model.get("max_context_length"),
-            meta.and_then(|m| m.get("n_ctx_train")),
         ];
         candidates
             .into_iter()
@@ -133,6 +135,61 @@ pub fn parse_models_context_window(body: &str, model_id: &str) -> Option<u32> {
     // the placeholder id means the config never named a model at all.
     if data.len() == 1 || model_id == PLACEHOLDER_MODEL {
         return data.first().and_then(window_of);
+    }
+    None
+}
+
+/// Context window from an Ollama-native `GET /api/ps` response body, for
+/// the running model matching `model_id`.
+///
+/// Ollama serves no `/props`, and its OpenAI-compatible `/v1/models` list
+/// carries no context length — the generic probe resolves to "no window"
+/// on every Ollama deployment (#2135 review, P2). `/api/ps` lists the
+/// RUNNING models with their allocated `context_length` (the num_ctx the
+/// model is actually loaded with), which is exactly the number a session
+/// budget must respect. Matching mirrors [`parse_models_context_window`]:
+/// exact id (`name` or `model`, with and without the `:latest` suffix),
+/// then substring, then the sole running model. `None` (older Ollama
+/// without the field, model not loaded yet) falls back to the catalog.
+pub fn parse_ollama_ps_context_window(body: &str, model_id: &str) -> Option<u32> {
+    let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
+    let models = value.get("models")?.as_array()?;
+    let window_of = |entry: &serde_json::Value| -> Option<u32> {
+        entry
+            .get("context_length")
+            .and_then(|v| v.as_u64())
+            .and_then(sane_context_window)
+    };
+    let ids_of = |entry: &serde_json::Value| -> Vec<String> {
+        ["name", "model"]
+            .iter()
+            .filter_map(|k| entry.get(*k).and_then(|v| v.as_str()))
+            .map(str::to_owned)
+            .collect()
+    };
+    let normalized = model_id.trim_end_matches(":latest").to_lowercase();
+    // Pass 1: exact (suffix-insensitive) id.
+    if let Some(entry) = models.iter().find(|m| {
+        ids_of(m)
+            .iter()
+            .any(|id| id.trim_end_matches(":latest").to_lowercase() == normalized)
+    }) {
+        return window_of(entry);
+    }
+    // Pass 2: substring either direction.
+    if model_id != PLACEHOLDER_MODEL {
+        if let Some(entry) = models.iter().find(|m| {
+            ids_of(m).iter().any(|id| {
+                let id = id.to_lowercase();
+                id.contains(&normalized) || normalized.contains(&id)
+            })
+        }) {
+            return window_of(entry);
+        }
+    }
+    // Pass 3: exactly one running model serves whatever was configured.
+    if models.len() == 1 || model_id == PLACEHOLDER_MODEL {
+        return models.first().and_then(window_of);
     }
     None
 }
@@ -235,9 +292,10 @@ mod tests {
     fn should_prefer_runtime_n_ctx_over_trained_maximum() {
         let body = r#"{"data":[{"id":"qwen","meta":{"n_ctx":65536,"n_ctx_train":262144}}]}"#;
         assert_eq!(parse_models_context_window(body, "qwen"), Some(65_536));
-        // Only the trained maximum present: better than nothing.
+        // Trained maxima are NOT runtime capacity: a model trained for 256K
+        // but launched smaller must not be pinned at 256K (#2135 review P2).
         let body = r#"{"data":[{"id":"qwen","meta":{"n_ctx_train":262144}}]}"#;
-        assert_eq!(parse_models_context_window(body, "qwen"), Some(262_144));
+        assert_eq!(parse_models_context_window(body, "qwen"), None);
     }
 
     /// vLLM (`max_model_len`) and LM Studio (`max_context_length`) spellings.
@@ -248,6 +306,9 @@ mod tests {
         let body =
             r#"{"data":[{"id":"m","max_context_length":32768,"loaded_context_length":8192}]}"#;
         assert_eq!(parse_models_context_window(body, "m"), Some(8_192));
+        // The trained-maximum spelling alone is not accepted (#2135 P2).
+        let body = r#"{"data":[{"id":"m","max_context_length":32768}]}"#;
+        assert_eq!(parse_models_context_window(body, "m"), None);
     }
 
     /// No known field → None (catalog fallback), not a guess.
@@ -302,5 +363,36 @@ mod tests {
     fn should_keep_placeholder_namespaced() {
         assert_ne!(PLACEHOLDER_MODEL, "default");
         assert!(PLACEHOLDER_MODEL.contains('-'));
+    }
+
+    /// Ollama `/api/ps`: allocated context of the RUNNING model, matched
+    /// suffix-insensitively (`qwen3:latest` vs `qwen3`); a missing
+    /// `context_length` (older Ollama) or an empty list yields None so the
+    /// catalog stands and the probe retries once the model loads.
+    #[test]
+    fn should_read_allocated_context_from_ollama_ps() {
+        let body = r#"{"models":[
+            {"name":"embed:latest","model":"embed:latest","context_length":8192},
+            {"name":"qwen3:latest","model":"qwen3:latest","context_length":131072}
+        ]}"#;
+        assert_eq!(parse_ollama_ps_context_window(body, "qwen3"), Some(131_072));
+        assert_eq!(parse_ollama_ps_context_window(body, "embed"), Some(8_192));
+        // Sole running model serves whatever id was configured.
+        let sole = r#"{"models":[{"name":"anything","context_length":65536}]}"#;
+        assert_eq!(
+            parse_ollama_ps_context_window(sole, "my-alias"),
+            Some(65_536)
+        );
+        // Older Ollama without the field / nothing running: catalog stands.
+        let old = r#"{"models":[{"name":"qwen3:latest","size":123}]}"#;
+        assert_eq!(parse_ollama_ps_context_window(old, "qwen3"), None);
+        assert_eq!(
+            parse_ollama_ps_context_window(r#"{"models":[]}"#, "qwen3"),
+            None
+        );
+        assert_eq!(
+            parse_ollama_ps_context_window("<html></html>", "qwen3"),
+            None
+        );
     }
 }

--- a/crates/octos-llm/src/local_discovery.rs
+++ b/crates/octos-llm/src/local_discovery.rs
@@ -194,6 +194,36 @@ pub fn parse_ollama_ps_context_window(body: &str, model_id: &str) -> Option<u32>
     None
 }
 
+/// Runtime-configured context from an Ollama-native `POST /api/show`
+/// response body: the Modelfile `parameters` text block, line
+/// `num_ctx <n>`.
+///
+/// This is the COLD-model fallback (#2135 re-review, P2): before a model
+/// is loaded, `/api/ps` lists nothing, but `/api/show` answers from the
+/// registry — and `num_ctx` there is a runtime CONFIGURATION (what the
+/// model will be loaded with), not a trained maximum, so it is safe to
+/// pin. The trained `context_length` under `model_info` is deliberately
+/// ignored. Models whose Modelfile sets no num_ctx yield `None` — the
+/// catalog stands for the first turn and `/api/ps` corrects on the next
+/// probe once the model is running.
+pub fn parse_ollama_show_num_ctx(body: &str) -> Option<u32> {
+    let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
+    let parameters = value.get("parameters")?.as_str()?;
+    for line in parameters.lines() {
+        let mut tokens = line.split_whitespace();
+        if tokens.next() == Some("num_ctx") {
+            if let Some(window) = tokens
+                .next()
+                .and_then(|raw| raw.parse::<u64>().ok())
+                .and_then(sane_context_window)
+            {
+                return Some(window);
+            }
+        }
+    }
+    None
+}
+
 /// Model ids from an OpenAI-compatible `GET /v1/models` response body.
 ///
 /// `None` means the body is not the list-models shape at all (HTML from an
@@ -394,5 +424,18 @@ mod tests {
             parse_ollama_ps_context_window("<html></html>", "qwen3"),
             None
         );
+    }
+
+    /// Ollama `/api/show`: the Modelfile-configured `num_ctx` is a runtime
+    /// setting and may be pinned; trained `context_length` under model_info
+    /// is ignored; no num_ctx line yields None.
+    #[test]
+    fn should_read_configured_num_ctx_from_ollama_show() {
+        let body = r#"{"parameters":"num_ctx                        32768\nstop                           \"<|im_end|>\"","model_info":{"qwen3.context_length":262144}}"#;
+        assert_eq!(parse_ollama_show_num_ctx(body), Some(32_768));
+        let no_ctx =
+            r#"{"parameters":"stop \"<|im_end|>\"","model_info":{"qwen3.context_length":262144}}"#;
+        assert_eq!(parse_ollama_show_num_ctx(no_ctx), None);
+        assert_eq!(parse_ollama_show_num_ctx("{}"), None);
     }
 }

--- a/crates/octos-llm/src/local_discovery.rs
+++ b/crates/octos-llm/src/local_discovery.rs
@@ -35,6 +35,64 @@ pub const CANDIDATE_BASE_URLS: &[&str] = &[
     "http://127.0.0.1:1234/v1",
 ];
 
+/// Bounds for a believable context window read off a server response.
+/// Anything below 1K is not a window a session could run in (and is more
+/// likely a mis-keyed field); the upper bound guards against reading a
+/// byte count or a typo'd value into the compaction budget, where an
+/// absurd window would disable compaction entirely.
+fn sane_context_window(value: u64) -> Option<u32> {
+    (1_024..=16_777_216).contains(&value).then_some(value as u32)
+}
+
+/// Context window from a llama.cpp `GET /props` response body.
+///
+/// `/props` reports `default_generation_settings.n_ctx` — the context the
+/// server was actually LAUNCHED with (`llama-server -c N`), which is the
+/// number a session budget must respect. This is more authoritative than
+/// any per-model metadata: a model trained for 256K but served with
+/// `-c 32768` really does have 32K. `None` means the body is not the
+/// `/props` shape or carries no plausible window.
+pub fn parse_props_context_window(body: &str) -> Option<u32> {
+    let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
+    let n_ctx = value
+        .get("default_generation_settings")?
+        .get("n_ctx")?
+        .as_u64()?;
+    sane_context_window(n_ctx)
+}
+
+/// Context window from an OpenAI-compatible `GET /v1/models` response body.
+///
+/// The engines disagree on where they put it, so this checks every known
+/// spelling on each model entry and takes the first plausible value:
+/// llama.cpp exposes `meta.n_ctx` (runtime) and `meta.n_ctx_train`
+/// (model's trained maximum), vLLM exposes `max_model_len`, LM Studio
+/// exposes `max_context_length` / `loaded_context_length`. Runtime values
+/// are preferred over trained maxima within an entry. `None` means no
+/// entry carried a plausible window — callers should fall back to the
+/// catalog, not error.
+pub fn parse_models_context_window(body: &str) -> Option<u32> {
+    let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
+    let data = value.get("data")?.as_array()?;
+    for model in data {
+        let meta = model.get("meta");
+        let candidates = [
+            meta.and_then(|m| m.get("n_ctx")),
+            model.get("loaded_context_length"),
+            model.get("max_model_len"),
+            model.get("context_length"),
+            model.get("max_context_length"),
+            meta.and_then(|m| m.get("n_ctx_train")),
+        ];
+        for candidate in candidates.into_iter().flatten() {
+            if let Some(window) = candidate.as_u64().and_then(sane_context_window) {
+                return Some(window);
+            }
+        }
+    }
+    None
+}
+
 /// Model ids from an OpenAI-compatible `GET /v1/models` response body.
 ///
 /// `None` means the body is not the list-models shape at all (HTML from an
@@ -104,6 +162,54 @@ mod tests {
         assert_eq!(parse_models_response("<html>404</html>"), None);
         assert_eq!(parse_models_response(r#"{"models":["x"]}"#), None);
         assert_eq!(parse_models_response(r#"{"data":"nope"}"#), None);
+    }
+
+    /// llama.cpp `/props`: the launched `-c` value is the authoritative
+    /// window.
+    #[test]
+    fn should_read_n_ctx_from_props_shape() {
+        let body = r#"{"default_generation_settings":{"n_ctx":262144,"n_predict":-1},"total_slots":1}"#;
+        assert_eq!(parse_props_context_window(body), Some(262_144));
+    }
+
+    /// Wrong shapes and implausible values fall through to None so callers
+    /// keep the catalog fallback.
+    #[test]
+    fn should_reject_props_without_plausible_window() {
+        assert_eq!(parse_props_context_window("<html>404</html>"), None);
+        assert_eq!(parse_props_context_window(r#"{"n_ctx":262144}"#), None);
+        assert_eq!(
+            parse_props_context_window(r#"{"default_generation_settings":{"n_ctx":16}}"#),
+            None
+        );
+    }
+
+    /// llama.cpp `/v1/models` puts the runtime window in `meta.n_ctx`;
+    /// prefer it over the trained maximum.
+    #[test]
+    fn should_prefer_runtime_n_ctx_over_trained_maximum() {
+        let body = r#"{"data":[{"id":"qwen","meta":{"n_ctx":65536,"n_ctx_train":262144}}]}"#;
+        assert_eq!(parse_models_context_window(body), Some(65_536));
+        // Only the trained maximum present: better than nothing.
+        let body = r#"{"data":[{"id":"qwen","meta":{"n_ctx_train":262144}}]}"#;
+        assert_eq!(parse_models_context_window(body), Some(262_144));
+    }
+
+    /// vLLM (`max_model_len`) and LM Studio (`max_context_length`) spellings.
+    #[test]
+    fn should_read_vllm_and_lmstudio_spellings() {
+        let body = r#"{"data":[{"id":"m","max_model_len":131072}]}"#;
+        assert_eq!(parse_models_context_window(body), Some(131_072));
+        let body = r#"{"data":[{"id":"m","max_context_length":32768,"loaded_context_length":8192}]}"#;
+        assert_eq!(parse_models_context_window(body), Some(8_192));
+    }
+
+    /// No known field → None (catalog fallback), not a guess.
+    #[test]
+    fn should_return_none_when_models_carry_no_window() {
+        assert_eq!(parse_models_context_window(r#"{"data":[{"id":"m"}]}"#), None);
+        assert_eq!(parse_models_context_window(r#"{"data":[]}"#), None);
+        assert_eq!(parse_models_context_window("<html></html>"), None);
     }
 
     /// The placeholder stays namespaced — a generic id would become a broad

--- a/crates/octos-llm/src/provider.rs
+++ b/crates/octos-llm/src/provider.rs
@@ -53,6 +53,17 @@ pub trait LlmProvider: Send + Sync {
         context::context_window_tokens(self.model_id())
     }
 
+    /// Complete any asynchronous initialization that feeds the SYNC
+    /// accessors (notably [`Self::context_window`]). Default: no-op.
+    ///
+    /// The agent loop and the prompt-context bridges await this before
+    /// their first window-dependent decision of a turn, so a provider that
+    /// learns its true window asynchronously — the local context probe —
+    /// resolves BEFORE compaction reads the window, not after the first
+    /// chat. Implementations must return immediately once resolved and be
+    /// bounded (a few seconds at most) when not. Wrappers delegate.
+    async fn ensure_ready(&self) {}
+
     /// Get the maximum output tokens this model supports per call.
     fn max_output_tokens(&self) -> u32 {
         context::max_output_tokens(self.model_id())

--- a/crates/octos-llm/src/registry/local.rs
+++ b/crates/octos-llm/src/registry/local.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use eyre::Result;
 
+use crate::local_context_probe::LocalContextProbe;
 use crate::openai::OpenAIProvider;
 use crate::provider::LlmProvider;
 
@@ -59,7 +60,12 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     if let Some((t, c)) = http_timeout {
         provider = provider.with_http_timeout(t, c);
     }
-    Ok(Arc::new(provider))
+    // The catalog row for this family is a guess (the operator's server was
+    // not running at registration time); the running server knows its real
+    // window. The probe wrapper asks it once, on the first request, and
+    // corrects the budget — see `local_context_probe` for why budgeting a
+    // 256K server as 32K is not a safe under-estimate.
+    Ok(Arc::new(LocalContextProbe::new(Arc::new(provider), &url)))
 }
 
 #[cfg(test)]

--- a/crates/octos-llm/src/registry/local.rs
+++ b/crates/octos-llm/src/registry/local.rs
@@ -50,6 +50,10 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
         .or_else(|| ENTRY.default_model().map(str::to_string))
         .unwrap_or_else(|| PLACEHOLDER_MODEL.into());
     let url = p.base_url.unwrap_or_else(|| DEFAULT_BASE_URL.into());
+    // The probe must authenticate exactly like the provider (llama-server
+    // --api-key deployments 401 anonymous GETs), so capture the real key
+    // before the placeholder default.
+    let probe_key = p.api_key.clone();
     let key = p.api_key.unwrap_or_else(|| "no-key".into());
     let mut provider = OpenAIProvider::new(&key, &model)
         .with_provider_label("local")
@@ -62,10 +66,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     }
     // The catalog row for this family is a guess (the operator's server was
     // not running at registration time); the running server knows its real
-    // window. The probe wrapper asks it once, on the first request, and
-    // corrects the budget — see `local_context_probe` for why budgeting a
-    // 256K server as 32K is not a safe under-estimate.
-    Ok(Arc::new(LocalContextProbe::new(Arc::new(provider), &url)))
+    // window. The probe wrapper asks it and corrects the budget — see
+    // `local_context_probe` for why budgeting a 256K server as 32K is not
+    // a safe under-estimate.
+    Ok(LocalContextProbe::new(
+        Arc::new(provider),
+        &url,
+        probe_key,
+        http_timeout,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/octos-llm/src/registry/ollama.rs
+++ b/crates/octos-llm/src/registry/ollama.rs
@@ -46,13 +46,13 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
         provider = provider.with_http_timeout(t, c);
     }
     // Same class of local server as the `local` family: the catalog's
-    // context_window is a guess, the running server knows — probe it (see
-    // `local_context_probe`). Ollama has no `--api-key`; anonymous GETs
-    // are what its own CLI sends.
-    Ok(LocalContextProbe::new(
+    // context_window is a guess, the running server knows. Ollama serves
+    // neither /props nor context metadata on /v1/models — its allocated
+    // window lives on the native GET /api/ps, so the probe uses that
+    // (#2135 review, P2).
+    Ok(LocalContextProbe::new_ollama(
         Arc::new(provider),
         &url,
-        None,
         http_timeout,
     ))
 }

--- a/crates/octos-llm/src/registry/ollama.rs
+++ b/crates/octos-llm/src/registry/ollama.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use eyre::Result;
 
+use crate::local_context_probe::LocalContextProbe;
 use crate::openai::OpenAIProvider;
 use crate::provider::LlmProvider;
 
@@ -44,5 +45,14 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     if let Some((t, c)) = http_timeout {
         provider = provider.with_http_timeout(t, c);
     }
-    Ok(Arc::new(provider))
+    // Same class of local server as the `local` family: the catalog's
+    // context_window is a guess, the running server knows — probe it (see
+    // `local_context_probe`). Ollama has no `--api-key`; anonymous GETs
+    // are what its own CLI sends.
+    Ok(LocalContextProbe::new(
+        Arc::new(provider),
+        &url,
+        None,
+        http_timeout,
+    ))
 }

--- a/crates/octos-llm/src/registry/vllm.rs
+++ b/crates/octos-llm/src/registry/vllm.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use eyre::Result;
 
+use crate::local_context_probe::LocalContextProbe;
 use crate::openai::OpenAIProvider;
 use crate::provider::LlmProvider;
 
@@ -23,6 +24,9 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
 
 fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let http_timeout = p.http_timeout();
+    // The probe authenticates like the provider (`vllm --api-key`
+    // deployments 401 anonymous GETs); capture before the placeholder.
+    let probe_key = p.api_key.clone();
     let key = p.api_key.unwrap_or_else(|| "token".into());
     let model = p
         .model
@@ -39,5 +43,13 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     if let Some((t, c)) = http_timeout {
         provider = provider.with_http_timeout(t, c);
     }
-    Ok(Arc::new(provider))
+    // Same class of local server as the `local` family: the catalog's
+    // context_window is a guess, the running server knows (vLLM reports
+    // max_model_len on /v1/models) — probe it (see `local_context_probe`).
+    Ok(LocalContextProbe::new(
+        Arc::new(provider),
+        &url,
+        probe_key,
+        http_timeout,
+    ))
 }

--- a/crates/octos-llm/src/retry.rs
+++ b/crates/octos-llm/src/retry.rs
@@ -400,6 +400,22 @@ impl LlmProvider for RetryProvider {
         eyre::bail!("retry loop exited unexpectedly")
     }
 
+    // #2135 review P1: without these delegations the trait defaults re-read
+    // the static catalog by model id, silently discarding a probed or
+    // overridden window on the standard runtime path (every session wraps
+    // the base provider in RetryProvider).
+    fn context_window(&self) -> u32 {
+        self.inner.context_window()
+    }
+
+    fn max_output_tokens(&self) -> u32 {
+        self.inner.max_output_tokens()
+    }
+
+    async fn ensure_ready(&self) {
+        self.inner.ensure_ready().await;
+    }
+
     fn model_id(&self) -> &str {
         self.inner.model_id()
     }

--- a/crates/octos-llm/src/swappable.rs
+++ b/crates/octos-llm/src/swappable.rs
@@ -96,6 +96,12 @@ impl LlmProvider for SwappableProvider {
         self.inner.read().unwrap().context_window()
     }
 
+    async fn ensure_ready(&self) {
+        // Clone out of the guard: the await must not hold the lock.
+        let provider = self.inner.read().unwrap().clone();
+        provider.ensure_ready().await;
+    }
+
     fn model_id(&self) -> &str {
         // &'static str is Copy — reading it from the guard yields a value
         // that doesn't depend on the guard's lifetime.

--- a/crates/octos-llm/src/throttle.rs
+++ b/crates/octos-llm/src/throttle.rs
@@ -74,6 +74,10 @@ impl LlmProvider for SemaphoreThrottledProvider {
         }))
     }
 
+    async fn ensure_ready(&self) {
+        self.inner.ensure_ready().await;
+    }
+
     fn context_window(&self) -> u32 {
         self.inner.context_window()
     }

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -954,7 +954,7 @@ impl Handler for CodergenHandler {
         }
 
         let instruction =
-            compact_pipeline_instruction(&ctx.input, Some(provider.context_window()), max_tokens);
+            sized_pipeline_instruction(provider.as_ref(), &ctx.input, max_tokens).await;
         let task = Task::new(
             TaskKind::Code {
                 instruction,
@@ -1426,6 +1426,20 @@ impl Handler for WaitHandler {
             files_modified: vec![],
         })
     }
+}
+
+/// #2135 round-3 P1: the pipeline instruction is truncated ONCE, before
+/// the task starts — the later run_task readiness hook cannot restore an
+/// omitted middle. Readiness therefore resolves HERE, before the window is
+/// read to size the cut; a lazily-probed local provider otherwise truncates
+/// against the stale catalog value.
+async fn sized_pipeline_instruction(
+    provider: &dyn LlmProvider,
+    input: &str,
+    max_output_tokens: Option<u32>,
+) -> String {
+    provider.ensure_ready().await;
+    compact_pipeline_instruction(input, Some(provider.context_window()), max_output_tokens)
 }
 
 fn compact_pipeline_instruction(
@@ -2054,6 +2068,63 @@ mod tests {
             e,
             ProgressEvent::ToolProgress { name, .. } if name == "run_pipeline"
         )));
+    }
+
+    /// #2135 round-3 P1 regression (delayed probe): the instruction cut
+    /// must be sized AFTER provider readiness. A probing provider whose
+    /// window resolves from a stale small value to the server's real one
+    /// must not lose the middle of a long instruction; drop the
+    /// ensure_ready call inside sized_pipeline_instruction and this fails.
+    #[tokio::test]
+    async fn sized_instruction_waits_for_probed_window() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        struct DelayedProbeProvider {
+            window: AtomicU32,
+        }
+
+        #[async_trait::async_trait]
+        impl LlmProvider for DelayedProbeProvider {
+            async fn chat(
+                &self,
+                _messages: &[octos_core::Message],
+                _tools: &[octos_llm::ToolSpec],
+                _config: &octos_llm::ChatConfig,
+            ) -> eyre::Result<octos_llm::ChatResponse> {
+                unreachable!("sizing must not chat");
+            }
+
+            fn model_id(&self) -> &str {
+                "delayed-probe"
+            }
+
+            fn provider_name(&self) -> &str {
+                "local"
+            }
+
+            fn context_window(&self) -> u32 {
+                self.window.load(Ordering::SeqCst)
+            }
+
+            async fn ensure_ready(&self) {
+                // The probe resolves the REAL window (like a llama-server
+                // reporting 262144 after the catalog guessed 1024).
+                self.window.store(1_048_576, Ordering::SeqCst);
+            }
+        }
+
+        let input = format!("HEAD:{}:TAIL", " middle".repeat(2_000));
+        let provider = DelayedProbeProvider {
+            window: AtomicU32::new(1_024),
+        };
+        // Un-ready sizing WOULD truncate this input (proves the test
+        // discriminates):
+        assert!(
+            super::compact_pipeline_instruction(&input, Some(1_024), Some(256)).len() < input.len()
+        );
+        // The seam resolves readiness first, so nothing is lost:
+        let sized = super::sized_pipeline_instruction(&provider, &input, Some(256)).await;
+        assert_eq!(sized, input, "instruction must be sized post-readiness");
     }
 
     #[test]


### PR DESCRIPTION
Part of #2127 — implements the probe; the per-profile `context_window` override is split to #2142 (the provider construction fans out across profile_factory/chat/fallback paths and needs its own factory tests). #2127 stays open until #2142 ships.

## Problem

`model_catalog.json` hardcodes `context_window: 32768` for `local/local-default`, and the compaction budget runs off that guess no matter what the server was launched with. Observed cost (llm.c C→Rust conversion, Qwen 3.8 27B on a `-c 262144` llama-server): the ledger pinned live context at ~19K of an actual 256K, 248 compaction checkpoints, the same 1,182-line file read 66 times, zero output files written.

## Change

`LocalContextProbe` wraps the `local`, `ollama`, and `vllm` family providers and asks the running server for its real window: llama.cpp `GET /props` (`default_generation_settings.n_ctx` — the launched `-c`, which caps everything) first, then `GET /v1/models` (all known spellings: `meta.n_ctx`, `max_model_len`, `max_context_length`, …), selected for the configured model id on multi-model servers.

- Probes in the background at construction (resumed sessions get the corrected window before their first compaction pass); the request path is the fallback and retry driver.
- Definitive answers pin; transient failures (server loading, 5xx, timeout) retry up to 5 attempts — never pinned as "32K forever".
- Probe GETs authenticate with the provider's API key and honor the configured HTTP timeouts.
- `context_window()` stays sync and non-blocking: catalog value before the probe lands, server truth after.
- Full trait passthrough (metadata/metrics), mirroring `ThrottledProvider`.

Second commit addresses all 10 findings from the pre-landing review (auth, transient-pinning, multi-model selection, metadata passthrough, resume-time probing, concurrent GETs, configured timeouts, single-suffix `/v1` stripping, ollama/vllm coverage).

## Verification

- 533/533 `octos-llm` tests pass (18 new), clippy clean.
- Parsers verified against a live llama-server (Qwen3.8-27B): `/props` and `/v1/models` both report `262144`.

## Known follow-up

`router::register_with_full_meta` snapshots `context_window()` at registration time, so the LLM-visible model catalog can still render the pre-probe value even after live readers (compaction, streaming) see the corrected one. Tracked in #2127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTroMcwSu1yKgX3LkBjQaZ

