### PR TITLE
feat(sandbox): let the toolchain work inside the sandbox, and say so when it can't

### DIFF
--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -1645,8 +1645,8 @@ mod tests {
     fn toolchain_grants_emitted_with_workspace_write() {
         let sb = MacosSandbox {
             toolchain_write_grants: super::super::ToolchainWriteGrants {
-                literals: vec!["/Users/t/.rustup/settings.toml".into()],
-                subpaths: vec!["/Users/t/.rustup/tmp".into()],
+                literals: vec!["/Users/t/.cargo/.package-cache".into()],
+                subpaths: vec![],
             },
             allow_network: false,
             read_allow_paths: Vec::new(),
@@ -1665,12 +1665,12 @@ mod tests {
             .find(|a| a.contains("deny default"))
             .expect("should have SBPL profile");
         assert!(
-            profile.contains("(allow file-write* (literal \"/Users/t/.rustup/settings.toml\"))"),
-            "rustup settings lock must be writable: {profile}"
+            profile.contains("(allow file-write* (literal \"/Users/t/.cargo/.package-cache\"))"),
+            "the cargo lock must be writable: {profile}"
         );
         assert!(
-            profile.contains("(allow file-write* (subpath \"/Users/t/.rustup/tmp\"))"),
-            "rustup scratch must be writable: {profile}"
+            !profile.contains("/registry/index"),
+            "index must NOT be writable by default: {profile}"
         );
     }
 
@@ -1732,7 +1732,7 @@ mod tests {
         let sb = MacosSandbox {
             toolchain_write_grants: super::super::ToolchainWriteGrants {
                 literals: vec!["/Users/t/.cargo/.package-cache".into()],
-                subpaths: vec!["/Users/t/.cargo/registry/index".into()],
+                subpaths: vec![],
             },
             allow_network: false,
             read_allow_paths: Vec::new(),
@@ -1758,10 +1758,6 @@ mod tests {
         assert!(
             profile.contains("(allow file-write* (literal \"/Users/t/.cargo/.package-cache\"))"),
             "lock must be writable: {profile}"
-        );
-        assert!(
-            profile.contains("(allow file-write* (subpath \"/Users/t/.cargo/registry/index\"))"),
-            "index must be writable: {profile}"
         );
         assert!(
             !cmd.as_std()

--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -201,8 +201,18 @@ impl Sandbox for MacosSandbox {
         // Path is validated above -- no escaping needed since \ and " are rejected.
         let cwd_escaped = &cwd_str;
 
+        let toolchains_active = !self.toolchain_write_grants.literals.is_empty()
+            || !self.toolchain_write_grants.subpaths.is_empty();
         let network_rule = if self.allow_network {
             "(allow network*)"
+        } else if toolchains_active {
+            // #2136 review, P1: a default build must be able to DOWNLOAD
+            // dependencies — with full network deny, cargo only works when
+            // every crate is already cached. Scoped egress: outbound HTTPS
+            // and HTTP (registry + git transports) plus DNS, nothing
+            // inbound, no other ports. Operators who need the full deny
+            // back set `sandbox.allow_toolchains = false`.
+            "(deny network*)\n(allow network-outbound (remote tcp \"*:443\"))\n(allow network-outbound (remote tcp \"*:80\"))\n(allow network-outbound (remote udp \"*:53\"))\n(allow system-socket)"
         } else {
             "(deny network*)"
         };
@@ -461,6 +471,17 @@ impl Sandbox for MacosSandbox {
         cmd.env("TMPDIR", &user_tmp);
         cmd.env("TEMP", &user_tmp);
         cmd.env("TMP", &user_tmp);
+        // #2136 review, P1: per-workspace Cargo overlay. The shared
+        // ~/.cargo caches hold sources/build scripts/proc macros that
+        // cargo EXECUTES in other workspaces and outside the sandbox, so
+        // they must never be sandbox-writable; redirecting CARGO_HOME into
+        // the (writable, tracking-ignored) scratch dir gives builds a
+        // working cache with workspace-local blast radius. Reads of the
+        // host cache are irrelevant once CARGO_HOME moves — cargo uses one
+        // home for both — so the price is a per-workspace re-download.
+        if toolchains_active {
+            cmd.env("CARGO_HOME", user_tmp.join("cargo-home"));
+        }
         // Clear dangerous environment variables (sandbox-exec inherits parent env)
         for var in BLOCKED_ENV_VARS {
             cmd.env_remove(var);
@@ -1632,7 +1653,7 @@ mod tests {
         let sb = MacosSandbox {
             toolchain_write_grants: super::super::ToolchainWriteGrants {
                 literals: vec!["/Users/t/.rustup/settings.toml".into()],
-                subpaths: vec!["/Users/t/.cargo/registry".into()],
+                subpaths: vec!["/Users/t/.rustup/tmp".into()],
             },
             allow_network: false,
             read_allow_paths: Vec::new(),
@@ -1655,8 +1676,8 @@ mod tests {
             "rustup settings lock must be writable: {profile}"
         );
         assert!(
-            profile.contains("(allow file-write* (subpath \"/Users/t/.cargo/registry\"))"),
-            "cargo registry must be writable: {profile}"
+            profile.contains("(allow file-write* (subpath \"/Users/t/.rustup/tmp\"))"),
+            "rustup scratch must be writable: {profile}"
         );
     }
 
@@ -1667,7 +1688,7 @@ mod tests {
     fn toolchain_grants_suppressed_when_writes_confined() {
         let grants = super::super::ToolchainWriteGrants {
             literals: vec!["/Users/t/.rustup/settings.toml".into()],
-            subpaths: vec!["/Users/t/.cargo/registry".into()],
+            subpaths: vec!["/Users/t/.rustup/tmp".into()],
         };
         for (label, sb) in [
             (
@@ -1708,5 +1729,85 @@ mod tests {
                 "{label}: toolchain grants must be suppressed, got: {profile}"
             );
         }
+    }
+
+    /// #2136 review P1: with toolchains active and general network OFF,
+    /// the profile allows SCOPED egress only (443/80 + DNS) so a default
+    /// build can download dependencies; toolchains off keeps the full
+    /// deny; allow_network keeps the full allow. And sandboxed commands
+    /// get a per-workspace CARGO_HOME under the scratch dir — never the
+    /// shared host cache.
+    #[test]
+    fn toolchains_enable_scoped_egress_and_cargo_overlay() {
+        let sb = MacosSandbox {
+            toolchain_write_grants: super::super::ToolchainWriteGrants {
+                literals: vec!["/Users/t/.rustup/settings.toml".into()],
+                subpaths: vec![],
+            },
+            allow_network: false,
+            read_allow_paths: Vec::new(),
+            workspace_write: true,
+            repo_git_write: None,
+            write_allow_globs: None,
+        };
+        let cmd = sb.wrap_command("cargo build", Path::new("/tmp/ws"));
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let profile = args
+            .iter()
+            .find(|a| a.contains("deny default"))
+            .expect("profile");
+        assert!(profile.contains("(deny network*)"), "{profile}");
+        assert!(
+            profile.contains("(allow network-outbound (remote tcp \"*:443\"))"),
+            "registry egress must be allowed: {profile}"
+        );
+        assert!(
+            profile.contains("(allow network-outbound (remote udp \"*:53\"))"),
+            "DNS must be allowed: {profile}"
+        );
+        let cargo_home = cmd
+            .as_std()
+            .get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("CARGO_HOME"))
+            .and_then(|(_, v)| v)
+            .expect("CARGO_HOME must be redirected")
+            .to_string_lossy()
+            .to_string();
+        assert!(
+            cargo_home.starts_with("/tmp/ws"),
+            "CARGO_HOME must live in the workspace scratch, got {cargo_home}"
+        );
+
+        // Toolchains OFF: full deny, no overlay.
+        let plain = MacosSandbox {
+            toolchain_write_grants: Default::default(),
+            allow_network: false,
+            read_allow_paths: Vec::new(),
+            workspace_write: true,
+            repo_git_write: None,
+            write_allow_globs: None,
+        };
+        let cmd = plain.wrap_command("echo hi", Path::new("/tmp/ws"));
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let profile = args
+            .iter()
+            .find(|a| a.contains("deny default"))
+            .expect("profile");
+        assert!(profile.contains("(deny network*)"), "{profile}");
+        assert!(!profile.contains("network-outbound"), "{profile}");
+        assert!(
+            !cmd.as_std()
+                .get_envs()
+                .any(|(k, _)| k == std::ffi::OsStr::new("CARGO_HOME")),
+            "no overlay without toolchains"
+        );
     }
 }

--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -99,6 +99,16 @@ fn canonicalize_lexical(path: &Path) -> std::path::PathBuf {
 /// `[^/]*`, `?` → `[^/]`, everything else a regex-escaped literal. v1 grant
 /// validation already rejected `**`/classes/alternations, so the two layers
 /// provably grant the same path set.
+/// SBPL-injection guard: true when `path` holds a byte that could break out
+/// of a `(literal "…")` / `(subpath "…")` string or inject a rule. One
+/// definition for every host-derived path interpolated into an SBPL
+/// profile — a future tightening (e.g. rejecting more bytes) lands in one
+/// place instead of the several ad-hoc copies scattered through this file.
+pub(crate) fn path_has_sbpl_metachars(path: &str) -> bool {
+    path.bytes()
+        .any(|b| b < 0x20 || b == 0x7F || b == b'(' || b == b')' || b == b'\\' || b == b'"')
+}
+
 pub(crate) fn glob_to_sbpl_regex(real_cwd: &str, glob: &str) -> String {
     let mut pattern = String::with_capacity(real_cwd.len() + glob.len() + 8);
     pattern.push('^');
@@ -307,20 +317,15 @@ impl Sandbox for MacosSandbox {
         // unwritable — fail closed), never emitted.
         let toolchain_write_rules = {
             let mut rules = String::new();
-            let unsafe_path = |p: &String| {
-                p.bytes().any(|b| {
-                    b < 0x20 || b == 0x7F || b == b'(' || b == b')' || b == b'\\' || b == b'"'
-                })
-            };
             for path in &self.toolchain_write_grants.literals {
-                if unsafe_path(path) {
+                if path_has_sbpl_metachars(path) {
                     tracing::error!(path = %path, "toolchain grant contains SBPL metacharacters, skipping");
                     continue;
                 }
                 rules.push_str(&format!("(allow file-write* (literal \"{path}\"))\n"));
             }
             for path in &self.toolchain_write_grants.subpaths {
-                if unsafe_path(path) {
+                if path_has_sbpl_metachars(path) {
                     tracing::error!(path = %path, "toolchain grant contains SBPL metacharacters, skipping");
                     continue;
                 }

--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -201,18 +201,16 @@ impl Sandbox for MacosSandbox {
         // Path is validated above -- no escaping needed since \ and " are rejected.
         let cwd_escaped = &cwd_str;
 
-        let toolchains_active = !self.toolchain_write_grants.literals.is_empty()
-            || !self.toolchain_write_grants.subpaths.is_empty();
+        // #2136 review round 2, P1: `allow_network` stays AUTHORITATIVE.
+        // A prior cut punched scoped egress for cargo when toolchains were
+        // active — that silently overrode `allow_network=false` (and fleet
+        // workers' network grants) for EVERY command, and the DNS hole did
+        // not even resolve on macOS. Network is now exactly the flag: the
+        // sandbox builds with CACHED dependencies (reads are allowed;
+        // cargo's lock/index are writable), and fresh downloads require
+        // `allow_network` (and, ultimately, proxy-isolated fetch).
         let network_rule = if self.allow_network {
             "(allow network*)"
-        } else if toolchains_active {
-            // #2136 review, P1: a default build must be able to DOWNLOAD
-            // dependencies — with full network deny, cargo only works when
-            // every crate is already cached. Scoped egress: outbound HTTPS
-            // and HTTP (registry + git transports) plus DNS, nothing
-            // inbound, no other ports. Operators who need the full deny
-            // back set `sandbox.allow_toolchains = false`.
-            "(deny network*)\n(allow network-outbound (remote tcp \"*:443\"))\n(allow network-outbound (remote tcp \"*:80\"))\n(allow network-outbound (remote udp \"*:53\"))\n(allow system-socket)"
         } else {
             "(deny network*)"
         };
@@ -471,17 +469,12 @@ impl Sandbox for MacosSandbox {
         cmd.env("TMPDIR", &user_tmp);
         cmd.env("TEMP", &user_tmp);
         cmd.env("TMP", &user_tmp);
-        // #2136 review, P1: per-workspace Cargo overlay. The shared
-        // ~/.cargo caches hold sources/build scripts/proc macros that
-        // cargo EXECUTES in other workspaces and outside the sandbox, so
-        // they must never be sandbox-writable; redirecting CARGO_HOME into
-        // the (writable, tracking-ignored) scratch dir gives builds a
-        // working cache with workspace-local blast radius. Reads of the
-        // host cache are irrelevant once CARGO_HOME moves — cargo uses one
-        // home for both — so the price is a per-workspace re-download.
-        if toolchains_active {
-            cmd.env("CARGO_HOME", user_tmp.join("cargo-home"));
-        }
+        // No CARGO_HOME redirect (#2136 review round 2, P2): a
+        // <cwd>/tmp/cargo-home overlay polluted non-git-ignored repos,
+        // fragmented the cache per workdir, and hid host cargo config +
+        // credentials. Host CARGO_HOME stands; cached deps are read from
+        // it (reads allowed), and only the non-executable lock/index are
+        // writable (see toolchain_write_grants).
         // Clear dangerous environment variables (sandbox-exec inherits parent env)
         for var in BLOCKED_ENV_VARS {
             cmd.env_remove(var);
@@ -1731,18 +1724,15 @@ mod tests {
         }
     }
 
-    /// #2136 review P1: with toolchains active and general network OFF,
-    /// the profile allows SCOPED egress only (443/80 + DNS) so a default
-    /// build can download dependencies; toolchains off keeps the full
-    /// deny; allow_network keeps the full allow. And sandboxed commands
-    /// get a per-workspace CARGO_HOME under the scratch dir — never the
-    /// shared host cache.
+    /// #2136 review round 2: `allow_network` is AUTHORITATIVE — toolchains
+    /// being active does NOT punch egress — and there is NO CARGO_HOME
+    /// overlay (host cargo home stands; only the lock/index are writable).
     #[test]
-    fn toolchains_enable_scoped_egress_and_cargo_overlay() {
+    fn toolchains_keep_network_authoritative_and_do_not_redirect_cargo_home() {
         let sb = MacosSandbox {
             toolchain_write_grants: super::super::ToolchainWriteGrants {
-                literals: vec!["/Users/t/.rustup/settings.toml".into()],
-                subpaths: vec![],
+                literals: vec!["/Users/t/.cargo/.package-cache".into()],
+                subpaths: vec!["/Users/t/.cargo/registry/index".into()],
             },
             allow_network: false,
             read_allow_paths: Vec::new(),
@@ -1762,52 +1752,22 @@ mod tests {
             .expect("profile");
         assert!(profile.contains("(deny network*)"), "{profile}");
         assert!(
-            profile.contains("(allow network-outbound (remote tcp \"*:443\"))"),
-            "registry egress must be allowed: {profile}"
+            !profile.contains("network-outbound"),
+            "toolchains must not punch egress: {profile}"
         );
         assert!(
-            profile.contains("(allow network-outbound (remote udp \"*:53\"))"),
-            "DNS must be allowed: {profile}"
+            profile.contains("(allow file-write* (literal \"/Users/t/.cargo/.package-cache\"))"),
+            "lock must be writable: {profile}"
         );
-        let cargo_home = cmd
-            .as_std()
-            .get_envs()
-            .find(|(k, _)| *k == std::ffi::OsStr::new("CARGO_HOME"))
-            .and_then(|(_, v)| v)
-            .expect("CARGO_HOME must be redirected")
-            .to_string_lossy()
-            .to_string();
         assert!(
-            cargo_home.starts_with("/tmp/ws"),
-            "CARGO_HOME must live in the workspace scratch, got {cargo_home}"
+            profile.contains("(allow file-write* (subpath \"/Users/t/.cargo/registry/index\"))"),
+            "index must be writable: {profile}"
         );
-
-        // Toolchains OFF: full deny, no overlay.
-        let plain = MacosSandbox {
-            toolchain_write_grants: Default::default(),
-            allow_network: false,
-            read_allow_paths: Vec::new(),
-            workspace_write: true,
-            repo_git_write: None,
-            write_allow_globs: None,
-        };
-        let cmd = plain.wrap_command("echo hi", Path::new("/tmp/ws"));
-        let args: Vec<_> = cmd
-            .as_std()
-            .get_args()
-            .map(|a| a.to_string_lossy().to_string())
-            .collect();
-        let profile = args
-            .iter()
-            .find(|a| a.contains("deny default"))
-            .expect("profile");
-        assert!(profile.contains("(deny network*)"), "{profile}");
-        assert!(!profile.contains("network-outbound"), "{profile}");
         assert!(
             !cmd.as_std()
                 .get_envs()
                 .any(|(k, _)| k == std::ffi::OsStr::new("CARGO_HOME")),
-            "no overlay without toolchains"
+            "CARGO_HOME must NOT be redirected"
         );
     }
 }

--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -164,6 +164,12 @@ pub struct MacosSandbox {
     /// create-vs-overwrite, so `create_only`'s no-overwrite half remains
     /// tool-layer enforced (documented on `SandboxConfig::write_allow_globs`).
     pub(crate) write_allow_globs: Option<Vec<String>>,
+    /// Precise toolchain write set (rustup settings/scratch, cargo caches —
+    /// see `toolchain_write_grants` in `mod.rs` for what is and is NOT in
+    /// it). Emitted ONLY alongside a full workspace write grant: a read-only
+    /// workspace or a #1976 fence suppresses it (deny-wins — a profile that
+    /// confines writes must not quietly regain toolchain caches).
+    pub(crate) toolchain_write_grants: super::ToolchainWriteGrants,
 }
 
 impl Sandbox for MacosSandbox {
@@ -284,6 +290,36 @@ impl Sandbox for MacosSandbox {
         //   denies the write. `/dev/null` stays writable regardless so shell
         //   redirections and git internals still function.
         let cwd_write_rule = format!("(allow file-write* (subpath \"{cwd}\"))\n", cwd = real_cwd);
+        // Toolchain write rules (rustup settings/scratch, cargo caches).
+        // Built here, appended ONLY in the full-workspace-write arms below:
+        // under a #1976 fence or a read-only workspace the profile said
+        // "confine writes", and deny-wins means these grants vanish with it.
+        // Each path is validated for SBPL metacharacters like every other
+        // injected path; an unsafe entry is skipped (that path simply stays
+        // unwritable — fail closed), never emitted.
+        let toolchain_write_rules = {
+            let mut rules = String::new();
+            let unsafe_path = |p: &String| {
+                p.bytes().any(|b| {
+                    b < 0x20 || b == 0x7F || b == b'(' || b == b')' || b == b'\\' || b == b'"'
+                })
+            };
+            for path in &self.toolchain_write_grants.literals {
+                if unsafe_path(path) {
+                    tracing::error!(path = %path, "toolchain grant contains SBPL metacharacters, skipping");
+                    continue;
+                }
+                rules.push_str(&format!("(allow file-write* (literal \"{path}\"))\n"));
+            }
+            for path in &self.toolchain_write_grants.subpaths {
+                if unsafe_path(path) {
+                    tracing::error!(path = %path, "toolchain grant contains SBPL metacharacters, skipping");
+                    continue;
+                }
+                rules.push_str(&format!("(allow file-write* (subpath \"{path}\"))\n"));
+            }
+            rules
+        };
         let workspace_write_rule = if let Some(globs) = &self.write_allow_globs {
             let mut rules = String::new();
             for glob in globs {
@@ -320,12 +356,14 @@ impl Sandbox for MacosSandbox {
                 tracing::error!(
                     "repo_git_write path contains SBPL metacharacters, granting cwd-only write"
                 );
-                cwd_write_rule
+                format!("{cwd_write_rule}{toolchain_write_rules}")
             } else {
-                format!("{cwd_write_rule}(allow file-write* (subpath \"{real_git}\"))\n")
+                format!(
+                    "{cwd_write_rule}(allow file-write* (subpath \"{real_git}\"))\n{toolchain_write_rules}"
+                )
             }
         } else if self.workspace_write {
-            cwd_write_rule
+            format!("{cwd_write_rule}{toolchain_write_rules}")
         } else {
             String::new()
         };
@@ -445,6 +483,7 @@ mod tests {
     #[test]
     fn test_macos_sandbox_command() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: true,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -490,6 +529,7 @@ mod tests {
         // above its grant). Only reached under unrestricted reads, which
         // `supports_repo_git_write` gates.
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -532,6 +572,7 @@ mod tests {
 
         // Default (no repo_git_write): only the cwd subpath is writable, no global.
         let plain = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -560,6 +601,7 @@ mod tests {
         // `.git` READ `git commit` needs, so it must NOT be reported as
         // supporting the worktree flow (the pool gate falls back to scratch).
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec!["/opt/custom".to_string()],
             workspace_write: true,
@@ -576,6 +618,7 @@ mod tests {
     #[test]
     fn test_macos_sandbox_rejects_control_chars() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -599,6 +642,7 @@ mod tests {
     #[test]
     fn test_macos_sandbox_rejects_sbpl_metacharacters() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -630,6 +674,7 @@ mod tests {
     #[test]
     fn test_macos_sandbox_denies_network() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -652,6 +697,7 @@ mod tests {
     #[test]
     fn test_macos_sandbox_accepts_valid_path() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -667,6 +713,7 @@ mod tests {
     #[test]
     fn test_macos_sandbox_rejects_del_character() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -684,6 +731,7 @@ mod tests {
     #[test]
     fn should_use_global_file_read_when_no_read_paths() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -714,6 +762,7 @@ mod tests {
             .to_string();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec!["/custom/path".to_string()],
             workspace_write: true,
@@ -760,6 +809,7 @@ mod tests {
     #[test]
     fn should_reject_read_allow_paths_with_sbpl_metacharacters() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec![
                 "/safe/path".to_string(),
@@ -802,6 +852,7 @@ mod tests {
     #[test]
     fn should_reject_read_allow_paths_with_parens() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec!["/path/with(parens)".to_string()],
             workspace_write: true,
@@ -828,6 +879,7 @@ mod tests {
     #[test]
     fn should_reject_read_allow_paths_with_control_chars() {
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec![
                 "/path/with\x01control".to_string(),
@@ -871,6 +923,7 @@ mod tests {
         let cwd = tmp.path();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec![],
             workspace_write: true,
@@ -898,6 +951,7 @@ mod tests {
         let cwd = tmp.path();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec![],
             workspace_write: true,
@@ -932,6 +986,7 @@ mod tests {
             .to_string();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: false,
@@ -970,6 +1025,7 @@ mod tests {
             .to_string();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -1003,6 +1059,7 @@ mod tests {
         let cwd = tmp.path();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: false,
@@ -1048,6 +1105,7 @@ mod tests {
         let cwd = tmp.path();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: false,
@@ -1223,6 +1281,7 @@ mod tests {
         let real_cwd = std::fs::canonicalize(cwd).expect("canonicalize cwd");
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: false,
@@ -1270,6 +1329,7 @@ mod tests {
         let cwd = tmp.path();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec![],
             workspace_write: false,
@@ -1296,6 +1356,7 @@ mod tests {
         let cwd = tmp.path();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec![],
             workspace_write: false,
@@ -1325,6 +1386,7 @@ mod tests {
         std::fs::write(&secret_file, "top-secret-data").expect("write secret");
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: vec!["/nonexistent/path".to_string()],
             workspace_write: true,
@@ -1384,6 +1446,7 @@ mod tests {
             .to_string();
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -1456,6 +1519,7 @@ mod tests {
         // path is simply not writable — and no injected rule appears.
         let tmp = tempfile::tempdir().expect("create temp dir");
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -1500,6 +1564,7 @@ mod tests {
         std::fs::create_dir(cwd.join("cards")).expect("pre-create cards/");
 
         let sb = MacosSandbox {
+            toolchain_write_grants: Default::default(),
             allow_network: false,
             read_allow_paths: Vec::new(),
             workspace_write: true,
@@ -1555,5 +1620,93 @@ mod tests {
             "shell append to a granted path is OS-allowed (documented) — create_only \
              overwrite protection lives at the file-tool layer"
         );
+    }
+
+    /// The precise toolchain set rides along with a FULL workspace write
+    /// grant: rustup's settings lock as a literal, cargo's registry as a
+    /// subpath — and never `<cargo>/bin` or `<rustup>/toolchains` (those
+    /// are persistence vectors; `toolchain_write_grants` excludes them at
+    /// detection, this test pins the emission side).
+    #[test]
+    fn toolchain_grants_emitted_with_workspace_write() {
+        let sb = MacosSandbox {
+            toolchain_write_grants: super::super::ToolchainWriteGrants {
+                literals: vec!["/Users/t/.rustup/settings.toml".into()],
+                subpaths: vec!["/Users/t/.cargo/registry".into()],
+            },
+            allow_network: false,
+            read_allow_paths: Vec::new(),
+            workspace_write: true,
+            repo_git_write: None,
+            write_allow_globs: None,
+        };
+        let cmd = sb.wrap_command("cargo build", Path::new("/tmp/ws"));
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let profile = args
+            .iter()
+            .find(|a| a.contains("deny default"))
+            .expect("should have SBPL profile");
+        assert!(
+            profile.contains("(allow file-write* (literal \"/Users/t/.rustup/settings.toml\"))"),
+            "rustup settings lock must be writable: {profile}"
+        );
+        assert!(
+            profile.contains("(allow file-write* (subpath \"/Users/t/.cargo/registry\"))"),
+            "cargo registry must be writable: {profile}"
+        );
+    }
+
+    /// Deny-wins: a profile that CONFINES writes (read-only workspace, or a
+    /// #1976 per-path fence) must not quietly regain toolchain caches — the
+    /// grants vanish with the workspace write grant.
+    #[test]
+    fn toolchain_grants_suppressed_when_writes_confined() {
+        let grants = super::super::ToolchainWriteGrants {
+            literals: vec!["/Users/t/.rustup/settings.toml".into()],
+            subpaths: vec!["/Users/t/.cargo/registry".into()],
+        };
+        for (label, sb) in [
+            (
+                "read-only workspace",
+                MacosSandbox {
+                    toolchain_write_grants: grants.clone(),
+                    allow_network: false,
+                    read_allow_paths: Vec::new(),
+                    workspace_write: false,
+                    repo_git_write: None,
+                    write_allow_globs: None,
+                },
+            ),
+            (
+                "write fence",
+                MacosSandbox {
+                    toolchain_write_grants: grants.clone(),
+                    allow_network: false,
+                    read_allow_paths: Vec::new(),
+                    workspace_write: true,
+                    repo_git_write: None,
+                    write_allow_globs: Some(vec!["out.txt".into()]),
+                },
+            ),
+        ] {
+            let cmd = sb.wrap_command("cargo build", Path::new("/tmp/ws"));
+            let args: Vec<_> = cmd
+                .as_std()
+                .get_args()
+                .map(|a| a.to_string_lossy().to_string())
+                .collect();
+            let profile = args
+                .iter()
+                .find(|a| a.contains("deny default"))
+                .expect("should have SBPL profile");
+            assert!(
+                !profile.contains(".rustup") && !profile.contains(".cargo"),
+                "{label}: toolchain grants must be suppressed, got: {profile}"
+            );
+        }
     }
 }

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -183,12 +183,28 @@ pub(crate) struct ToolchainWriteGrants {
 ///   toolchain archives are hash-verified by rustup on install, so a
 ///   poisoned staging file fails verification rather than executing.
 ///
-/// Deliberately NOT granted: anything under `~/.cargo` (#2136 review, P1 —
-/// the shared registry/git caches hold code cargo later executes OUTSIDE
-/// the sandbox; sandboxed commands get a per-workspace CARGO_HOME overlay
-/// instead), `<cargo>/bin` (on PATH — a writable shim is persistence), and
-/// `<rustup>/toolchains` (writable compiler binaries outlive the session).
-/// Only paths whose toolchain home actually exists are returned.
+/// Cargo, detected via `$CARGO_HOME` or `~/.cargo`, is granted ONLY its
+/// non-executable coordination files so an OFFLINE build against an
+/// already-populated host cache works without opening a poisoning vector:
+/// - `<cargo>/.package-cache` — the advisory build lock cargo opens
+///   write-intent on every invocation (an EPERM here fails the build
+///   before it starts).
+/// - `<cargo>/registry/index` — the registry INDEX cache (JSON/bincode
+///   metadata cargo writes during dependency resolution). Not executable
+///   code; a tampered checksum here is caught against the read-only crate
+///   cache rather than substituting a crate.
+///
+/// Deliberately NOT granted (read-only — reads are globally allowed, so
+/// cached deps remain usable): `<cargo>/registry/cache` and
+/// `<cargo>/registry/src` (the .crate archives and extracted sources cargo
+/// EXECUTES — the review's poisoning vector), `<cargo>/git` (source
+/// checkouts, likewise), `<cargo>/bin` (on PATH — a writable shim is
+/// persistence), `<rustup>/toolchains` (compiler binaries outlive the
+/// session). Fresh DOWNLOADS need writes to registry/cache+src and so
+/// need `allow_network` plus, ultimately, proxy-isolated fetch (tracked
+/// separately) — the sandbox supports BUILDING with cached dependencies,
+/// not populating the cache. Only paths whose home actually exists are
+/// returned.
 pub(crate) fn toolchain_write_grants() -> ToolchainWriteGrants {
     let mut grants = ToolchainWriteGrants::default();
     let home = std::env::var("HOME").ok();
@@ -209,14 +225,22 @@ pub(crate) fn toolchain_write_grants() -> ToolchainWriteGrants {
                 .push(rustup.join(dir).to_string_lossy().into_owned());
         }
     }
-    // NO shared-cargo grants (#2136 review, P1): ~/.cargo/registry and
-    // ~/.cargo/git hold dependency sources, build scripts, and proc
-    // macros that cargo later EXECUTES in other workspaces and outside
-    // the sandbox — a writable shared cache is a persistent poisoning
-    // vector. Sandboxed commands instead get a per-workspace CARGO_HOME
-    // overlay under the scratch dir (see the macOS backend), which is
-    // already writable and already ignored by workspace tracking. The
-    // cost is a per-workspace dependency cache; safety over reuse.
+    if let Some(cargo) = resolve("CARGO_HOME", ".cargo") {
+        // Lock file (literal): opened write-intent on every cargo run.
+        grants
+            .literals
+            .push(cargo.join(".package-cache").to_string_lossy().into_owned());
+        // Registry INDEX only (metadata, non-executable). NOT registry/cache
+        // or registry/src (executable payloads — read-only, so a cached
+        // build reads them but nothing can overwrite a crate), and NOT git.
+        grants.subpaths.push(
+            cargo
+                .join("registry")
+                .join("index")
+                .to_string_lossy()
+                .into_owned(),
+        );
+    }
     grants
 }
 
@@ -1111,12 +1135,17 @@ mod tests {
     fn toolchain_grants_exclude_persistence_vectors_and_honor_config() {
         let grants = toolchain_write_grants();
         for path in grants.literals.iter().chain(grants.subpaths.iter()) {
-            // #2136 review P1: NOTHING under ~/.cargo is ever granted —
-            // the shared caches hold code cargo executes outside the
-            // sandbox; sandboxed builds use a per-workspace CARGO_HOME.
+            // #2136 review: the EXECUTABLE cargo payloads stay read-only —
+            // registry/cache (.crate archives), registry/src (extracted
+            // sources), git (checkouts) — plus the persistence vectors.
+            // Only the non-executable lock + index are writable.
             assert!(
-                !path.contains("/.cargo") && !path.contains("/.rustup/toolchains"),
-                "persistence vector granted: {path}"
+                !path.contains("/registry/cache")
+                    && !path.contains("/registry/src")
+                    && !path.contains("/.cargo/git")
+                    && !path.contains("/.cargo/bin")
+                    && !path.contains("/.rustup/toolchains"),
+                "executable/persistence path granted writable: {path}"
             );
         }
         let off = configured_toolchain_grants(&SandboxConfig {

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -172,40 +172,27 @@ pub(crate) struct ToolchainWriteGrants {
     pub(crate) subpaths: Vec<String>,
 }
 
-/// Detect installed toolchains and return the PRECISE write set each needs.
+/// The PRECISE write set a Rust build needs inside the sandbox.
 ///
-/// Rust (rustup), detected via `$RUSTUP_HOME` or the conventional
-/// `~/.rustup` home:
-/// - `<rustup>/settings.toml` — the shim write-locks it on EVERY
-///   cargo/rustc invocation; this single literal is what turns "could not
-///   read settings file: Operation not permitted" into a working build.
-/// - `<rustup>/tmp`, `<rustup>/downloads` — rustup's own scratch; staged
-///   toolchain archives are hash-verified by rustup on install, so a
-///   poisoned staging file fails verification rather than executing.
+/// Reads of `~/.cargo` and `~/.rustup` are globally allowed, so cached
+/// dependencies, the registry index, and the installed toolchain are all
+/// usable WITHOUT any write grant. The only default write is:
+/// - `<cargo>/.package-cache` — cargo's advisory build lock, opened
+///   write-intent on every invocation (an EPERM here fails the build).
 ///
-/// Cargo, detected via `$CARGO_HOME` or `~/.cargo`, is granted ONLY its
-/// non-executable coordination files so an OFFLINE build against an
-/// already-populated host cache works without opening a poisoning vector:
-/// - `<cargo>/.package-cache` — the advisory build lock cargo opens
-///   write-intent on every invocation (an EPERM here fails the build
-///   before it starts).
-/// - `<cargo>/registry/index` — the registry INDEX cache (JSON/bincode
-///   metadata cargo writes during dependency resolution). Not executable
-///   code; a tampered checksum here is caught against the read-only crate
-///   cache rather than substituting a crate.
+/// When `allow_network` is set (the operator's explicit trust decision,
+/// which is also what makes fresh fetches possible), the DOWNLOAD-write
+/// set is added: `<cargo>/registry/{index,cache,src}` and `<cargo>/git`.
+/// These hold code cargo executes, so they are writable ONLY under
+/// network-on; the default keeps them read-only to prevent cross-workspace
+/// poisoning.
 ///
-/// Deliberately NOT granted (read-only — reads are globally allowed, so
-/// cached deps remain usable): `<cargo>/registry/cache` and
-/// `<cargo>/registry/src` (the .crate archives and extracted sources cargo
-/// EXECUTES — the review's poisoning vector), `<cargo>/git` (source
-/// checkouts, likewise), `<cargo>/bin` (on PATH — a writable shim is
-/// persistence), `<rustup>/toolchains` (compiler binaries outlive the
-/// session). Fresh DOWNLOADS need writes to registry/cache+src and so
-/// need `allow_network` plus, ultimately, proxy-isolated fetch (tracked
-/// separately) — the sandbox supports BUILDING with cached dependencies,
-/// not populating the cache. Only paths whose home actually exists are
-/// returned.
-pub(crate) fn toolchain_write_grants() -> ToolchainWriteGrants {
+/// Nothing under `~/.rustup` is ever granted (a plain build only reads it),
+/// and `<cargo>/bin` / `<rustup>/toolchains` are never writable
+/// (persistence vectors). The sandbox supports BUILDING with cached
+/// dependencies by default; fresh downloads need `allow_network` (see
+/// also the proxy-isolated-fetch follow-up).
+pub(crate) fn toolchain_write_grants(allow_network: bool) -> ToolchainWriteGrants {
     let mut grants = ToolchainWriteGrants::default();
     let home = std::env::var("HOME").ok();
     let resolve = |env_name: &str, conventional: &str| -> Option<PathBuf> {
@@ -215,32 +202,38 @@ pub(crate) fn toolchain_write_grants() -> ToolchainWriteGrants {
             .or_else(|| home.as_ref().map(|h| Path::new(h).join(conventional)))?;
         path.is_dir().then_some(path)
     };
-    if let Some(rustup) = resolve("RUSTUP_HOME", ".rustup") {
-        grants
-            .literals
-            .push(rustup.join("settings.toml").to_string_lossy().into_owned());
-        for dir in ["tmp", "downloads"] {
-            grants
-                .subpaths
-                .push(rustup.join(dir).to_string_lossy().into_owned());
-        }
-    }
+    // Cargo, default (network OFF): ONLY the advisory build lock. Reads of
+    // the whole cargo home are globally allowed, so a cached/offline build
+    // reads its deps and index without any write — the reviewer confirmed
+    // a live cached build with the index entirely READ-ONLY. registry
+    // index/cache/src and git stay read-only so nothing can corrupt
+    // dependency resolution or overwrite a crate across workspaces
+    // (#2136 review round 3, P1).
     if let Some(cargo) = resolve("CARGO_HOME", ".cargo") {
-        // Lock file (literal): opened write-intent on every cargo run.
         grants
             .literals
             .push(cargo.join(".package-cache").to_string_lossy().into_owned());
-        // Registry INDEX only (metadata, non-executable). NOT registry/cache
-        // or registry/src (executable payloads — read-only, so a cached
-        // build reads them but nothing can overwrite a crate), and NOT git.
-        grants.subpaths.push(
-            cargo
-                .join("registry")
-                .join("index")
-                .to_string_lossy()
-                .into_owned(),
-        );
+        // Download-write set — ONLY when the operator has explicitly
+        // enabled network (#2136 review round 3, P1: allow_network must be
+        // a WORKING download escape hatch, and enabling it IS the trust
+        // decision that also accepts the writable-cache surface fresh
+        // fetches require). Off by default.
+        if allow_network {
+            for dir in ["registry/index", "registry/cache", "registry/src", "git"] {
+                grants
+                    .subpaths
+                    .push(cargo.join(dir).to_string_lossy().into_owned());
+            }
+        }
     }
+    // NO rustup grants (#2136 review round 3, P1): a plain build via the
+    // rustup proxy only READS ~/.rustup (default-toolchain lookup), which
+    // is globally allowed; it does not write settings.toml or the toolchain
+    // dirs. Granting settings.toml write let a sandboxed command
+    // persistently change the user's default toolchain/overrides — removed.
+    // (rustup's original "could not READ settings" symptom was an
+    // octoscode read-restriction, not an octos one.)
+    let _ = resolve; // retained for the cargo branch above
     grants
 }
 
@@ -248,7 +241,7 @@ pub(crate) fn toolchain_write_grants() -> ToolchainWriteGrants {
 /// is on, nothing otherwise.
 fn configured_toolchain_grants(config: &SandboxConfig) -> ToolchainWriteGrants {
     if config.allow_toolchains {
-        toolchain_write_grants()
+        toolchain_write_grants(config.allow_network)
     } else {
         ToolchainWriteGrants::default()
     }
@@ -300,9 +293,10 @@ pub(crate) fn sandbox_denial_hint(
     if cfg!(target_os = "macos") {
         Some(
             "\n[sandbox] This denial usually means the OS sandbox blocked a file access \
-             outside the workspace — not a bug in the command. Toolchain caches \
-             (~/.rustup settings, ~/.cargo registry) are writable when \
-             `sandbox.allow_toolchains` is enabled (the default); other paths need an \
+             outside the workspace — not a bug in the command. With \
+             `sandbox.allow_toolchains` on (the default), builds with CACHED \
+             dependencies work; fetching NEW crates is denied unless \
+             `sandbox.allow_network` is also enabled. Other paths need an \
              explicit allowance in the sandbox config.",
         )
     } else {
@@ -1133,21 +1127,50 @@ mod tests {
     /// `allow_toolchains: false` must yield nothing at all.
     #[test]
     fn toolchain_grants_exclude_persistence_vectors_and_honor_config() {
-        let grants = toolchain_write_grants();
-        for path in grants.literals.iter().chain(grants.subpaths.iter()) {
-            // #2136 review: the EXECUTABLE cargo payloads stay read-only —
-            // registry/cache (.crate archives), registry/src (extracted
-            // sources), git (checkouts) — plus the persistence vectors.
-            // Only the non-executable lock + index are writable.
+        // DEFAULT (network off): only the cargo lock is writable. Nothing
+        // under ~/.rustup, no registry/index/cache/src, no git — a plain
+        // cached build reads everything it needs (#2136 review round 3).
+        let default_grants = toolchain_write_grants(false);
+        for path in default_grants
+            .literals
+            .iter()
+            .chain(default_grants.subpaths.iter())
+        {
             assert!(
-                !path.contains("/registry/cache")
+                !path.contains("/.rustup")
+                    && !path.contains("/registry/index")
+                    && !path.contains("/registry/cache")
                     && !path.contains("/registry/src")
                     && !path.contains("/.cargo/git")
-                    && !path.contains("/.cargo/bin")
-                    && !path.contains("/.rustup/toolchains"),
-                "executable/persistence path granted writable: {path}"
+                    && !path.contains("/.cargo/bin"),
+                "default grant must be lock-only, got: {path}"
             );
         }
+        assert!(
+            default_grants
+                .literals
+                .iter()
+                .any(|p| p.ends_with("/.cargo/.package-cache")),
+            "the cargo lock must be writable by default"
+        );
+
+        // NETWORK ON: the download-write set is added (operator trust
+        // decision), but NEVER the persistence vectors.
+        let net_grants = toolchain_write_grants(true);
+        assert!(
+            net_grants
+                .subpaths
+                .iter()
+                .any(|p| p.ends_with("/registry/cache")),
+            "network-on must allow crate downloads"
+        );
+        for path in net_grants.literals.iter().chain(net_grants.subpaths.iter()) {
+            assert!(
+                !path.contains("/.cargo/bin") && !path.contains("/.rustup/toolchains"),
+                "persistence vector granted even under network: {path}"
+            );
+        }
+
         let off = configured_toolchain_grants(&SandboxConfig {
             allow_toolchains: false,
             ..SandboxConfig::default()

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -200,7 +200,16 @@ pub(crate) fn toolchain_write_grants(allow_network: bool) -> ToolchainWriteGrant
             .ok()
             .map(PathBuf::from)
             .or_else(|| home.as_ref().map(|h| Path::new(h).join(conventional)))?;
-        path.is_dir().then_some(path)
+        if !path.is_dir() {
+            return None;
+        }
+        // #2136 review: seatbelt matches the SYMLINK-RESOLVED path (macos.rs
+        // canonicalizes cwd/git for the same reason). A symlinked HOME or
+        // CARGO_HOME (e.g. /tmp -> /private/tmp) would otherwise emit a rule
+        // that never matches and the write stays denied — fail-closed and
+        // silent. Canonicalize the (existing) home dir; leaf names append
+        // cleanly onto the resolved path.
+        Some(std::fs::canonicalize(&path).unwrap_or(path))
     };
     // Cargo, default (network OFF): ONLY the advisory build lock. Reads of
     // the whole cargo home are globally allowed, so a cached/offline build
@@ -233,7 +242,6 @@ pub(crate) fn toolchain_write_grants(allow_network: bool) -> ToolchainWriteGrant
     // persistently change the user's default toolchain/overrides — removed.
     // (rustup's original "could not READ settings" symptom was an
     // octoscode read-restriction, not an octos one.)
-    let _ = resolve; // retained for the cargo branch above
     grants
 }
 

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -219,22 +219,9 @@ pub(crate) fn toolchain_write_grants(allow_network: bool) -> ToolchainWriteGrant
     // dependency resolution or overwrite a crate across workspaces
     // (#2136 review round 3, P1).
     if let Some(cargo) = resolve("CARGO_HOME", ".cargo") {
-        grants
-            .literals
-            .push(cargo.join(".package-cache").to_string_lossy().into_owned());
-        // Download-write set — ONLY when the operator has explicitly
-        // enabled network (#2136 review round 3, P1: allow_network must be
-        // a WORKING download escape hatch, and enabling it IS the trust
-        // decision that also accepts the writable-cache surface fresh
-        // fetches require). Off by default.
-        if allow_network {
-            for dir in ["registry/index", "registry/cache", "registry/src", "git"] {
-                grants
-                    .subpaths
-                    .push(cargo.join(dir).to_string_lossy().into_owned());
-            }
-        }
+        push_cargo_grants(&mut grants, &cargo, allow_network);
     }
+
     // NO rustup grants (#2136 review round 3, P1): a plain build via the
     // rustup proxy only READS ~/.rustup (default-toolchain lookup), which
     // is globally allowed; it does not write settings.toml or the toolchain
@@ -243,6 +230,24 @@ pub(crate) fn toolchain_write_grants(allow_network: bool) -> ToolchainWriteGrant
     // (rustup's original "could not READ settings" symptom was an
     // octoscode read-restriction, not an octos one.)
     grants
+}
+
+/// Pure grant-builder for a KNOWN cargo home (no filesystem probe) — the
+/// testable core of [`toolchain_write_grants`]. Default: just the advisory
+/// build lock. With `allow_network`, the download-write set
+/// (registry/{index,cache,src} + git) is added. Never the persistence
+/// vectors (bin, toolchains).
+fn push_cargo_grants(grants: &mut ToolchainWriteGrants, cargo: &Path, allow_network: bool) {
+    grants
+        .literals
+        .push(cargo.join(".package-cache").to_string_lossy().into_owned());
+    if allow_network {
+        for dir in ["registry/index", "registry/cache", "registry/src", "git"] {
+            grants
+                .subpaths
+                .push(cargo.join(dir).to_string_lossy().into_owned());
+        }
+    }
 }
 
 /// The grants a config asks for: the detected set when `allow_toolchains`
@@ -1135,50 +1140,53 @@ mod tests {
     /// `allow_toolchains: false` must yield nothing at all.
     #[test]
     fn toolchain_grants_exclude_persistence_vectors_and_honor_config() {
-        // DEFAULT (network off): only the cargo lock is writable. Nothing
-        // under ~/.rustup, no registry/index/cache/src, no git — a plain
-        // cached build reads everything it needs (#2136 review round 3).
-        let default_grants = toolchain_write_grants(false);
-        for path in default_grants
+        use std::path::Path;
+        // Hermetic: exercise the pure builder against a KNOWN cargo home so
+        // the test does not depend on the runner having ~/.cargo (Windows CI
+        // does not) and uses component-based checks, not `/`-slash strings.
+        let cargo = Path::new("/tmp/octos-test-cargo");
+
+        // DEFAULT (network off): only the cargo lock is writable.
+        let mut default_grants = ToolchainWriteGrants::default();
+        push_cargo_grants(&mut default_grants, cargo, false);
+        assert!(
+            default_grants.subpaths.is_empty(),
+            "no download-write set without network: {:?}",
+            default_grants.subpaths
+        );
+        let lock = cargo.join(".package-cache");
+        assert_eq!(
+            default_grants.literals,
+            vec![lock.to_string_lossy().into_owned()],
+            "the only default grant is the cargo lock"
+        );
+
+        // NETWORK ON: the download-write set is added, but NEVER the
+        // persistence vectors.
+        let mut net_grants = ToolchainWriteGrants::default();
+        push_cargo_grants(&mut net_grants, cargo, true);
+        let net_paths: Vec<&str> = net_grants
             .literals
             .iter()
-            .chain(default_grants.subpaths.iter())
-        {
-            assert!(
-                !path.contains("/.rustup")
-                    && !path.contains("/registry/index")
-                    && !path.contains("/registry/cache")
-                    && !path.contains("/registry/src")
-                    && !path.contains("/.cargo/git")
-                    && !path.contains("/.cargo/bin"),
-                "default grant must be lock-only, got: {path}"
-            );
-        }
+            .chain(net_grants.subpaths.iter())
+            .map(String::as_str)
+            .collect();
         assert!(
-            default_grants
-                .literals
+            net_paths
                 .iter()
-                .any(|p| p.ends_with("/.cargo/.package-cache")),
-            "the cargo lock must be writable by default"
+                .any(|p| Path::new(p).ends_with("registry/cache")),
+            "network-on must allow crate downloads: {net_paths:?}"
         );
-
-        // NETWORK ON: the download-write set is added (operator trust
-        // decision), but NEVER the persistence vectors.
-        let net_grants = toolchain_write_grants(true);
-        assert!(
-            net_grants
-                .subpaths
-                .iter()
-                .any(|p| p.ends_with("/registry/cache")),
-            "network-on must allow crate downloads"
-        );
-        for path in net_grants.literals.iter().chain(net_grants.subpaths.iter()) {
+        for p in &net_paths {
+            let path = Path::new(p);
             assert!(
-                !path.contains("/.cargo/bin") && !path.contains("/.rustup/toolchains"),
-                "persistence vector granted even under network: {path}"
+                !path.ends_with(".cargo/bin")
+                    && !path.components().any(|c| c.as_os_str() == "toolchains"),
+                "persistence vector granted even under network: {p}"
             );
         }
 
+        // allow_toolchains=false yields nothing regardless of environment.
         let off = configured_toolchain_grants(&SandboxConfig {
             allow_toolchains: false,
             ..SandboxConfig::default()

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -174,21 +174,21 @@ pub(crate) struct ToolchainWriteGrants {
 
 /// Detect installed toolchains and return the PRECISE write set each needs.
 ///
-/// Rust (rustup + cargo), detected via `$RUSTUP_HOME`/`$CARGO_HOME` or their
-/// conventional `~/.rustup`/`~/.cargo` homes:
-/// - `<rustup>/settings.toml` — the shim write-locks it on EVERY cargo/rustc
-///   invocation; this single literal is what turns "could not read settings
-///   file: Operation not permitted" into a working build.
-/// - `<rustup>/tmp`, `<rustup>/downloads` — rustup's own scratch.
-/// - `<cargo>/registry`, `<cargo>/git` — the crate cache `cargo build` must
-///   populate.
-/// - `<cargo>/.package-cache`, `<cargo>/.rustc_info.json`,
-///   `<cargo>/.global-cache` — cargo's lock and metadata files.
+/// Rust (rustup), detected via `$RUSTUP_HOME` or the conventional
+/// `~/.rustup` home:
+/// - `<rustup>/settings.toml` — the shim write-locks it on EVERY
+///   cargo/rustc invocation; this single literal is what turns "could not
+///   read settings file: Operation not permitted" into a working build.
+/// - `<rustup>/tmp`, `<rustup>/downloads` — rustup's own scratch; staged
+///   toolchain archives are hash-verified by rustup on install, so a
+///   poisoned staging file fails verification rather than executing.
 ///
-/// Deliberately NOT granted: `<cargo>/bin` (on PATH — a writable shim there
-/// is persistence beyond the sandbox) and `<rustup>/toolchains` (writable
-/// compiler binaries outlive the session). Only paths whose toolchain home
-/// actually exists are returned, so a machine without rustup grants nothing.
+/// Deliberately NOT granted: anything under `~/.cargo` (#2136 review, P1 —
+/// the shared registry/git caches hold code cargo later executes OUTSIDE
+/// the sandbox; sandboxed commands get a per-workspace CARGO_HOME overlay
+/// instead), `<cargo>/bin` (on PATH — a writable shim is persistence), and
+/// `<rustup>/toolchains` (writable compiler binaries outlive the session).
+/// Only paths whose toolchain home actually exists are returned.
 pub(crate) fn toolchain_write_grants() -> ToolchainWriteGrants {
     let mut grants = ToolchainWriteGrants::default();
     let home = std::env::var("HOME").ok();
@@ -209,18 +209,14 @@ pub(crate) fn toolchain_write_grants() -> ToolchainWriteGrants {
                 .push(rustup.join(dir).to_string_lossy().into_owned());
         }
     }
-    if let Some(cargo) = resolve("CARGO_HOME", ".cargo") {
-        for dir in ["registry", "git"] {
-            grants
-                .subpaths
-                .push(cargo.join(dir).to_string_lossy().into_owned());
-        }
-        for file in [".package-cache", ".rustc_info.json", ".global-cache"] {
-            grants
-                .literals
-                .push(cargo.join(file).to_string_lossy().into_owned());
-        }
-    }
+    // NO shared-cargo grants (#2136 review, P1): ~/.cargo/registry and
+    // ~/.cargo/git hold dependency sources, build scripts, and proc
+    // macros that cargo later EXECUTES in other workspaces and outside
+    // the sandbox — a writable shared cache is a persistent poisoning
+    // vector. Sandboxed commands instead get a per-workspace CARGO_HOME
+    // overlay under the scratch dir (see the macOS backend), which is
+    // already writable and already ignored by workspace tracking. The
+    // cost is a per-workspace dependency cache; safety over reuse.
     grants
 }
 
@@ -1115,8 +1111,11 @@ mod tests {
     fn toolchain_grants_exclude_persistence_vectors_and_honor_config() {
         let grants = toolchain_write_grants();
         for path in grants.literals.iter().chain(grants.subpaths.iter()) {
+            // #2136 review P1: NOTHING under ~/.cargo is ever granted —
+            // the shared caches hold code cargo executes outside the
+            // sandbox; sandboxed builds use a per-workspace CARGO_HOME.
             assert!(
-                !path.contains("/.cargo/bin") && !path.contains("/.rustup/toolchains"),
+                !path.contains("/.cargo") && !path.contains("/.rustup/toolchains"),
                 "persistence vector granted: {path}"
             );
         }

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -113,6 +113,26 @@ pub struct SandboxConfig {
     /// Profile name for sandbox isolation (used as AppContainer profile ID on Windows).
     #[serde(default)]
     pub profile_name: Option<String>,
+
+    /// Grant the shell WRITE to the handful of paths a language toolchain
+    /// must touch to function at all (default: `true`).
+    ///
+    /// The motivating failure: with writes confined to the cwd, `cargo build`
+    /// dies before compiling anything — rustup's cargo shim takes a write
+    /// lock on `~/.rustup/settings.toml` ("could not read settings file:
+    /// Operation not permitted"), and cargo itself must populate
+    /// `~/.cargo/registry`. A coding agent that cannot compile writes broken
+    /// code with no feedback loop, so the pragmatic default is on.
+    ///
+    /// The grant is PRECISE, not a blanket toolchain-home write:
+    /// `~/.cargo/bin` (on PATH — a writable shim there is persistence) and
+    /// `~/.rustup/toolchains` (writable compiler binaries) are deliberately
+    /// NOT granted. Deny-wins: a read-only workspace
+    /// (`workspace_write: false`) or a #1976 write fence suppresses these
+    /// grants entirely — a profile that says "this shell writes nothing /
+    /// only these globs" must not quietly regain toolchain caches.
+    #[serde(default = "default_enabled")]
+    pub allow_toolchains: bool,
 }
 
 /// Default system paths that must be readable for shell commands to work.
@@ -144,6 +164,76 @@ pub(crate) const DEFAULT_READ_ALLOW_PATHS: &[&str] = &[
     "/dev/random",
 ];
 
+/// The write grants a detected toolchain needs — split by SBPL rule kind:
+/// `literals` are single files, `subpaths` are directory trees.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub(crate) struct ToolchainWriteGrants {
+    pub(crate) literals: Vec<String>,
+    pub(crate) subpaths: Vec<String>,
+}
+
+/// Detect installed toolchains and return the PRECISE write set each needs.
+///
+/// Rust (rustup + cargo), detected via `$RUSTUP_HOME`/`$CARGO_HOME` or their
+/// conventional `~/.rustup`/`~/.cargo` homes:
+/// - `<rustup>/settings.toml` — the shim write-locks it on EVERY cargo/rustc
+///   invocation; this single literal is what turns "could not read settings
+///   file: Operation not permitted" into a working build.
+/// - `<rustup>/tmp`, `<rustup>/downloads` — rustup's own scratch.
+/// - `<cargo>/registry`, `<cargo>/git` — the crate cache `cargo build` must
+///   populate.
+/// - `<cargo>/.package-cache`, `<cargo>/.rustc_info.json`,
+///   `<cargo>/.global-cache` — cargo's lock and metadata files.
+///
+/// Deliberately NOT granted: `<cargo>/bin` (on PATH — a writable shim there
+/// is persistence beyond the sandbox) and `<rustup>/toolchains` (writable
+/// compiler binaries outlive the session). Only paths whose toolchain home
+/// actually exists are returned, so a machine without rustup grants nothing.
+pub(crate) fn toolchain_write_grants() -> ToolchainWriteGrants {
+    let mut grants = ToolchainWriteGrants::default();
+    let home = std::env::var("HOME").ok();
+    let resolve = |env_name: &str, conventional: &str| -> Option<PathBuf> {
+        let path = std::env::var(env_name)
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| home.as_ref().map(|h| Path::new(h).join(conventional)))?;
+        path.is_dir().then_some(path)
+    };
+    if let Some(rustup) = resolve("RUSTUP_HOME", ".rustup") {
+        grants
+            .literals
+            .push(rustup.join("settings.toml").to_string_lossy().into_owned());
+        for dir in ["tmp", "downloads"] {
+            grants
+                .subpaths
+                .push(rustup.join(dir).to_string_lossy().into_owned());
+        }
+    }
+    if let Some(cargo) = resolve("CARGO_HOME", ".cargo") {
+        for dir in ["registry", "git"] {
+            grants
+                .subpaths
+                .push(cargo.join(dir).to_string_lossy().into_owned());
+        }
+        for file in [".package-cache", ".rustc_info.json", ".global-cache"] {
+            grants
+                .literals
+                .push(cargo.join(file).to_string_lossy().into_owned());
+        }
+    }
+    grants
+}
+
+/// The grants a config asks for: the detected set when `allow_toolchains`
+/// is on, nothing otherwise.
+fn configured_toolchain_grants(config: &SandboxConfig) -> ToolchainWriteGrants {
+    if config.allow_toolchains {
+        toolchain_write_grants()
+    } else {
+        ToolchainWriteGrants::default()
+    }
+}
+
 impl Default for SandboxConfig {
     fn default() -> Self {
         Self {
@@ -156,6 +246,7 @@ impl Default for SandboxConfig {
             read_allow_paths: Vec::new(),
             write_allow_globs: None,
             profile_name: None,
+            allow_toolchains: true,
         }
     }
 }
@@ -403,6 +494,7 @@ pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
             repo_git_write: config.repo_git_write.clone(),
             // #1976: macOS EXPRESSES the fence (per-glob SBPL regex rules).
             write_allow_globs: config.write_allow_globs.clone(),
+            toolchain_write_grants: configured_toolchain_grants(config),
         }),
         SandboxMode::Docker => Box::new(DockerSandbox {
             config: fence_degraded_docker(config),
@@ -479,6 +571,7 @@ fn create_auto_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                 repo_git_write: config.repo_git_write.clone(),
                 // #1976: macOS EXPRESSES the fence (per-glob regex rules).
                 write_allow_globs: config.write_allow_globs.clone(),
+                toolchain_write_grants: configured_toolchain_grants(config),
             });
         }
     }
@@ -639,6 +732,7 @@ mod tests {
     #[test]
     fn test_create_sandbox_disabled() {
         let config = SandboxConfig {
+            allow_toolchains: true,
             enabled: false,
             ..SandboxConfig::default()
         };
@@ -784,6 +878,7 @@ mod tests {
     #[test]
     fn test_create_sandbox_mode_none() {
         let config = SandboxConfig {
+            allow_toolchains: true,
             enabled: true,
             mode: SandboxMode::None,
             allow_network: false,
@@ -825,6 +920,7 @@ mod tests {
         // so a fenced workspace is bound READ-ONLY for the shell (fail
         // closed; granted paths stay writable via the fenced file tools).
         let config = SandboxConfig {
+            allow_toolchains: true,
             mode: SandboxMode::Bwrap,
             workspace_write: true,
             write_allow_globs: Some(vec!["exemplar.card".to_string()]),
@@ -861,6 +957,7 @@ mod tests {
         // #1976 honest degradation: Docker mounts are concrete too — a
         // fenced workspace mounts `:ro` (fail closed for the shell).
         let config = SandboxConfig {
+            allow_toolchains: true,
             mode: SandboxMode::Docker,
             write_allow_globs: Some(vec!["exemplar.card".to_string()]),
             ..SandboxConfig::default()
@@ -888,6 +985,7 @@ mod tests {
         // macOS is the one backend that EXPRESSES the fence (SBPL regex);
         // create_sandbox must thread the globs through, not degrade them.
         let config = SandboxConfig {
+            allow_toolchains: true,
             mode: SandboxMode::Macos,
             write_allow_globs: Some(vec!["exemplar.card".to_string()]),
             ..SandboxConfig::default()
@@ -931,10 +1029,12 @@ mod tests {
         // (refuse). This is host-independent.
         for config in [
             SandboxConfig {
+                allow_toolchains: true,
                 enabled: false,
                 ..SandboxConfig::default()
             },
             SandboxConfig {
+                allow_toolchains: true,
                 enabled: true,
                 mode: SandboxMode::None,
                 ..SandboxConfig::default()
@@ -945,5 +1045,33 @@ mod tests {
                 "config {config:?} must produce a no-op sandbox"
             );
         }
+    }
+
+    /// The detected toolchain write set must NEVER include the persistence
+    /// vectors: `<cargo>/bin` is on PATH (a writable shim there outlives the
+    /// sandbox) and `<rustup>/toolchains` holds the compiler binaries. And
+    /// `allow_toolchains: false` must yield nothing at all.
+    #[test]
+    fn toolchain_grants_exclude_persistence_vectors_and_honor_config() {
+        let grants = toolchain_write_grants();
+        for path in grants.literals.iter().chain(grants.subpaths.iter()) {
+            assert!(
+                !path.contains("/.cargo/bin") && !path.contains("/.rustup/toolchains"),
+                "persistence vector granted: {path}"
+            );
+        }
+        let off = configured_toolchain_grants(&SandboxConfig {
+            allow_toolchains: false,
+            ..SandboxConfig::default()
+        });
+        assert_eq!(off, ToolchainWriteGrants::default());
+    }
+
+    /// An old config JSON that predates `allow_toolchains` must deserialize
+    /// with the pragmatic default (true) — serde default, not Rust default.
+    #[test]
+    fn allow_toolchains_defaults_true_for_old_configs() {
+        let config: SandboxConfig = serde_json::from_str("{}").expect("empty config");
+        assert!(config.allow_toolchains);
     }
 }

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -234,6 +234,66 @@ fn configured_toolchain_grants(config: &SandboxConfig) -> ToolchainWriteGrants {
     }
 }
 
+/// The kernel phrasings a sandbox denial surfaces as, per backend: macOS
+/// seatbelt returns EPERM ("Operation not permitted"), Landlock returns
+/// EACCES ("Permission denied"), bwrap ro-binds and Docker `:ro` mounts
+/// return EROFS ("Read-only file system").
+const DENIAL_PHRASES: &[&str] = &[
+    "Operation not permitted",
+    "Permission denied",
+    "Read-only file system",
+];
+
+/// Explain a sandbox denial the kernel reports as a bare errno string.
+///
+/// Inside the sandbox, a denied access surfaces as the failing program's
+/// own confused error ("could not read settings file: Operation not
+/// permitted"), which reads as a bug in the command — the one party that
+/// knows the sandbox denied it is the harness, so the harness must say so.
+/// Observed cost of not saying so: a coding session whose every `cargo`
+/// invocation died on the rustup settings lock, with the model (and user)
+/// left debugging cargo instead of the sandbox.
+///
+/// Returns a hint ONLY when the command FAILED under a real sandbox and
+/// `scan_text` carries one of the kernel's denial phrases — a successful
+/// command that merely logged the phrase is not a denial. Callers scan the
+/// PRE-truncation text (the denial line may be exactly what truncation
+/// cuts) and append the hint AFTER truncating, so the hint itself survives.
+///
+/// The toolchain-cache pointer is macOS-only on purpose: `allow_toolchains`
+/// grants are implemented in the seatbelt backend today, and advertising
+/// the lever on a backend that ignores it would misstate what is writable.
+pub(crate) fn sandbox_denial_hint(
+    sandboxed: bool,
+    success: bool,
+    scan_text: &str,
+) -> Option<&'static str> {
+    if success || !sandboxed {
+        return None;
+    }
+    if !DENIAL_PHRASES
+        .iter()
+        .any(|phrase| scan_text.contains(phrase))
+    {
+        return None;
+    }
+    if cfg!(target_os = "macos") {
+        Some(
+            "\n[sandbox] This denial usually means the OS sandbox blocked a file access \
+             outside the workspace — not a bug in the command. Toolchain caches \
+             (~/.rustup settings, ~/.cargo registry) are writable when \
+             `sandbox.allow_toolchains` is enabled (the default); other paths need an \
+             explicit allowance in the sandbox config.",
+        )
+    } else {
+        Some(
+            "\n[sandbox] This denial usually means the OS sandbox blocked a file access \
+             outside the workspace — not a bug in the command. Grant the path in the \
+             sandbox config, or run under a less restrictive sandbox mode.",
+        )
+    }
+}
+
 impl Default for SandboxConfig {
     fn default() -> Self {
         Self {

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -484,14 +484,18 @@ impl ExecCommandTool {
         let session_id = next_exec_session_id();
         let output = Arc::new(Mutex::new(String::new()));
         let exit_code = Arc::new(Mutex::new(None));
-        // #2136 review round 2, P2: the exit-code task must JOIN the pipe
-        // readers before publishing completion. Otherwise a process that
-        // exits right at the yield deadline can flip `running` to false
-        // before its final stdout/stderr (including a denial line) is
-        // captured — the payload then omits the [sandbox] hint and the
-        // caller may not poll again. Draining the pipes to EOF (which
-        // happens when the child's fds close, i.e. at/after exit) before
-        // recording the code makes "not running" imply "output complete".
+        // #2136 review: after the child exits, give the pipe readers a
+        // BOUNDED grace to drain before publishing the exit code, then
+        // publish regardless. A plain reader-join deadlocked when a
+        // descendant (a backgrounded `server &`, a daemon that inherits
+        // stdout) keeps a pipe write-end open — EOF never arrives and the
+        // session reported `running` forever. The grace closes the
+        // round-2 race (a fast-exiting command's final output — e.g. a
+        // denial line — is captured within the window, since its fds close
+        // at exit) without hanging on a surviving descendant; combined
+        // with sampling the exit code BEFORE the output, "not running"
+        // implies "output drained" in the common case.
+        const READER_DRAIN_GRACE: Duration = Duration::from_millis(200);
         let stdout_reader = stdout
             .map(|stdout| tokio::spawn(append_reader_output(stdout, output.clone(), "stdout")));
         let stderr_reader = stderr
@@ -499,12 +503,15 @@ impl ExecCommandTool {
         let exit_code_for_wait = exit_code.clone();
         tokio::spawn(async move {
             let code = child.wait().await.ok().and_then(|status| status.code());
-            if let Some(handle) = stdout_reader {
-                let _ = handle.await;
-            }
-            if let Some(handle) = stderr_reader {
-                let _ = handle.await;
-            }
+            let _ = tokio::time::timeout(READER_DRAIN_GRACE, async {
+                if let Some(handle) = stdout_reader {
+                    let _ = handle.await;
+                }
+                if let Some(handle) = stderr_reader {
+                    let _ = handle.await;
+                }
+            })
+            .await;
             *exit_code_for_wait.lock().await = Some(code.unwrap_or(-1));
         });
         exec_sessions().lock().await.insert(

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -66,6 +66,30 @@ fn truncate_output(mut output: String, max_bytes: usize) -> String {
     output
 }
 
+/// Explain a sandbox denial the kernel reports as a bare EPERM.
+///
+/// Inside the sandbox, a denied write surfaces as the failing program's own
+/// confused error ("could not read settings file: Operation not permitted"),
+/// which reads as a bug in the command — the one party that knows the
+/// sandbox denied it is the harness, so the harness must say so. Observed
+/// cost of not saying so: a coding session whose every `cargo` invocation
+/// died on the rustup settings lock, with the model (and user) left
+/// debugging cargo instead of the sandbox. Appended only when the command
+/// FAILED under a real sandbox and the text carries the kernel's phrase;
+/// a successful command that logged the phrase is not a denial.
+fn append_sandbox_denial_hint(text: &mut String, sandboxed: bool, success: bool) {
+    if success || !sandboxed || !text.contains("Operation not permitted") {
+        return;
+    }
+    text.push_str(
+        "\n[sandbox] 'Operation not permitted' here usually means the OS sandbox denied a \
+         file access outside the workspace — not a bug in the command. Toolchain caches \
+         (~/.rustup settings, ~/.cargo registry) are writable when `sandbox.allow_toolchains` \
+         is enabled (the default); other paths need an explicit allowance in the sandbox \
+         config.",
+    );
+}
+
 fn resolve_optional_workdir(
     base_dir: &Path,
     workdir: Option<&str>,
@@ -397,6 +421,11 @@ impl ExecCommandTool {
                     "\n\nExit code: {}",
                     output.status.code().unwrap_or(-1)
                 ));
+                append_sandbox_denial_hint(
+                    &mut text,
+                    !self.sandbox.is_noop(),
+                    output.status.success(),
+                );
                 let max = input.max_output_tokens.unwrap_or(MAX_CAPTURE_BYTES);
                 Ok(ToolResult {
                     output: truncate_output(text, max),
@@ -1833,6 +1862,11 @@ impl Tool for BashTool {
                 }
                 let exit_code = output.status.code().unwrap_or(-1);
                 text.push_str(&format!("\n\nExit code: {exit_code}"));
+                append_sandbox_denial_hint(
+                    &mut text,
+                    !self.sandbox.is_noop(),
+                    output.status.success(),
+                );
                 Ok(ToolResult {
                     output: truncate_output(text, MAX_CAPTURE_BYTES),
                     success: output.status.success(),

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -51,6 +51,7 @@ struct ExecSession {
     stdin: Arc<Mutex<Option<ChildStdin>>>,
     output: Arc<Mutex<String>>,
     exit_code: Arc<Mutex<Option<i32>>>,
+    sandboxed: bool,
 }
 
 fn next_exec_session_id() -> String {
@@ -67,6 +68,27 @@ fn truncate_output(mut output: String, max_bytes: usize) -> String {
 }
 
 use crate::sandbox::sandbox_denial_hint;
+
+/// Session-output payload shared by `exec_command`'s yielded path and
+/// `write_stdin` (#2136 review, P1: the principal ASYNC execution path
+/// returned permission failures without the [sandbox] explanation the
+/// synchronous paths carry). Scans the FULL captured text, truncates,
+/// then appends the hint so it survives the cap — same ordering contract
+/// as the synchronous assemblers.
+fn session_output_payload(
+    captured: String,
+    exit_code: Option<i32>,
+    sandboxed: bool,
+    cap: usize,
+) -> String {
+    let failed = matches!(exit_code, Some(code) if code != 0);
+    let hint = sandbox_denial_hint(sandboxed, !failed, &captured);
+    let mut output = truncate_output(captured, cap);
+    if let Some(hint) = hint {
+        output.push_str(hint);
+    }
+    output
+}
 
 fn resolve_optional_workdir(
     base_dir: &Path,
@@ -479,6 +501,7 @@ impl ExecCommandTool {
                 stdin: Arc::new(Mutex::new(stdin)),
                 output: output.clone(),
                 exit_code: exit_code.clone(),
+                sandboxed: !self.sandbox.is_noop(),
             },
         );
         tokio::time::sleep(Duration::from_millis(
@@ -492,7 +515,12 @@ impl ExecCommandTool {
                 "session_id": session_id,
                 "running": code.is_none(),
                 "exit_code": code,
-                "output": truncate_output(captured, input.max_output_tokens.unwrap_or(MAX_CAPTURE_BYTES)),
+                "output": session_output_payload(
+                    captured,
+                    code,
+                    !self.sandbox.is_noop(),
+                    input.max_output_tokens.unwrap_or(MAX_CAPTURE_BYTES),
+                ),
             })
             .to_string(),
             success: true,
@@ -572,7 +600,12 @@ impl Tool for WriteStdinTool {
                 "session_id": input.session_id,
                 "running": code.is_none(),
                 "exit_code": code,
-                "output": truncate_output(output, input.max_output_tokens.unwrap_or(MAX_CAPTURE_BYTES)),
+                "output": session_output_payload(
+                    output,
+                    code,
+                    session.sandboxed,
+                    input.max_output_tokens.unwrap_or(MAX_CAPTURE_BYTES),
+                ),
             })
             .to_string(),
             success: true,

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -520,8 +520,13 @@ impl ExecCommandTool {
             input.yield_time_ms.unwrap_or(DEFAULT_EXEC_YIELD_MS),
         ))
         .await;
-        let captured = output.lock().await.clone();
+        // #2136 review round 3, P2: sample the exit code FIRST, then the
+        // output. The exit-code task sets the code only AFTER joining the
+        // pipe readers, so `code.is_some()` (not running) guarantees the
+        // output buffer is fully drained — reading output after the code
+        // therefore never sees a stale/empty capture with running:false.
         let code = *exit_code.lock().await;
+        let captured = output.lock().await.clone();
         Ok(ToolResult {
             output: json!({
                 "session_id": session_id,
@@ -605,8 +610,9 @@ impl Tool for WriteStdinTool {
             }
         }
         tokio::time::sleep(Duration::from_millis(input.yield_time_ms.unwrap_or(250))).await;
-        let output = session.output.lock().await.clone();
+        // #2136 review round 3, P2: code before output (see spawn_session).
         let code = *session.exit_code.lock().await;
+        let output = session.output.lock().await.clone();
         Ok(ToolResult {
             output: json!({
                 "session_id": input.session_id,

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -484,15 +484,27 @@ impl ExecCommandTool {
         let session_id = next_exec_session_id();
         let output = Arc::new(Mutex::new(String::new()));
         let exit_code = Arc::new(Mutex::new(None));
-        if let Some(stdout) = stdout {
-            tokio::spawn(append_reader_output(stdout, output.clone(), "stdout"));
-        }
-        if let Some(stderr) = stderr {
-            tokio::spawn(append_reader_output(stderr, output.clone(), "stderr"));
-        }
+        // #2136 review round 2, P2: the exit-code task must JOIN the pipe
+        // readers before publishing completion. Otherwise a process that
+        // exits right at the yield deadline can flip `running` to false
+        // before its final stdout/stderr (including a denial line) is
+        // captured — the payload then omits the [sandbox] hint and the
+        // caller may not poll again. Draining the pipes to EOF (which
+        // happens when the child's fds close, i.e. at/after exit) before
+        // recording the code makes "not running" imply "output complete".
+        let stdout_reader = stdout
+            .map(|stdout| tokio::spawn(append_reader_output(stdout, output.clone(), "stdout")));
+        let stderr_reader = stderr
+            .map(|stderr| tokio::spawn(append_reader_output(stderr, output.clone(), "stderr")));
         let exit_code_for_wait = exit_code.clone();
         tokio::spawn(async move {
             let code = child.wait().await.ok().and_then(|status| status.code());
+            if let Some(handle) = stdout_reader {
+                let _ = handle.await;
+            }
+            if let Some(handle) = stderr_reader {
+                let _ = handle.await;
+            }
             *exit_code_for_wait.lock().await = Some(code.unwrap_or(-1));
         });
         exec_sessions().lock().await.insert(

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -66,29 +66,7 @@ fn truncate_output(mut output: String, max_bytes: usize) -> String {
     output
 }
 
-/// Explain a sandbox denial the kernel reports as a bare EPERM.
-///
-/// Inside the sandbox, a denied write surfaces as the failing program's own
-/// confused error ("could not read settings file: Operation not permitted"),
-/// which reads as a bug in the command — the one party that knows the
-/// sandbox denied it is the harness, so the harness must say so. Observed
-/// cost of not saying so: a coding session whose every `cargo` invocation
-/// died on the rustup settings lock, with the model (and user) left
-/// debugging cargo instead of the sandbox. Appended only when the command
-/// FAILED under a real sandbox and the text carries the kernel's phrase;
-/// a successful command that logged the phrase is not a denial.
-fn append_sandbox_denial_hint(text: &mut String, sandboxed: bool, success: bool) {
-    if success || !sandboxed || !text.contains("Operation not permitted") {
-        return;
-    }
-    text.push_str(
-        "\n[sandbox] 'Operation not permitted' here usually means the OS sandbox denied a \
-         file access outside the workspace — not a bug in the command. Toolchain caches \
-         (~/.rustup settings, ~/.cargo registry) are writable when `sandbox.allow_toolchains` \
-         is enabled (the default); other paths need an explicit allowance in the sandbox \
-         config.",
-    );
-}
+use crate::sandbox::sandbox_denial_hint;
 
 fn resolve_optional_workdir(
     base_dir: &Path,
@@ -421,14 +399,17 @@ impl ExecCommandTool {
                     "\n\nExit code: {}",
                     output.status.code().unwrap_or(-1)
                 ));
-                append_sandbox_denial_hint(
-                    &mut text,
-                    !self.sandbox.is_noop(),
-                    output.status.success(),
-                );
+                // Scan BEFORE truncation (the denial line may be what gets
+                // cut), append AFTER (so the hint itself survives the cut).
+                let hint =
+                    sandbox_denial_hint(!self.sandbox.is_noop(), output.status.success(), &text);
                 let max = input.max_output_tokens.unwrap_or(MAX_CAPTURE_BYTES);
+                let mut out = truncate_output(text, max);
+                if let Some(hint) = hint {
+                    out.push_str(hint);
+                }
                 Ok(ToolResult {
-                    output: truncate_output(text, max),
+                    output: out,
                     success: output.status.success(),
                     ..Default::default()
                 })
@@ -1862,13 +1843,15 @@ impl Tool for BashTool {
                 }
                 let exit_code = output.status.code().unwrap_or(-1);
                 text.push_str(&format!("\n\nExit code: {exit_code}"));
-                append_sandbox_denial_hint(
-                    &mut text,
-                    !self.sandbox.is_noop(),
-                    output.status.success(),
-                );
+                // Scan BEFORE truncation, append AFTER — see run_to_completion.
+                let hint =
+                    sandbox_denial_hint(!self.sandbox.is_noop(), output.status.success(), &text);
+                let mut out = truncate_output(text, MAX_CAPTURE_BYTES);
+                if let Some(hint) = hint {
+                    out.push_str(hint);
+                }
                 Ok(ToolResult {
-                    output: truncate_output(text, MAX_CAPTURE_BYTES),
+                    output: out,
                     success: output.status.success(),
                     structured_metadata: Some(json!({
                         "codex_tool": "bash",

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -1403,6 +1403,51 @@ async fn exec_command_runs_to_completion() {
 
 #[cfg(not(windows))]
 #[tokio::test]
+async fn exec_session_completes_even_when_a_descendant_keeps_stdout_open() {
+    // #2136 review: joining pipe readers before publishing the exit code
+    // hung forever when a backgrounded descendant held a pipe write-end
+    // open (EOF never arrives). The bounded drain grace must let the
+    // foreground command report completion regardless. `sleep 30 &` keeps
+    // a child alive with stdout inherited; the foreground shell exits
+    // immediately, and the session must report running:false well within
+    // the sleep.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let registry = ToolRegistry::with_builtins(temp.path());
+    let start = std::time::Instant::now();
+    let result = registry
+        .execute(
+            "exec_command",
+            &json!({
+                // Yield past the reader-drain grace so the completed exit
+                // code has published; the background `sleep 30` is still
+                // alive, which is exactly the descendant-holds-stdout case.
+                "cmd": "sleep 30 & echo foreground-done",
+                "yield_time_ms": 600
+            }),
+        )
+        .await
+        .expect("exec command");
+    let payload: Value = serde_json::from_str(&result.output).expect("session payload");
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(5),
+        "must not block on a surviving descendant; took {:?}",
+        start.elapsed()
+    );
+    assert_eq!(
+        payload["running"],
+        Value::Bool(false),
+        "foreground command must report completion despite the background child: {}",
+        result.output
+    );
+    assert!(
+        payload["output"].as_str().unwrap_or("").contains("foreground-done"),
+        "foreground output must be captured: {}",
+        result.output
+    );
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
 async fn exec_session_captures_all_output_when_process_exits_at_deadline() {
     // #2136 review round 2, P2: a process that prints then exits right at
     // the yield deadline must still have its FULL output captured before

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -2641,3 +2641,36 @@ fn should_declare_element_schema_when_spawn_agent_items_is_array() {
     assert!(items["items"]["properties"]["type"].is_object());
     assert!(items["items"]["properties"]["text"].is_object());
 }
+
+/// The sandbox-denial hint fires only on the exact combination that needs
+/// explaining: a FAILED command, under a REAL sandbox, whose output carries
+/// the kernel's bare EPERM phrase. Every other combination stays untouched
+/// (a passing command that merely logs the phrase is not a denial).
+#[test]
+fn sandbox_denial_hint_fires_only_on_sandboxed_failures() {
+    let denial = "error: could not read settings file: Operation not permitted";
+
+    let mut text = denial.to_string();
+    super::append_sandbox_denial_hint(&mut text, true, false);
+    assert!(
+        text.contains("[sandbox]"),
+        "sandboxed failure must be explained"
+    );
+    assert!(
+        text.contains("allow_toolchains"),
+        "hint must name the config lever"
+    );
+
+    for (sandboxed, success, body) in [
+        (false, false, denial),                         // no sandbox: EPERM is real
+        (true, true, denial),                           // command succeeded
+        (true, false, "error: normal compile failure"), // failed, but no EPERM
+    ] {
+        let mut text = body.to_string();
+        super::append_sandbox_denial_hint(&mut text, sandboxed, success);
+        assert!(
+            !text.contains("[sandbox]"),
+            "no hint for ({sandboxed}, {success}, {body})"
+        );
+    }
+}

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -1440,7 +1440,10 @@ async fn exec_session_completes_even_when_a_descendant_keeps_stdout_open() {
         result.output
     );
     assert!(
-        payload["output"].as_str().unwrap_or("").contains("foreground-done"),
+        payload["output"]
+            .as_str()
+            .unwrap_or("")
+            .contains("foreground-done"),
         "foreground output must be captured: {}",
         result.output
     );

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -1403,6 +1403,41 @@ async fn exec_command_runs_to_completion() {
 
 #[cfg(not(windows))]
 #[tokio::test]
+async fn exec_session_captures_all_output_when_process_exits_at_deadline() {
+    // #2136 review round 2, P2: a process that prints then exits right at
+    // the yield deadline must still have its FULL output captured before
+    // `running` flips to false — the exit-code task joins the pipe readers
+    // first. Runs many trials because the race is timing-sensitive.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let registry = ToolRegistry::with_builtins(temp.path());
+    for _ in 0..15 {
+        let result = registry
+            .execute(
+                "exec_command",
+                &json!({
+                    // Emit a distinctive tail, then exit immediately; the
+                    // 5ms yield races the ~instant exit.
+                    "cmd": "printf 'HEAD MIDDLE TAIL_MARKER'; exit 0",
+                    "yield_time_ms": 5
+                }),
+            )
+            .await
+            .expect("exec command");
+        let payload: Value = serde_json::from_str(&result.output).expect("session payload");
+        // If it reports finished, the full output MUST be present (no
+        // truncated-by-race capture).
+        if payload["running"] == Value::Bool(false) {
+            let out = payload["output"].as_str().unwrap_or("");
+            assert!(
+                out.contains("TAIL_MARKER"),
+                "completed session dropped output to a race: {out:?}"
+            );
+        }
+    }
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
 async fn write_stdin_talks_to_exec_session() {
     let temp = tempfile::tempdir().expect("tempdir");
     let registry = ToolRegistry::with_builtins(temp.path());

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -2687,3 +2687,21 @@ fn sandbox_denial_hint_fires_only_on_sandboxed_failures() {
         );
     }
 }
+
+/// #2136 review P1: the session paths (exec_command yielded, write_stdin)
+/// carry the [sandbox] denial hint too — scan the FULL capture, truncate,
+/// then append so the hint survives the cap.
+#[test]
+fn session_payload_carries_denial_hint_on_sandboxed_failures() {
+    let denial = "error: could not read settings file: Operation not permitted".to_string();
+    let payload = super::session_output_payload(denial.clone(), Some(1), true, 4096);
+    if cfg!(target_os = "macos") {
+        assert!(payload.contains("[sandbox]"), "{payload}");
+    }
+    // Still running (no exit code): not a failure, no hint.
+    let payload = super::session_output_payload(denial.clone(), None, true, 4096);
+    assert!(!payload.contains("[sandbox]"), "{payload}");
+    // Unsandboxed: EPERM is real, no hint.
+    let payload = super::session_output_payload(denial, Some(1), false, 4096);
+    assert!(!payload.contains("[sandbox]"), "{payload}");
+}

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -1410,7 +1410,8 @@ async fn exec_session_captures_all_output_when_process_exits_at_deadline() {
     // first. Runs many trials because the race is timing-sensitive.
     let temp = tempfile::tempdir().expect("tempdir");
     let registry = ToolRegistry::with_builtins(temp.path());
-    for _ in 0..15 {
+    let mut completed = 0;
+    for _ in 0..40 {
         let result = registry
             .execute(
                 "exec_command",
@@ -1424,9 +1425,8 @@ async fn exec_session_captures_all_output_when_process_exits_at_deadline() {
             .await
             .expect("exec command");
         let payload: Value = serde_json::from_str(&result.output).expect("session payload");
-        // If it reports finished, the full output MUST be present (no
-        // truncated-by-race capture).
         if payload["running"] == Value::Bool(false) {
+            completed += 1;
             let out = payload["output"].as_str().unwrap_or("");
             assert!(
                 out.contains("TAIL_MARKER"),
@@ -1434,6 +1434,39 @@ async fn exec_session_captures_all_output_when_process_exits_at_deadline() {
             );
         }
     }
+    // Non-vacuous: the completed-session path MUST have been exercised
+    // (otherwise the assertion above never runs).
+    assert!(
+        completed > 0,
+        "no trial reached the completed path — test is vacuous"
+    );
+}
+
+/// #2128 acceptance: execute a command DENIED by a real sandbox and assert
+/// the tool response carries the [sandbox] explanation (macOS only — needs
+/// a live seatbelt profile).
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn denied_command_response_carries_sandbox_hint() {
+    use crate::sandbox::{SandboxConfig, create_sandbox};
+    let temp = tempfile::tempdir().expect("tempdir");
+    // Real seatbelt sandbox, workspace = temp; writing OUTSIDE it is denied.
+    let sandbox = create_sandbox(&SandboxConfig::default());
+    let registry = ToolRegistry::with_builtins_and_sandbox(temp.path(), sandbox);
+    // Target a path guaranteed outside the workspace and not otherwise
+    // writable; the shell's own error carries the kernel EPERM phrase.
+    let result = registry
+        .execute(
+            "exec_command",
+            &json!({ "cmd": "echo x > /etc/octos_denied_probe" }),
+        )
+        .await
+        .expect("exec command");
+    assert!(
+        result.output.contains("[sandbox]"),
+        "denied command must surface the sandbox hint, got: {}",
+        result.output
+    );
 }
 
 #[cfg(not(windows))]

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -2644,32 +2644,45 @@ fn should_declare_element_schema_when_spawn_agent_items_is_array() {
 
 /// The sandbox-denial hint fires only on the exact combination that needs
 /// explaining: a FAILED command, under a REAL sandbox, whose output carries
-/// the kernel's bare EPERM phrase. Every other combination stays untouched
-/// (a passing command that merely logs the phrase is not a denial).
+/// one of the kernel's denial phrases — EPERM (macOS seatbelt), EACCES
+/// (Landlock), or EROFS (bwrap/Docker read-only). Every other combination
+/// stays untouched (a passing command that merely logs a phrase is not a
+/// denial).
 #[test]
 fn sandbox_denial_hint_fires_only_on_sandboxed_failures() {
-    let denial = "error: could not read settings file: Operation not permitted";
+    use crate::sandbox::sandbox_denial_hint;
 
-    let mut text = denial.to_string();
-    super::append_sandbox_denial_hint(&mut text, true, false);
-    assert!(
-        text.contains("[sandbox]"),
-        "sandboxed failure must be explained"
-    );
-    assert!(
-        text.contains("allow_toolchains"),
-        "hint must name the config lever"
-    );
+    for denial in [
+        "error: could not read settings file: Operation not permitted",
+        "mkdir: cannot create directory: Permission denied",
+        "touch: cannot touch '/etc/x': Read-only file system",
+    ] {
+        let hint = sandbox_denial_hint(true, false, denial);
+        let hint = hint.expect("sandboxed failure must be explained");
+        assert!(hint.contains("[sandbox]"), "hint must be tagged: {hint}");
+    }
+
+    // The toolchain-cache lever is only advertised where it is implemented.
+    let hint = sandbox_denial_hint(true, false, "Operation not permitted").unwrap();
+    if cfg!(target_os = "macos") {
+        assert!(
+            hint.contains("allow_toolchains"),
+            "macOS hint names the lever"
+        );
+    } else {
+        assert!(
+            !hint.contains("allow_toolchains"),
+            "non-macOS backends do not implement the grants; the hint must not advertise them"
+        );
+    }
 
     for (sandboxed, success, body) in [
-        (false, false, denial),                         // no sandbox: EPERM is real
-        (true, true, denial),                           // command succeeded
-        (true, false, "error: normal compile failure"), // failed, but no EPERM
+        (false, false, "Operation not permitted"), // no sandbox: errno is real
+        (true, true, "Operation not permitted"),   // command succeeded
+        (true, false, "error: normal compile failure"), // failed, but no denial phrase
     ] {
-        let mut text = body.to_string();
-        super::append_sandbox_denial_hint(&mut text, sandboxed, success);
         assert!(
-            !text.contains("[sandbox]"),
+            sandbox_denial_hint(sandboxed, success, body).is_none(),
             "no hint for ({sandboxed}, {success}, {body})"
         );
     }

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -869,6 +869,15 @@ impl Tool for ShellTool {
                     result_text = "(no output)".to_string();
                 }
 
+                // Sandbox-denial scan runs on the FULL text (the denial line
+                // may be exactly what truncation cuts); the hint is appended
+                // after truncation so it survives the cut.
+                let denial_hint = crate::sandbox::sandbox_denial_hint(
+                    !self.sandbox.is_noop(),
+                    output.status.success(),
+                    &result_text,
+                );
+
                 // Truncate if too long (reserve space for exit code suffix)
                 let exit_suffix = format!("\n\nExit code: {exit_code}");
                 const MAX_OUTPUT: usize = 50000;
@@ -879,6 +888,9 @@ impl Tool for ShellTool {
                 );
 
                 result_text.push_str(&exit_suffix);
+                if let Some(hint) = denial_hint {
+                    result_text.push_str(hint);
+                }
 
                 Ok(ToolResult {
                     output: result_text,

--- a/crates/octos-agent/tests/security_sandbox.rs
+++ b/crates/octos-agent/tests/security_sandbox.rs
@@ -444,6 +444,7 @@ fn should_restrict_reads_when_configured() {
     // (needs mach-lookup, dyld shared cache access, etc.), so we test the profile
     // generation rather than live execution with restricted reads.
     let config = octos_agent::SandboxConfig {
+        allow_toolchains: true,
         enabled: true,
         mode: octos_agent::sandbox::SandboxMode::Macos,
         allow_network: false,
@@ -672,6 +673,7 @@ fn should_block_dangerous_docker_cwd() {
 
     // Test via the actual sandbox module
     let sb = octos_agent::sandbox::create_sandbox(&octos_agent::SandboxConfig {
+        allow_toolchains: true,
         enabled: true,
         mode: octos_agent::sandbox::SandboxMode::Docker,
         allow_network: false,


### PR DESCRIPTION
Closes #2128.

## Problem

With writes confined to the workspace cwd, a macOS coding session cannot compile Rust at all: rustup's cargo shim write-locks `~/.rustup/settings.toml` on every invocation and dies on `could not read settings file: Operation not permitted` before cargo starts; cargo also needs `~/.cargo/registry`. Observed cost: a session that wrote 15 Rust files with zero successful compiles, shipping hallucinated dependencies — and the denial surfaced only as the failing program's own confused error text.

## Change

1. **`sandbox.allow_toolchains`** (default `true`): grants the shell write access to the *precise* set a toolchain needs — the rustup settings lock (literal), rustup `tmp`/`downloads`, cargo `registry`/`git`, and cargo's three lock/metadata files. Deliberately **not** granted: `~/.cargo/bin` (on PATH — a writable shim is persistence) and `~/.rustup/toolchains` (writable compiler binaries). Deny-wins: a read-only workspace or a #1976 write fence suppresses the grants entirely. macOS backend only for now; Linux backends are a follow-up on #2128.
2. **Tagged denials**: a failed command under a real sandbox whose output carries `Operation not permitted` gets a `[sandbox]` line naming the layer that denied it and the config lever that fixes it.

## Verification

2,916/2,916 `octos-agent` tests pass (4 new: SBPL emission with grants, deny-wins suppression under read-only/fence, persistence-vector exclusion + serde default, denial-hint firing matrix), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTroMcwSu1yKgX3LkBjQaZ
