### PR TITLE
chore: advance embedded octos-web pin to 9630b25 + adopt pnpm contract (#2108)

### DIFF
--- a/scripts/build-web-app.sh
+++ b/scripts/build-web-app.sh
@@ -8,6 +8,11 @@
 # `BASE_URL=/app/` then copy `dist/` into `crates/octos-cli/static/web/`, which
 # `static_files.rs` embeds via rust-embed (`#[folder = "static/"]`).
 #
+# Package manager: octos-web migrated to pnpm (package.json
+# `packageManager: pnpm@…`, pnpm-lock.yaml, NO package-lock.json — 2026-08,
+# #2108), so this script installs with `pnpm install --frozen-lockfile`.
+# Requires corepack or a standalone pnpm on PATH; Node 22+ images have both.
+#
 # Mirrors scripts/build-dashboard.sh (admin SPA) and the swarm-app pattern.
 set -euo pipefail
 
@@ -22,15 +27,26 @@ if [ ! -d "$WEB_DIR" ] || [ ! -f "$WEB_DIR/package.json" ]; then
     exit 1
 fi
 
-if ! command -v npm >/dev/null 2>&1; then
-    echo "error: npm not found — install Node.js (https://nodejs.org) to build octos-web" >&2
+if ! command -v node >/dev/null 2>&1; then
+    echo "error: node not found — install Node.js (https://nodejs.org) to build octos-web" >&2
     exit 1
+fi
+if ! command -v pnpm >/dev/null 2>&1; then
+    # Corepack ships with Node >=16.10 and reads `packageManager` from
+    # package.json, so this also pins the exact pnpm version the lockfile needs.
+    if command -v corepack >/dev/null 2>&1; then
+        corepack enable pnpm
+        corepack prepare
+    else
+        echo "error: pnpm not found — octos-web is a pnpm workspace (no package-lock.json). Install pnpm or run 'corepack enable'." >&2
+        exit 1
+    fi
 fi
 
 cd "$WEB_DIR"
 if [ ! -d node_modules ]; then
-    echo "Installing octos-web dependencies (npm ci)…"
-    npm ci
+    echo "Installing octos-web dependencies (pnpm install --frozen-lockfile)…"
+    pnpm install --frozen-lockfile
 fi
 
 echo "Building octos-web (BASE_URL=$BASE_PATH) → $OUT_DIR"

--- a/scripts/build-web-app.sh
+++ b/scripts/build-web-app.sh
@@ -31,6 +31,10 @@ if ! command -v node >/dev/null 2>&1; then
     echo "error: node not found — install Node.js (https://nodejs.org) to build octos-web" >&2
     exit 1
 fi
+# corepack reads `packageManager` from package.json, so it must run INSIDE
+# $WEB_DIR — from the repo root (as on the windows base-url CI job) it exits
+# with "Couldn't find a project in the local directory".
+cd "$WEB_DIR"
 if ! command -v pnpm >/dev/null 2>&1; then
     # Corepack ships with Node >=16.10 and reads `packageManager` from
     # package.json, so this also pins the exact pnpm version the lockfile needs.
@@ -43,7 +47,6 @@ if ! command -v pnpm >/dev/null 2>&1; then
     fi
 fi
 
-cd "$WEB_DIR"
 if [ ! -d node_modules ]; then
     echo "Installing octos-web dependencies (pnpm install --frozen-lockfile)…"
     pnpm install --frozen-lockfile

--- a/scripts/tests/test-build-web-app-base-url.sh
+++ b/scripts/tests/test-build-web-app-base-url.sh
@@ -21,6 +21,7 @@ cat >"$fixture/octos-web/package.json" <<'JSON'
 {
   "name": "octos-web-base-url-fixture",
   "private": true,
+  "packageManager": "pnpm@10.0.0",
   "scripts": {
     "build": "node build.mjs"
   }
@@ -41,19 +42,24 @@ writeFileSync(
 );
 JS
 
-# On Windows, force the same native npm.cmd boundary used by release builds.
-# On Unix, wrapping the regular npm executable keeps the fixture portable.
+# The build script installs via pnpm (octos-web is a pnpm workspace, no
+# package-lock.json). Provide a stub pnpm that proxies to the same real
+# npm boundary as before — `pnpm install` is skipped because the fixture
+# ships a pre-populated node_modules, so only the `pnpm run build`
+# invocation reaches npm here, which runs it as `npm exec build`.
 if command -v npm.cmd >/dev/null 2>&1; then
     real_npm="$(command -v npm.cmd)"
 else
     real_npm="$(command -v npm)"
 fi
 mkdir -p "$fixture/bin"
-{
-    echo '#!/bin/sh'
-    printf 'exec %q "$@"\n' "$real_npm"
-} >"$fixture/bin/npm"
-chmod +x "$fixture/bin/npm"
+for tool in npm pnpm; do
+    {
+        echo '#!/bin/sh'
+        printf 'exec %q "$@"\n' "$real_npm"
+    } >"$fixture/bin/$tool"
+    chmod +x "$fixture/bin/$tool"
+done
 
 PATH="$fixture/bin:$PATH" "$BASH" "$fixture/scripts/build-web-app.sh"
 


### PR DESCRIPTION
Unblocks #2108 (embedded /app is a full release-generation behind octos-web main).

## Submodule bump

`octos-web`: `1e985386` (2026-07-10) → `9630b25` (2026-08-26 main), bringing in ~7 weeks of UI the embedded bundle never shipped: learning workspace (#297) + lesson presentation stabilisation, smart-home bridge page (#307), UI Protocol projection v2 migration (#282/#280/#279), studio previews (#271), spawn_complete dedup, onboarding, and the PWA manifest.

## Package-manager contract — the actual #2108 blocker

octos-web removed `package-lock.json` when it moved to pnpm (`packageManager: pnpm@11.5.2`, `pnpm-lock.yaml`). `npm ci` in `scripts/build-web-app.sh` therefore **cannot install any post-migration pin** — this bump would have failed mid-release otherwise. The script now:

- installs with `pnpm install --frozen-lockfile`
- prefers pnpm already on PATH; falls back to **corepack**, which reads `packageManager` from package.json and pins the exact version

`release.yml` callers unchanged (they invoke the script). Dashboard and swarm-app keep npm; they still ship lockfiles.

## Validation

- Script run end-to-end at the new pin: pnpm install → build → BASE_URL=/app/ asset-root check → sync to `crates/octos-cli/static/web/`
- `cargo build -p octos-cli --features api` clean against the rebuilt embed dir
- `cargo test -p octos-cli --lib`: **1551 passed / 0 failed** with the new assets compiled in
- Embedded output is NOT committed (gitignore policy: ephemeral bundle); releases rebuild from the submodule pin

Refs #2070 (v2.1.0 graduation): this pin should land before stable so the shipped /app is not four months behind.