### PR TITLE
fix(tools): tell the model to proceed when no question channel is attached

### DIFF
--- a/crates/octos-agent/src/tools/ask_user_question.rs
+++ b/crates/octos-agent/src/tools/ask_user_question.rs
@@ -219,7 +219,7 @@ fn unsupported_fallback_result(args: &Value, questions: &[UserQuestion]) -> Tool
             "body": body,
             "request": args,
             "answers": null,
-            "message": "User question recorded; no synchronous host response channel is attached to this runtime."
+            "message": "User question recorded in the transcript; no synchronous host response channel is attached to this runtime (non-interactive or unattended run). Do NOT wait or re-ask: pick the option you would recommend, state that assumption in one line, and continue the task so the user can redirect you later if needed."
         })
         .to_string(),
         success: true,
@@ -707,5 +707,26 @@ mod tests {
             header.chars().count()
         );
         assert_eq!(header, &clamp_header("Favorite Color"));
+    }
+
+    /// #2134: the degraded result must TELL the model to proceed — the
+    /// observed failure was a model that asked, got the fallback, and
+    /// stalled anyway because nothing said "do not wait".
+    #[test]
+    fn should_instruct_model_to_proceed_when_no_response_channel() {
+        let args = serde_json::json!({"questions": [{
+            "header": "Scope",
+            "question": "CPU only, or CUDA too?",
+            "options": [{"label": "CPU"}, {"label": "CUDA"}],
+        }]});
+        let questions = parse_questions(&args).unwrap();
+        let result = unsupported_fallback_result(&args, &questions);
+        assert!(result.success);
+        assert!(
+            result.output.contains("Do NOT wait"),
+            "fallback must instruct the model to continue: {}",
+            result.output
+        );
+        assert!(result.output.contains("redirect you later"));
     }
 }

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -763,7 +763,7 @@ async fn request_user_input_body(
             "status": "requested",
             "request": args,
             "response": null,
-            "message": "User input request recorded; no synchronous host response channel is attached to this runtime."
+            "message": "User input request recorded in the transcript; no synchronous host response channel is attached to this runtime (non-interactive or unattended run). Do NOT wait or re-ask: proceed with your best judgment, state the assumption in one line, and continue the task so the user can redirect you later if needed."
         })
         .to_string(),
         success: true,


### PR DESCRIPTION
Closes #2134 (fallback-message scope). Rebased onto main; the original #2139 auto-closed when its base branch was deleted on #2136's merge.

Both `ask_user_question` and `request_user_input` degraded fallbacks now instruct the model to proceed (pick your recommended option, state the assumption, continue) instead of only noting no channel is attached — the observed model stalled on that omission. The `set_unattended` mechanism from the first cut was withdrawn per review (hosts express unattendedness by not scoping the bridge; host follow-ups documented on #2134).

Review history on the original #2139. Verification: ask_user_question tests pass, clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTroMcwSu1yKgX3LkBjQaZ
