### PR TITLE
feat(session): wire the coding feedback loop that was built and never connected

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -526,7 +526,7 @@ impl Agent {
         // default delegation), so every field above was reaching only
         // task-local (`TOOL_CTX`) readers. TOOL_CTX stays scoped for plugin
         // tools that read the task-local.
-        let result = TOOL_APPROVAL_CTX
+        let mut result = TOOL_APPROVAL_CTX
             .scope(
                 approver,
                 TOOL_CTX.scope(
@@ -549,7 +549,14 @@ impl Agent {
                 tool_start.elapsed().as_millis() as u64,
                 self.hook_ctx().as_ref(),
             );
-            let _ = hooks.run(HookEvent::AfterToolCall, &payload).await;
+            // A failing after-hook carries checker output the model must
+            // see (the coding defaults run `cargo check` after edits) —
+            // discarding it here silenced the whole feedback loop.
+            if let HookResult::Error(feedback) = hooks.run(HookEvent::AfterToolCall, &payload).await
+            {
+                result.output.push_str("\n\n[hook] ");
+                result.output.push_str(&feedback);
+            }
         }
 
         Ok(result)
@@ -2345,7 +2352,11 @@ impl Agent {
                 }
             };
 
-            // After-tool hook (fire-and-forget)
+            // After-tool hooks. A failing hook carries checker output the
+            // model must see (the coding defaults run `cargo check` after
+            // edits); it is appended to the tool message below AFTER
+            // truncation so the feedback survives the output cap.
+            let mut hook_feedback: Option<String> = None;
             if let Some(ref hooks) = hooks {
                 let payload = HookPayload::after_tool(
                     &tc_name,
@@ -2355,7 +2366,11 @@ impl Agent {
                     duration.as_millis() as u64,
                     hook_ctx.as_ref(),
                 );
-                let _ = hooks.run(HookEvent::AfterToolCall, &payload).await;
+                if let HookResult::Error(feedback) =
+                    hooks.run(HookEvent::AfterToolCall, &payload).await
+                {
+                    hook_feedback = Some(feedback);
+                }
             }
 
             // Per-tool output truncation with head/tail split.
@@ -2384,7 +2399,12 @@ impl Agent {
                 }
             }
             let content = content;
-            let content = crate::sanitize::sanitize_tool_output(&content);
+            let mut content = crate::sanitize::sanitize_tool_output(&content);
+            if let Some(feedback) = hook_feedback {
+                content.push_str("\n\n[hook] ");
+                content.push_str(&feedback);
+            }
+            let content = content;
 
             // Pair the structured side-channel with the originating tool's
             // call id so the session actor (which keys cost rows by

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -441,6 +441,8 @@ impl Agent {
                         Err("tool arguments changed since approval request was created".to_string())
                     }
                 }
+                // Feedback is an after-event-only outcome; never arises here.
+                HookResult::Feedback(_) => Ok(()),
                 // Context injection is a `user_prompt_submit`-only outcome and
                 // never arises for a before-tool re-validation; allow the call.
                 HookResult::Context(_) => Ok(()),
@@ -547,13 +549,19 @@ impl Agent {
                 octos_core::truncated_utf8(&result.output, 500, "..."),
                 result.success,
                 tool_start.elapsed().as_millis() as u64,
+                Some(&pending.tool_args),
+                self.tools.workspace_root(),
                 self.hook_ctx().as_ref(),
             );
-            // A failing after-hook carries checker output the model must
-            // see (the coding defaults run `cargo check` after edits) —
-            // discarding it here silenced the whole feedback loop.
-            if let HookResult::Error(feedback) = hooks.run(HookEvent::AfterToolCall, &payload).await
+            // Feedback (a checker reporting diagnostics) reaches the model;
+            // infra errors (missing binary, timeout) stay log-only — see
+            // HookResult::Feedback. Sanitized like every other model-facing
+            // tool output: checkers quote source lines, and source lines
+            // carry secrets.
+            if let HookResult::Feedback(entries) =
+                hooks.run(HookEvent::AfterToolCall, &payload).await
             {
+                let feedback = crate::sanitize::sanitize_tool_output(&entries.join("\n\n"));
                 result.output.push_str("\n\n[hook] ");
                 result.output.push_str(&feedback);
             }
@@ -2352,10 +2360,11 @@ impl Agent {
                 }
             };
 
-            // After-tool hooks. A failing hook carries checker output the
-            // model must see (the coding defaults run `cargo check` after
-            // edits); it is appended to the tool message below AFTER
-            // truncation so the feedback survives the output cap.
+            // After-tool hooks. Hook FEEDBACK (a checker reporting
+            // diagnostics — see HookResult::Feedback) reaches the model:
+            // appended to the tool message below AFTER truncation so it
+            // survives the output cap, and sanitized because checkers quote
+            // source lines. Infra errors stay log-only.
             let mut hook_feedback: Option<String> = None;
             if let Some(ref hooks) = hooks {
                 let payload = HookPayload::after_tool(
@@ -2364,12 +2373,15 @@ impl Agent {
                     octos_core::truncated_utf8(&content, 500, "..."),
                     tool_success,
                     duration.as_millis() as u64,
+                    Some(&effective_args),
+                    tools.workspace_root(),
                     hook_ctx.as_ref(),
                 );
-                if let HookResult::Error(feedback) =
+                if let HookResult::Feedback(entries) =
                     hooks.run(HookEvent::AfterToolCall, &payload).await
                 {
-                    hook_feedback = Some(feedback);
+                    hook_feedback =
+                        Some(crate::sanitize::sanitize_tool_output(&entries.join("\n\n")));
                 }
             }
 

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -562,6 +562,12 @@ impl Agent {
                 hooks.run(HookEvent::AfterToolCall, &payload).await
             {
                 let feedback = crate::sanitize::sanitize_tool_output(&entries.join("\n\n"));
+                // #2129 review round 2, finding 4: truncate the tool output
+                // to its limit FIRST, then append feedback — mirrors the
+                // spawned dispatch site so a downstream cap cannot cut the
+                // checker feedback appended last.
+                let limit = octos_core::tool_output_limit(&pending.request.tool_name);
+                result.output = octos_core::truncate_head_tail(&result.output, limit, 0.7);
                 result.output.push_str("\n\n[hook] ");
                 result.output.push_str(&feedback);
             }

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1031,6 +1031,9 @@ impl Agent {
                         hook_ctx.as_ref(),
                     );
                     match hooks.run(HookEvent::UserPromptSubmit, &payload).await {
+                        // Feedback is an after-event-only outcome; treat as
+                        // allow for a prompt-submit hook.
+                        HookResult::Feedback(_) => {}
                         HookResult::Deny(reason) => {
                             let reason = reason.trim();
                             let message = if reason.is_empty() {

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -406,22 +406,34 @@ impl HookPayload {
     ///
     /// Result is sanitized: sensitive tools are redacted, others truncated
     /// to 1 KB to prevent secrets from leaking to hook processes.
+    #[allow(clippy::too_many_arguments)]
     pub fn after_tool(
         name: &str,
         tool_id: &str,
         result: String,
         success: bool,
         duration_ms: u64,
+        arguments: Option<&serde_json::Value>,
+        cwd: Option<&std::path::Path>,
         ctx: Option<&HookContext>,
     ) -> Self {
-        let (_, sanitized_result) = sanitize_payload(Some(name), None, Some(result));
+        // `arguments` is not decoration: the path-filter matcher reads
+        // `arguments.path` and SKIPS any path_filter-bearing hook when it is
+        // absent — an after_tool payload without arguments silently disables
+        // every path-filtered after-hook (#2129 review, finding 1). `cwd` is
+        // where the hook child runs; project-scoped checkers are meaningless
+        // in the daemon's start directory.
+        let (sanitized_args, sanitized_result) =
+            sanitize_payload(Some(name), arguments.cloned(), Some(result));
         let mut p = Self {
             event: HookEvent::AfterToolCall,
             tool_name: Some(name.to_string()),
             tool_id: Some(tool_id.to_string()),
+            arguments: sanitized_args,
             result: sanitized_result,
             success: Some(success),
             duration_ms: Some(duration_ms),
+            cwd: cwd.map(|c| c.to_string_lossy().into_owned()),
             ..Self::empty(HookEvent::AfterToolCall)
         };
         p.apply_context(ctx);
@@ -662,6 +674,14 @@ pub enum HookResult {
     Context(Vec<String>),
     /// A hook encountered an error (does not block).
     Error(String),
+    /// One or more AFTER-hooks exited 1 WITH output — the feedback channel
+    /// working as designed (a checker reporting diagnostics), distinct from
+    /// [`Self::Error`] infrastructure failures (missing binary, timeout,
+    /// exit >= 2) which must NOT be injected into the model conversation.
+    /// One entry per failing hook, in configuration order, so a failing
+    /// operator after-hook cannot overwrite the coding defaults' compile
+    /// errors (#2129 review, findings 8 and 9).
+    Feedback(Vec<String>),
 }
 
 /// Executes hooks with circuit breaker protection.
@@ -678,11 +698,6 @@ pub struct HookExecutor {
     failure_threshold: u32,
     /// Optional domain-data enricher applied to payloads before serialization.
     enricher: Option<Arc<dyn HookPayloadEnricher>>,
-    /// Working directory for hook child processes. Project-scoped hooks
-    /// (the coding defaults run `cargo check` / `eslint` / `ruff`) are
-    /// meaningless outside the workspace they check — without this they
-    /// would run in whatever directory the daemon happened to start in.
-    cwd: Option<std::path::PathBuf>,
 }
 
 impl HookExecutor {
@@ -702,7 +717,6 @@ impl HookExecutor {
             failures,
             failure_threshold,
             enricher: None,
-            cwd: None,
         }
     }
 
@@ -710,14 +724,6 @@ impl HookExecutor {
     /// not register an enricher see no payload change.
     pub fn with_enricher(mut self, enricher: Arc<dyn HookPayloadEnricher>) -> Self {
         self.enricher = Some(enricher);
-        self
-    }
-
-    /// Run hook child processes with this working directory. Session hosts
-    /// set it to the workspace root so project-scoped hooks (`cargo check`,
-    /// `eslint`, `ruff`) check the project the agent is editing.
-    pub fn with_cwd(mut self, cwd: impl Into<std::path::PathBuf>) -> Self {
-        self.cwd = Some(cwd.into());
         self
     }
 
@@ -768,6 +774,7 @@ impl HookExecutor {
         // matching hooks and returned as `HookResult::Context` at the end so
         // the caller can inject it into the turn before the first LLM call.
         let mut injected_contexts: Vec<String> = Vec::new();
+        let mut feedback: Vec<String> = Vec::new();
 
         for (i, hook) in self.hooks.iter().enumerate() {
             if hook.event != event {
@@ -842,7 +849,8 @@ impl HookExecutor {
                 continue;
             }
 
-            match self.execute_hook(hook, &payload_json).await {
+            let hook_cwd = payload_ref.cwd.as_deref().map(std::path::Path::new);
+            match self.execute_hook(hook, &payload_json, hook_cwd).await {
                 Ok((0, stdout, _stderr)) => {
                     self.failures[i].store(0, Ordering::Relaxed);
                     // Context injection (user_prompt_submit): a hook that exits
@@ -863,12 +871,13 @@ impl HookExecutor {
                         self.failures[i].store(0, Ordering::Relaxed);
                         return HookResult::Deny(stdout);
                     }
-                    // Exit 1 on after-hooks is an error (deny is meaningless
-                    // for after-events) — but an error that CARRIES the
-                    // hook's output. The coding defaults exist to feed
-                    // checker diagnostics back to the model; a message that
-                    // says only "exited with code 1" feeds back nothing.
-                    let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
+                    // Exit 1 WITH output on an after-hook is the feedback
+                    // channel WORKING — a checker reporting diagnostics.
+                    // It does NOT count toward the circuit breaker: a model
+                    // iterating on compile errors legitimately fails the
+                    // check many times in a row, and disabling the hook at
+                    // the third failure would kill the feedback loop exactly
+                    // when it is most needed (#2129 review, finding 2).
                     let mut output = if stderr.is_empty() {
                         stdout
                     } else if stdout.is_empty() {
@@ -877,19 +886,20 @@ impl HookExecutor {
                         format!("{stdout}\n{stderr}")
                     };
                     octos_core::truncate_utf8(&mut output, 2000, "\n... (hook output truncated)");
-                    let msg = if output.trim().is_empty() {
-                        format!(
+                    if output.trim().is_empty() {
+                        // Exit 1 with NOTHING to say is indistinguishable
+                        // from a broken hook: infrastructure error, counted.
+                        let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
+                        let msg = format!(
                             "hook {:?} exited with code 1 on after-event ({}/{})",
                             hook.command, new_count, self.failure_threshold
-                        )
+                        );
+                        warn!("{}", msg);
+                        last_error = Some(msg);
                     } else {
-                        format!(
-                            "hook {:?} failed ({}/{}):\n{}",
-                            hook.command, new_count, self.failure_threshold, output
-                        )
-                    };
-                    warn!("{}", msg);
-                    last_error = Some(msg);
+                        self.failures[i].store(0, Ordering::Relaxed);
+                        feedback.push(format!("{:?}:\n{}", hook.command, output));
+                    }
                 }
                 Ok((2, stdout, _stderr)) => {
                     // Exit 2 = modified input (before-hooks only).
@@ -949,7 +959,11 @@ impl HookExecutor {
             }
         }
 
-        if let Some(err) = last_error {
+        if !feedback.is_empty() {
+            // Feedback outranks infra errors: diagnostics are actionable,
+            // and infra errors are logged above either way.
+            HookResult::Feedback(feedback)
+        } else if let Some(err) = last_error {
             HookResult::Error(err)
         } else if !injected_contexts.is_empty() {
             HookResult::Context(injected_contexts)
@@ -958,11 +972,13 @@ impl HookExecutor {
         }
     }
 
-    /// Execute a single hook process. Returns (exit_code, stdout, stderr).
+    /// Execute a single hook process in `cwd` (when given — the payload's
+    /// workspace root). Returns (exit_code, stdout, stderr).
     async fn execute_hook(
         &self,
         hook: &HookConfig,
         payload_json: &str,
+        cwd: Option<&std::path::Path>,
     ) -> eyre::Result<(i32, String, String)> {
         let (program, args) = hook
             .command
@@ -975,7 +991,7 @@ impl HookExecutor {
 
         let mut cmd = tokio::process::Command::new(&program);
         cmd.args(&expanded_args);
-        if let Some(cwd) = &self.cwd {
+        if let Some(cwd) = cwd {
             cmd.current_dir(cwd);
         }
         cmd.stdin(std::process::Stdio::piped());
@@ -996,32 +1012,40 @@ impl HookExecutor {
             let _ = stdin.shutdown().await;
         }
 
-        // Take stdout/stderr handles so we can read them after wait
-        let stdout_handle = child.stdout.take();
-        let stderr_handle = child.stderr.take();
+        // Take stdout/stderr handles and read them CONCURRENTLY with the
+        // wait: reading only after wait() returns deadlocks the moment the
+        // child emits more than the pipe buffer (~64KB) — the child blocks
+        // on write, the parent blocks in wait, and the timeout kills the
+        // exact heavy-diagnostics run the feedback loop exists for (#2129
+        // review, finding 3).
+        let mut stdout_handle = child.stdout.take();
+        let mut stderr_handle = child.stderr.take();
+        let drain = async {
+            let mut out_buf = Vec::new();
+            let mut err_buf = Vec::new();
+            let stdout_read = async {
+                if let Some(handle) = stdout_handle.as_mut() {
+                    let _ = handle.read_to_end(&mut out_buf).await;
+                }
+            };
+            let stderr_read = async {
+                if let Some(handle) = stderr_handle.as_mut() {
+                    let _ = handle.read_to_end(&mut err_buf).await;
+                }
+            };
+            let (status, _, _) = tokio::join!(child.wait(), stdout_read, stderr_read);
+            status.map(|status| (status, out_buf, err_buf))
+        };
 
-        // Wait with timeout (use wait() instead of wait_with_output() so child isn't consumed)
         let timeout = Duration::from_millis(hook.timeout_ms);
-        match tokio::time::timeout(timeout, child.wait()).await {
-            Ok(Ok(status)) => {
-                let stdout = if let Some(mut handle) = stdout_handle {
-                    let mut buf = Vec::new();
-                    let _ = handle.read_to_end(&mut buf).await;
-                    String::from_utf8_lossy(&buf).trim().to_string()
-                } else {
-                    String::new()
-                };
-                // Capture stderr too: checkers put their diagnostics there
-                // (`cargo check --message-format=short` writes every
-                // diagnostic to stderr), and the after-event failure path
-                // surfaces them to the model. Still logged for operators.
-                let stderr = if let Some(mut handle) = stderr_handle {
-                    let mut buf = Vec::new();
-                    let _ = handle.read_to_end(&mut buf).await;
-                    String::from_utf8_lossy(&buf).trim().to_string()
-                } else {
-                    String::new()
-                };
+        match tokio::time::timeout(timeout, drain).await {
+            Ok(Ok((status, out_buf, err_buf))) => {
+                let stdout = String::from_utf8_lossy(&out_buf).trim().to_string();
+                // Checkers put their diagnostics on stderr (`cargo check
+                // --message-format=short` writes every diagnostic there);
+                // the after-event feedback path surfaces them to the model.
+                // Still logged for operators.
+                let stderr = String::from_utf8_lossy(&err_buf).trim().to_string();
                 for line in stderr.lines() {
                     let line = line.trim();
                     if !line.is_empty() {
@@ -1188,7 +1212,7 @@ mod tests {
     fn should_stamp_current_schema_version_on_every_constructor() {
         let payloads = vec![
             HookPayload::before_tool("shell", serde_json::json!({}), "tc1", None),
-            HookPayload::after_tool("shell", "tc1", "ok".into(), true, 10, None),
+            HookPayload::after_tool("shell", "tc1", "ok".into(), true, 10, None, None, None),
             HookPayload::before_llm("gpt-4", 0, 1, None),
             HookPayload::on_resume(None),
             HookPayload::on_turn_end("done", None),
@@ -1257,7 +1281,8 @@ mod tests {
         assert_eq!(after_llm.session_cost, Some(0.05));
         assert_eq!(after_llm.response_cost, Some(0.01));
 
-        let after_tool = HookPayload::after_tool("shell", "tc1", "ok".into(), true, 42, None);
+        let after_tool =
+            HookPayload::after_tool("shell", "tc1", "ok".into(), true, 42, None, None, None);
         assert_eq!(after_tool.event, HookEvent::AfterToolCall);
         assert_eq!(after_tool.success, Some(true));
         assert_eq!(after_tool.duration_ms, Some(42));
@@ -1613,7 +1638,8 @@ mod tests {
             }],
             3,
         );
-        let payload = HookPayload::after_tool("shell", "tc1", "ok".into(), true, 10, None);
+        let payload =
+            HookPayload::after_tool("shell", "tc1", "ok".into(), true, 10, None, None, None);
 
         // First two failures: hook still runs (returns Error, not Allow)
         let r1 = executor.run(HookEvent::AfterToolCall, &payload).await;
@@ -1637,7 +1663,8 @@ mod tests {
             }],
             3,
         );
-        let payload = HookPayload::after_tool("shell", "tc1", "ok".into(), true, 10, None);
+        let payload =
+            HookPayload::after_tool("shell", "tc1", "ok".into(), true, 10, None, None, None);
 
         // Trigger 3 failures to hit threshold
         for _ in 0..3 {
@@ -1668,7 +1695,8 @@ mod tests {
         executor.failures[0].store(2, Ordering::Relaxed);
 
         // Success resets counter
-        let payload = HookPayload::after_tool("shell", "tc1", "ok".into(), true, 10, None);
+        let payload =
+            HookPayload::after_tool("shell", "tc1", "ok".into(), true, 10, None, None, None);
         let r = executor.run(HookEvent::AfterToolCall, &payload).await;
         assert_eq!(r, HookResult::Allow);
         assert_eq!(executor.failures[0].load(Ordering::Relaxed), 0);
@@ -1717,6 +1745,8 @@ mod tests {
             "SECRET_KEY=hunter2\nDB_PASS=abc".into(),
             true,
             10,
+            None,
+            None,
             None,
         );
         let json = serde_json::to_string(&payload).unwrap();
@@ -1770,7 +1800,8 @@ mod tests {
             vec!["**/*.rs"],
         )]);
         // edit_file on a Python path — `**/*.rs` glob should NOT match.
-        let payload = HookPayload::after_tool("edit_file", "tc1", "ok".into(), true, 10, None);
+        let payload =
+            HookPayload::after_tool("edit_file", "tc1", "ok".into(), true, 10, None, None, None);
         let mut payload = payload;
         payload.arguments = Some(serde_json::json!({"path": "scripts/build.py"}));
         let result = executor.run(HookEvent::AfterToolCall, &payload).await;
@@ -2233,20 +2264,122 @@ mod tests {
             requires_bin: None,
         };
         let executor = HookExecutor::new(vec![hook]);
-        let payload = HookPayload::after_tool("edit_file", "id", "out".to_string(), true, 5, None);
+        let payload = HookPayload::after_tool(
+            "edit_file",
+            "id",
+            "out".to_string(),
+            true,
+            5,
+            None,
+            None,
+            None,
+        );
         match executor.run(HookEvent::AfterToolCall, &payload).await {
-            HookResult::Error(msg) => {
+            HookResult::Feedback(entries) => {
+                let msg = entries.join("\n");
                 assert!(msg.contains("out-line"), "stdout must surface: {msg}");
                 assert!(msg.contains("err-line"), "stderr must surface: {msg}");
             }
-            other => panic!("expected Error carrying output, got {other:?}"),
+            other => panic!("expected Feedback carrying output, got {other:?}"),
         }
     }
 
-    /// `with_cwd` runs the hook child in the given directory — a
-    /// project-scoped checker is meaningless in the daemon's start dir.
+    /// #2129 review finding 1: the after_tool payload must carry the tool
+    /// ARGUMENTS — the path-filter matcher reads `arguments.path` and skips
+    /// path_filtered hooks without it. Regression test for the
+    /// dead-on-arrival wiring.
     #[tokio::test]
-    async fn hook_child_runs_in_configured_cwd() {
+    async fn path_filtered_after_hook_fires_when_arguments_carry_the_path() {
+        let hook = HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "echo diagnostics; exit 1".to_string(),
+            ],
+            timeout_ms: 5000,
+            tool_filter: vec!["edit_file".to_string()],
+            path_filter: vec!["**/*.rs".to_string()],
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![hook]);
+        let args = serde_json::json!({"path": "src/lib.rs"});
+        let payload = HookPayload::after_tool(
+            "edit_file",
+            "id",
+            "ok".to_string(),
+            true,
+            5,
+            Some(&args),
+            None,
+            None,
+        );
+        assert!(matches!(
+            executor.run(HookEvent::AfterToolCall, &payload).await,
+            HookResult::Feedback(_)
+        ));
+        let args = serde_json::json!({"path": "README.md"});
+        let payload = HookPayload::after_tool(
+            "edit_file",
+            "id",
+            "ok".to_string(),
+            true,
+            5,
+            Some(&args),
+            None,
+            None,
+        );
+        assert!(matches!(
+            executor.run(HookEvent::AfterToolCall, &payload).await,
+            HookResult::Allow
+        ));
+    }
+
+    /// #2129 review finding 2: repeated exit-1-with-output must NOT trip
+    /// the circuit breaker — a model iterating on compile errors fails the
+    /// check many times in a row, and that is the channel working.
+    #[tokio::test]
+    async fn repeated_check_failures_do_not_trip_the_breaker() {
+        let hook = HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "echo still-broken; exit 1".to_string(),
+            ],
+            timeout_ms: 5000,
+            tool_filter: Vec::new(),
+            path_filter: Vec::new(),
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![hook]);
+        for i in 0..5 {
+            let payload = HookPayload::after_tool(
+                "edit_file",
+                "id",
+                "ok".to_string(),
+                true,
+                5,
+                None,
+                None,
+                None,
+            );
+            assert!(
+                matches!(
+                    executor.run(HookEvent::AfterToolCall, &payload).await,
+                    HookResult::Feedback(_)
+                ),
+                "attempt {i} must still deliver feedback (breaker must not trip)"
+            );
+        }
+    }
+
+    /// The hook child runs in the payload's cwd (the workspace root) — a
+    /// project-scoped checker is meaningless in the daemon's start dir, and
+    /// carrying cwd on the payload lets ONE profile-level executor serve
+    /// every session (#2129 review, findings 4 and 7).
+    #[tokio::test]
+    async fn hook_child_runs_in_payload_cwd() {
         let tmp = tempfile::tempdir().unwrap();
         let expected = tmp.path().canonicalize().unwrap();
         let hook = HookConfig {
@@ -2261,14 +2394,25 @@ mod tests {
             path_filter: Vec::new(),
             requires_bin: None,
         };
-        let executor = HookExecutor::new(vec![hook]).with_cwd(tmp.path());
-        let payload = HookPayload::after_tool("edit_file", "id", "out".to_string(), true, 5, None);
+        let executor = HookExecutor::new(vec![hook]);
+        let payload = HookPayload::after_tool(
+            "edit_file",
+            "id",
+            "out".to_string(),
+            true,
+            5,
+            None,
+            Some(tmp.path()),
+            None,
+        );
         match executor.run(HookEvent::AfterToolCall, &payload).await {
-            HookResult::Error(msg) => assert!(
-                msg.contains(&expected.to_string_lossy().to_string()),
-                "child must run in the configured cwd; got: {msg}"
+            HookResult::Feedback(entries) => assert!(
+                entries
+                    .join("\n")
+                    .contains(&expected.to_string_lossy().to_string()),
+                "child must run in the payload cwd; got: {entries:?}"
             ),
-            other => panic!("expected Error, got {other:?}"),
+            other => panic!("expected Feedback, got {other:?}"),
         }
     }
 }

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -678,6 +678,11 @@ pub struct HookExecutor {
     failure_threshold: u32,
     /// Optional domain-data enricher applied to payloads before serialization.
     enricher: Option<Arc<dyn HookPayloadEnricher>>,
+    /// Working directory for hook child processes. Project-scoped hooks
+    /// (the coding defaults run `cargo check` / `eslint` / `ruff`) are
+    /// meaningless outside the workspace they check — without this they
+    /// would run in whatever directory the daemon happened to start in.
+    cwd: Option<std::path::PathBuf>,
 }
 
 impl HookExecutor {
@@ -697,6 +702,7 @@ impl HookExecutor {
             failures,
             failure_threshold,
             enricher: None,
+            cwd: None,
         }
     }
 
@@ -705,6 +711,22 @@ impl HookExecutor {
     pub fn with_enricher(mut self, enricher: Arc<dyn HookPayloadEnricher>) -> Self {
         self.enricher = Some(enricher);
         self
+    }
+
+    /// Run hook child processes with this working directory. Session hosts
+    /// set it to the workspace root so project-scoped hooks (`cargo check`,
+    /// `eslint`, `ruff`) check the project the agent is editing.
+    pub fn with_cwd(mut self, cwd: impl Into<std::path::PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    /// The hook configurations this executor runs, in run order. Lets a
+    /// host MERGE executors (e.g. coding defaults + operator hooks) without
+    /// forking the runner: rebuild via `HookExecutor::new` from the
+    /// concatenated lists.
+    pub fn configs(&self) -> &[HookConfig] {
+        &self.hooks
     }
 
     /// Run all matching hooks for the given event sequentially.
@@ -821,7 +843,7 @@ impl HookExecutor {
             }
 
             match self.execute_hook(hook, &payload_json).await {
-                Ok((0, stdout)) => {
+                Ok((0, stdout, _stderr)) => {
                     self.failures[i].store(0, Ordering::Relaxed);
                     // Context injection (user_prompt_submit): a hook that exits
                     // 0 and prints to stdout contributes that text as extra
@@ -830,7 +852,7 @@ impl HookExecutor {
                         injected_contexts.push(stdout);
                     }
                 }
-                Ok((1, stdout)) => {
+                Ok((1, stdout, stderr)) => {
                     if matches!(
                         event,
                         HookEvent::UserPromptSubmit
@@ -841,16 +863,35 @@ impl HookExecutor {
                         self.failures[i].store(0, Ordering::Relaxed);
                         return HookResult::Deny(stdout);
                     }
-                    // Exit 1 on after-hooks is an error (deny is meaningless for after-events)
+                    // Exit 1 on after-hooks is an error (deny is meaningless
+                    // for after-events) — but an error that CARRIES the
+                    // hook's output. The coding defaults exist to feed
+                    // checker diagnostics back to the model; a message that
+                    // says only "exited with code 1" feeds back nothing.
                     let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
-                    let msg = format!(
-                        "hook {:?} exited with code 1 on after-event ({}/{})",
-                        hook.command, new_count, self.failure_threshold
-                    );
+                    let mut output = if stderr.is_empty() {
+                        stdout
+                    } else if stdout.is_empty() {
+                        stderr
+                    } else {
+                        format!("{stdout}\n{stderr}")
+                    };
+                    octos_core::truncate_utf8(&mut output, 2000, "\n... (hook output truncated)");
+                    let msg = if output.trim().is_empty() {
+                        format!(
+                            "hook {:?} exited with code 1 on after-event ({}/{})",
+                            hook.command, new_count, self.failure_threshold
+                        )
+                    } else {
+                        format!(
+                            "hook {:?} failed ({}/{}):\n{}",
+                            hook.command, new_count, self.failure_threshold, output
+                        )
+                    };
                     warn!("{}", msg);
                     last_error = Some(msg);
                 }
-                Ok((2, stdout)) => {
+                Ok((2, stdout, _stderr)) => {
                     // Exit 2 = modified input (before-hooks only).
                     // Stdout contains the replacement JSON payload.
                     if matches!(
@@ -887,7 +928,7 @@ impl HookExecutor {
                         last_error = Some(msg);
                     }
                 }
-                Ok((code, _stdout)) => {
+                Ok((code, _stdout, _stderr)) => {
                     let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
                     let msg = format!(
                         "hook {:?} exited with code {} ({}/{})",
@@ -917,12 +958,12 @@ impl HookExecutor {
         }
     }
 
-    /// Execute a single hook process. Returns (exit_code, stdout).
+    /// Execute a single hook process. Returns (exit_code, stdout, stderr).
     async fn execute_hook(
         &self,
         hook: &HookConfig,
         payload_json: &str,
-    ) -> eyre::Result<(i32, String)> {
+    ) -> eyre::Result<(i32, String, String)> {
         let (program, args) = hook
             .command
             .split_first()
@@ -934,6 +975,9 @@ impl HookExecutor {
 
         let mut cmd = tokio::process::Command::new(&program);
         cmd.args(&expanded_args);
+        if let Some(cwd) = &self.cwd {
+            cmd.current_dir(cwd);
+        }
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
@@ -967,19 +1011,24 @@ impl HookExecutor {
                 } else {
                     String::new()
                 };
-                // Log stderr from the hook process (diagnostic output)
-                if let Some(mut handle) = stderr_handle {
+                // Capture stderr too: checkers put their diagnostics there
+                // (`cargo check --message-format=short` writes every
+                // diagnostic to stderr), and the after-event failure path
+                // surfaces them to the model. Still logged for operators.
+                let stderr = if let Some(mut handle) = stderr_handle {
                     let mut buf = Vec::new();
                     let _ = handle.read_to_end(&mut buf).await;
-                    let stderr = String::from_utf8_lossy(&buf);
-                    for line in stderr.lines() {
-                        let line = line.trim();
-                        if !line.is_empty() {
-                            tracing::info!(
-                                hook = ?hook.command,
-                                "{line}"
-                            );
-                        }
+                    String::from_utf8_lossy(&buf).trim().to_string()
+                } else {
+                    String::new()
+                };
+                for line in stderr.lines() {
+                    let line = line.trim();
+                    if !line.is_empty() {
+                        tracing::info!(
+                            hook = ?hook.command,
+                            "{line}"
+                        );
                     }
                 }
                 let code = status.code().unwrap_or(2);
@@ -989,7 +1038,7 @@ impl HookExecutor {
                     stdout_len = stdout.len(),
                     "hook executed"
                 );
-                Ok((code, stdout))
+                Ok((code, stdout, stderr))
             }
             Ok(Err(e)) => Err(e.into()),
             Err(_) => {
@@ -2163,5 +2212,63 @@ mod tests {
         let payload = HookPayload::user_prompt_submit("hi", "m", None, None);
         let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
         assert_eq!(result, HookResult::Allow);
+    }
+
+    /// A failing AFTER-hook must carry its child's output — stdout and
+    /// stderr both, since checkers (`cargo check --message-format=short`)
+    /// write diagnostics to stderr. The pre-#2129 message ("exited with
+    /// code 1 on after-event") fed the model nothing actionable.
+    #[tokio::test]
+    async fn after_hook_failure_carries_child_output() {
+        let hook = HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "echo out-line; echo err-line >&2; exit 1".to_string(),
+            ],
+            timeout_ms: 5000,
+            tool_filter: Vec::new(),
+            path_filter: Vec::new(),
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![hook]);
+        let payload = HookPayload::after_tool("edit_file", "id", "out".to_string(), true, 5, None);
+        match executor.run(HookEvent::AfterToolCall, &payload).await {
+            HookResult::Error(msg) => {
+                assert!(msg.contains("out-line"), "stdout must surface: {msg}");
+                assert!(msg.contains("err-line"), "stderr must surface: {msg}");
+            }
+            other => panic!("expected Error carrying output, got {other:?}"),
+        }
+    }
+
+    /// `with_cwd` runs the hook child in the given directory — a
+    /// project-scoped checker is meaningless in the daemon's start dir.
+    #[tokio::test]
+    async fn hook_child_runs_in_configured_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let expected = tmp.path().canonicalize().unwrap();
+        let hook = HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "pwd; exit 1".to_string(),
+            ],
+            timeout_ms: 5000,
+            tool_filter: Vec::new(),
+            path_filter: Vec::new(),
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![hook]).with_cwd(tmp.path());
+        let payload = HookPayload::after_tool("edit_file", "id", "out".to_string(), true, 5, None);
+        match executor.run(HookEvent::AfterToolCall, &payload).await {
+            HookResult::Error(msg) => assert!(
+                msg.contains(&expected.to_string_lossy().to_string()),
+                "child must run in the configured cwd; got: {msg}"
+            ),
+            other => panic!("expected Error, got {other:?}"),
+        }
     }
 }

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -264,7 +264,23 @@ fn sanitize_payload(
 
     let sanitized_args = arguments.map(|args| {
         if is_sensitive {
-            serde_json::json!({"redacted": true, "reason": "sensitive tool"})
+            // #2129 review round 2, finding 2: a file PATH is not a secret
+            // (the file CONTENT is), and the path_filter matcher reads
+            // `arguments.path` to decide whether a checker fires. Redacting
+            // the whole object silently disabled every path-filtered hook
+            // on write_file (the new-file case). Preserve the path-
+            // identifying keys; redact everything else.
+            let mut kept = serde_json::Map::new();
+            if let Some(obj) = args.as_object() {
+                for key in ["path", "file_path", "filename", "file"] {
+                    if let Some(v @ serde_json::Value::String(_)) = obj.get(key) {
+                        kept.insert(key.to_string(), v.clone());
+                    }
+                }
+            }
+            kept.insert("redacted".into(), serde_json::Value::Bool(true));
+            kept.insert("reason".into(), serde_json::json!("sensitive tool"));
+            serde_json::Value::Object(kept)
         } else {
             truncate_json_value(&args, MAX_PAYLOAD_FIELD_BYTES)
         }
@@ -850,6 +866,14 @@ impl HookExecutor {
             }
 
             let hook_cwd = payload_ref.cwd.as_deref().map(std::path::Path::new);
+            // #2129 review round 2, finding 5: a project-scoped checker
+            // (declares `requires_bin`: cargo/eslint/ruff) is meaningless
+            // without a known workspace root — running it in the daemon's
+            // start directory checks an unrelated project (or exits 101 and
+            // trips the breaker). Skip rather than run in the wrong place.
+            if hook_cwd.is_none() && hook.requires_bin.is_some() {
+                continue;
+            }
             match self.execute_hook(hook, &payload_json, hook_cwd).await {
                 Ok((0, stdout, _stderr)) => {
                     self.failures[i].store(0, Ordering::Relaxed);
@@ -860,92 +884,89 @@ impl HookExecutor {
                         injected_contexts.push(stdout);
                     }
                 }
-                Ok((1, stdout, stderr)) => {
+                // Exit 2 on a before-modify event = replacement payload.
+                Ok((2, stdout, _stderr))
                     if matches!(
+                        event,
+                        HookEvent::BeforeToolCall | HookEvent::BeforeSpawnVerify
+                    ) =>
+                {
+                    self.failures[i].store(0, Ordering::Relaxed);
+                    match serde_json::from_str::<serde_json::Value>(&stdout) {
+                        Ok(modified_args) => {
+                            tracing::info!(
+                                hook_command = ?hook.command,
+                                ?event,
+                                "hook modified event payload"
+                            );
+                            return HookResult::Modified(modified_args);
+                        }
+                        Err(e) => {
+                            warn!(
+                                hook_command = ?hook.command,
+                                error = %e,
+                                "hook exit 2 but stdout is not valid JSON, treating as error"
+                            );
+                            last_error = Some(format!("hook modified output not valid JSON: {e}"));
+                        }
+                    }
+                }
+                // Any OTHER nonzero exit.
+                Ok((code, stdout, stderr)) => {
+                    let is_before = matches!(
                         event,
                         HookEvent::UserPromptSubmit
                             | HookEvent::BeforeToolCall
                             | HookEvent::BeforeLlmCall
                             | HookEvent::BeforeSpawnVerify
-                    ) {
-                        self.failures[i].store(0, Ordering::Relaxed);
-                        return HookResult::Deny(stdout);
-                    }
-                    // Exit 1 WITH output on an after-hook is the feedback
-                    // channel WORKING — a checker reporting diagnostics.
-                    // It does NOT count toward the circuit breaker: a model
-                    // iterating on compile errors legitimately fails the
-                    // check many times in a row, and disabling the hook at
-                    // the third failure would kill the feedback loop exactly
-                    // when it is most needed (#2129 review, finding 2).
-                    let mut output = if stderr.is_empty() {
-                        stdout
-                    } else if stdout.is_empty() {
-                        stderr
-                    } else {
-                        format!("{stdout}\n{stderr}")
-                    };
-                    octos_core::truncate_utf8(&mut output, 2000, "\n... (hook output truncated)");
-                    if output.trim().is_empty() {
-                        // Exit 1 with NOTHING to say is indistinguishable
-                        // from a broken hook: infrastructure error, counted.
-                        let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
-                        let msg = format!(
-                            "hook {:?} exited with code 1 on after-event ({}/{})",
-                            hook.command, new_count, self.failure_threshold
-                        );
-                        warn!("{}", msg);
-                        last_error = Some(msg);
-                    } else {
-                        self.failures[i].store(0, Ordering::Relaxed);
-                        feedback.push(format!("{:?}:\n{}", hook.command, output));
-                    }
-                }
-                Ok((2, stdout, _stderr)) => {
-                    // Exit 2 = modified input (before-hooks only).
-                    // Stdout contains the replacement JSON payload.
-                    if matches!(
-                        event,
-                        HookEvent::BeforeToolCall | HookEvent::BeforeSpawnVerify
-                    ) {
-                        self.failures[i].store(0, Ordering::Relaxed);
-                        match serde_json::from_str::<serde_json::Value>(&stdout) {
-                            Ok(modified_args) => {
-                                tracing::info!(
-                                    hook_command = ?hook.command,
-                                    ?event,
-                                    "hook modified event payload"
-                                );
-                                return HookResult::Modified(modified_args);
-                            }
-                            Err(e) => {
-                                warn!(
-                                    hook_command = ?hook.command,
-                                    error = %e,
-                                    "hook exit 2 but stdout is not valid JSON, treating as error"
-                                );
-                                last_error =
-                                    Some(format!("hook modified output not valid JSON: {e}"));
-                            }
-                        }
-                    } else {
-                        let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
-                        let msg = format!(
-                            "hook {:?} exited with code 2 on non-before-tool event ({}/{})",
-                            hook.command, new_count, self.failure_threshold
-                        );
-                        warn!("{}", msg);
-                        last_error = Some(msg);
-                    }
-                }
-                Ok((code, _stdout, _stderr)) => {
-                    let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
-                    let msg = format!(
-                        "hook {:?} exited with code {} ({}/{})",
-                        hook.command, code, new_count, self.failure_threshold
                     );
-                    warn!("{}", msg);
-                    last_error = Some(msg);
+                    if is_before {
+                        // Before-events: exit 1 DENIES; anything else is infra.
+                        if code == 1 {
+                            self.failures[i].store(0, Ordering::Relaxed);
+                            return HookResult::Deny(stdout);
+                        }
+                        let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
+                        let msg = format!(
+                            "hook {:?} exited with code {} on before-event ({}/{})",
+                            hook.command, code, new_count, self.failure_threshold
+                        );
+                        warn!("{}", msg);
+                        last_error = Some(msg);
+                    } else {
+                        // AFTER-events: a checker reporting problems. ANY
+                        // nonzero exit WITH output is FEEDBACK and does NOT
+                        // count toward the breaker — cargo check exits 101
+                        // on compile errors (#2129 review round 2, finding
+                        // 1), eslint/ruff exit 1, tsc 1/2; a model iterating
+                        // on errors legitimately fails many times in a row.
+                        // Empty output on a nonzero exit is indistinguishable
+                        // from a broken hook: infra error, counted.
+                        let mut output = if stderr.is_empty() {
+                            stdout
+                        } else if stdout.is_empty() {
+                            stderr
+                        } else {
+                            format!("{stdout}\n{stderr}")
+                        };
+                        octos_core::truncate_utf8(
+                            &mut output,
+                            2000,
+                            "\n... (hook output truncated)",
+                        );
+                        if output.trim().is_empty() {
+                            let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
+                            let msg = format!(
+                                "hook {:?} exited with code {} and no output ({}/{})",
+                                hook.command, code, new_count, self.failure_threshold
+                            );
+                            warn!("{}", msg);
+                            last_error = Some(msg);
+                        } else {
+                            self.failures[i].store(0, Ordering::Relaxed);
+                            feedback.push(format!("{:?}:\n{}", hook.command, output));
+                        }
+                    }
                 }
                 Err(e) => {
                     let new_count = self.failures[i].fetch_add(1, Ordering::Relaxed) + 1;
@@ -2337,6 +2358,116 @@ mod tests {
 
     /// #2129 review finding 2: repeated exit-1-with-output must NOT trip
     /// the circuit breaker — a model iterating on compile errors fails the
+    /// #2129 review round 2, finding 1: cargo check exits 101 on compile
+    /// errors — its diagnostics must reach the model as Feedback (not the
+    /// discarded infra arm) and must NOT count toward the breaker.
+    #[tokio::test]
+    async fn cargo_style_101_exit_reaches_the_model_as_feedback() {
+        let hook = HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "echo 'error[E0308]: mismatched types' >&2; exit 101".to_string(),
+            ],
+            timeout_ms: 5000,
+            tool_filter: Vec::new(),
+            path_filter: Vec::new(),
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![hook]);
+        for _ in 0..10 {
+            let payload =
+                HookPayload::after_tool("edit_file", "id", "ok".into(), true, 5, None, None, None);
+            match executor.run(HookEvent::AfterToolCall, &payload).await {
+                HookResult::Feedback(entries) => {
+                    assert!(
+                        entries.join("\n").contains("E0308"),
+                        "diagnostics must surface"
+                    );
+                }
+                other => panic!("cargo 101 must be Feedback, got {other:?}"),
+            }
+        }
+    }
+
+    /// #2129 review round 2, finding 2: write_file is a SENSITIVE_TOOL, but
+    /// its PATH is not a secret — the path must survive redaction so a
+    /// path-filtered checker still fires on new-file creation.
+    #[tokio::test]
+    async fn write_file_path_survives_redaction_so_checkers_fire() {
+        let hook = HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "echo diag; exit 1".to_string(),
+            ],
+            timeout_ms: 5000,
+            tool_filter: vec!["write_file".to_string()],
+            path_filter: vec!["**/*.rs".to_string()],
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![hook]);
+        // write_file args carry both a path AND file content (a secret-
+        // bearing field). The path must be preserved; the content redacted.
+        let args = serde_json::json!({
+            "path": "src/lib.rs",
+            "content": "const API_KEY: &str = \"sk-secret\";"
+        });
+        let payload = HookPayload::after_tool(
+            "write_file",
+            "id",
+            "ok".into(),
+            true,
+            5,
+            Some(&args),
+            None,
+            None,
+        );
+        // The sanitized payload keeps the path, drops the content.
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("src/lib.rs"), "path must survive: {json}");
+        assert!(
+            !json.contains("sk-secret"),
+            "content must be redacted: {json}"
+        );
+        // And the path-filtered checker fires (matches src/lib.rs).
+        assert!(matches!(
+            executor.run(HookEvent::AfterToolCall, &payload).await,
+            HookResult::Feedback(_)
+        ));
+    }
+
+    /// #2129 review round 2, finding 5: a project-scoped checker
+    /// (requires_bin) must be SKIPPED when the workspace root is unknown
+    /// (cwd None) rather than run in the daemon's directory.
+    #[tokio::test]
+    async fn project_hook_skipped_when_workspace_root_unknown() {
+        let hook = HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "echo should-not-run; exit 1".to_string(),
+            ],
+            timeout_ms: 5000,
+            tool_filter: Vec::new(),
+            path_filter: Vec::new(),
+            requires_bin: Some("sh".to_string()), // present, but cwd is None
+        };
+        let executor = HookExecutor::new(vec![hook]);
+        let payload =
+            HookPayload::after_tool("edit_file", "id", "ok".into(), true, 5, None, None, None);
+        assert!(
+            matches!(
+                executor.run(HookEvent::AfterToolCall, &payload).await,
+                HookResult::Allow
+            ),
+            "project hook must be skipped without a workspace root"
+        );
+    }
+
     /// check many times in a row, and that is the channel working.
     #[tokio::test]
     async fn repeated_check_failures_do_not_trip_the_breaker() {

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -2509,6 +2509,13 @@ mod tests {
     /// project-scoped checker is meaningless in the daemon's start dir, and
     /// carrying cwd on the payload lets ONE profile-level executor serve
     /// every session (#2129 review, findings 4 and 7).
+    ///
+    /// Unix-gated: it drives `sh -c "pwd"` and matches the output against
+    /// Rust's canonicalized path — on Windows Git Bash's `pwd` emits a
+    /// unix-style path (`/c/...`) that never equals the `C:\...` form, so
+    /// the assertion is inherently POSIX. The cwd-passing behavior is
+    /// platform-independent; only this path-format check is unix-specific.
+    #[cfg(unix)]
     #[tokio::test]
     async fn hook_child_runs_in_payload_cwd() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -968,6 +968,11 @@ async fn emit_lifecycle_hook(hooks: Option<&Arc<HookExecutor>>, payload: HookPay
         // Context injection is a `user_prompt_submit`-only outcome; a spawn
         // lifecycle event never produces it, but the match must be exhaustive.
         HookResult::Context(_) => {}
+        // Feedback is an AfterToolCall-only outcome; spawn lifecycle events
+        // have no tool result to append it to — log and continue.
+        HookResult::Feedback(entries) => {
+            warn!(event = ?event, count = entries.len(), "lifecycle hook produced feedback; ignored");
+        }
         HookResult::Deny(reason) => {
             warn!(
                 event = ?event,
@@ -1030,6 +1035,8 @@ async fn run_before_spawn_verify_hook(
         // `before_spawn_verify` never yields context injection (that is a
         // `user_prompt_submit`-only outcome); treat it like a plain allow.
         HookResult::Context(_) => Ok(default_files),
+        // Feedback is an AfterToolCall-only outcome; never arises here.
+        HookResult::Feedback(_) => Ok(default_files),
         HookResult::Deny(reason) => Err(reason),
         HookResult::Error(error) => {
             warn!(

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -1477,7 +1477,15 @@ pub fn coding_default_hooks() -> Vec<crate::hooks::HookConfig> {
             command: vec!["eslint".into(), "--max-warnings".into(), "0".into()],
             timeout_ms: 60_000,
             tool_filter: edit_tools.clone(),
-            path_filter: vec!["**/*.{js,ts,tsx,jsx}".into()],
+            // Four explicit patterns: the `glob` crate treats braces as
+            // LITERALS, so "**/*.{js,ts,tsx,jsx}" matches no real file
+            // (#2129 review, finding 10 — verified empirically).
+            path_filter: vec![
+                "**/*.js".into(),
+                "**/*.ts".into(),
+                "**/*.tsx".into(),
+                "**/*.jsx".into(),
+            ],
             requires_bin: Some("eslint".into()),
         },
         // Python: `ruff check` on `.py` edits.
@@ -3017,12 +3025,15 @@ ignore = []
         // ESLint hook must be opt-out friendly via requires_bin — operators
         // without eslint on PATH must NOT see hook failures every edit.
         assert_eq!(eslint.requires_bin.as_deref(), Some("eslint"));
-        assert!(
-            eslint
-                .path_filter
-                .iter()
-                .any(|p| p.ends_with(".{js,ts,tsx,jsx}"))
-        );
+        // Four explicit patterns — the glob crate treats braces as literals
+        // (#2129 review, finding 10).
+        for ext in ["js", "ts", "tsx", "jsx"] {
+            let pattern = format!("**/*.{ext}");
+            assert!(
+                eslint.path_filter.iter().any(|p| p == &pattern),
+                "missing {pattern}"
+            );
+        }
     }
 
     #[test]

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -3127,4 +3127,29 @@ ignore = []
         let reread = read_workspace_policy(&project_root).unwrap().unwrap();
         assert_eq!(reread, upgraded);
     }
+
+    /// #2129: the session bootstrap path routes a detected coding workspace
+    /// to `for_coding()`. This pins the two halves the wiring depends on:
+    /// detection keys on the manifest, and the coding policy carries the
+    /// Coding kind marker while inheriting the session contracts.
+    #[test]
+    fn coding_bootstrap_pieces_compose() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Cargo.toml"), "[package]").unwrap();
+        assert_eq!(
+            detect_workspace_policy_kind(tmp.path()),
+            WorkspacePolicyKind::Coding
+        );
+        let policy = WorkspacePolicy::for_coding();
+        assert_eq!(policy.workspace.kind, WorkspacePolicyKind::Coding);
+        // The defaults the session merges for that kind include the Rust
+        // checker, gated on the binary being present.
+        let hooks = coding_default_hooks();
+        assert!(
+            hooks
+                .iter()
+                .any(|h| h.command.first().map(String::as_str) == Some("cargo")),
+            "coding defaults must include the cargo hook"
+        );
+    }
 }

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -710,13 +710,20 @@ impl ProfileRuntime {
         }
         let system_prompt = prompt_parts.joined();
 
-        let mut all_hooks = reload.host_hooks.clone();
+        // #2129: the coding default hooks (cargo check / eslint / ruff after
+        // edits) merge at THIS shared assembly point so every host —
+        // bootstrap sessions, WS per-turn rebuilds, chat, gateway — gets
+        // them, not just one consumer. They are SELF-GATING: each declares a
+        // path_filter (fires only on matching source edits) and requires_bin
+        // (skips when the checker is absent), so a podcast workspace never
+        // runs cargo. Defaults first, operator hooks after, per the
+        // coding_default_hooks contract. The hook child's working directory
+        // comes from the per-turn payload cwd (the workspace root), not the
+        // executor, so one profile-level executor serves every session.
+        let mut all_hooks = octos_agent::workspace_policy::coding_default_hooks();
+        all_hooks.extend(reload.host_hooks.clone());
         all_hooks.extend(plugin_result.hooks.clone());
-        let hook_executor = if all_hooks.is_empty() {
-            None
-        } else {
-            Some(Arc::new(HookExecutor::new(all_hooks)))
-        };
+        let hook_executor = Some(Arc::new(HookExecutor::new(all_hooks)));
         let skills_dir_candidate = self.data_dir.join("skills");
 
         Ok(Arc::new(Self {
@@ -1409,13 +1416,20 @@ impl ProfileRuntime {
         // `Option<Arc<HookExecutor>>` preserves the pre-M11-F default
         // when neither source carries any hooks (the agent's
         // `hooks: None` field remains untouched).
-        let mut all_hooks = config.hooks.clone();
+        // #2129: the coding default hooks (cargo check / eslint / ruff after
+        // edits) merge at THIS shared assembly point so every host —
+        // bootstrap sessions, WS per-turn rebuilds, chat, gateway — gets
+        // them, not just one consumer. They are SELF-GATING: each declares a
+        // path_filter (fires only on matching source edits) and requires_bin
+        // (skips when the checker is absent), so a podcast workspace never
+        // runs cargo. Defaults first, operator hooks after, per the
+        // coding_default_hooks contract. The hook child's working directory
+        // comes from the per-turn payload cwd (the workspace root), not the
+        // executor, so one profile-level executor serves every session.
+        let mut all_hooks = octos_agent::workspace_policy::coding_default_hooks();
+        all_hooks.extend(config.hooks.clone());
         all_hooks.extend(plugin_result.hooks.clone());
-        let hook_executor = if all_hooks.is_empty() {
-            None
-        } else {
-            Some(Arc::new(HookExecutor::new(all_hooks)))
-        };
+        let hook_executor = Some(Arc::new(HookExecutor::new(all_hooks)));
 
         info!(
             profile_id = %profile.id,
@@ -2524,11 +2538,18 @@ mod tests {
             .await
             .expect("bootstrap should succeed");
 
-        // With no config-side hooks and no plugin-side hooks the field
-        // must be None so the agent's default `hooks: None` is kept.
-        assert!(
-            rt.hook_executor.is_none(),
-            "hook_executor must be None when neither config nor plugins supply hooks",
+        // #2129: the coding defaults (cargo check / eslint / ruff) merge at
+        // this shared assembly point unconditionally (they are self-gating
+        // via path_filter + requires_bin), so the executor is always Some —
+        // with EXACTLY the defaults when neither config nor plugins add any.
+        let executor = rt
+            .hook_executor
+            .as_ref()
+            .expect("hook_executor must carry the coding defaults");
+        assert_eq!(
+            executor.configs().len(),
+            octos_agent::workspace_policy::coding_default_hooks().len(),
+            "no config/plugin hooks: executor must hold exactly the coding defaults",
         );
     }
 

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -647,33 +647,8 @@ impl SessionRuntime {
         // `before_tool_call` / `after_tool_call` / `before_llm_call` /
         // `after_llm_call` hook configured for the profile, breaking
         // parity with `octos gateway`.
-        // Audit Gap-1 wiring (#2129), second half: merge the coding default
-        // hooks (`cargo check` / `eslint` / `ruff` after edits) for coding
-        // workspaces. The defaults were authored for hosts to merge at
-        // bootstrap ("chat.rs / gateway.rs / serve.rs call this on
-        // bootstrap") but no host ever did. Defaults run FIRST, operator
-        // hooks after — per the contract on `coding_default_hooks`. The
-        // executor gets the workspace root as cwd so the checkers check the
-        // project the agent is editing, not the daemon's start directory.
-        let coding_defaults =
-            match octos_agent::workspace_policy::detect_workspace_policy_kind(&workspace_root) {
-                octos_agent::workspace_policy::WorkspacePolicyKind::Coding => {
-                    octos_agent::workspace_policy::coding_default_hooks()
-                }
-                _ => Vec::new(),
-            };
-        if coding_defaults.is_empty() {
-            if let Some(hooks) = profile.hook_executor.clone() {
-                agent = agent.with_hooks(hooks);
-            }
-        } else {
-            let mut configs = coding_defaults;
-            if let Some(hooks) = &profile.hook_executor {
-                configs.extend(hooks.configs().iter().cloned());
-            }
-            agent = agent.with_hooks(Arc::new(
-                octos_agent::HookExecutor::new(configs).with_cwd(&workspace_root),
-            ));
+        if let Some(hooks) = profile.hook_executor.clone() {
+            agent = agent.with_hooks(hooks);
         }
 
         // RFC-1 (issue #1290): same pattern for the `mofa_make`

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -647,8 +647,33 @@ impl SessionRuntime {
         // `before_tool_call` / `after_tool_call` / `before_llm_call` /
         // `after_llm_call` hook configured for the profile, breaking
         // parity with `octos gateway`.
-        if let Some(hooks) = profile.hook_executor.clone() {
-            agent = agent.with_hooks(hooks);
+        // Audit Gap-1 wiring (#2129), second half: merge the coding default
+        // hooks (`cargo check` / `eslint` / `ruff` after edits) for coding
+        // workspaces. The defaults were authored for hosts to merge at
+        // bootstrap ("chat.rs / gateway.rs / serve.rs call this on
+        // bootstrap") but no host ever did. Defaults run FIRST, operator
+        // hooks after — per the contract on `coding_default_hooks`. The
+        // executor gets the workspace root as cwd so the checkers check the
+        // project the agent is editing, not the daemon's start directory.
+        let coding_defaults =
+            match octos_agent::workspace_policy::detect_workspace_policy_kind(&workspace_root) {
+                octos_agent::workspace_policy::WorkspacePolicyKind::Coding => {
+                    octos_agent::workspace_policy::coding_default_hooks()
+                }
+                _ => Vec::new(),
+            };
+        if coding_defaults.is_empty() {
+            if let Some(hooks) = profile.hook_executor.clone() {
+                agent = agent.with_hooks(hooks);
+            }
+        } else {
+            let mut configs = coding_defaults;
+            if let Some(hooks) = &profile.hook_executor {
+                configs.extend(hooks.configs().iter().cloned());
+            }
+            agent = agent.with_hooks(Arc::new(
+                octos_agent::HookExecutor::new(configs).with_cwd(&workspace_root),
+            ));
         }
 
         // RFC-1 (issue #1290): same pattern for the `mofa_make`
@@ -913,7 +938,17 @@ context_ledgers/
 /// `write_workspace_policy` (no semantic change to the legacy
 /// function).
 fn bootstrap_session_policy(workspace_root: &Path) -> Result<()> {
-    write_workspace_policy_if_absent(workspace_root, &WorkspacePolicy::for_session())
+    // Audit Gap-1 wiring (#2129): `detect_workspace_policy_kind` and
+    // `WorkspacePolicy::for_coding` were authored for exactly this call
+    // site but never called — every session workspace was bootstrapped as
+    // the generic `for_session()` policy, so a repo full of Rust got the
+    // same contract as a podcast workspace. The detector keys on observable
+    // manifests (Cargo.toml / package.json / pyproject.toml), not LLM input.
+    let policy = match octos_agent::workspace_policy::detect_workspace_policy_kind(workspace_root) {
+        octos_agent::workspace_policy::WorkspacePolicyKind::Coding => WorkspacePolicy::for_coding(),
+        _ => WorkspacePolicy::for_session(),
+    };
+    write_workspace_policy_if_absent(workspace_root, &policy)
         .wrap_err("failed to bootstrap session workspace policy")
 }
 

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4683,6 +4683,17 @@ impl SessionActor {
             // Context injection is a `user_prompt_submit`-only outcome; these
             // emitted lifecycle events never produce it. Exhaustive-match arm.
             HookResult::Context(_) => {}
+            // Feedback is an AfterToolCall-only outcome (checker diagnostics
+            // appended by the agent's own dispatch sites); these lifecycle
+            // events have no tool result to carry it — log and continue.
+            HookResult::Feedback(entries) => {
+                warn!(
+                    session = %self.session_key,
+                    event = ?event,
+                    count = entries.len(),
+                    "lifecycle hook produced feedback; ignored"
+                );
+            }
             HookResult::Deny(reason) => {
                 warn!(
                     session = %self.session_key,


### PR DESCRIPTION
Closes #2129. Rebased onto main; the original #2138 auto-closed when its base branch was deleted on #2136's merge.

Wires the coding feedback loop octos had built but never connected: `detect_workspace_policy_kind` / `for_coding` / `coding_default_hooks` (cargo check / eslint / ruff after edits) now merge at the shared ProfileRuntime assembly point, so every host inherits them. The defaults are self-gating (path_filter + requires_bin); hook children run in the workspace via the per-turn payload cwd; `execute_hook` captures stderr with concurrent pipe reads; a failing checker's diagnostics reach the model as sanitized `HookResult::Feedback` (infra errors stay log-only, legitimate check failures don't trip the circuit breaker); eslint's brace glob (matched nothing) expanded to four patterns.

Largest behavior change of the batch — the profile hook executor is now always constructed and checker diagnostics enter model-visible tool results. All 10 findings from the pre-landing /code-review addressed on the original #2138. Verification: 60 hook tests + 22 profile tests pass, clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTroMcwSu1yKgX3LkBjQaZ
