### PR TITLE
feat(profile): fix the lean coding roster — add check/update_plan/tool_search, drop apply_patch (#2133)

### DIFF
--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -1541,6 +1541,7 @@ mod profile_integration_tests {
         );
         for kept in [
             "read_file",
+            "shell",
             "bash",
             "edit_file",
             "grep",

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -1539,7 +1539,14 @@ mod profile_integration_tests {
             lean_names.iter().all(|n| base_names.contains(n)),
             "lean set must be a subset of the default set",
         );
-        for kept in ["read_file", "shell", "edit_file", "grep"] {
+        for kept in [
+            "read_file",
+            "bash",
+            "edit_file",
+            "grep",
+            "check",
+            "update_plan",
+        ] {
             assert!(
                 lean_names.contains(&kept.to_string()),
                 "core-loop tool {kept} missing from lean set: {lean_names:?}",

--- a/crates/octos-agent/src/assets/profiles/coding.json
+++ b/crates/octos-agent/src/assets/profiles/coding.json
@@ -1,7 +1,7 @@
 {
   "name": "coding",
   "version": 1,
-  "description": "Default profile — a tight core coding loop: read/write/edit files, one shell (bash), search (grep/glob/list_dir), the workspace check tool, plan tracking, structured user questions, and tool_search as the on-demand escape hatch to every other builtin. Memory, sub-agent spawn, web/research/media/messaging/pipeline tools and bundled skills are NOT front-loaded into each round's tool schemas (they dilute a small model's tool choice and tax context); the model reaches them via tool_search, or run `--profile coding-full` to restore the unfiltered set. The M8.2 built-in sub-agents stay preloaded so a tool_search'd spawn resolves them by id.",
+  "description": "Default profile — the lean core-coding surface plus the loop tools it was missing. It ADDS `check`, `update_plan`, and `tool_search` (which the earlier lean list denied — a default coding session literally could not run the workspace check or track a plan) on top of files, shell (group:runtime), search, long-term memory (group:memory), and sub-agent spawn. Only `apply_patch` is dropped (edit_file/diff_edit cover it). The heavy web/research/media/messaging/pipeline tools and bundled skills stay excluded to keep per-round tool-schema overhead low; note the allow-list filter is applied to the visible registry, so those excluded tools are restored with `--profile coding-full`, not discovered at runtime. The M8.2 built-in sub-agents stay preloaded so `spawn` resolves them by id.",
   "tools": {
     "mode": "allow_list",
     "tools": [
@@ -9,13 +9,13 @@
       "write_file",
       "edit_file",
       "diff_edit",
-      "bash",
-      "grep",
-      "glob",
-      "list_dir",
+      "group:runtime",
+      "group:search",
+      "group:memory",
+      "spawn",
+      "ask_user_question",
       "check",
       "update_plan",
-      "ask_user_question",
       "tool_search"
     ]
   },

--- a/crates/octos-agent/src/assets/profiles/coding.json
+++ b/crates/octos-agent/src/assets/profiles/coding.json
@@ -1,16 +1,22 @@
 {
   "name": "coding",
   "version": 1,
-  "description": "Default profile — lean core-coding tool surface: files (group:fs), shell (group:runtime), search (group:search), long-term memory (group:memory), sub-agent spawn, and structured user questions. Web/research/media/messaging/pipeline tools and bundled skills are excluded to keep per-round tool-schema overhead low; run with `--profile coding-full` to restore the unfiltered set. The M8.2 built-in sub-agents are preloaded.",
+  "description": "Default profile — a tight core coding loop: read/write/edit files, one shell (bash), search (grep/glob/list_dir), the workspace check tool, plan tracking, structured user questions, and tool_search as the on-demand escape hatch to every other builtin. Memory, sub-agent spawn, web/research/media/messaging/pipeline tools and bundled skills are NOT front-loaded into each round's tool schemas (they dilute a small model's tool choice and tax context); the model reaches them via tool_search, or run `--profile coding-full` to restore the unfiltered set. The M8.2 built-in sub-agents stay preloaded so a tool_search'd spawn resolves them by id.",
   "tools": {
     "mode": "allow_list",
     "tools": [
-      "group:fs",
-      "group:runtime",
-      "group:search",
-      "group:memory",
-      "spawn",
-      "ask_user_question"
+      "read_file",
+      "write_file",
+      "edit_file",
+      "diff_edit",
+      "bash",
+      "grep",
+      "glob",
+      "list_dir",
+      "check",
+      "update_plan",
+      "ask_user_question",
+      "tool_search"
     ]
   },
   "mcp_servers": [],

--- a/crates/octos-agent/src/profile/mod.rs
+++ b/crates/octos-agent/src/profile/mod.rs
@@ -10,13 +10,13 @@
 //! across a dozen startup sites; afterwards, a single profile declaration
 //! consolidates the envelope.
 //!
-//! The built-in `coding` profile is the no-flag default and carries a tight
-//! core-coding allow list (files, one shell, search, the workspace check
-//! tool, plan tracking, user questions, and `tool_search` as the on-demand
-//! escape hatch to every other builtin) so `octos chat` does not ship every
-//! tool schema to the LLM on every round. The `coding-full` built-in
-//! preserves the pre-lean unfiltered surface byte-for-byte for sessions that
-//! want everything.
+//! The built-in `coding` profile is the no-flag default and carries a lean
+//! core-coding allow list (files, shell, search, memory, spawn, the workspace
+//! check tool, plan tracking, user questions, and tool_search) so `octos chat`
+//! does not ship every tool schema to the LLM on every round. The allow-list
+//! filter narrows the VISIBLE registry, so tools it excludes (web/research/
+//! media/pipeline) are restored via the `coding-full` built-in, which
+//! preserves the pre-lean unfiltered surface byte-for-byte.
 //! Alternate profiles (e.g. `swarm`) declare their own allow lists and
 //! expanded agent sets.
 //!
@@ -683,26 +683,23 @@ mod tests {
         // per-round tool-schema overhead.
         match &coding.tools {
             ProfileTools::AllowList { tools } => {
-                // #2133: the allow list names the core loop EXPLICITLY (not
-                // via groups) so it lands exactly the intended surface —
-                // `group:fs` drags in `apply_patch`, `group:runtime` drags in
-                // three redundant shell entry points, and neither `check`,
-                // `update_plan`, nor `tool_search` belongs to any group.
+                // #2133: the lean surface KEEPS files/shell/search/memory/spawn
+                // and ADDS the three core-loop tools it was missing — `check`,
+                // `update_plan`, `tool_search`. Only `apply_patch` is dropped
+                // (edit_file/diff_edit cover it), so the fs tools are named
+                // explicitly instead of via `group:fs`.
                 for required in [
                     "read_file",
                     "write_file",
                     "edit_file",
                     "diff_edit",
-                    "bash",
-                    "grep",
-                    "glob",
-                    "list_dir",
+                    "group:runtime",
+                    "group:search",
+                    "group:memory",
+                    "spawn",
+                    "ask_user_question",
                     "check",
                     "update_plan",
-                    "ask_user_question",
-                    // The escape hatch: without it the lean surface is a
-                    // dead end — the model can neither use nor recover the
-                    // tools the allow list drops.
                     "tool_search",
                 ] {
                     assert!(
@@ -710,21 +707,13 @@ mod tests {
                         "coding allow list must keep {required}, got {tools:?}",
                     );
                 }
-                // Dropped from the default surface (still reachable via
-                // `tool_search` or `coding-full`): memory, sub-agent spawn,
-                // redundant shell aliases / patch, and the heavy web /
-                // research / media / pipeline surfaces.
+                // Dropped or never-included: `apply_patch` (redundant), the
+                // `group:fs` alias (fs named explicitly to exclude apply_patch),
+                // and the heavy web / research / media / pipeline surfaces
+                // (restored via `--profile coding-full`).
                 for excluded in [
                     "group:fs",
-                    "group:runtime",
-                    "group:memory",
-                    "spawn",
                     "apply_patch",
-                    "shell",
-                    "exec_command",
-                    "write_stdin",
-                    "recall_memory",
-                    "save_memory",
                     "group:web",
                     "group:research",
                     "group:media",
@@ -810,9 +799,9 @@ mod tests {
             name: "get_weather",
         });
         // `spawn` is registered by the chat/acp bootstrap (SpawnTool),
-        // not by `with_builtins`; a stub stands in so the exclusion
-        // assertion proves the lean profile filters it out (#2133 drops it
-        // from the default surface — it is reached via `tool_search`).
+        // not by `with_builtins`; a stub stands in so the inclusion
+        // assertion proves the lean profile keeps it (#2133 softened: spawn
+        // stays in the default surface).
         tools.register(StubTool { name: "spawn" });
 
         let coding = ProfileDefinition::builtin("coding").expect("coding");
@@ -826,10 +815,16 @@ mod tests {
             "write_file",
             "edit_file",
             "diff_edit",
+            // group:runtime — all shells kept (interactive sessions live on
+            // exec_command + write_stdin; bash is the Codex-compatible alias).
             "bash",
+            "shell",
+            "exec_command",
+            "write_stdin",
             "glob",
             "grep",
             "list_dir",
+            "spawn",
             "check",
             "update_plan",
             "tool_search",
@@ -841,13 +836,9 @@ mod tests {
             );
         }
         for excluded in [
-            // #2133: spawn + memory + redundant shell/patch aliases are no
-            // longer front-loaded — the model reaches them via `tool_search`.
-            "spawn",
+            // #2133: only apply_patch is dropped (edit_file/diff_edit cover
+            // it); the heavy web/research/media surfaces stay out.
             "apply_patch",
-            "shell",
-            "exec_command",
-            "write_stdin",
             "web_search",
             "web_fetch",
             "browser",
@@ -865,10 +856,10 @@ mod tests {
         }
         // Budget pin (#1578 harness review: 48 tools ≈ 9.3K tokens per
         // round in the unfiltered default). The lean surface must stay a
-        // small fraction of that; 20 leaves headroom for core-loop growth
-        // while failing loudly on accidental bloat.
+        // small fraction of that; 24 leaves headroom for the core loop +
+        // shells + memory while failing loudly on accidental bloat.
         assert!(
-            names.len() <= 20,
+            names.len() <= 24,
             "lean coding profile grew to {} tools: {names:?}",
             names.len(),
         );

--- a/crates/octos-agent/src/profile/mod.rs
+++ b/crates/octos-agent/src/profile/mod.rs
@@ -10,11 +10,13 @@
 //! across a dozen startup sites; afterwards, a single profile declaration
 //! consolidates the envelope.
 //!
-//! The built-in `coding` profile is the no-flag default and carries a lean
-//! core-coding allow list (files, shell, search, memory, spawn, user
-//! questions) so `octos chat` does not ship every tool schema to the LLM on
-//! every round. The `coding-full` built-in preserves the pre-lean
-//! unfiltered surface byte-for-byte for sessions that want everything.
+//! The built-in `coding` profile is the no-flag default and carries a tight
+//! core-coding allow list (files, one shell, search, the workspace check
+//! tool, plan tracking, user questions, and `tool_search` as the on-demand
+//! escape hatch to every other builtin) so `octos chat` does not ship every
+//! tool schema to the LLM on every round. The `coding-full` built-in
+//! preserves the pre-lean unfiltered surface byte-for-byte for sessions that
+//! want everything.
 //! Alternate profiles (e.g. `swarm`) declare their own allow lists and
 //! expanded agent sets.
 //!

--- a/crates/octos-agent/src/profile/mod.rs
+++ b/crates/octos-agent/src/profile/mod.rs
@@ -681,22 +681,48 @@ mod tests {
         // per-round tool-schema overhead.
         match &coding.tools {
             ProfileTools::AllowList { tools } => {
+                // #2133: the allow list names the core loop EXPLICITLY (not
+                // via groups) so it lands exactly the intended surface —
+                // `group:fs` drags in `apply_patch`, `group:runtime` drags in
+                // three redundant shell entry points, and neither `check`,
+                // `update_plan`, nor `tool_search` belongs to any group.
                 for required in [
-                    "group:fs",
-                    "group:runtime",
-                    "group:search",
-                    "group:memory",
-                    "spawn",
+                    "read_file",
+                    "write_file",
+                    "edit_file",
+                    "diff_edit",
+                    "bash",
+                    "grep",
+                    "glob",
+                    "list_dir",
+                    "check",
+                    "update_plan",
                     "ask_user_question",
+                    // The escape hatch: without it the lean surface is a
+                    // dead end — the model can neither use nor recover the
+                    // tools the allow list drops.
+                    "tool_search",
                 ] {
                     assert!(
                         tools.contains(&required.to_string()),
                         "coding allow list must keep {required}, got {tools:?}",
                     );
                 }
-                // The heavy non-core surfaces must stay out of the lean
-                // default (available via `coding-full` or a custom profile).
+                // Dropped from the default surface (still reachable via
+                // `tool_search` or `coding-full`): memory, sub-agent spawn,
+                // redundant shell aliases / patch, and the heavy web /
+                // research / media / pipeline surfaces.
                 for excluded in [
+                    "group:fs",
+                    "group:runtime",
+                    "group:memory",
+                    "spawn",
+                    "apply_patch",
+                    "shell",
+                    "exec_command",
+                    "write_stdin",
+                    "recall_memory",
+                    "save_memory",
                     "group:web",
                     "group:research",
                     "group:media",
@@ -782,8 +808,9 @@ mod tests {
             name: "get_weather",
         });
         // `spawn` is registered by the chat/acp bootstrap (SpawnTool),
-        // not by `with_builtins`; a stub stands in for the inclusion
-        // assertion.
+        // not by `with_builtins`; a stub stands in so the exclusion
+        // assertion proves the lean profile filters it out (#2133 drops it
+        // from the default surface — it is reached via `tool_search`).
         tools.register(StubTool { name: "spawn" });
 
         let coding = ProfileDefinition::builtin("coding").expect("coding");
@@ -796,11 +823,14 @@ mod tests {
             "read_file",
             "write_file",
             "edit_file",
-            "shell",
+            "diff_edit",
+            "bash",
             "glob",
             "grep",
             "list_dir",
-            "spawn",
+            "check",
+            "update_plan",
+            "tool_search",
             "ask_user_question",
         ] {
             assert!(
@@ -809,6 +839,13 @@ mod tests {
             );
         }
         for excluded in [
+            // #2133: spawn + memory + redundant shell/patch aliases are no
+            // longer front-loaded — the model reaches them via `tool_search`.
+            "spawn",
+            "apply_patch",
+            "shell",
+            "exec_command",
+            "write_stdin",
             "web_search",
             "web_fetch",
             "browser",
@@ -818,7 +855,6 @@ mod tests {
             "workspace_diff",
             "spawn_agent",
             "delegate",
-            "update_plan",
         ] {
             assert!(
                 !names.contains(excluded),

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -2192,12 +2192,13 @@ mod tests {
                 "{resurrected} must stay excluded in the rebound session registry"
             );
         }
-        // #2133: `tool_search` is now in the lean allow list (the escape
-        // hatch) and `bash` is the single retained shell; both must survive
-        // the rebind re-narrowing. `check`/`update_plan` too.
+        // #2133: `tool_search`, `check`, and `update_plan` are now in the lean
+        // allow list, and the shells (group:runtime) are kept; all must survive
+        // the rebind re-narrowing.
         for kept in [
             "read_file",
             "bash",
+            "shell",
             "grep",
             "edit_file",
             "tool_search",

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -2186,13 +2186,24 @@ mod tests {
             "gpt-test",
             &profile,
         );
-        for resurrected in ["workspace_diff", "view_image", "tool_search", "web_search"] {
+        for resurrected in ["workspace_diff", "view_image", "web_search"] {
             assert!(
                 !session.is_tool_visible(resurrected),
                 "{resurrected} must stay excluded in the rebound session registry"
             );
         }
-        for kept in ["read_file", "shell", "grep", "edit_file"] {
+        // #2133: `tool_search` is now in the lean allow list (the escape
+        // hatch) and `bash` is the single retained shell; both must survive
+        // the rebind re-narrowing. `check`/`update_plan` too.
+        for kept in [
+            "read_file",
+            "bash",
+            "grep",
+            "edit_file",
+            "tool_search",
+            "check",
+            "update_plan",
+        ] {
             assert!(
                 session.is_tool_visible(kept),
                 "{kept} must survive the rebound session registry"

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -104,12 +104,11 @@ pub struct ChatCommand {
     /// so you don't re-enter a model or key that a profile already holds.
     /// `--config`, `--provider`, and `--model` still override.
     ///
-    /// Defaults to `coding`, the tight core-coding tool surface (files,
-    /// one shell, search, check, plan tracking, user questions, and
-    /// `tool_search` as the escape hatch to everything else). Use
-    /// `coding-full` for the unfiltered pre-lean tool set (web, research,
-    /// pipelines,
-    /// bundled skills).
+    /// Defaults to `coding`, the lean core-coding tool surface (files,
+    /// shell, search, memory, spawn, check, plan tracking, user questions,
+    /// and tool_search). Use `coding-full` for the unfiltered pre-lean tool
+    /// set (web, research, pipelines, bundled skills) that the allow list
+    /// excludes.
     #[arg(long)]
     pub profile: Option<String>,
 

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -104,9 +104,11 @@ pub struct ChatCommand {
     /// so you don't re-enter a model or key that a profile already holds.
     /// `--config`, `--provider`, and `--model` still override.
     ///
-    /// Defaults to `coding`, the lean core-coding tool surface (files,
-    /// shell, search, memory, spawn, user questions). Use `coding-full`
-    /// for the unfiltered pre-lean tool set (web, research, pipelines,
+    /// Defaults to `coding`, the tight core-coding tool surface (files,
+    /// one shell, search, check, plan tracking, user questions, and
+    /// `tool_search` as the escape hatch to everything else). Use
+    /// `coding-full` for the unfiltered pre-lean tool set (web, research,
+    /// pipelines,
     /// bundled skills).
     #[arg(long)]
     pub profile: Option<String>,


### PR DESCRIPTION
## What & why

Closes #2133. Fixes the actual defect in the lean `coding` profile: a default `octos chat` session had **`check`, `update_plan`, and `tool_search` denied** — it literally could not run the workspace check tool or track a plan.

## Change (softened after review)

An adversarial review caught that an earlier revision rested on a **false premise**: `tool_search` searches only the *post-filter* visible registry (`filter_by_profile` physically removes tools; there's no activation tool), so a tool the allow-list drops is **not** reachable at runtime — only `--profile coding-full` restores it. Dropping spawn/memory/interactive-shell would have been a real capability cut.

So this is now a **purely-additive** fix with **no capability cut**:

- **Keep** files, shell (`group:runtime`), search, long-term memory (`group:memory`), and sub-agent `spawn`.
- **Add** `check`, `update_plan`, `tool_search`.
- **Drop** only `apply_patch` (edit_file/diff_edit fully cover it) — so fs is named explicitly instead of via `group:fs`.

`group:runtime` is kept whole on purpose: interactive sessions live on `exec_command` + `write_stdin`, and `bash` is the Codex-compatible alias local models are trained on — cherry-picking shells risked a capability/compat cut for exactly the local-model audience.

All docs/comments now state plainly that the excluded heavy surfaces (web/research/media/pipeline) are restored via `coding-full`, **not** discovered at runtime. The false tool_search-escape-hatch claim is gone.

## Tests

`should_load_builtin_coding_profile_without_error`, `coding_profile_narrows_registry_to_core_coding_loop`, `coding_profile_narrows_default_tool_set`, and the acp rebind test are updated to the softened envelope (spawn/shells/memory kept, apply_patch dropped, budget ≤ 24). `coding-full` parity untouched. `cargo test -p octos-agent -p octos-cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
