### PR TITLE
feat(llm): per-profile context_window override (config.llm.primary/fallbacks) (#2142)

### DIFF
--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -4586,6 +4586,7 @@ mod tests {
                 model_hints: None,
                 cost_per_m: None,
                 strong: None,
+                context_window: None,
             }),
             fallbacks: vec![],
         });

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1142,6 +1142,16 @@ impl ChatCommand {
         }
         let model_id = base_provider.model_id().to_string();
 
+        // #2142: operator override of the primary's effective context window
+        // (config.llm.primary.context_window). Wraps the probed provider so it
+        // beats both the catalog and the runtime probe through the delegating
+        // stack.
+        let base_provider = crate::qos_catalog::apply_context_window_override(
+            base_provider,
+            config.context_window,
+            "primary",
+        );
+
         let llm: Arc<dyn LlmProvider> = if self.no_retry {
             base_provider
         } else if config.fallback_models.is_empty() {
@@ -1164,7 +1174,15 @@ impl ChatCommand {
                     fb.base_url.clone(),
                     fb.api_type.as_deref(),
                 ) {
-                    Ok(p) => providers.push(Arc::new(RetryProvider::new(p))),
+                    Ok(p) => {
+                        // #2142: per-fallback context-window override.
+                        let p = crate::qos_catalog::apply_context_window_override(
+                            p,
+                            fb.context_window,
+                            "fallback",
+                        );
+                        providers.push(Arc::new(RetryProvider::new(p)));
+                    }
                     Err(e) => {
                         tracing::warn!(provider = %fb.provider, error = %e, "skipping fallback provider");
                     }

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -280,6 +280,13 @@ pub(crate) fn build_llm_stack(config: &Config, no_retry: bool) -> Result<LlmStac
     let base_provider = create_provider(&provider_name, config, model, base_url)?;
     let mut adaptive_router_ref: Option<Arc<AdaptiveRouter>> = None;
 
+    // #2142: operator override of the primary's effective context window.
+    let base_provider = crate::qos_catalog::apply_context_window_override(
+        base_provider,
+        config.context_window,
+        "primary",
+    );
+
     let llm: Arc<dyn LlmProvider> = if no_retry {
         base_provider
     } else if config.fallback_models.is_empty() {
@@ -304,6 +311,12 @@ pub(crate) fn build_llm_stack(config: &Config, no_retry: bool) -> Result<LlmStac
                 fallback.api_type.as_deref(),
             ) {
                 Ok(provider) => {
+                    // #2142: per-fallback context-window override.
+                    let provider = crate::qos_catalog::apply_context_window_override(
+                        provider,
+                        fallback.context_window,
+                        "fallback",
+                    );
                     providers.push(Arc::new(RetryProvider::new(provider)));
                     costs.push(fallback.cost_per_m.unwrap_or(0.0));
                 }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -36,6 +36,15 @@ pub struct Config {
     #[serde(default)]
     pub model: Option<String>,
 
+    /// Operator override for the primary provider's effective context window,
+    /// in tokens. When set it wraps the (probed) primary provider in
+    /// `ContextWindowOverride` as the OUTERMOST layer, so it beats both the
+    /// static catalog and the runtime probe (#2135). Projected from
+    /// `LlmModelSelectionConfig.context_window` by `config_from_profile`.
+    /// `None` = defer to probe/catalog. (#2142)
+    #[serde(default)]
+    pub context_window: Option<u32>,
+
     /// Custom base URL for the API endpoint.
     #[serde(default)]
     pub base_url: Option<String>,
@@ -455,6 +464,13 @@ pub struct FallbackModel {
     /// Defaults to true for backward compat — set false for weak/proxy providers.
     #[serde(default = "default_true")]
     pub strong: bool,
+    /// Operator override for THIS fallback's effective context window, in
+    /// tokens. Wraps this fallback provider in `ContextWindowOverride`
+    /// (outermost) so it beats the catalog and the probe (#2135). Projected
+    /// from the per-fallback `LlmModelSelectionConfig.context_window`.
+    /// `None` = defer to probe/catalog. (#2142)
+    #[serde(default)]
+    pub context_window: Option<u32>,
 }
 
 pub fn default_true() -> bool {

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -815,6 +815,17 @@ pub struct LlmModelSelectionConfig {
     /// Whether this is considered a strong model for large tool-heavy runs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strong: Option<bool>,
+    /// Operator override for the effective context window, in tokens. When
+    /// set it takes precedence over BOTH the static catalog and the runtime
+    /// probe (#2135): the provider is wrapped in `ContextWindowOverride` as
+    /// the outermost layer, so `context_window()` resolves to this value
+    /// through the entire runtime stack. Use it to pin a smaller window than
+    /// a server advertises (e.g. cap a 262K llama-server at 16384 to bound
+    /// KV/compaction) or to correct a mis-probed backend. `None` = defer to
+    /// probe/catalog. Applies to the primary and to each fallback
+    /// independently. (#2142, split from #2127.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u32>,
 }
 
 /// A provider route / endpoint choice for one model.
@@ -1183,6 +1194,9 @@ impl LlmModelSelectionConfig {
             && self.model_hints.is_none()
             && self.cost_per_m.is_none()
             && self.strong.is_none()
+            // #2142: a selection that pins ONLY a context_window override is
+            // meaningful — it must not be collapsed as "empty" and dropped.
+            && self.context_window.is_none()
     }
 }
 
@@ -2698,12 +2712,16 @@ pub(crate) fn config_from_profile(
             api_type: fb.route.as_ref().and_then(|route| route.api_type.clone()),
             cost_per_m: fb.cost_per_m,
             strong: fb.strong.unwrap_or_else(crate::config::default_true),
+            // #2142: per-fallback operator override of the effective window.
+            context_window: fb.context_window,
         })
         .collect();
 
     Config {
         provider: primary.and_then(|selection| selection.family_id.clone()),
         model: primary.and_then(|selection| selection.model_id.clone()),
+        // #2142: operator override of the primary's effective context window.
+        context_window: primary.and_then(|selection| selection.context_window),
         base_url: primary.and_then(|selection| {
             selection
                 .route
@@ -3866,6 +3884,8 @@ mod tests {
                         }),
                         cost_per_m: Some(4.5),
                         strong: Some(true),
+                        // #2142: operator window override on the primary.
+                        context_window: Some(16_384),
                     }),
                     fallbacks: vec![LlmModelSelectionConfig {
                         family_id: Some("minimax".into()),
@@ -3886,6 +3906,9 @@ mod tests {
                         }),
                         cost_per_m: Some(3.2),
                         strong: Some(true),
+                        // #2142: a DIFFERENT per-fallback window override —
+                        // must project independently of the primary's.
+                        context_window: Some(8_192),
                     }],
                 }),
                 ..Default::default()
@@ -3927,6 +3950,12 @@ mod tests {
                 .map(|h| h.merge_system_messages),
             Some(true)
         );
+        // #2142: the per-selection context_window overrides project through
+        // to the flattened Config — primary onto `config.context_window`, and
+        // each fallback onto its own `FallbackModel.context_window`,
+        // independently (16384 vs 8192).
+        assert_eq!(config.context_window, Some(16_384));
+        assert_eq!(config.fallback_models[0].context_window, Some(8_192));
     }
 
     #[test]

--- a/crates/octos-cli/src/qos_catalog.rs
+++ b/crates/octos-cli/src/qos_catalog.rs
@@ -2,13 +2,42 @@ use std::path::Path;
 use std::sync::Arc;
 
 use octos_llm::{
-    AdaptiveConfig, AdaptiveMode, AdaptiveRouter, BaselineEntry, LlmProvider, ModelCatalogEntry,
-    ProviderChain, QosCatalog, RetryProvider,
+    AdaptiveConfig, AdaptiveMode, AdaptiveRouter, BaselineEntry, ContextWindowOverride,
+    LlmProvider, ModelCatalogEntry, ProviderChain, QosCatalog, RetryProvider,
 };
 use tracing::{info, warn};
 
 use crate::commands::chat::create_provider_with_api_type;
 use crate::config::Config;
+
+/// #2142: wrap a freshly-created (probe-wrapped) provider in the operator's
+/// `context_window` override when the config sets one.
+///
+/// The override sits just OUTSIDE the local-context probe (#2135) and INSIDE
+/// `RetryProvider` / `ProviderChain` / `AdaptiveRouter` — all of which delegate
+/// `context_window()` as of #2135 — so the operator's value resolves through
+/// the entire runtime stack and beats BOTH the static catalog and the runtime
+/// probe. Applied per provider (primary and each fallback independently) so a
+/// primary pin never leaks onto a fallback's own window; the router then
+/// aggregates the per-slot values as it already does. `None` leaves the
+/// provider untouched.
+pub(crate) fn apply_context_window_override(
+    provider: Arc<dyn LlmProvider>,
+    window: Option<u32>,
+    slot: &str,
+) -> Arc<dyn LlmProvider> {
+    match window {
+        Some(w) => {
+            info!(
+                context_window = w,
+                slot,
+                "context window overridden by config.llm (operator override wins over probe/catalog)"
+            );
+            Arc::new(ContextWindowOverride::new(provider, w))
+        }
+        None => provider,
+    }
+}
 
 /// The canonical model catalog (`model_catalog.json`), compiled in. This is the
 /// single source of truth for model provisioning and the researched
@@ -231,6 +260,12 @@ pub(crate) fn build_adaptive_provider_chain(
 ) -> AdaptiveProviderBundle {
     let mut adaptive_router_ref: Option<Arc<AdaptiveRouter>> = None;
 
+    // #2142: operator override of the primary's effective context window,
+    // applied before RetryProvider/router wrap it so it propagates through
+    // the delegating stack and beats the probe/catalog.
+    let base_provider =
+        apply_context_window_override(base_provider, config.context_window, "primary");
+
     let llm: Arc<dyn LlmProvider> = if no_retry {
         base_provider
     } else if config.fallback_models.is_empty() {
@@ -257,6 +292,8 @@ pub(crate) fn build_adaptive_provider_chain(
                 fb.api_type.as_deref(),
             ) {
                 Ok(p) => {
+                    // #2142: per-fallback context-window override.
+                    let p = apply_context_window_override(p, fb.context_window, "fallback");
                     providers.push(Arc::new(RetryProvider::new(p)));
                     costs.push(fb.cost_per_m.unwrap_or(0.0));
                 }
@@ -839,6 +876,7 @@ mod tests {
                     api_type: None,
                     cost_per_m: Some(0.5),
                     strong: true,
+                    context_window: None,
                 },
                 // Deliberately-broken third fallback — must be skipped
                 // via `warn!` without taking the helper down.
@@ -851,6 +889,7 @@ mod tests {
                     api_type: None,
                     cost_per_m: None,
                     strong: true,
+                    context_window: None,
                 },
             ],
             // A1: AdaptiveRoutingConfig::default() now has `enabled = false`
@@ -1117,6 +1156,7 @@ mod tests {
                 api_type: None,
                 cost_per_m: Some(0.5),
                 strong: true,
+                context_window: None,
             }],
             adaptive_routing: Some(AdaptiveRoutingConfig {
                 enabled: false,
@@ -1178,6 +1218,7 @@ mod tests {
                 api_type: None,
                 cost_per_m: Some(0.5),
                 strong: true,
+                context_window: None,
             }],
             adaptive_routing: None,
             ..Default::default()
@@ -1190,6 +1231,93 @@ mod tests {
         assert!(
             bundle.adaptive_router.is_none(),
             "missing adaptive_routing block MUST default to OFF (no router)"
+        );
+    }
+
+    /// #2142: an operator `context_window` override must resolve through the
+    /// WHOLE assembled stack (RetryProvider here), beating what the underlying
+    /// provider reports — the acceptance criterion "a profile pinning
+    /// context_window: 16384 on a 262K server reports 16384 through the full
+    /// runtime stack".
+    #[test]
+    fn context_window_override_wins_through_the_assembled_stack() {
+        use crate::config::Config;
+        use octos_core::Message;
+        use octos_llm::{ChatConfig, ChatResponse, LlmProvider, ToolSpec};
+        use std::sync::Arc;
+
+        // A backend that advertises a large window (stands in for the probed
+        // 262K llama-server).
+        struct WideProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for WideProvider {
+            async fn chat(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSpec],
+                _config: &ChatConfig,
+            ) -> eyre::Result<ChatResponse> {
+                Err(eyre::eyre!("stub not callable in tests"))
+            }
+            fn model_id(&self) -> &str {
+                "wide-model"
+            }
+            fn provider_name(&self) -> &str {
+                "wide"
+            }
+            fn context_window(&self) -> u32 {
+                262_144
+            }
+        }
+
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().to_path_buf();
+
+        // Control: no override → the backend's own window survives the
+        // RetryProvider wrap (delegation, per #2135).
+        let control = build_adaptive_provider_chain(
+            Arc::new(WideProvider),
+            &Config::default(),
+            &data_dir,
+            false,
+            ExporterMode::Disabled,
+        );
+        assert_eq!(
+            control.llm.context_window(),
+            262_144,
+            "without an override the probed/backend window must pass through the stack"
+        );
+
+        // Override: 16384 must win through RetryProvider all the way out.
+        let config = Config {
+            context_window: Some(16_384),
+            ..Default::default()
+        };
+        let overridden = build_adaptive_provider_chain(
+            Arc::new(WideProvider),
+            &config,
+            &data_dir,
+            false,
+            ExporterMode::Disabled,
+        );
+        assert_eq!(
+            overridden.llm.context_window(),
+            16_384,
+            "config.context_window must override the 262K backend through the full stack"
+        );
+
+        // And in the no_retry path (bare provider) the override still holds.
+        let bare = build_adaptive_provider_chain(
+            Arc::new(WideProvider),
+            &config,
+            &data_dir,
+            true,
+            ExporterMode::Disabled,
+        );
+        assert_eq!(
+            bare.llm.context_window(),
+            16_384,
+            "override must hold even on the no_retry (unwrapped) path"
         );
     }
 }


### PR DESCRIPTION
## What & why

Closes #2142 (split from #2127; the probe half landed in #2135). Operators can now **pin** the effective context window from profile config and have it beat **both** the static catalog and the runtime probe:

    config.llm.primary.context_window       -> the primary provider
    config.llm.fallbacks[i].context_window  -> each fallback, independently

Use it to cap a 262K llama-server at a smaller window (bounding KV/compaction) or to correct a mis-probed backend.

## How

- `LlmModelSelectionConfig` gains `context_window: Option<u32>`. The struct is `deny_unknown_fields`, so declaring the field is what keeps existing configs parsing. `is_empty()` now counts it — a selection that pins **only** a window is meaningful and must not be collapsed away.
- `Config.context_window` + `FallbackModel.context_window` carry the flattened values; `config_from_profile` projects primary → `Config` and each fallback → `FallbackModel`.
- A shared `apply_context_window_override` helper wraps the freshly-created (probe-wrapped) provider in the existing `ContextWindowOverride`. It sits just **outside** the local-context probe (#2135) and **inside** Retry/Chain/AdaptiveRouter — all of which delegate `context_window()` as of #2135 — so the operator value resolves through the whole stack. Applied **per provider** (primary + each fallback) so a primary pin never leaks onto a fallback's window; the router aggregates per-slot as before. A startup `info!` names the override.
- Wired at the three load-bearing builders: `build_adaptive_provider_chain` (serve / ProfileRuntime / acp / gateway_runtime), `build_llm_stack` (gateway), and the `octos chat` inline assembly (the local-model coding path this is most for).

## Scope

Deliberately **not** wired into `build_strong_chain` (slides strong-only lane) or the peripheral rebuild lanes (switch_model, memory_refresh, goal-verifier, UI transport rebuild) — the issue's scope is chat / fallback / task+pipeline. Pipeline sub-provider lanes already carry their own `SubProviderConfig.default_context_window`. Happy to extend to the strong-chain if you want it there.

## Tests

- `context_window_override_wins_through_the_assembled_stack` — a backend advertising 262144 reports **16384** through the assembled stack when overridden; passes 262144 through untouched without one; holds on the `no_retry` (unwrapped) path too.
- `test_config_from_profile_uses_structured_llm_contract` — primary 16384 and a **different** per-fallback 8192 project independently into the flattened Config.

`cargo test -p octos-cli` green; `cargo fmt --all` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
