### PR TITLE
feat(prompt): three-phase work-turn / yield-point coding output contract (#2141)

### DIFF
--- a/crates/octos-cli/src/commands/gateway/prompt.rs
+++ b/crates/octos-cli/src/commands/gateway/prompt.rs
@@ -185,6 +185,32 @@ mod tests {
     const PROMPT: &str = include_str!("../../prompts/gateway_default.txt");
 
     #[test]
+    fn should_carry_the_three_phase_coding_output_contract() {
+        // #2141: the coding output contract (octoscode#585) lives in the
+        // server/harness prompt, not the TUI. Pin its load-bearing pieces so
+        // an edit can't silently drop the anti-off-ramp guidance that keeps a
+        // small local model from ending each work turn with a polished
+        // summary INSTEAD of continuing the task.
+        assert!(
+            PROMPT.contains("Output shape for a multi-step coding task"),
+            "prompt is missing the three-phase coding output contract header (#2141)"
+        );
+        for marker in [
+            "THREE output phases",
+            "Task start",  // phase 1: one plan checklist
+            "Work turns",  // phase 2: tool-only + at most one status line
+            "Yield point", // phase 3: the full answer
+            "Session Summary",
+            "never a substitute for continuing", // the anti-off-ramp rule
+        ] {
+            assert!(
+                PROMPT.contains(marker),
+                "coding output contract must keep the phrase {marker:?} (#2141)"
+            );
+        }
+    }
+
+    #[test]
     fn should_have_act_directly_specialist_tools_section() {
         assert!(
             PROMPT.contains("ACT-DIRECTLY for registered specialist tools"),

--- a/crates/octos-cli/src/prompts/gateway_default.txt
+++ b/crates/octos-cli/src/prompts/gateway_default.txt
@@ -93,7 +93,7 @@ A multi-step coding task has exactly THREE output phases. Each formatting rule b
 
 2. **Work turns** (you are still calling tools and continuing on your own) — tool calls plus AT MOST one short status line. No tables, no summaries, no re-printed plan, and no per-command `Command` / `Purpose` / `Expected result` narration. Do NOT stop mid-task to write a polished walkthrough summary: a summary is never a substitute for continuing the work you were asked to do.
 
-3. **Yield point** (you stop and hand control back — the task is done, you are blocked on input, or you hit an error you cannot resolve) — THIS is the only place the full answer belongs:
+3. **Yield point** (you stop and hand control back — the task is done, you are blocked on input, or you hit an error you cannot resolve) — THIS is the only place the full answer belongs. (This end-of-task Session Summary is a summary of the WORK you did; it is not the conversation recap the top of this prompt tells you to skip, and it is the one summary a completed task owes.)
 
    Session Summary
    - Files changed: ...

--- a/crates/octos-cli/src/prompts/gateway_default.txt
+++ b/crates/octos-cli/src/prompts/gateway_default.txt
@@ -79,6 +79,29 @@ For coding, debugging, repo-edit, filesystem, and command-output tasks, prefer t
 
 For bounded coding tasks, keep the change small and reviewable. Prefer one deterministic edit and show the resulting diff or exact changed content.
 
+### Output shape for a multi-step coding task
+
+A multi-step coding task has exactly THREE output phases. Each formatting rule below belongs to ONE phase — a formatted answer in the wrong phase is a bug. For a small local model this is not a trimming, it IS the contract: every extra formatted turn competes with the task itself for attention and context.
+
+1. **Task start** — emit ONE plan checklist, once:
+
+   Plan:
+   - [ ] <step>
+   - [ ] <step>
+
+   Use 3-6 items, each under one line, `- [ ]` for pending and `- [x]` for done. Put no reasoning, evidence, or output inside an item. Do NOT re-emit the checklist on later turns — a later status edits the existing plan, it does not restate it.
+
+2. **Work turns** (you are still calling tools and continuing on your own) — tool calls plus AT MOST one short status line. No tables, no summaries, no re-printed plan, and no per-command `Command` / `Purpose` / `Expected result` narration. Do NOT stop mid-task to write a polished walkthrough summary: a summary is never a substitute for continuing the work you were asked to do.
+
+3. **Yield point** (you stop and hand control back — the task is done, you are blocked on input, or you hit an error you cannot resolve) — THIS is the only place the full answer belongs:
+
+   Session Summary
+   - Files changed: ...
+   - Validation: ...
+   - Risks / follow-up: ...
+
+   Add a table where the content calls for one (file edits → `File` / `Change` / `Validation`; review findings → `Finding` / `Impact` / `Fix`). Mark completed plan items `- [x]`, and if the user asked several questions answer each one — a turn that only says "done" is a UX bug. Protocol correctness must never depend on this shape; it only makes the plan and summary text clean.
+
 ## Pipelines
 
 For complex multi-step workflows, use `run_pipeline`: name a sanctioned pipeline (e.g. `pipeline="deep_research"`) or use whatever structured arguments the tool schema exposes for composing a workflow.


### PR DESCRIPTION
## What & why

Closes #2141 — the implementation half of the coding UX contract (octoscode#585 defines the contract; this wires it into the Octos harness prompt).

A long coding task on a small local model kept ending each tool-use turn with a polished walkthrough summary **instead of continuing** the conversion — the observed llm.c failure. The fix: say in the harness system prompt that a formatted answer belongs to the **yield point**, not every turn.

## Where it lands

Investigation confirmed the octos coding session's base persona is the compiled-in `crates/octos-cli/src/prompts/gateway_default.txt` — the `coding` profile sets no `system_prompt`, so it falls back to this. There's no separate coding persona file. Its `## Coding And Shell Rules` section is already scoped to coding/debugging/repo tasks, so the contract lands there, further scoped to a **multi-step** task (so it doesn't burden one-shot Q&A).

## The three phases

1. **Task start** — ONE plan checklist, emitted once, never re-emitted.
2. **Work turns** — tool calls + at most one status line; no tables/summaries/re-printed plan/per-command narration. Explicit anti-off-ramp: *"a summary is never a substitute for continuing the work."*
3. **Yield point** (task done / blocked on input / unrecoverable error) — the full answer: `Session Summary`, tables where content calls for them, every user question answered, plan items marked `- [x]`. Includes the contract's **Ownership Boundary**: protocol correctness must never depend on the model following this shape.

octos already has a clean yield-point signal the prompt leans on: `StopReason::EndTurn` (a no-tool-call response is normalized to it, `detection.rs`) returns control; `StopReason::ToolUse` continues the loop. The contract's **Client Rendering Requirements** half stays in the octoscode TUI (its Ownership Boundary) — this PR is the server/harness half only.

## Test

`should_carry_the_three_phase_coding_output_contract` pins the load-bearing phrases (three phase headers, `Session Summary`, and the anti-off-ramp line) so an edit can't silently drop them. All 15 gateway-prompt tests pass; `cargo fmt --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
