### PR TITLE
feat(llm): AdaptiveRouter turn-pinning + per-route re-compaction + per-provider sizing (#2143)

### DIFF
--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -949,9 +949,17 @@ async fn process_chat_turn(
     history: &[Message],
     approval_requester: Arc<dyn ToolApprovalRequester>,
 ) -> Result<ConversationResponse> {
-    with_chat_approval(
-        approval_requester,
-        agent.process_message(input, history, vec![]),
+    // #2143: scope the whole turn so an AdaptiveRouter pins ONE route for it —
+    // readiness, history sizing, and the send all resolve to the same slot,
+    // instead of sizing for the conservative min-across-slots envelope. The
+    // serve/API paths already wrap their turns this way; the local `octos chat`
+    // coding harness (the local-model path these fixes target) did not.
+    octos_llm::with_router_context(
+        octos_llm::RouterContext::default(),
+        with_chat_approval(
+            approval_requester,
+            agent.process_message(input, history, vec![]),
+        ),
     )
     .await
 }

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -710,15 +710,66 @@ tokio::task_local! {
     pub static ROUTER_CONTEXT: RouterContext;
 }
 
-/// Wave4-A: run `fut` with the given `RouterContext` accessible via
-/// [`ROUTER_CONTEXT`]. The API layer wraps `run_standalone_turn`'s
-/// chat() path with this so the originating session id reaches the
-/// router's failover publisher.
+/// #2143 turn-pinning: ONE provider selection carried through a whole turn.
+///
+/// Without this, readiness/identity used the deterministic core, sizing used
+/// the conservative min-across-slots window, and the chat dispatch re-selected
+/// (stochastic probe included) — three different views of "the route" inside
+/// one turn, so a prompt was always sized for the smallest lane even when it
+/// would dispatch to a 256K primary. A turn pin resolves the selection ONCE
+/// (on the first sizing/readiness/dispatch call of the turn) and every later
+/// call in the same turn reuses it, so sizing matches the route the send
+/// actually takes.
+///
+/// Encoded in one atomic so the pin is `Send + Sync` (task-locals cross the
+/// `.await` thread boundary): `0` = unpinned; otherwise
+/// `((slot_index + 1) << 1) | (is_probe as u64)`.
+#[derive(Debug, Default)]
+pub struct TurnPin {
+    slot: std::sync::atomic::AtomicU64,
+}
+
+impl TurnPin {
+    /// Read the pinned `(slot_index, is_probe)`, or `None` when this turn has
+    /// not selected a route yet.
+    fn get(&self) -> Option<(usize, bool)> {
+        let raw = self.slot.load(Ordering::Relaxed);
+        (raw != 0).then(|| (((raw >> 1) - 1) as usize, (raw & 1) == 1))
+    }
+
+    /// Record this turn's selection. First writer wins — a later probe/read
+    /// never re-pins a turn that already chose a route.
+    fn set(&self, idx: usize, is_probe: bool) {
+        let encoded = (((idx as u64) + 1) << 1) | (is_probe as u64);
+        let _ = self
+            .slot
+            .compare_exchange(0, encoded, Ordering::Relaxed, Ordering::Relaxed);
+    }
+}
+
+tokio::task_local! {
+    /// #2143: the per-turn selection pin. Present only inside a
+    /// [`with_router_context`] scope (every real turn); absent on test/CLI
+    /// smoke paths, where the router falls back to its pre-#2143 per-call
+    /// selection and min-across-slots sizing.
+    static TURN_PIN: Arc<TurnPin>;
+}
+
+/// Snapshot the active turn pin, if a turn scope wraps the caller.
+fn current_turn_pin() -> Option<Arc<TurnPin>> {
+    TURN_PIN.try_with(Arc::clone).ok()
+}
+
+/// Wave4-A / #2143: run `fut` with the given [`RouterContext`] AND a fresh
+/// per-turn selection [`TurnPin`] in scope. The API/session layer wraps every
+/// turn's chat() path with this, so failover attribution (RouterContext) and
+/// turn-pinning (TurnPin) both cover the whole turn without new call sites.
 pub async fn with_router_context<F, T>(ctx: RouterContext, fut: F) -> T
 where
     F: std::future::Future<Output = T>,
 {
-    ROUTER_CONTEXT.scope(ctx, fut).await
+    let pin: Arc<TurnPin> = Arc::new(TurnPin::default());
+    ROUTER_CONTEXT.scope(ctx, TURN_PIN.scope(pin, fut)).await
 }
 
 /// Snapshot the active [`RouterContext`]. Returns [`RouterContext::default`]
@@ -2055,6 +2106,41 @@ impl AdaptiveRouter {
         prob < self.config.probe_probability
     }
 
+    /// #2143: the slot pinned for the current turn.
+    ///
+    /// On the FIRST sizing/readiness/dispatch call of a turn this resolves the
+    /// (possibly stochastic) selection once and pins it; every later call in
+    /// the same turn returns the same `(idx, is_probe)` so readiness, sizing,
+    /// and the send all agree on one route. Outside a turn scope (no
+    /// [`TURN_PIN`], e.g. unit tests / CLI smoke) it selects fresh per call —
+    /// the pre-#2143 behavior.
+    fn pinned_slot(&self) -> (usize, bool) {
+        let Some(pin) = current_turn_pin() else {
+            return self.select_provider();
+        };
+        if let Some(sel) = pin.get()
+            && sel.0 < self.slots.len()
+        {
+            return sel;
+        }
+        let sel = self.select_provider();
+        pin.set(sel.0, sel.1);
+        // A concurrent first-call may have won the compare-exchange; honor
+        // whoever pinned first so the turn stays on one route.
+        pin.get().filter(|s| s.0 < self.slots.len()).unwrap_or(sel)
+    }
+
+    /// The slot backing the identity accessors (`model_id`, `provider_name`,
+    /// `provider_metadata`): the turn's pinned route inside a turn, the
+    /// deterministic core outside one (#2143).
+    fn identity_slot(&self) -> usize {
+        if current_turn_pin().is_some() {
+            self.pinned_slot().0
+        } else {
+            self.select_provider_deterministic()
+        }
+    }
+
     /// Race request against two providers. Returns `Some(result)` if a race
     /// was executed, `None` if no second provider is available.
     ///
@@ -2335,7 +2421,7 @@ impl LlmProvider for AdaptiveRouter {
         // `enabled: false` configs see identical behavior (invariant #2).
         let _classifier_decision = self.classify_turn(messages);
         let mode = self.mode();
-        let (start_idx, is_probe) = self.select_provider();
+        let (start_idx, is_probe) = self.pinned_slot();
 
         debug!(
             selected = self.slots[start_idx].provider.provider_name(),
@@ -2434,7 +2520,7 @@ impl LlmProvider for AdaptiveRouter {
     ) -> Result<ChatStream> {
         // Classify the turn before lane selection (see invariant #5 above).
         let _classifier_decision = self.classify_turn(messages);
-        let (start_idx, _is_probe) = self.select_provider();
+        let (start_idx, _is_probe) = self.pinned_slot();
         let fail_fast = crate::current_llm_call_policy() == crate::LlmCallPolicy::FailFast;
 
         // Wave4-A: failover elapsed-time anchor — see equivalent comment
@@ -2502,14 +2588,19 @@ impl LlmProvider for AdaptiveRouter {
         }
     }
 
-    // #2135 round-6 P1: the sizing accessors take the MINIMUM across all
-    // slots — selection-INDEPENDENT and safe for every route this router
-    // can take (Lane-mode stochastic probes, hedged sends, failover): a
-    // prompt sized for a probed 256K local primary must not reach a 32K
-    // lane. Per-route resizing at dispatch is the precise fix and belongs
-    // to the router itself; until then the conservative envelope is the
-    // pre-probe catalog behavior restored, minus its staleness.
+    // #2143: INSIDE a turn (a [`TURN_PIN`] scope) the sizing/readiness/identity
+    // accessors all resolve to the ONE slot pinned for that turn, so a prompt
+    // is sized for the exact route the send will take — the precise per-route
+    // fix the #2135 round-6 comment deferred. OUTSIDE a turn (unit tests / CLI
+    // smoke, no pin) they keep the pre-#2143 behavior: sizing takes the
+    // conservative MIN across slots (safe for any route the router might pick)
+    // and identity/readiness use the deterministic core (no stochastic probe
+    // decides which model preloads).
     fn context_window(&self) -> u32 {
+        if current_turn_pin().is_some() {
+            let (idx, _) = self.pinned_slot();
+            return self.slots[idx].provider.context_window();
+        }
         self.slots
             .iter()
             .map(|slot| slot.provider.context_window())
@@ -2518,6 +2609,10 @@ impl LlmProvider for AdaptiveRouter {
     }
 
     fn max_output_tokens(&self) -> u32 {
+        if current_turn_pin().is_some() {
+            let (idx, _) = self.pinned_slot();
+            return self.slots[idx].provider.max_output_tokens();
+        }
         self.slots
             .iter()
             .map(|slot| slot.provider.max_output_tokens())
@@ -2526,34 +2621,33 @@ impl LlmProvider for AdaptiveRouter {
     }
 
     async fn ensure_ready(&self) {
-        // Readiness preps the lane the router would DETERMINISTICALLY
-        // prefer (best score, no stochastic exploration — #2135 round-6
-        // P1): readiness may preload, and a coin-flipped lane must not
-        // decide which model gets loaded into memory.
-        let idx = self.select_provider_deterministic();
+        // In a turn: ready EXACTLY the pinned route (the one sizing + the send
+        // will use). Outside a turn: the deterministic core, so a coin-flipped
+        // lane never decides which model gets preloaded (#2135 round-6 P1).
+        let idx = if current_turn_pin().is_some() {
+            self.pinned_slot().0
+        } else {
+            self.select_provider_deterministic()
+        };
         self.slots[idx].provider.ensure_ready().await;
     }
 
     fn model_id(&self) -> &str {
-        self.slots[self.select_provider_deterministic()]
-            .provider
-            .model_id()
+        self.slots[self.identity_slot()].provider.model_id()
     }
 
     fn provider_name(&self) -> &str {
-        self.slots[self.select_provider_deterministic()]
-            .provider
-            .provider_name()
+        self.slots[self.identity_slot()].provider.provider_name()
     }
 
     fn provider_metadata(&self) -> ProviderMetadata {
-        self.slots[self.select_provider_deterministic()]
+        self.slots[self.identity_slot()]
             .provider
             .provider_metadata()
     }
 
     fn provider_metadata_for_index(&self, provider_index: Option<usize>) -> ProviderMetadata {
-        let idx = provider_index.unwrap_or_else(|| self.select_provider().0);
+        let idx = provider_index.unwrap_or_else(|| self.pinned_slot().0);
         self.slots
             .get(idx)
             .map(|slot| slot.provider.provider_metadata())
@@ -2565,7 +2659,7 @@ impl LlmProvider for AdaptiveRouter {
     }
 
     fn report_late_failure(&self) {
-        let (idx, _) = self.select_provider();
+        let (idx, _) = self.pinned_slot();
         self.slots[idx].metrics.record_failure();
         let consec = self.slots[idx]
             .metrics

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -2274,15 +2274,26 @@ impl AdaptiveRouter {
         // slot's metrics (not the provider's fault; the circuit breaker
         // must not open over prompt size) — failover treats it like any
         // other error and moves to a lane that fits.
-        if !crate::context::route_fits_request(&self.slots[idx].provider, messages, tools).await {
-            return Err(eyre::eyre!(
-                "route {} skipped: request does not fit its context window ({} tokens)",
-                self.slots[idx].provider.provider_name(),
-                self.slots[idx].provider.context_window()
-            ));
-        }
+        // #2143 part 2: fit-or-refit-or-skip. When the request doesn't fit this
+        // route, try a per-route re-compaction before giving up on the lane.
+        let decision =
+            crate::context::decide_route(&self.slots[idx].provider, messages, tools).await;
+        let send_messages: &[Message] = match &decision {
+            crate::context::RouteDecision::Fits => messages,
+            crate::context::RouteDecision::Refit(refit) => refit,
+            crate::context::RouteDecision::Skip => {
+                return Err(eyre::eyre!(
+                    "route {} skipped: request does not fit its context window ({} tokens)",
+                    self.slots[idx].provider.provider_name(),
+                    self.slots[idx].provider.context_window()
+                ));
+            }
+        };
         let start = Instant::now();
-        let result = self.slots[idx].provider.chat(messages, tools, config).await;
+        let result = self.slots[idx]
+            .provider
+            .chat(send_messages, tools, config)
+            .await;
         let elapsed_us = start.elapsed().as_micros() as u64;
 
         match &result {
@@ -2369,17 +2380,24 @@ impl AdaptiveRouter {
         // slot's metrics (not the provider's fault; the circuit breaker
         // must not open over prompt size) — failover treats it like any
         // other error and moves to a lane that fits.
-        if !crate::context::route_fits_request(&self.slots[idx].provider, messages, tools).await {
-            return Err(eyre::eyre!(
-                "route {} skipped: request does not fit its context window ({} tokens)",
-                self.slots[idx].provider.provider_name(),
-                self.slots[idx].provider.context_window()
-            ));
-        }
+        // #2143 part 2: fit-or-refit-or-skip (see try_chat).
+        let decision =
+            crate::context::decide_route(&self.slots[idx].provider, messages, tools).await;
+        let send_messages: &[Message] = match &decision {
+            crate::context::RouteDecision::Fits => messages,
+            crate::context::RouteDecision::Refit(refit) => refit,
+            crate::context::RouteDecision::Skip => {
+                return Err(eyre::eyre!(
+                    "route {} skipped: request does not fit its context window ({} tokens)",
+                    self.slots[idx].provider.provider_name(),
+                    self.slots[idx].provider.context_window()
+                ));
+            }
+        };
         let start = Instant::now();
         let result = self.slots[idx]
             .provider
-            .chat_stream(messages, tools, config)
+            .chat_stream(send_messages, tools, config)
             .await;
         let elapsed_us = start.elapsed().as_micros() as u64;
 

--- a/crates/octos-llm/src/adaptive_tests.rs
+++ b/crates/octos-llm/src/adaptive_tests.rs
@@ -2508,6 +2508,79 @@ async fn test_sizing_is_min_across_slots_and_identity_is_deterministic() {
     assert_eq!(first, "m1", "cold identical slots must select the primary");
 }
 
+/// #2143 part 1: INSIDE a turn scope, the sizing accessors resolve to the ONE
+/// pinned route's window (not the conservative min), and the pin is stable for
+/// the whole turn — so a prompt is sized for the exact route the send takes.
+#[tokio::test]
+async fn turn_pin_sizes_for_the_pinned_route_not_the_min() {
+    let big: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+        Arc::new(MockProvider {
+            name: "primary",
+            model: "m1",
+            latency_ms: 0,
+            fail: false,
+            error_msg: "",
+        }),
+        262_144,
+    ));
+    let small: Arc<dyn LlmProvider> = Arc::new(crate::ContextWindowOverride::new(
+        Arc::new(MockProvider {
+            name: "fallback",
+            model: "m2",
+            latency_ms: 0,
+            fail: false,
+            error_msg: "",
+        }),
+        32_768,
+    ));
+    let router = Arc::new(AdaptiveRouter::new(
+        vec![big, small],
+        &[],
+        AdaptiveConfig {
+            // No stochastic probe so the pin resolves to the deterministic
+            // primary and the assertion is stable.
+            probe_probability: 0.0,
+            ..Default::default()
+        },
+    ));
+
+    // Outside a turn: the pre-#2143 conservative min-across-slots envelope.
+    assert_eq!(
+        router.context_window(),
+        32_768,
+        "unpinned sizing is the min"
+    );
+
+    // Inside a turn: pinned to the deterministic primary → its full window,
+    // stable across repeated sizing/identity calls.
+    let r = router.clone();
+    with_router_context(RouterContext::default(), async move {
+        assert_eq!(
+            r.context_window(),
+            262_144,
+            "turn sizing must use the pinned route's window"
+        );
+        for _ in 0..10 {
+            assert_eq!(
+                r.context_window(),
+                262_144,
+                "the pin is stable for the turn"
+            );
+        }
+        assert_eq!(r.max_output_tokens(), r.max_output_tokens());
+        assert_eq!(r.model_id(), "m1", "identity resolves to the pinned route");
+        r.ensure_ready().await;
+    })
+    .await;
+
+    // A fresh turn re-resolves the pin (no leakage across turns).
+    let r2 = router.clone();
+    with_router_context(RouterContext::default(), async move {
+        assert_eq!(r2.context_window(), 262_144);
+    })
+    .await;
+}
+
 /// #2135 round-8 P1: every adaptive dispatch passes the route-fit guard —
 /// a lane that resolves too small at dispatch is skipped (its chat never
 /// invoked), failover serves from a fitting lane, and the skip must NOT

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -287,6 +287,25 @@ impl LlmProvider for AnthropicProvider {
         Ok(Box::pin(event_stream))
     }
 
+    fn estimate_request_tokens(
+        &self,
+        messages: &[Message],
+        tools: &[crate::types::ToolSpec],
+    ) -> u32 {
+        // #2143 part 3: the base estimate (messages + tool schemas) plus the
+        // Anthropic request-envelope overhead the flat estimator omits — each
+        // message is wrapped in a content-block array, system parts are lifted
+        // into a separate top-level `system` array, and cache_control
+        // breakpoints / tool_choice / metadata ride along. Conservative fixed
+        // additions (they only ever OVER-count, so the route-fit guard never
+        // under-estimates and lets an oversized request through).
+        let base = crate::context::estimate_request_tokens_base(messages, tools);
+        let per_message_framing = messages.len() as u32 * 4;
+        const REQUEST_ENVELOPE_OVERHEAD: u32 = 24;
+        base.saturating_add(per_message_framing)
+            .saturating_add(REQUEST_ENVELOPE_OVERHEAD)
+    }
+
     fn model_id(&self) -> &str {
         &self.model
     }

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -311,6 +311,13 @@ async fn mechanical_route_refit(
     if sys_end >= last {
         return None; // only system + one turn; nothing to drop
     }
+    // Orphan-safety depends on octos's invariant that a tool_result sits in the
+    // contiguous block immediately after its assistant tool_call (see
+    // message_repair::synthesize_missing_tool_results): because the only
+    // dropped span is the contiguous middle `[sys_end, split)` and the kept
+    // tail never STARTS on a Tool message, a kept tool_result's call is always
+    // kept too. If a future change interleaves a non-tool message between a
+    // call and its result, this guard would need to widen.
     let mut split = sys_end + 1;
     while split < last {
         // Never begin the kept tail on a tool result — its assistant call may
@@ -322,6 +329,24 @@ async fn mechanical_route_refit(
         let mut candidate: Vec<octos_core::Message> = messages[..sys_end].to_vec();
         candidate.extend_from_slice(&messages[split..]);
         if route_fits_request(provider, &candidate, tools).await {
+            // #2143 review (item 4): re-fitting silently drops history — the
+            // model answers from a truncated conversation and the old "route
+            // skipped" error is suppressed. Surface it so operators can see the
+            // context loss (which route, how much dropped) instead of it being
+            // invisible.
+            let dropped = messages.len().saturating_sub(candidate.len());
+            tracing::debug!(
+                provider = provider.provider_name(),
+                window = provider.context_window(),
+                messages_dropped = dropped,
+                kept = candidate.len(),
+                "route re-fit: trimmed conversation history to fit a smaller route"
+            );
+            metrics::counter!(
+                "octos_route_refit_total",
+                "provider" => provider.provider_name().to_string()
+            )
+            .increment(1);
             return Some(candidate);
         }
         split += 1;

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -228,6 +228,24 @@ pub(crate) fn estimate_tool_tokens(tool: &crate::types::ToolSpec) -> u32 {
         + 8 // serialization scaffolding per tool
 }
 
+/// Provider-agnostic base request-size estimate (#2143 part 3): messages plus
+/// serialized tool declarations. This is what the route-fit guard summed
+/// inline before #2143; it is now the DEFAULT body of
+/// [`crate::provider::LlmProvider::estimate_request_tokens`], which concrete
+/// providers override to add their own request-envelope overhead (a separate
+/// system block, per-message content-block framing, cache-control metadata)
+/// that this base does not model.
+pub fn estimate_request_tokens_base(
+    messages: &[octos_core::Message],
+    tools: &[crate::types::ToolSpec],
+) -> u32 {
+    messages
+        .iter()
+        .map(estimate_message_tokens)
+        .chain(tools.iter().map(estimate_tool_tokens))
+        .sum()
+}
+
 /// Route-fit guard for failover/fallback dispatch (#2135 rounds 7-8, P1):
 /// before re-sending an UNCHANGED request to an alternate route, resolve
 /// that route's readiness (a lazily-probed local provider may still be
@@ -246,11 +264,11 @@ pub(crate) async fn route_fits_request(
 ) -> bool {
     provider.ensure_ready().await;
     let window = provider.context_window();
-    let estimated: u32 = messages
-        .iter()
-        .map(estimate_message_tokens)
-        .chain(tools.iter().map(estimate_tool_tokens))
-        .sum();
+    // #2143 part 3: ask the provider itself, so its request-envelope overhead
+    // (system-block framing, per-message metadata) is counted instead of only
+    // approximated by the margin below. The default impl is the base estimate,
+    // so unspecialized providers behave exactly as before.
+    let estimated = provider.estimate_request_tokens(messages, tools);
     let margin = (window / 8).clamp(64, 1024);
     estimated <= window.saturating_sub(margin)
 }
@@ -297,6 +315,78 @@ mod tests {
         assert!(
             !route_fits_request(&provider, &msg, &[fat_tool]).await,
             "tool schema must count against the window"
+        );
+    }
+
+    /// #2143 part 3: the route-fit guard asks the PROVIDER for the request size,
+    /// so a provider's request-envelope overhead is counted — and the override
+    /// must survive the RetryProvider + ContextWindowOverride wrappers the
+    /// router dispatches through (delegation).
+    #[tokio::test]
+    async fn route_fit_uses_provider_request_estimate_through_wrappers() {
+        use std::sync::Arc;
+        struct Heavy;
+        #[async_trait::async_trait]
+        impl crate::provider::LlmProvider for Heavy {
+            async fn chat(
+                &self,
+                _m: &[octos_core::Message],
+                _t: &[crate::types::ToolSpec],
+                _c: &crate::config::ChatConfig,
+            ) -> eyre::Result<crate::types::ChatResponse> {
+                unreachable!()
+            }
+            fn model_id(&self) -> &str {
+                "heavy"
+            }
+            fn provider_name(&self) -> &str {
+                "local"
+            }
+            fn estimate_request_tokens(
+                &self,
+                messages: &[octos_core::Message],
+                tools: &[crate::types::ToolSpec],
+            ) -> u32 {
+                // A big request envelope the flat estimator would miss.
+                estimate_request_tokens_base(messages, tools) + 3_000
+            }
+        }
+        struct Light;
+        #[async_trait::async_trait]
+        impl crate::provider::LlmProvider for Light {
+            async fn chat(
+                &self,
+                _m: &[octos_core::Message],
+                _t: &[crate::types::ToolSpec],
+                _c: &crate::config::ChatConfig,
+            ) -> eyre::Result<crate::types::ChatResponse> {
+                unreachable!()
+            }
+            fn model_id(&self) -> &str {
+                "light"
+            }
+            fn provider_name(&self) -> &str {
+                "local"
+            }
+        }
+        let msg = [octos_core::Message::user("hi")];
+        // Window 2000: the tiny message alone would fit, but Heavy's +3000
+        // envelope pushes the request over — proving the estimate reaches the
+        // guard through RetryProvider(ContextWindowOverride(..)).
+        let heavy: Arc<dyn crate::provider::LlmProvider> = Arc::new(crate::RetryProvider::new(
+            Arc::new(crate::ContextWindowOverride::new(Arc::new(Heavy), 2_000)),
+        ));
+        assert!(
+            !route_fits_request(&heavy, &msg, &[]).await,
+            "the provider's request-envelope estimate must count through the wrappers"
+        );
+        // Control: the default (base-only) provider fits the same window.
+        let light: Arc<dyn crate::provider::LlmProvider> = Arc::new(crate::RetryProvider::new(
+            Arc::new(crate::ContextWindowOverride::new(Arc::new(Light), 2_000)),
+        ));
+        assert!(
+            route_fits_request(&light, &msg, &[]).await,
+            "a base-estimate provider still fits"
         );
     }
 

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -246,6 +246,137 @@ pub fn estimate_request_tokens_base(
         .sum()
 }
 
+/// #2143 part 2: turn-scoped cooperation so the router can RE-COMPACT a
+/// conversation for a specific route instead of SKIPPING it.
+///
+/// A router wrapper cannot re-compact on its own — it has no
+/// tool-result-placeholder / summary logic — so the prompt-construction layer
+/// can inject a richer resizer for the turn via [`with_route_resizer`]. When
+/// none is injected the router falls back to [`mechanical_route_refit`], a
+/// safe best-effort trim. An implementation MUST return a message set that
+/// preserves the provider-required tool_call/tool_result pairing, or `None` to
+/// leave the route skipped (the pre-#2143 behavior).
+#[async_trait::async_trait]
+pub trait RouteResizer: Send + Sync {
+    /// Re-fit `messages` to `window` tokens for one route, or `None` if it
+    /// cannot.
+    async fn refit(
+        &self,
+        messages: &[octos_core::Message],
+        window: u32,
+    ) -> Option<Vec<octos_core::Message>>;
+}
+
+tokio::task_local! {
+    /// #2143 part 2: the optional turn-scoped route resizer. Absent by default
+    /// (the built-in mechanical refit is used); the session layer may inject a
+    /// full-compaction resizer for the turn.
+    static ROUTE_RESIZER: std::sync::Arc<dyn RouteResizer>;
+}
+
+/// Run `fut` with `resizer` available to the router's per-route re-fit
+/// (#2143 part 2). Nest inside a turn scope alongside `with_router_context`.
+pub async fn with_route_resizer<F, T>(resizer: std::sync::Arc<dyn RouteResizer>, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    ROUTE_RESIZER.scope(resizer, fut).await
+}
+
+fn current_route_resizer() -> Option<std::sync::Arc<dyn RouteResizer>> {
+    ROUTE_RESIZER.try_with(std::sync::Arc::clone).ok()
+}
+
+/// Best-effort mechanical re-fit of a conversation to a route's window
+/// (#2143 part 2). Drops the OLDEST history — always keeping the leading
+/// system message(s), never starting the kept tail on a `Tool` message (which
+/// would orphan a tool result from its assistant `tool_call`), and always
+/// keeping the final message (the current turn) — until the request fits or
+/// nothing more can be dropped. Deliberately simpler than full compaction (no
+/// summaries/placeholders); a richer resizer can be injected via
+/// [`with_route_resizer`]. Returns `None` when it cannot make the request fit,
+/// so the route is skipped exactly as before.
+async fn mechanical_route_refit(
+    provider: &std::sync::Arc<dyn crate::provider::LlmProvider>,
+    messages: &[octos_core::Message],
+    tools: &[crate::types::ToolSpec],
+) -> Option<Vec<octos_core::Message>> {
+    use octos_core::MessageRole;
+    let last = messages.len().checked_sub(1)?;
+    // Leading system messages are always kept.
+    let sys_end = messages
+        .iter()
+        .position(|m| m.role != MessageRole::System)
+        .unwrap_or(0);
+    if sys_end >= last {
+        return None; // only system + one turn; nothing to drop
+    }
+    let mut split = sys_end + 1;
+    while split < last {
+        // Never begin the kept tail on a tool result — its assistant call may
+        // have been in the dropped prefix.
+        if messages[split].role == MessageRole::Tool {
+            split += 1;
+            continue;
+        }
+        let mut candidate: Vec<octos_core::Message> = messages[..sys_end].to_vec();
+        candidate.extend_from_slice(&messages[split..]);
+        if route_fits_request(provider, &candidate, tools).await {
+            return Some(candidate);
+        }
+        split += 1;
+    }
+    None
+}
+
+/// #2143 part 2: when the request does not fit `provider`, ask the turn-scoped
+/// [`RouteResizer`] (or the built-in mechanical refit) to re-compact for the
+/// route's window, returning the refitted messages IFF they now actually fit.
+/// `None` means "skip this route" — the pre-#2143 behavior.
+pub(crate) async fn refit_for_route(
+    provider: &std::sync::Arc<dyn crate::provider::LlmProvider>,
+    messages: &[octos_core::Message],
+    tools: &[crate::types::ToolSpec],
+) -> Option<Vec<octos_core::Message>> {
+    if let Some(resizer) = current_route_resizer() {
+        let window = provider.context_window();
+        if let Some(refit) = resizer.refit(messages, window).await
+            && route_fits_request(provider, &refit, tools).await
+        {
+            return Some(refit);
+        }
+    }
+    mechanical_route_refit(provider, messages, tools).await
+}
+
+/// The dispatch decision for one route (#2143 part 2).
+pub(crate) enum RouteDecision {
+    /// The request fits as-is; dispatch the original messages.
+    Fits,
+    /// The request was re-fitted for this route; dispatch these instead.
+    Refit(Vec<octos_core::Message>),
+    /// The route cannot serve this request even after a re-fit; skip it.
+    Skip,
+}
+
+/// Decide how to dispatch `messages` to `provider` (#2143 part 2): send as-is
+/// if they fit, re-fit for this route if a resizer (or the mechanical refit)
+/// can make them fit, else skip. This replaces the pre-#2143 fit-or-skip guard
+/// at the dispatch funnel.
+pub(crate) async fn decide_route(
+    provider: &std::sync::Arc<dyn crate::provider::LlmProvider>,
+    messages: &[octos_core::Message],
+    tools: &[crate::types::ToolSpec],
+) -> RouteDecision {
+    if route_fits_request(provider, messages, tools).await {
+        return RouteDecision::Fits;
+    }
+    match refit_for_route(provider, messages, tools).await {
+        Some(refit) => RouteDecision::Refit(refit),
+        None => RouteDecision::Skip,
+    }
+}
+
 /// Route-fit guard for failover/fallback dispatch (#2135 rounds 7-8, P1):
 /// before re-sending an UNCHANGED request to an alternate route, resolve
 /// that route's readiness (a lazily-probed local provider may still be
@@ -387,6 +518,97 @@ mod tests {
         assert!(
             route_fits_request(&light, &msg, &[]).await,
             "a base-estimate provider still fits"
+        );
+    }
+
+    /// #2143 part 2: a route the FULL history overflows is re-fitted (oldest
+    /// turns dropped, system + recent kept) and SERVED, instead of skipped.
+    #[tokio::test]
+    async fn decide_route_refits_when_trimming_makes_it_fit() {
+        use octos_core::{Message, MessageRole};
+        use std::sync::Arc;
+        struct Tiny;
+        #[async_trait::async_trait]
+        impl crate::provider::LlmProvider for Tiny {
+            async fn chat(
+                &self,
+                _m: &[Message],
+                _t: &[crate::types::ToolSpec],
+                _c: &crate::config::ChatConfig,
+            ) -> eyre::Result<crate::types::ChatResponse> {
+                unreachable!()
+            }
+            fn model_id(&self) -> &str {
+                "tiny"
+            }
+            fn provider_name(&self) -> &str {
+                "local"
+            }
+        }
+        let provider: Arc<dyn crate::provider::LlmProvider> =
+            Arc::new(crate::ContextWindowOverride::new(Arc::new(Tiny), 2_000));
+        let big = "x".repeat(4_000); // ~1000 tokens each
+        let messages = vec![
+            Message::system("system prompt"),
+            Message::user(&big),
+            Message::assistant(&big),
+            Message::user("what changed?"), // small, recent
+        ];
+        // Whole history overflows 2000 tokens; dropping the two big old turns
+        // leaves system + the recent user turn, which fits.
+        match decide_route(&provider, &messages, &[]).await {
+            RouteDecision::Refit(refit) => {
+                assert!(refit.len() < messages.len(), "refit drops old history");
+                assert_eq!(refit[0].role, MessageRole::System, "system is preserved");
+                assert_eq!(
+                    refit.last().unwrap().content,
+                    "what changed?",
+                    "the current turn is preserved"
+                );
+                assert!(
+                    route_fits_request(&provider, &refit, &[]).await,
+                    "the refit actually fits the route"
+                );
+            }
+            RouteDecision::Fits => panic!("full history should not fit a 2000-token window"),
+            RouteDecision::Skip => panic!("a trimmable history must refit, not skip"),
+        }
+    }
+
+    /// #2143 part 2: a single message that alone overflows the window cannot be
+    /// re-fit, so the route is still SKIPPED (no regression, no orphaning).
+    #[tokio::test]
+    async fn decide_route_skips_when_the_tail_alone_overflows() {
+        use octos_core::Message;
+        use std::sync::Arc;
+        struct Tiny;
+        #[async_trait::async_trait]
+        impl crate::provider::LlmProvider for Tiny {
+            async fn chat(
+                &self,
+                _m: &[Message],
+                _t: &[crate::types::ToolSpec],
+                _c: &crate::config::ChatConfig,
+            ) -> eyre::Result<crate::types::ChatResponse> {
+                unreachable!()
+            }
+            fn model_id(&self) -> &str {
+                "tiny"
+            }
+            fn provider_name(&self) -> &str {
+                "local"
+            }
+        }
+        let provider: Arc<dyn crate::provider::LlmProvider> =
+            Arc::new(crate::ContextWindowOverride::new(Arc::new(Tiny), 2_000));
+        let huge = "x".repeat(40_000); // ~10k tokens, the current turn itself
+        let messages = vec![Message::system("s"), Message::user(&huge)];
+        assert!(
+            matches!(
+                decide_route(&provider, &messages, &[]).await,
+                RouteDecision::Skip
+            ),
+            "an unshrinkable request must skip the route, not orphan or overflow"
         );
     }
 

--- a/crates/octos-llm/src/context_override.rs
+++ b/crates/octos-llm/src/context_override.rs
@@ -52,6 +52,16 @@ impl LlmProvider for ContextWindowOverride {
         self.window
     }
 
+    fn estimate_request_tokens(
+        &self,
+        messages: &[Message],
+        tools: &[crate::types::ToolSpec],
+    ) -> u32 {
+        // #2143 part 3: delegate so a concrete provider's request-size override
+        // survives this wrapper (mirrors context_window delegation).
+        self.inner.estimate_request_tokens(messages, tools)
+    }
+
     fn model_id(&self) -> &str {
         self.inner.model_id()
     }

--- a/crates/octos-llm/src/local_context_probe.rs
+++ b/crates/octos-llm/src/local_context_probe.rs
@@ -708,6 +708,16 @@ impl LlmProvider for LocalContextProbe {
         self.inner.max_output_tokens()
     }
 
+    fn estimate_request_tokens(
+        &self,
+        messages: &[Message],
+        tools: &[crate::types::ToolSpec],
+    ) -> u32 {
+        // #2143 part 3: delegate so the inner provider's request-size override
+        // reaches the route-fit guard through the probe wrapper.
+        self.inner.estimate_request_tokens(messages, tools)
+    }
+
     fn model_id(&self) -> &str {
         self.inner.model_id()
     }

--- a/crates/octos-llm/src/provider.rs
+++ b/crates/octos-llm/src/provider.rs
@@ -69,6 +69,24 @@ pub trait LlmProvider: Send + Sync {
         context::max_output_tokens(self.model_id())
     }
 
+    /// #2143 part 3: estimate the token size of the REQUEST this provider would
+    /// build from `messages` + `tools`, INCLUDING provider-specific
+    /// serialization overhead (a separate system block, per-message
+    /// content-block framing, cache-control metadata) that the flat estimator
+    /// omits. The route-fit guard calls this instead of summing messages/tools
+    /// itself, so the ~12.5% safety margin no longer has to stand in for that
+    /// overhead. The default is the provider-agnostic base estimate; concrete
+    /// providers override to tighten it, and WRAPPERS DELEGATE to their inner
+    /// provider so the override survives the RetryProvider / context-override /
+    /// local-probe stack the router dispatches through.
+    fn estimate_request_tokens(
+        &self,
+        messages: &[Message],
+        tools: &[crate::types::ToolSpec],
+    ) -> u32 {
+        context::estimate_request_tokens_base(messages, tools)
+    }
+
     /// Get the model identifier.
     fn model_id(&self) -> &str;
 

--- a/crates/octos-llm/src/retry.rs
+++ b/crates/octos-llm/src/retry.rs
@@ -408,6 +408,16 @@ impl LlmProvider for RetryProvider {
         self.inner.context_window()
     }
 
+    fn estimate_request_tokens(
+        &self,
+        messages: &[Message],
+        tools: &[crate::types::ToolSpec],
+    ) -> u32 {
+        // #2143 part 3: delegate so a concrete provider's request-size override
+        // survives this wrapper (mirrors context_window delegation).
+        self.inner.estimate_request_tokens(messages, tools)
+    }
+
     fn max_output_tokens(&self) -> u32 {
         self.inner.max_output_tokens()
     }


### PR DESCRIPTION
## What & why

Closes #2143 — the full three-part change. Follows the merged #2135 (probed context windows), whose wrapper-level solution was deliberately conservative. The root problem: **all sizing/compaction ran against the min-across-slots window *before* any route was selected**, and the actual route was chosen only at dispatch — three different views of "the route" inside one turn.

Landed as three reviewable commits.

### Part 1 — turn-pinning (`e27d8385`)
A per-turn selection **pin** (an atomic-encoded `(slot, is_probe)` carried as a task-local, folded into the existing `with_router_context` so every already-wrapped turn gets it for free) resolves the selection **once** on the first sizing/readiness/dispatch call and every later call in the turn reuses it. `context_window` / `max_output_tokens` / `ensure_ready` / identity / `chat` / `chat_stream` all route through `pinned_slot()` inside a turn, so a prompt is sized for the exact route the send takes. **Outside** a turn (unit tests, CLI smoke) they keep the pre-#2143 behavior (min sizing, deterministic identity), so the min-across-slots invariant test still holds. The local `octos chat` coding harness — the local-model path these fixes target — didn't wrap its turns, so `process_chat_turn` now scopes each turn (the serve/API paths already did).

### Part 2 — per-route re-compaction (`c7324580`)
With part 1 the pinned route is sized correctly, so the remaining gap is **failover** to a smaller lane, where the dispatch guard used to just **skip**. The issue notes a router wrapper can't re-compact on its own, so this adds a turn-scoped **`RouteResizer`** hook (`context::with_route_resizer`) the session layer *may* inject, plus a safe built-in default when none is: `mechanical_route_refit` drops the oldest history — always keeping the leading system message(s), never orphaning a tool result from its assistant `tool_call`, always keeping the current turn — until it fits, or returns `None` to skip as before. **It touches no persistent compaction state**, so there's zero risk of corrupting a session's generation. The dispatch funnel now decides fit-or-refit-or-skip via `decide_route`.

### Part 3 — per-provider request-size accounting (`c05b4a2f`)
The route-fit guard summed messages+tools with a flat estimator and leaned on a ~12.5% margin to stand in for provider serialization overhead. Add an `estimate_request_tokens` trait method (default = the old base estimate, so no behavior change) that concrete providers override; `route_fits_request` asks the provider; the dispatch-path wrappers (Retry / ContextWindowOverride / LocalContextProbe) delegate so the override survives the stack (mirroring #2135's `context_window` delegation). `AnthropicProvider` ships the reference override; the margin stays as the residual buffer.

## Reviewer notes

- **Part 2 default vs injection:** the mechanical refit is intentionally simpler than full compaction (no summaries/placeholders) — chosen because it's *stateless and safe*. The `RouteResizer` trait is the seam for a richer prompt-layer resizer later, without touching this PR.
- **Behavioral change:** a lane the full history overflows may now be *served* (re-fitted) where it was previously skipped — the intended part-2 fix. A genuinely unshrinkable request still skips.
- **Part 3 overhead constants** (Anthropic per-message framing + envelope) are conservative heuristics that only ever over-count; the hook is the substantive part, precise tokenization can plug in later.

## Tests

- `turn_pin_sizes_for_the_pinned_route_not_the_min` — inside a turn, sizing uses the pinned route's window and is stable; a fresh turn re-resolves.
- `decide_route_refits_when_trimming_makes_it_fit` / `decide_route_skips_when_the_tail_alone_overflows`.
- `route_fit_uses_provider_request_estimate_through_wrappers`.
- All existing invariants hold: `test_sizing_is_min_across_slots_and_identity_is_deterministic`, `test_unfit_lane_is_skipped_without_breaker_pollution`, `should_count_tool_schemas_in_route_fit`.

`cargo test -p octos-llm -p octos-agent -p octos-cli` green; `fmt` + `clippy` (incl. matrix-feature) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
