### PR TITLE
fix(llm): don't cap streaming responses with the total request timeout (#2170)

### DIFF
--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -22,6 +22,10 @@ use crate::types::{
 /// Anthropic Claude provider.
 pub struct AnthropicProvider {
     client: Client,
+    /// Separate client for streaming requests, built without a total request
+    /// timeout so a healthy long generation is never cut off mid-stream. See
+    /// [`crate::provider::build_streaming_http_client`].
+    stream_client: Client,
     api_key: SecretString,
     model: String,
     base_url: String,
@@ -69,6 +73,9 @@ impl AnthropicProvider {
                 crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
                 crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
             ),
+            stream_client: crate::provider::build_streaming_http_client(
+                crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
+            ),
             api_key: SecretString::from(api_key.into()),
             model: model.into(),
             base_url: "https://api.anthropic.com".to_string(),
@@ -91,8 +98,14 @@ impl AnthropicProvider {
     }
 
     /// Replace the HTTP client with one using custom timeouts (in seconds).
+    ///
+    /// `timeout_secs` is the **total** request timeout for non-streaming
+    /// requests. The streaming client is rebuilt only with the connect timeout —
+    /// it never takes a total timeout, so a long streamed generation is not
+    /// capped regardless of this value.
     pub fn with_http_timeout(mut self, timeout_secs: u64, connect_timeout_secs: u64) -> Self {
         self.client = crate::provider::build_http_client(timeout_secs, connect_timeout_secs);
+        self.stream_client = crate::provider::build_streaming_http_client(connect_timeout_secs);
         self
     }
 
@@ -252,8 +265,11 @@ impl LlmProvider for AnthropicProvider {
             .ok_or_else(|| eyre::eyre!("failed to build Anthropic request body"))?
             .insert("stream".into(), true.into());
 
+        // Stream client: no total timeout, so a long healthy generation is not
+        // cut off. Stalls are bounded by the client's per-read timeout and the
+        // agent's stream-timeout guards (see build_streaming_http_client).
         let response = self
-            .client
+            .stream_client
             .post(format!("{}/v1/messages", self.base_url))
             .header("x-api-key", self.api_key.expose_secret())
             .header("anthropic-version", "2023-06-01")

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -78,6 +78,10 @@ enum GeminiAuth {
 /// Google Gemini provider.
 pub struct GeminiProvider {
     client: Client,
+    /// Separate client for streaming requests, built without a total request
+    /// timeout so a healthy long generation is never cut off mid-stream. See
+    /// [`crate::provider::build_streaming_http_client`].
+    stream_client: Client,
     auth: GeminiAuth,
     model: String,
     base_url: String,
@@ -89,6 +93,9 @@ impl GeminiProvider {
         Self {
             client: crate::provider::build_http_client(
                 crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
+                crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
+            ),
+            stream_client: crate::provider::build_streaming_http_client(
                 crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
             ),
             auth: GeminiAuth::ApiKey(SecretString::from(api_key.into())),
@@ -107,6 +114,9 @@ impl GeminiProvider {
         Self {
             client: crate::provider::build_http_client(
                 crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
+                crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
+            ),
+            stream_client: crate::provider::build_streaming_http_client(
                 crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
             ),
             auth: GeminiAuth::Vertex {
@@ -164,8 +174,14 @@ impl GeminiProvider {
     }
 
     /// Replace the HTTP client with one using custom timeouts (in seconds).
+    ///
+    /// `timeout_secs` is the **total** request timeout for non-streaming
+    /// requests. The streaming client is rebuilt only with the connect timeout —
+    /// it never takes a total timeout, so a long streamed generation is not
+    /// capped regardless of this value.
     pub fn with_http_timeout(mut self, timeout_secs: u64, connect_timeout_secs: u64) -> Self {
         self.client = crate::provider::build_http_client(timeout_secs, connect_timeout_secs);
+        self.stream_client = crate::provider::build_streaming_http_client(connect_timeout_secs);
         self
     }
 
@@ -295,8 +311,11 @@ impl LlmProvider for GeminiProvider {
 
         let url = self.build_url(true);
 
+        // Stream client: no total timeout, so a long healthy generation is not
+        // cut off. Stalls are bounded by the client's per-read timeout and the
+        // agent's stream-timeout guards (see build_streaming_http_client).
         let req = self
-            .client
+            .stream_client
             .post(&url)
             .header("Content-Type", "application/json")
             .json(&request);

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -240,6 +240,10 @@ fn tool_call_arguments_to_wire(arguments: &serde_json::Value) -> String {
 /// OpenAI GPT provider.
 pub struct OpenAIProvider {
     client: Client,
+    /// Separate client for streaming requests, built without a total request
+    /// timeout so a healthy long generation is never cut off mid-stream. See
+    /// [`crate::provider::build_streaming_http_client`].
+    stream_client: Client,
     api_key: SecretString,
     model: String,
     base_url: String,
@@ -258,6 +262,9 @@ impl OpenAIProvider {
         Self {
             client: crate::provider::build_http_client(
                 crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
+                crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
+            ),
+            stream_client: crate::provider::build_streaming_http_client(
                 crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
             ),
             api_key: SecretString::from(api_key.into()),
@@ -321,8 +328,14 @@ impl OpenAIProvider {
     }
 
     /// Replace the HTTP client with one using custom timeouts (in seconds).
+    ///
+    /// `timeout_secs` is the **total** request timeout for non-streaming
+    /// requests. The streaming client is rebuilt only with the connect timeout —
+    /// it never takes a total timeout, so a long streamed generation is not
+    /// capped regardless of this value.
     pub fn with_http_timeout(mut self, timeout_secs: u64, connect_timeout_secs: u64) -> Self {
         self.client = crate::provider::build_http_client(timeout_secs, connect_timeout_secs);
+        self.stream_client = crate::provider::build_streaming_http_client(connect_timeout_secs);
         self
     }
 
@@ -367,7 +380,10 @@ impl OpenAIProvider {
             "stream_options".into(),
             serde_json::json!({"include_usage": true}),
         );
-        self.client
+        // Stream client: no total timeout, so a long healthy generation is not
+        // cut off. Stalls are bounded by the client's per-read timeout and the
+        // agent's stream-timeout guards (see build_streaming_http_client).
+        self.stream_client
             .post(format!("{}/chat/completions", self.base_url))
             .header(
                 "Authorization",

--- a/crates/octos-llm/src/openai_responses.rs
+++ b/crates/octos-llm/src/openai_responses.rs
@@ -22,6 +22,10 @@ use crate::types::{ChatResponse, ChatStream, StopReason, StreamEvent, TokenUsage
 /// OpenAI provider using the Responses API.
 pub struct OpenAIResponsesProvider {
     client: Client,
+    /// Separate client for streaming requests, built without a total request
+    /// timeout so a healthy long generation is never cut off mid-stream. See
+    /// [`crate::provider::build_streaming_http_client`].
+    stream_client: Client,
     api_key: SecretString,
     model: String,
     base_url: String,
@@ -32,6 +36,9 @@ impl OpenAIResponsesProvider {
         Self {
             client: crate::provider::build_http_client(
                 crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
+                crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
+            ),
+            stream_client: crate::provider::build_streaming_http_client(
                 crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
             ),
             api_key: SecretString::from(api_key.into()),
@@ -47,6 +54,7 @@ impl OpenAIResponsesProvider {
 
     pub fn with_http_timeout(mut self, timeout_secs: u64, connect_timeout_secs: u64) -> Self {
         self.client = crate::provider::build_http_client(timeout_secs, connect_timeout_secs);
+        self.stream_client = crate::provider::build_streaming_http_client(connect_timeout_secs);
         self
     }
 
@@ -153,8 +161,11 @@ impl LlmProvider for OpenAIResponsesProvider {
         let mut body = self.build_request(messages, tools, config);
         body["stream"] = true.into();
 
+        // Stream client: no total timeout, so a long healthy generation is not
+        // cut off. Stalls are bounded by the client's per-read timeout and the
+        // agent's stream-timeout guards (see build_streaming_http_client).
         let response = self
-            .client
+            .stream_client
             .post(format!("{}/responses", self.base_url))
             .header(
                 "Authorization",

--- a/crates/octos-llm/src/openrouter.rs
+++ b/crates/octos-llm/src/openrouter.rs
@@ -20,6 +20,10 @@ use crate::types::{ChatResponse, ChatStream, ProviderMetadata, StopReason, Token
 /// OpenRouter provider (routes to many LLM providers).
 pub struct OpenRouterProvider {
     client: Client,
+    /// Separate client for streaming requests, built without a total request
+    /// timeout so a healthy long generation is never cut off mid-stream. See
+    /// [`crate::provider::build_streaming_http_client`].
+    stream_client: Client,
     api_key: SecretString,
     model: String,
     base_url: String,
@@ -31,6 +35,9 @@ impl OpenRouterProvider {
         Self {
             client: crate::provider::build_http_client(
                 crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
+                crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
+            ),
+            stream_client: crate::provider::build_streaming_http_client(
                 crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
             ),
             api_key: SecretString::from(api_key.into()),
@@ -53,8 +60,14 @@ impl OpenRouterProvider {
     }
 
     /// Replace the HTTP client with one using custom timeouts (in seconds).
+    ///
+    /// `timeout_secs` is the **total** request timeout for non-streaming
+    /// requests. The streaming client is rebuilt only with the connect timeout —
+    /// it never takes a total timeout, so a long streamed generation is not
+    /// capped regardless of this value.
     pub fn with_http_timeout(mut self, timeout_secs: u64, connect_timeout_secs: u64) -> Self {
         self.client = crate::provider::build_http_client(timeout_secs, connect_timeout_secs);
+        self.stream_client = crate::provider::build_streaming_http_client(connect_timeout_secs);
         self
     }
 }
@@ -177,8 +190,11 @@ impl LlmProvider for OpenRouterProvider {
             serde_json::json!({"include_usage": true}),
         );
 
+        // Stream client: no total timeout, so a long healthy generation is not
+        // cut off. Stalls are bounded by the client's per-read timeout and the
+        // agent's stream-timeout guards (see build_streaming_http_client).
         let response = self
-            .client
+            .stream_client
             .post(format!("{}/chat/completions", self.base_url))
             .header(
                 "Authorization",

--- a/crates/octos-llm/src/provider.rs
+++ b/crates/octos-llm/src/provider.rs
@@ -145,12 +145,24 @@ pub(crate) fn truncate_error_body(body: &str) -> String {
     }
 }
 
-/// Default LLM request timeout in seconds.
-/// 120s accommodates long multi-tool chains and reasoning-heavy models.
-/// Connect timeout (10s) ensures fast failover when a provider is unreachable.
-/// Default LLM request timeout in seconds (for non-streaming requests).
-/// Streaming responses should disable this and use per-chunk timeout instead.
+/// Default LLM request timeout in seconds, applied as a reqwest **total**
+/// request deadline — for **non-streaming** requests only.
+///
+/// Streaming responses must NOT use a total timeout: it would cap a healthy,
+/// actively-streaming generation regardless of progress (a slow local model
+/// writing a large output gets cut off mid-stream). Streaming clients are
+/// built by [`build_streaming_http_client`] instead, which bounds connect and
+/// per-read stalls but never the total generation time. The tunable
+/// stream-timeout system (TTFT / inter-chunk idle / overall wall-clock cap)
+/// lives in `octos-agent`'s `streaming.rs` on the response body.
 pub const DEFAULT_LLM_TIMEOUT_SECS: u64 = 300;
+/// Default per-read idle timeout for **streaming** clients, in seconds.
+///
+/// Applied via reqwest's `.read_timeout()`, which **resets after every read**.
+/// It bounds the initial header-wait and any genuine stall, but a stream that
+/// keeps producing tokens is never capped, no matter how long the full
+/// generation runs — mirroring Pi's `timeoutMs`-as-stream-idleness model.
+pub const DEFAULT_LLM_STREAM_IDLE_TIMEOUT_SECS: u64 = 300;
 /// Default LLM connect timeout in seconds.
 /// Reduced from 30s: if a provider can't connect in 10s, fail over sooner.
 pub const DEFAULT_LLM_CONNECT_TIMEOUT_SECS: u64 = 10;
@@ -159,10 +171,14 @@ pub const DEFAULT_EMBEDDING_TIMEOUT_SECS: u64 = 60;
 /// Default embedding connect timeout in seconds.
 pub const DEFAULT_EMBEDDING_CONNECT_TIMEOUT_SECS: u64 = 15;
 
-/// Build a `reqwest::Client` with a generous global timeout.
-/// The global timeout acts as a safety net — individual callers can override
-/// with per-request `.timeout()` for tighter or looser limits.
-/// Streaming callers also have per-chunk timeout in consume_stream (30s).
+/// Build a `reqwest::Client` with a **total** request timeout.
+/// The total timeout acts as a safety net for **non-streaming** requests —
+/// individual callers can override with per-request `.timeout()` for tighter
+/// or looser limits.
+///
+/// Do NOT use this for streaming: a total timeout caps the whole response and
+/// kills a healthy, actively-streaming generation once it exceeds the deadline.
+/// Use [`build_streaming_http_client`] for stream requests instead.
 pub fn build_http_client(timeout_secs: u64, connect_timeout_secs: u64) -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(timeout_secs))
@@ -170,6 +186,27 @@ pub fn build_http_client(timeout_secs: u64, connect_timeout_secs: u64) -> reqwes
         .pool_idle_timeout(std::time::Duration::from_secs(90))
         .build()
         .expect("failed to build HTTP client")
+}
+
+/// Build a `reqwest::Client` for **streaming** requests.
+///
+/// Unlike [`build_http_client`], this sets **no total request timeout** — a
+/// stream that keeps producing tokens must never be cut off, however long the
+/// full generation runs. Instead it bounds stalls with `.read_timeout()`, which
+/// applies per read and **resets after each successful read**, so it catches a
+/// never-arriving header or a genuinely stalled stream without capping healthy
+/// progress. The tunable, typed stream-timeout system (TTFT / inter-chunk idle
+/// / overall wall-clock cap → `StreamError::IdleTimeout`) lives in
+/// `octos-agent`'s `streaming.rs` on top of this.
+pub fn build_streaming_http_client(connect_timeout_secs: u64) -> reqwest::Client {
+    reqwest::Client::builder()
+        .read_timeout(std::time::Duration::from_secs(
+            DEFAULT_LLM_STREAM_IDLE_TIMEOUT_SECS,
+        ))
+        .connect_timeout(std::time::Duration::from_secs(connect_timeout_secs))
+        .pool_idle_timeout(std::time::Duration::from_secs(90))
+        .build()
+        .expect("failed to build streaming HTTP client")
 }
 
 #[cfg(test)]
@@ -217,5 +254,57 @@ mod tests {
     fn test_build_http_client_succeeds() {
         let _client = build_http_client(30, 10);
         // Just verify it doesn't panic
+    }
+
+    #[test]
+    fn test_build_streaming_http_client_succeeds() {
+        let _client = build_streaming_http_client(10);
+        // Just verify it doesn't panic
+    }
+
+    /// The core of the streaming-timeout fix: the regular client's **total**
+    /// timeout kills a response that takes longer than the deadline, while the
+    /// streaming client (no total timeout) does not — a slow-but-healthy
+    /// response completes. Regression guard for a slow local model being cut
+    /// off mid-generation.
+    #[tokio::test]
+    async fn streaming_client_is_not_capped_by_total_timeout() {
+        use std::time::Duration;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // Respond after 2s — longer than the regular client's 1s total timeout,
+        // but far under the streaming client's per-read idle timeout.
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("ok")
+                    .set_delay(Duration::from_secs(2)),
+            )
+            .mount(&server)
+            .await;
+
+        // Regular client, 1s total timeout: the 2s response exceeds it → error.
+        let capped = build_http_client(1, 10);
+        let capped_result = capped.get(server.uri()).send().await;
+        assert!(
+            capped_result.is_err(),
+            "regular client with a 1s total timeout must time out on a 2s response"
+        );
+        assert!(
+            capped_result.unwrap_err().is_timeout(),
+            "the regular client's failure must be a timeout"
+        );
+
+        // Streaming client, no total timeout: the same 2s response completes.
+        let streaming = build_streaming_http_client(10);
+        let streaming_result = streaming.get(server.uri()).send().await;
+        assert!(
+            streaming_result.is_ok(),
+            "streaming client must not cap a healthy 2s response: {:?}",
+            streaming_result.err()
+        );
+        assert_eq!(streaming_result.unwrap().status(), 200);
     }
 }


### PR DESCRIPTION
## What & why

Closes #2170. A slow local model (Qwen 3.8 27B on llama.cpp, the llm.c C→Rust task) is cut off **mid-generation at exactly 5 minutes** with `SSE stream error: error decoding response body`, retry-looping every +5:00. It investigates fine (small tool-call outputs) but dies the moment it streams a large output (writing code).

**Root cause:** `build_http_client` (`provider.rs`) bakes a reqwest **total** request timeout (`DEFAULT_LLM_TIMEOUT_SECS = 300`) into the client, and the streaming paths reuse that client. reqwest's `.timeout()` is a deadline on the *whole* request/response, so a healthy, actively-streaming generation is killed at 300s regardless of progress. The code's own doc comment already prescribed the fix — *"Streaming responses should disable this and use per-chunk timeout instead"* — but it was never implemented.

## Evidence (exact 300s cadence)

Live capture on the `octos chat` local path, **with `gateway.llm_timeout_secs: 1800` set** as a workaround:

```
16:43:34  INFO calling LLM (iteration 7 request start)
16:48:34  WARN retryable stream error … error decoding response body   (+300s)
16:53:35  WARN retryable stream error … error decoding response body   (+300s)
```

Cut at **exactly 300s**, not 1800s. This nails it twice over: the cap is unambiguously `DEFAULT_LLM_TIMEOUT_SECS`, **and** raising `llm_timeout_secs` doesn't even reach the streaming client — so a config workaround is not a reliable fix. Removing the total cap at the source is.

## How Pi handles it (reference)

Pi (`earendil-works/pi`, `packages/ai`) applies an HTTP timeout to an LLM call **only if explicitly configured**, and documents it as **stream idleness** (resets per chunk), never a total cap (`types.ts:212-216`; `openai-responses.ts:148`, `anthropic-messages.ts:572`: `...(timeoutMs !== undefined ? { timeout } : {})`). So Pi's default is *no* total cap on a streaming generation — which is why the pi harness completes the same task and octos did not.

## The stream layer already owns the right timeouts

`octos-agent`'s `streaming.rs` already implements the correct, tunable stream-timeout system on the response body — TTFT, inter-chunk idle (`inter_chunk_idle_secs`), and an overall wall-clock cap (`overall_max_secs`) — all surfacing a typed, retryable `StreamError::IdleTimeout`. The reqwest 300s total *pre-empts* this with a crude cap, and surfaces as an opaque `error decoding response body` (a hyper/reqwest error) the retry loop can't reason about.

## Change

- **`build_streaming_http_client(connect_timeout_secs)`** in `provider.rs`: `.connect_timeout()` + reqwest 0.12 **`.read_timeout()`** (per read, **resets after each read**) + `.pool_idle_timeout()`, and **no** `.timeout()`. `read_timeout` is Pi's `timeoutMs`-as-idleness at the HTTP layer: it bounds the initial header/first-byte wait and any genuine stall, but never a healthy stream, however long the full generation runs.
- Give every **direct-HTTP streaming provider** a dedicated `stream_client` used only on its streaming POST: **OpenAI, Anthropic, Gemini, OpenRouter, OpenAI-Responses**. Non-streaming keeps the total-timeout `client` (OpenAI's `post_chat` already sets its own explicit per-request `.timeout()`).
- `with_http_timeout` rebuilds the stream client with the **connect timeout only** — an operator's `llm_timeout_secs` can never cap a stream.
- Wrapper providers (retry / failover / router / swappable / …) delegate `chat_stream` to their inner provider and need no change; embedding / vertex-auth / context-probe clients keep the total timeout (non-streaming, appropriately bounded).

Because `stream_client` has no total cap **by construction** (independent of any config), this fixes the observed 300s cutoff even on paths where `llm_timeout_secs` never reaches the provider — the failure mode captured above.

## Test

`streaming_client_is_not_capped_by_total_timeout` (`provider.rs`): a `build_http_client(1s total)` request times out on a 2s-delayed response (asserts `is_timeout()`), while a `build_streaming_http_client` request to the same endpoint completes with 200. Plus a smoke test that the builder constructs.

`cargo test -p octos-llm` green (560 passed); `fmt` + `clippy` clean.

## Follow-up (out of scope)

`read_timeout` defaults to `DEFAULT_LLM_STREAM_IDLE_TIMEOUT_SECS = 300` (a generous HTTP-layer backstop; the agent's finer `inter_chunk_idle_secs` fires first in practice). Making it operator-configurable is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
