### PR TITLE
feat(agent): cloud-safe temperature override to avoid forced-greedy repetition collapse (#2172)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -688,14 +688,10 @@ impl Agent {
         (limited, blocked_messages)
     }
 
-    /// Build a `ChatConfig` with optional `chat_max_tokens` override from `AgentConfig`.
+    /// Build a `ChatConfig` with optional `chat_max_tokens` / `chat_temperature`
+    /// overrides from `AgentConfig`. Delegates to [`build_chat_config`].
     fn chat_config(&self) -> ChatConfig {
-        let mut c = ChatConfig::default();
-        if let Some(max) = self.config.chat_max_tokens {
-            c.max_tokens = Some(max);
-        }
-        c.reasoning_effort = self.config.reasoning_effort;
-        c
+        build_chat_config(&self.config)
     }
 
     /// Decide what to surface when the loop detector fires.
@@ -3797,6 +3793,28 @@ fn shell_retry_limit_message(content: &str) -> String {
     format!(
         "[SHELL RETRY LIMIT] Repeated shell repair attempts did not converge. Stop retrying shell and summarize the blocker.\n\nLatest shell output:\n{latest_output}"
     )
+}
+
+/// Build a `ChatConfig` from an `AgentConfig`, applying the optional
+/// `chat_max_tokens` / `chat_temperature` overrides.
+///
+/// Extracted as a free function so the override semantics are unit-testable
+/// without constructing a full `Agent` — in particular the cloud-safety
+/// invariant (#2172): an unset `chat_temperature` must leave the built-in
+/// `0.0` default untouched, so cloud requests are byte-for-byte unchanged.
+fn build_chat_config(config: &crate::AgentConfig) -> ChatConfig {
+    let mut c = ChatConfig::default();
+    if let Some(max) = config.chat_max_tokens {
+        c.max_tokens = Some(max);
+    }
+    // Temperature override. Unset → keep the built-in default (0.0), so cloud
+    // requests are unchanged; set → override, primarily to avoid forced-greedy
+    // repetition collapse on local models.
+    if let Some(temp) = config.chat_temperature {
+        c.temperature = Some(temp);
+    }
+    c.reasoning_effort = config.reasoning_effort;
+    c
 }
 
 #[cfg(test)]

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6383,3 +6383,42 @@ async fn truncated_tool_output_reaches_the_model_with_its_recovery_advice() {
         &tool_message.content[tool_message.content.len().saturating_sub(200)..]
     );
 }
+
+// --- build_chat_config: temperature/max_tokens override semantics (#2172) ---
+
+#[test]
+fn build_chat_config_keeps_default_temperature_when_unset() {
+    // Cloud-safety invariant: with no chat_temperature override, the chat
+    // temperature must remain the built-in ChatConfig default (0.0), so cloud
+    // requests are byte-for-byte unchanged.
+    let cfg = AgentConfig {
+        chat_temperature: None,
+        ..AgentConfig::default()
+    };
+    let chat = build_chat_config(&cfg);
+    assert_eq!(chat.temperature, ChatConfig::default().temperature);
+    assert_eq!(chat.temperature, Some(0.0));
+}
+
+#[test]
+fn build_chat_config_applies_temperature_override() {
+    let cfg = AgentConfig {
+        chat_temperature: Some(0.7),
+        ..AgentConfig::default()
+    };
+    let chat = build_chat_config(&cfg);
+    assert_eq!(chat.temperature, Some(0.7));
+}
+
+#[test]
+fn build_chat_config_applies_max_tokens_override_independently() {
+    // Overrides compose without clobbering each other.
+    let cfg = AgentConfig {
+        chat_max_tokens: Some(4096),
+        chat_temperature: Some(0.5),
+        ..AgentConfig::default()
+    };
+    let chat = build_chat_config(&cfg);
+    assert_eq!(chat.max_tokens, Some(4096));
+    assert_eq!(chat.temperature, Some(0.5));
+}

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -85,6 +85,12 @@ pub struct AgentConfig {
     /// Per-call max output tokens override. When set, overrides `ChatConfig::default()`.
     /// Useful for pipeline nodes that produce long outputs (e.g. synthesize).
     pub chat_max_tokens: Option<u32>,
+    /// Sampling temperature override. When set, overrides `ChatConfig::default()`
+    /// (which is `0.0`/greedy). When `None`, the default is used unchanged — so
+    /// cloud requests are byte-for-byte identical. Primarily for local /
+    /// OpenAI-compatible models, where forced greedy decoding causes repetition
+    /// collapse. See issue #2172.
+    pub chat_temperature: Option<f32>,
     /// Reasoning effort for thinking models. Flows into `ChatConfig::reasoning_effort`;
     /// providers translate it per model (no-op for models without a reasoning style).
     pub reasoning_effort: Option<octos_llm::ReasoningEffort>,
@@ -198,6 +204,7 @@ impl Default for AgentConfig {
                 DEFAULT_INTERACTIVE_TOOL_TIMEOUT_SECS,
             ),
             chat_max_tokens: None,
+            chat_temperature: None,
             reasoning_effort: None,
             suppress_auto_send_files: false,
             llm_first_token_grace: env_secs_or(

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -434,6 +434,7 @@ impl AcpSharedStores {
             max_iterations,
             save_episodes: true,
             chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
+            chat_temperature: config.gateway.as_ref().and_then(|g| g.llm_temperature),
             reasoning_effort: config.gateway.as_ref().and_then(|g| g.reasoning_effort),
             // #1774: opt-in post-edit formatting (rustfmt/prettier/black/gofmt).
             format_after_edit: config.format_after_edit,

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1779,6 +1779,7 @@ impl ChatCommand {
             // `--no-session-persistence` (claude parity): skip the episode write.
             save_episodes: !self.no_session_persistence,
             chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
+            chat_temperature: config.gateway.as_ref().and_then(|g| g.llm_temperature),
             // `--effort` (claude/codex parity) overrides `gateway.reasoning_effort`.
             reasoning_effort: self
                 .effort

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1276,6 +1276,7 @@ impl GatewayRuntime {
             // can run up to 30 minutes without the agent loop aborting early.
             max_timeout: Some(std::time::Duration::from_secs(session_timeout_secs)),
             chat_max_tokens: gw_config.max_output_tokens,
+            chat_temperature: gw_config.llm_temperature,
             reasoning_effort: gw_config.reasoning_effort,
             // Phase 4 (docs/ROBRIX-PHASE4-APPROVAL-FLOW-ADR.md): config-driven
             // human-approval rules gate matching tool calls behind a

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1561,6 +1561,16 @@ pub struct GatewayConfig {
     /// and Grok get `reasoning_effort`), so non-thinking models silently ignore it.
     #[serde(default)]
     pub reasoning_effort: Option<octos_llm::ReasoningEffort>,
+
+    /// Sampling temperature override for chat LLM calls. When unset (the
+    /// default), the built-in `ChatConfig` default (`0.0`, greedy) is used and
+    /// the request is byte-for-byte unchanged — so cloud providers are
+    /// unaffected. Set a value (e.g. `0.7`) to override it; this is primarily
+    /// for **local / OpenAI-compatible** models, where forced greedy decoding
+    /// triggers repetition collapse (a small model re-emits the same tool call
+    /// until `max_tokens`). See issue #2172.
+    #[serde(default)]
+    pub llm_temperature: Option<f32>,
 }
 
 impl Default for GatewayConfig {
@@ -1583,6 +1593,7 @@ impl Default for GatewayConfig {
             session_timeout_secs: None,
             max_output_tokens: None,
             reasoning_effort: None,
+            llm_temperature: None,
         }
     }
 }
@@ -2366,6 +2377,26 @@ mod tests {
         let json = r#"{"provider": "anthropic"}"#;
         let config: Config = serde_json::from_str(json).unwrap();
         assert!(config.gateway.is_none());
+    }
+
+    #[test]
+    fn test_gateway_llm_temperature_parses() {
+        let json = r#"{
+            "channels": [{"type": "cli"}],
+            "llm_temperature": 0.7
+        }"#;
+        let gw: GatewayConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(gw.llm_temperature, Some(0.7));
+    }
+
+    #[test]
+    fn test_gateway_llm_temperature_absent_is_none() {
+        // Cloud-safety guarantee (#2172): a config without llm_temperature
+        // yields None, so chat_config() keeps the built-in 0.0 default and the
+        // request is unchanged. Old configs must still parse.
+        let json = r#"{"channels": [{"type": "cli"}]}"#;
+        let gw: GatewayConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(gw.llm_temperature, None);
     }
 
     #[test]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1497,6 +1497,11 @@ pub struct GatewaySettings {
     /// Overrides the built-in default from model_limits.json.
     #[serde(default)]
     pub max_output_tokens: Option<u32>,
+    /// Sampling temperature override for chat LLM calls. `None` keeps the
+    /// built-in default (`0.0`/greedy). Primarily for local / OpenAI-compatible
+    /// models, where forced greedy decoding causes repetition collapse. #2172.
+    #[serde(default)]
+    pub llm_temperature: Option<f32>,
     /// Per-profile watchdog override. `None` inherits the system monitor default.
     #[serde(default)]
     pub watchdog_enabled: Option<bool>,
@@ -2779,6 +2784,10 @@ pub(crate) fn config_from_profile(
             max_concurrent_sessions: profile.config.gateway.max_concurrent_sessions.unwrap_or(10),
             browser_timeout_secs: profile.config.gateway.browser_timeout_secs,
             max_output_tokens: profile.config.gateway.max_output_tokens,
+            // #2172: surface the profile's temperature override to serve /
+            // octoscode sessions (which run via a profile), so a local model
+            // can escape forced greedy decoding.
+            llm_temperature: profile.config.gateway.llm_temperature,
             ..Default::default()
         }),
         fallback_models,


### PR DESCRIPTION
## What & why

Closes #2172. octos hardcoded **`temperature = 0.0` (greedy)** for every chat request with **no override**. On a small local model this deterministically triggers a **repetition collapse** — greedy argmax re-emits the same tool call until `max_tokens`.

Live-tested with Qwen 3.8 (llama.cpp) on the llm.c C→Rust task, then re-tested with temperature omitted:

| | forced `0.0` (current) | temperature omitted |
|---|---|---|
| `update_plan` calls in the write turn | **763** (collapse) | **1** (normal) |
| stop_reason | `MaxTokens` | `ToolUse` |
| run progress | died at **iteration 7** | reached **iteration 16** |

Letting the local server sample with its own defaults (temp ~0.8 + `repeat_penalty`) eliminated the collapse — which is exactly how **Pi** behaves: it sends no `temperature` by default (`openai-completions.ts:829`) rather than clobbering the server's sampling with greedy.

## Change

- New **`gateway.llm_temperature: Option<f32>`** knob (`GatewayConfig`), threaded to **`AgentConfig.chat_temperature`** at the three construction sites that already thread `chat_max_tokens` / `reasoning_effort` (`chat.rs`, `gateway_runtime.rs`, `acp.rs`).
- Applied in `Agent::chat_config()` via a new pure **`build_chat_config()`** helper (extracted so the semantics are unit-testable without a full `Agent`).
- Also surfaced through **`config_from_profile`** (the serve / octoscode profile projection) — added to the profile `GatewaySettings` schema and copied in the projection — so a **profile-driven** local session (octoscode) can set it too, not just a config-file `octos chat`.

## Cloud safety (the primary use case — unaffected)

Fast cloud models are robust at `0.0` and many agentic setups want it for determinism, so the default is preserved. When `llm_temperature` is unset, `build_chat_config` keeps `ChatConfig::default()` (`0.0`) — cloud requests are **byte-for-byte unchanged**. The override also cannot break `fixed_temperature` models (o-series/gpt-5/kimi): `openai.rs:515` still forces `None` for them regardless. Behavior changes only when an operator explicitly sets the knob.

## Tests

- `test_gateway_llm_temperature_parses` / `_absent_is_none` — config parses the field; **absent → `None`** (old configs unchanged — the cloud-safety guarantee at the parse layer).
- `build_chat_config_keeps_default_temperature_when_unset` — the **cloud-safety invariant**: no override ⇒ temperature stays `Some(0.0)`.
- `build_chat_config_applies_temperature_override` / `_max_tokens_override_independently` — the override applies and composes.

`cargo test -p octos-cli` (1587) + `-p octos-agent` (2647) green; `fmt` + `clippy` clean. An adversarial review of the core confirmed cloud-safety by construction; this PR additionally closes the two items it flagged (the profile-path threading and the `chat_config` invariant test).

## Follow-up (out of scope)

Full Pi parity: a way to **omit** temperature entirely, a **`samplingParams` passthrough** so local servers can receive `repeat_penalty` / `top_p` / `min_p` (`OpenAIRequest` has no such fields today), and a `ProfileConfigPatch`/API field so the TUI can set it. These matter for the *next* local-model degeneration (an empty-output `MaxTokens` stall observed after this fix), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
