### PR TITLE
fix(agent): recover from degenerate empty MaxTokens in the conversation loop (#2174)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -31,6 +31,14 @@ use crate::tools::{TURN_ATTACHMENT_CTX, TurnAttachmentContext};
 const MAX_PARALLEL_TOOL_CALLS_PER_BATCH: usize = 8;
 const MAX_TOKENS_CONTINUATION_LIMIT: usize = 2;
 const MAX_TOKENS_CONTINUATION_PROMPT: &str = "Your output was truncated at the token limit. Continue directly from where you stopped. Do not repeat or summarize what you already wrote.";
+/// Nudge issued when a `MaxTokens` response carried NO content and NO tool call
+/// — a degenerate generation that consumed the whole output budget producing
+/// nothing usable (#2174). Unlike the truncation-continuation prompt, there is
+/// nothing to "continue from", so this asks for a single concise next action.
+const MAX_TOKENS_EMPTY_RECOVERY_PROMPT: &str = "Your previous response reached the output token limit without producing any text or tool call. Respond concisely: take your single next action now — call one tool or give a brief answer. Do not repeat yourself.";
+/// Terminal message when empty-`MaxTokens` recovery is exhausted. Surfaced
+/// instead of an empty success so the turn never silently dead-ends (#2174).
+const MAX_TOKENS_EMPTY_EXHAUSTED_MESSAGE: &str = "[The model repeatedly reached the output token limit without producing any text or tool call — a degenerate or looping generation. Try a stronger model, reduce the context size, or configure an anti-repetition sampler (a non-zero temperature or a repeat penalty).]";
 const SHELL_RETRY_RECOVERY_THRESHOLD: usize = 4;
 
 /// Prepended to the user content on a live video-call turn so the model treats
@@ -1006,6 +1014,9 @@ impl Agent {
                 // #1691 (codex gap G6): fire the in-band budget reminder once,
                 // when the run first crosses ~80% of its iteration cap.
                 let mut budget_reminder_sent = false;
+                // #2174: bounded recovery for a degenerate empty `MaxTokens`
+                // response (no content, no tool call) in the conversation loop.
+                let mut max_token_empty_recoveries: usize = 0;
 
                 // UserPromptSubmit lifecycle hook. Fires exactly once here —
                 // when a real user-submitted prompt enters the turn, after the
@@ -2061,9 +2072,46 @@ impl Agent {
                             }
                         }
                         StopReason::MaxTokens => {
+                            let content_empty = response
+                                .content
+                                .as_deref()
+                                .is_none_or(|c| c.trim().is_empty());
+                            // #2174: a MaxTokens response with NO content AND no
+                            // tool call is a degenerate generation — the whole
+                            // output budget was spent producing nothing usable.
+                            // Returning here would end the turn empty and the
+                            // process would exit silently. Attempt a bounded
+                            // nudge-and-retry (mirroring the task loop's max-token
+                            // continuation), then surface a clear error instead of
+                            // an empty success. A MaxTokens response WITH content
+                            // is returned unchanged — cloud / normal truncation is
+                            // unaffected.
+                            if content_empty
+                                && response.tool_calls.is_empty()
+                                && max_token_empty_recoveries < MAX_TOKENS_CONTINUATION_LIMIT
+                            {
+                                max_token_empty_recoveries += 1;
+                                let mut assistant = Message::assistant(String::new());
+                                assistant.reasoning_content = response.reasoning_content.clone();
+                                messages.push(assistant);
+                                messages.push(Message::user(MAX_TOKENS_EMPTY_RECOVERY_PROMPT));
+                                warn!(
+                                    iteration,
+                                    attempt = max_token_empty_recoveries,
+                                    max = MAX_TOKENS_CONTINUATION_LIMIT,
+                                    "empty MaxTokens response (no content, no tool call); \
+                                     nudging and retrying"
+                                );
+                                continue 'agent_loop;
+                            }
                             self.emit_cost_update(&turn, &response, attributed_cost);
+                            let content = if content_empty && response.tool_calls.is_empty() {
+                                MAX_TOKENS_EMPTY_EXHAUSTED_MESSAGE.to_string()
+                            } else {
+                                response.content.clone().unwrap_or_default()
+                            };
                             return Ok(ConversationResponse {
-                                content: response.content.unwrap_or_default(),
+                                content,
                                 reasoning_content: response.reasoning_content.clone(),
                                 provider_metadata: Some(
                                     self.llm.provider_metadata_for_index(response.provider_index),

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6422,3 +6422,129 @@ fn build_chat_config_applies_max_tokens_override_independently() {
     assert_eq!(chat.max_tokens, Some(4096));
     assert_eq!(chat.temperature, Some(0.5));
 }
+
+// --- #2174: conversation-loop recovery from a degenerate empty MaxTokens ---
+
+fn empty_max_tokens_response() -> ChatResponse {
+    // Models the REAL degenerate case: the whole output budget was spent on
+    // reasoning, so `content` is empty and there are no tool calls, but
+    // `reasoning_content` is present. That makes `is_retriable_response` return
+    // false (has_reasoning), so the response is NOT caught by the call-level
+    // empty-retry and instead reaches the conversation-loop MaxTokens branch.
+    ChatResponse {
+        content: None,
+        reasoning_content: Some("(long internal reasoning, no final answer)".to_string()),
+        tool_calls: vec![],
+        stop_reason: StopReason::MaxTokens,
+        usage: LlmTokenUsage {
+            input_tokens: 5,
+            output_tokens: 128,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+async fn run_conversation_content(responses: Vec<ChatResponse>) -> String {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = Arc::new(ScriptedProvider::new(responses));
+    let tools = ToolRegistry::new();
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("empty-maxtokens"), provider, tools, memory).with_config(
+        AgentConfig {
+            max_iterations: 10,
+            save_episodes: false,
+            ..Default::default()
+        },
+    );
+    agent
+        .process_message("go", &[], vec![])
+        .await
+        .unwrap()
+        .content
+}
+
+#[tokio::test]
+async fn empty_max_tokens_recovers_when_retry_succeeds() {
+    // A degenerate empty MaxTokens (no content, no tool call) must trigger a
+    // nudge-and-retry instead of returning empty; the retry succeeds and its
+    // content is returned — not a silent empty exit.
+    let content = run_conversation_content(vec![
+        empty_max_tokens_response(),
+        end_turn("recovered answer", 4, 6),
+    ])
+    .await;
+    assert_eq!(content, "recovered answer");
+}
+
+/// Always returns the degenerate empty-MaxTokens response, so the loop's
+/// behavior is bounded solely by the recovery cap (not by a fixed script).
+struct AlwaysEmptyMaxTokensProvider;
+
+#[async_trait]
+impl LlmProvider for AlwaysEmptyMaxTokensProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &ChatConfig,
+    ) -> Result<ChatResponse> {
+        Ok(empty_max_tokens_response())
+    }
+    fn model_id(&self) -> &str {
+        "always-empty"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+#[tokio::test]
+async fn empty_max_tokens_surfaces_error_after_recovery_exhausted() {
+    // A model that keeps returning a degenerate empty MaxTokens: the loop does
+    // two bounded recoveries then surfaces a clear terminal error rather than a
+    // silent empty return. If the recovery counter did NOT persist across
+    // iterations this would instead loop until max_iterations — so this also
+    // pins the bound.
+    let dir = tempfile::tempdir().unwrap();
+    let provider = Arc::new(AlwaysEmptyMaxTokensProvider);
+    let tools = ToolRegistry::new();
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("empty-maxtokens"), provider, tools, memory).with_config(
+        AgentConfig {
+            max_iterations: 10,
+            save_episodes: false,
+            ..Default::default()
+        },
+    );
+    // Uses the default (non-FailFast) call policy — the path `octos chat`
+    // takes, where an empty-but-reasoning MaxTokens reaches the conversation
+    // loop rather than being failed fast. (Under FailFast the empty response is
+    // terminal earlier, a different — also non-silent — outcome.)
+    let content = agent
+        .process_message("go", &[], vec![])
+        .await
+        .unwrap()
+        .content;
+    assert_eq!(content, MAX_TOKENS_EMPTY_EXHAUSTED_MESSAGE);
+}
+
+#[tokio::test]
+async fn non_empty_max_tokens_returns_content_unchanged() {
+    // Cloud-safety: a MaxTokens response WITH content is returned as-is, with
+    // no retry — behavior unchanged from before #2174.
+    let content = run_conversation_content(vec![ChatResponse {
+        content: Some("partial but real".to_string()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::MaxTokens,
+        usage: LlmTokenUsage {
+            input_tokens: 5,
+            output_tokens: 128,
+            ..Default::default()
+        },
+        provider_index: None,
+    }])
+    .await;
+    assert_eq!(content, "partial but real");
+}


### PR DESCRIPTION
## What & why

Closes #2174. The conversation loop's `StopReason::MaxTokens` arm returned immediately with `content.unwrap_or_default()`. When a small local model spent its whole output budget producing only reasoning — no content, no tool call — that returned an **empty** `ConversationResponse` and the process exited cleanly: **a silent dead-end, no output and no error.**

Found live: after a context compaction, Qwen 3.8 (llama.cpp) burned a full 16384-token budget yielding nothing (`stop_reason=MaxTokens, tool_calls=0, content_len=0`) and `octos chat` just quit mid-task. The **task loop** already recovers (max-token continuation), but the **conversation loop** — the interactive path — did not. This is the asymmetry Pi doesn't have: Pi detects a length-truncation that produced too little and compacts-and-retries once, then surfaces a visible error, never a silent exit.

## Change

Mirror the task loop, **gated strictly on the degenerate case** (`content_empty && tool_calls.is_empty()`):

- Under `MAX_TOKENS_CONTINUATION_LIMIT` (2): push the (empty) assistant message + a corrective user nudge (`MAX_TOKENS_EMPTY_RECOVERY_PROMPT`, which asks for a single concise next action rather than "continue from where you stopped") and `continue 'agent_loop`.
- On exhaustion: return a **clear terminal error** (`MAX_TOKENS_EMPTY_EXHAUSTED_MESSAGE`) instead of an empty success.
- A `MaxTokens` response **with content** is returned unchanged.

The recovery counter is per-turn (declared outside `'agent_loop`), so the bound is real; `max_iterations` remains the backstop.

## Cloud safety

Strictly gated on the empty-degenerate case — a normal cloud truncation (non-empty content at `MaxTokens`) returns byte-identically to before. No default behavior change for cloud/normal use.

## Relationship to the existing empty-response ladder

The **fully-empty** case (no reasoning) is already handled upstream by the call-level retry ladder (`is_retriable_response` → `is_empty` when content+tools+reasoning are all absent). This arm catches the **reasoning-only** degenerate response, which `is_retriable_response` returns `false` for (`has_reasoning`) and so reaches the loop. The arm's gate is a proper superset, so even a fully-empty one slipping through recovers harmlessly.

## Tests

- `empty_max_tokens_recovers_when_retry_succeeds` — recovery nudge + a successful retry returns the recovered content.
- `empty_max_tokens_surfaces_error_after_recovery_exhausted` — an always-degenerate model yields the terminal error after 2 bounded recoveries; genuinely **pins the bound** (a non-persisting counter would instead loop to `max_iterations`, a different message).
- `non_empty_max_tokens_returns_content_unchanged` — cloud-safety: content-bearing `MaxTokens` is returned as-is.

`cargo test -p octos-agent` green (2650+); fmt + clippy clean. (The exhaustion test runs ~20s because it exercises the real default-policy retry-then-recover path with backoff; it parallelizes within the suite.)

An adversarial review of the loop control-flow found no correctness or regression issues.

## Follow-up (out of scope)

The *trigger* for this degeneration — a small model spinning after a lossy compaction — is better attacked with an anti-repetition sampler (the `repeat_penalty` / `samplingParams` passthrough tracked separately) and gentler compaction. This PR is the safety net that turns the silent exit into recovery-or-a-clear-error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
