### PR TITLE
feat(llm): cloud-safe sampler passthrough (repeat_penalty etc.) for OpenAI-compatible servers (#2172)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -3861,6 +3861,11 @@ fn build_chat_config(config: &crate::AgentConfig) -> ChatConfig {
     if let Some(temp) = config.chat_temperature {
         c.temperature = Some(temp);
     }
+    // Extra sampler params (e.g. repeat_penalty) for OpenAI-compatible servers.
+    // Unset → nothing added, cloud unchanged.
+    if let Some(sampling) = &config.chat_sampling_params {
+        c.sampling_params = Some(sampling.clone());
+    }
     c.reasoning_effort = config.reasoning_effort;
     c
 }

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6411,6 +6411,29 @@ fn build_chat_config_applies_temperature_override() {
 }
 
 #[test]
+fn build_chat_config_threads_sampling_params() {
+    // #2172: chat_sampling_params flows into ChatConfig.sampling_params; unset
+    // → None (cloud unchanged).
+    let mut sp = serde_json::Map::new();
+    sp.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+    let cfg = AgentConfig {
+        chat_sampling_params: Some(sp),
+        ..AgentConfig::default()
+    };
+    let chat = build_chat_config(&cfg);
+    assert_eq!(
+        chat.sampling_params
+            .as_ref()
+            .and_then(|m| m.get("repeat_penalty")),
+        Some(&serde_json::json!(1.1))
+    );
+    assert_eq!(
+        build_chat_config(&AgentConfig::default()).sampling_params,
+        None
+    );
+}
+
+#[test]
 fn build_chat_config_applies_max_tokens_override_independently() {
     // Overrides compose without clobbering each other.
     let cfg = AgentConfig {

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -91,6 +91,10 @@ pub struct AgentConfig {
     /// OpenAI-compatible models, where forced greedy decoding causes repetition
     /// collapse. See issue #2172.
     pub chat_temperature: Option<f32>,
+    /// Extra sampler params (e.g. `repeat_penalty`) flattened into the request
+    /// for OpenAI-compatible servers. `None` → nothing added (cloud unchanged).
+    /// The robust fix for local-model repetition collapse. See issue #2172.
+    pub chat_sampling_params: Option<serde_json::Map<String, serde_json::Value>>,
     /// Reasoning effort for thinking models. Flows into `ChatConfig::reasoning_effort`;
     /// providers translate it per model (no-op for models without a reasoning style).
     pub reasoning_effort: Option<octos_llm::ReasoningEffort>,
@@ -205,6 +209,7 @@ impl Default for AgentConfig {
             ),
             chat_max_tokens: None,
             chat_temperature: None,
+            chat_sampling_params: None,
             reasoning_effort: None,
             suppress_auto_send_files: false,
             llm_first_token_grace: env_secs_or(

--- a/crates/octos-agent/src/subagent_summary.rs
+++ b/crates/octos-agent/src/subagent_summary.rs
@@ -476,6 +476,7 @@ async fn fetch_summary(
         reasoning_effort: None,
         response_format: None,
         context_management: None,
+        sampling_params: None,
     };
     let messages = vec![Message::user(prompt)];
     let fut = async move { provider.chat(&messages, &[], &config).await };

--- a/crates/octos-agent/src/summarizer.rs
+++ b/crates/octos-agent/src/summarizer.rs
@@ -299,6 +299,7 @@ rather than appending duplicates.\n\n",
                 strict: true,
             }),
             context_management: None,
+            sampling_params: None,
         };
         let messages = vec![Message::user(prompt)];
         // Bridge the async LLM call to the synchronous Summarizer contract.

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -12788,6 +12788,7 @@ objective is fully met, or `NOT_DONE: <short reason>` otherwise."
         reasoning_effort: None,
         response_format: None,
         context_management: None,
+        sampling_params: None,
     };
     let messages = vec![octos_core::Message::user(prompt)];
     let (verdict_text, usage) = match provider.chat(&messages, &[], &config).await {

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -435,6 +435,10 @@ impl AcpSharedStores {
             save_episodes: true,
             chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
             chat_temperature: config.gateway.as_ref().and_then(|g| g.llm_temperature),
+            chat_sampling_params: config
+                .gateway
+                .as_ref()
+                .and_then(|g| g.llm_sampling_params.clone()),
             reasoning_effort: config.gateway.as_ref().and_then(|g| g.reasoning_effort),
             // #1774: opt-in post-edit formatting (rustfmt/prettier/black/gofmt).
             format_after_edit: config.format_after_edit,

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1780,6 +1780,10 @@ impl ChatCommand {
             save_episodes: !self.no_session_persistence,
             chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
             chat_temperature: config.gateway.as_ref().and_then(|g| g.llm_temperature),
+            chat_sampling_params: config
+                .gateway
+                .as_ref()
+                .and_then(|g| g.llm_sampling_params.clone()),
             // `--effort` (claude/codex parity) overrides `gateway.reasoning_effort`.
             reasoning_effort: self
                 .effort

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1277,6 +1277,7 @@ impl GatewayRuntime {
             max_timeout: Some(std::time::Duration::from_secs(session_timeout_secs)),
             chat_max_tokens: gw_config.max_output_tokens,
             chat_temperature: gw_config.llm_temperature,
+            chat_sampling_params: gw_config.llm_sampling_params.clone(),
             reasoning_effort: gw_config.reasoning_effort,
             // Phase 4 (docs/ROBRIX-PHASE4-APPROVAL-FLOW-ADR.md): config-driven
             // human-approval rules gate matching tool calls behind a

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1571,6 +1571,14 @@ pub struct GatewayConfig {
     /// until `max_tokens`). See issue #2172.
     #[serde(default)]
     pub llm_temperature: Option<f32>,
+
+    /// Extra sampler params for OpenAI-compatible servers, flattened verbatim
+    /// into the request body — e.g. `{"repeat_penalty": 1.1, "top_p": 0.95}`.
+    /// For params octos does not model. `None` → nothing added, so cloud
+    /// requests are unchanged. The robust fix for local-model repetition
+    /// collapse (temperature alone is only a partial mitigation). #2172.
+    #[serde(default)]
+    pub llm_sampling_params: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl Default for GatewayConfig {
@@ -1594,6 +1602,7 @@ impl Default for GatewayConfig {
             max_output_tokens: None,
             reasoning_effort: None,
             llm_temperature: None,
+            llm_sampling_params: None,
         }
     }
 }
@@ -2397,6 +2406,26 @@ mod tests {
         let json = r#"{"channels": [{"type": "cli"}]}"#;
         let gw: GatewayConfig = serde_json::from_str(json).unwrap();
         assert_eq!(gw.llm_temperature, None);
+    }
+
+    #[test]
+    fn test_gateway_llm_sampling_params_parses() {
+        let json = r#"{
+            "channels": [{"type": "cli"}],
+            "llm_sampling_params": {"repeat_penalty": 1.1, "top_p": 0.95}
+        }"#;
+        let gw: GatewayConfig = serde_json::from_str(json).unwrap();
+        let sp = gw.llm_sampling_params.expect("sampling params present");
+        assert_eq!(sp.get("repeat_penalty"), Some(&serde_json::json!(1.1)));
+        assert_eq!(sp.get("top_p"), Some(&serde_json::json!(0.95)));
+    }
+
+    #[test]
+    fn test_gateway_llm_sampling_params_absent_is_none() {
+        // Cloud-safety: absent → None → nothing flattened into the request.
+        let json = r#"{"channels": [{"type": "cli"}]}"#;
+        let gw: GatewayConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(gw.llm_sampling_params, None);
     }
 
     #[test]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1502,6 +1502,10 @@ pub struct GatewaySettings {
     /// models, where forced greedy decoding causes repetition collapse. #2172.
     #[serde(default)]
     pub llm_temperature: Option<f32>,
+    /// Extra sampler params (e.g. `repeat_penalty`) flattened into the request
+    /// for OpenAI-compatible servers. `None` → nothing added. #2172.
+    #[serde(default)]
+    pub llm_sampling_params: Option<serde_json::Map<String, serde_json::Value>>,
     /// Per-profile watchdog override. `None` inherits the system monitor default.
     #[serde(default)]
     pub watchdog_enabled: Option<bool>,
@@ -2788,6 +2792,8 @@ pub(crate) fn config_from_profile(
             // octoscode sessions (which run via a profile), so a local model
             // can escape forced greedy decoding.
             llm_temperature: profile.config.gateway.llm_temperature,
+            // #2172: same for the sampler passthrough (repeat_penalty, …).
+            llm_sampling_params: profile.config.gateway.llm_sampling_params.clone(),
             ..Default::default()
         }),
         fallback_models,

--- a/crates/octos-llm/src/config.rs
+++ b/crates/octos-llm/src/config.rs
@@ -33,6 +33,14 @@ pub struct ChatConfig {
     /// Anthropic ignore this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_management: Option<serde_json::Value>,
+    /// Extra sampler params for OpenAI-compatible servers, flattened verbatim
+    /// into the request body — e.g. `{"repeat_penalty": 1.1, "top_p": 0.95}`.
+    /// For params octos does not model (`repeat_penalty`, `top_p`, `top_k`,
+    /// `min_p`, `frequency_penalty`, `presence_penalty`, …). `None` → nothing is
+    /// added, so cloud requests are unchanged. Do not put `temperature` /
+    /// `max_tokens` here — use their dedicated fields. See issue #2172.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sampling_params: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 /// Structured output format for chat responses.
@@ -85,6 +93,7 @@ impl Default for ChatConfig {
             reasoning_effort: None,
             response_format: None,
             context_management: None,
+            sampling_params: None,
         }
     }
 }
@@ -146,6 +155,7 @@ mod tests {
             reasoning_effort: None,
             response_format: None,
             context_management: None,
+            sampling_params: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: ChatConfig = serde_json::from_str(&json).unwrap();
@@ -165,6 +175,7 @@ mod tests {
             reasoning_effort: None,
             response_format: None,
             context_management: None,
+            sampling_params: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert!(json.get("max_tokens").is_none());

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -632,9 +632,39 @@ impl OpenAIProvider {
             response_format,
             reasoning_effort,
             thinking,
+            // Flatten operator-supplied sampler params (e.g. repeat_penalty) into
+            // the request. Empty unless configured → no wire change for cloud.
+            extra_sampling: {
+                let mut extra = config.sampling_params.clone().unwrap_or_default();
+                // Defense-in-depth (#2172): drop keys octos already models with
+                // dedicated fields, so a misconfigured sampler param can't emit
+                // duplicate/divergent keys across the streaming (to_value,
+                // last-wins) and non-streaming (to_vec, duplicate) send paths.
+                for reserved in RESERVED_SAMPLING_KEYS {
+                    extra.remove(*reserved);
+                }
+                extra
+            },
         }
     }
 }
+
+/// Request keys octos sets via dedicated `OpenAIRequest` fields; if an operator
+/// puts one of these in `sampling_params` it is dropped (the dedicated field /
+/// knob wins) rather than emitted twice. See [`OpenAIProvider::build_request`].
+const RESERVED_SAMPLING_KEYS: &[&str] = &[
+    "model",
+    "messages",
+    "max_tokens",
+    "max_completion_tokens",
+    "temperature",
+    "tools",
+    "response_format",
+    "reasoning_effort",
+    "thinking",
+    "stream",
+    "stream_options",
+];
 
 #[async_trait]
 impl LlmProvider for OpenAIProvider {
@@ -875,6 +905,13 @@ struct OpenAIRequest<'a> {
     /// DeepSeek V4 thinking toggle (`{"type": "enabled"}`); other styles omit it.
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<serde_json::Value>,
+    /// Operator-supplied extra sampler params flattened into the request body
+    /// (`repeat_penalty`, `top_p`, `top_k`, `min_p`, `frequency_penalty`, …) for
+    /// OpenAI-compatible servers (llama.cpp / vLLM / SGLang) — params octos does
+    /// not model. Empty by default, so it flattens to nothing and cloud requests
+    /// are unchanged. See `ChatConfig::sampling_params` / issue #2172.
+    #[serde(flatten)]
+    extra_sampling: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Serialize)]
@@ -1570,6 +1607,58 @@ mod tests {
         let v = serde_json::to_value(p.build_request(&msgs, &[], &cfg, false)).unwrap();
         assert_eq!(v["reasoning_effort"], "high");
         assert_eq!(v["thinking"], serde_json::json!({ "type": "enabled" }));
+    }
+
+    #[test]
+    fn build_request_flattens_sampling_params() {
+        // Operator-supplied sampler params (#2172) appear as top-level fields in
+        // the request body, so an OpenAI-compatible server receives e.g.
+        // repeat_penalty even though octos does not model it.
+        let p = OpenAIProvider::new("key", "gpt-4o");
+        let mut sp = serde_json::Map::new();
+        sp.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+        sp.insert("top_p".to_string(), serde_json::json!(0.95));
+        let cfg = ChatConfig {
+            sampling_params: Some(sp),
+            ..Default::default()
+        };
+        let msgs = [msg("hi")];
+        let v = serde_json::to_value(p.build_request(&msgs, &[], &cfg, false)).unwrap();
+        assert_eq!(v["repeat_penalty"], serde_json::json!(1.1));
+        assert_eq!(v["top_p"], serde_json::json!(0.95));
+    }
+
+    #[test]
+    fn build_request_drops_reserved_keys_from_sampling_params() {
+        // Defense-in-depth (#2172): a modeled key put in sampling_params is
+        // dropped so it can't duplicate/override the dedicated field. The
+        // dedicated `temperature` (0.5, exactly representable) wins; the stray
+        // one (1.9) is gone. `repeat_penalty` (unmodeled) passes through.
+        let p = OpenAIProvider::new("key", "gpt-4o");
+        let mut sp = serde_json::Map::new();
+        sp.insert("temperature".to_string(), serde_json::json!(1.9));
+        sp.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+        let cfg = ChatConfig {
+            temperature: Some(0.5),
+            sampling_params: Some(sp),
+            ..Default::default()
+        };
+        let msgs = [msg("hi")];
+        let v = serde_json::to_value(p.build_request(&msgs, &[], &cfg, false)).unwrap();
+        assert_eq!(v["temperature"], serde_json::json!(0.5));
+        assert_eq!(v["repeat_penalty"], serde_json::json!(1.1));
+    }
+
+    #[test]
+    fn build_request_omits_sampling_params_when_unset() {
+        // Cloud-safety: with no sampling_params, no extra keys are added — the
+        // request body is unchanged.
+        let p = OpenAIProvider::new("key", "gpt-4o");
+        let msgs = [msg("hi")];
+        let v = serde_json::to_value(p.build_request(&msgs, &[], &ChatConfig::default(), false))
+            .unwrap();
+        assert!(v.get("repeat_penalty").is_none());
+        assert!(v.get("top_p").is_none());
     }
 
     #[test]

--- a/crates/octos-services/src/persona_service.rs
+++ b/crates/octos-services/src/persona_service.rs
@@ -224,6 +224,7 @@ impl PersonaService {
             reasoning_effort: None,
             response_format: None,
             context_management: None,
+            sampling_params: None,
         };
 
         match self.llm.chat(&messages, &[], &config).await {
@@ -386,6 +387,7 @@ impl PersonaService {
             reasoning_effort: None,
             response_format: None,
             context_management: None,
+            sampling_params: None,
         };
 
         match self.llm.chat(&messages, &[], &config).await {


### PR DESCRIPTION
## What & why

Completes the follow-up documented in #2172 (merged as #2173). The temperature knob only *reduces* local-model repetition collapse — it's run-to-run stochastic: one `temperature=0.7` conversion run scaffolded a clean Rust project, the very next collapsed into **763 identical `update_plan` calls** until `max_tokens`. The robust fix is an anti-repetition sampler, but `OpenAIRequest` had **no** `frequency_penalty` / `presence_penalty` / `repetition_penalty` field — octos literally could not send one. Pi handles exactly this with a `samplingParams` passthrough (`types.ts:186`).

## Change

A `sampling_params` map threaded end-to-end and **flattened verbatim** into the OpenAI request body, so an OpenAI-compatible server (llama.cpp / vLLM / SGLang) receives params octos doesn't model — `repeat_penalty`, `top_p`, `top_k`, `min_p`, `frequency_penalty`, `presence_penalty`:

- `ChatConfig.sampling_params` → `OpenAIRequest` `#[serde(flatten)] extra_sampling`.
- `AgentConfig.chat_sampling_params` → applied in `build_chat_config()`.
- `gateway.llm_sampling_params` (config.json) → threaded at the `chat` / `gateway_runtime` / `acp` sites and surfaced through `config_from_profile` (the serve / octoscode profile path), mirroring `llm_temperature`.

Usage (config.json or profile gateway):
```json
"gateway": { "llm_temperature": 0.7,
             "llm_sampling_params": { "repeat_penalty": 1.15, "top_p": 0.95, "min_p": 0.05 } }
```

## Cloud safety

Cloud-safe by construction: unset → the flatten map is empty → **nothing** is added to the request, byte-for-byte unchanged for cloud. And keys octos already models (`temperature`, `max_tokens`, `tools`, …) are stripped from the passthrough (`RESERVED_SAMPLING_KEYS`), so a misconfigured param cannot emit duplicate/divergent keys across the streaming (`to_value`, last-wins) and non-streaming (`to_vec`, duplicate) send paths — the dedicated field/knob always wins.

## Tests

- `build_request_flattens_sampling_params` — `repeat_penalty`/`top_p` appear as top-level request fields.
- `build_request_omits_sampling_params_when_unset` — cloud-safety: nothing added when unset.
- `build_request_drops_reserved_keys_from_sampling_params` — a stray `temperature` in the passthrough is dropped; the dedicated field wins.
- `test_gateway_llm_sampling_params_parses` / `_absent_is_none` — config surface (absent → None).
- `build_chat_config_threads_sampling_params` — threading, unset → None.

octos-llm (563) + octos-cli (1589) + octos-agent (2651) green; fmt + clippy clean. An adversarial review found the change ship-ready; this PR additionally closes the one edge it flagged (the reserved-key guard above).

## Note

This is the 4th and final octos gap surfaced by the pi-harness comparison (after the streaming total-timeout #2171, the forced-greedy temperature #2173, and the empty-`MaxTokens` dead-end #2175). It's the piece most likely to make a slow local model complete a real conversion reliably rather than collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
