### PR TITLE
fix(cli): thread profile gateway LLM knobs onto serve/octoscode sessions (#2179)

### DIFF
--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -563,6 +563,32 @@ impl SessionRuntime {
             human_approval_rules: profile.human_approval_rules.clone(),
             // #1774: opt-in post-edit formatting (rustfmt/prettier/black/gofmt).
             format_after_edit: profile.format_after_edit,
+            // #2172: thread the profile's gateway LLM knobs onto serve /
+            // octoscode sessions, exactly as `octos chat` does. Without this a
+            // profile-driven session silently ran with the built-in defaults
+            // (greedy temperature=0.0, no sampler, 16384 max output) — dropping
+            // the local-model repetition-collapse mitigations. Each is `None`
+            // unless the operator set it, so cloud sessions are unchanged.
+            chat_max_tokens: profile
+                .config
+                .gateway
+                .as_ref()
+                .and_then(|g| g.max_output_tokens),
+            chat_temperature: profile
+                .config
+                .gateway
+                .as_ref()
+                .and_then(|g| g.llm_temperature),
+            chat_sampling_params: profile
+                .config
+                .gateway
+                .as_ref()
+                .and_then(|g| g.llm_sampling_params.clone()),
+            reasoning_effort: profile
+                .config
+                .gateway
+                .as_ref()
+                .and_then(|g| g.reasoning_effort),
             ..Default::default()
         })
         // M11-F regression fix (#891): propagate the pre-assembled
@@ -1237,6 +1263,51 @@ mod tests {
             prompt.contains("Friday again"),
             "read-refresh must pick up post-bootstrap consolidations: {prompt}"
         );
+    }
+
+    #[tokio::test]
+    async fn session_agent_threads_profile_gateway_llm_knobs() {
+        // #2172: a serve / octoscode session must honor the profile's gateway
+        // LLM knobs (temperature, sampler, max output) rather than silently
+        // falling back to the greedy 0.0 / 16384 / no-sampler defaults.
+        let dir = tempfile::tempdir().unwrap();
+        let mut profile = make_profile(dir.path().to_path_buf()).await;
+        let mut sp = serde_json::Map::new();
+        sp.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+        Arc::get_mut(&mut profile).unwrap().config.gateway = Some(crate::config::GatewayConfig {
+            max_output_tokens: Some(32768),
+            llm_temperature: Some(0.7),
+            llm_sampling_params: Some(sp),
+            reasoning_effort: Some(octos_llm::ReasoningEffort::High),
+            ..Default::default()
+        });
+        let rt = SessionRuntime::bootstrap(&profile, SessionKey::new("appui", "gw"), None)
+            .await
+            .expect("bootstrap");
+        let cfg = rt.agent.agent_config();
+        assert_eq!(cfg.chat_max_tokens, Some(32768));
+        assert_eq!(cfg.chat_temperature, Some(0.7));
+        assert_eq!(
+            cfg.chat_sampling_params
+                .and_then(|m| m.get("repeat_penalty").cloned()),
+            Some(serde_json::json!(1.1))
+        );
+        assert_eq!(cfg.reasoning_effort, Some(octos_llm::ReasoningEffort::High));
+    }
+
+    #[tokio::test]
+    async fn session_agent_keeps_defaults_when_profile_has_no_gateway_knobs() {
+        // Cloud-safety: a profile without the gateway knobs yields None (the
+        // built-in defaults), so serve behavior is unchanged.
+        let dir = tempfile::tempdir().unwrap();
+        let profile = make_profile(dir.path().to_path_buf()).await;
+        let rt = SessionRuntime::bootstrap(&profile, SessionKey::new("appui", "gw2"), None)
+            .await
+            .expect("bootstrap");
+        let cfg = rt.agent.agent_config();
+        assert_eq!(cfg.chat_max_tokens, None);
+        assert_eq!(cfg.chat_temperature, None);
+        assert_eq!(cfg.chat_sampling_params, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What & why

Closes #2179. The **serve / octoscode** per-session agent (`SessionRuntime::bootstrap`) built its `AgentConfig` with `..Default::default()` and threaded **none** of the profile's gateway LLM knobs. So a profile-driven session silently ran with the built-in defaults — **greedy `temperature=0.0`, no sampler passthrough, 16384 max output** — dropping the local-model mitigations the profile configured (#2173 temperature, #2176 sampler) and the operator's `max_output_tokens`. `octos chat` threads all of these; the serve path did not.

This was the missing link behind a long local-model debugging chain: with the knobs set in the profile they *do* reach `octos chat` (verified — request goes out with `temperature=0.7, max_tokens=32768, sampling_params={…}`), but a serve/octoscode session had no wiring at all, so those same knobs were ignored.

## Change

Thread `chat_max_tokens` / `chat_temperature` / `chat_sampling_params` / `reasoning_effort` from `profile.config.gateway` onto the SessionRuntime `AgentConfig`, mirroring `commands/chat.rs` exactly (`profile.config.gateway.as_ref().and_then(|g| g.<field>)`).

## Cloud safety

Each field is `None` unless the operator set it in the profile gateway, so `build_chat_config` keeps the built-in defaults and a profile without these keys is **byte-for-byte unchanged**. Cloud/serve behavior is unaffected.

## Tests

- `session_agent_threads_profile_gateway_llm_knobs` — a bootstrapped session agent's `agent_config()` reflects the profile's `max_output_tokens: 32768` / `llm_temperature: 0.7` / `llm_sampling_params: {repeat_penalty}`.
- `session_agent_keeps_defaults_when_profile_has_no_gateway_knobs` — a profile without them keeps `None` (cloud-safety).

`cargo test -p octos-cli` green for the new tests; fmt + clippy clean. (Note: an unrelated `autonomy::agent_orchestrator` test fails on current `main` independent of this change.)

## Follow-up (out of scope)

The MCP-serve path (`commands/mcp_serve.rs` `run_session`) has the same gap, but its `AgentConfig` site has no gateway config in scope — `SessionDispatchConfig` would need to carry it. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
