### PR TITLE
feat(appui): typed inference-parameter schema for profile/llm/* — reject silently-dropped fields

### DIFF
--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -4586,6 +4586,10 @@ mod tests {
                 model_hints: None,
                 cost_per_m: None,
                 strong: None,
+                // #2166 typed inference defaults (unset here).
+                temperature: None,
+                top_p: None,
+                reasoning_effort: None,
                 context_window: None,
             }),
             fallbacks: vec![],

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -1160,6 +1160,403 @@ async fn llm_select_does_not_abandon_running_skill_action_jobs() {
     );
 }
 
+// ===========================================================================
+// #2166 — typed AppUI inference-parameter schema (reject / round-trip /
+// ownership). The old schema silently DROPPED any extra field the client
+// sent (temperature, top_p, max_output_tokens, context_window, nested
+// reasoning objects) while answering `applied: true`.
+// ===========================================================================
+
+/// Unknown fields on `profile/llm/upsert` must be rejected with EVERY
+/// rejected field named by its dotted path — never accepted with
+/// `applied: true` while the values are silently discarded — and the prior
+/// configuration must be left untouched.
+#[tokio::test]
+async fn llm_upsert_rejects_unknown_fields_and_names_every_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    let error = raw_profile_llm_upsert(
+        &state,
+        &RpcRequest::new(
+            "u-unknown".to_string(),
+            APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "selection": {
+                    "family_id": "custom",
+                    "model_id": "fixture-model",
+                    "route": {
+                        "route_id": "fixture",
+                        "base_url": "http://127.0.0.1:9/v1",
+                        "api_type": "openai",
+                        "bogus_route_key": true
+                    },
+                    "inference": { "temperature": 0.2 },
+                    "temperature2": 0.5
+                },
+                "set_primary": true
+            }),
+        ),
+        None,
+    )
+    .await
+    .expect_err("unknown fields must be rejected, not silently dropped");
+    let data = error.data.as_ref().expect("typed error data");
+    assert_eq!(data["kind"], json!("llm_unknown_fields"));
+    let rejected = data["rejected_fields"].as_array().expect("field list");
+    for expected in [
+        "selection.temperature2",
+        "selection.inference",
+        "selection.route.bogus_route_key",
+    ] {
+        assert!(
+            rejected.iter().any(|value| *value == json!(expected)),
+            "rejected_fields must name {expected}: {data}"
+        );
+    }
+    // The rejection happens BEFORE any store mutation: the profile is not
+    // even created.
+    assert!(
+        state
+            .profile_store
+            .as_ref()
+            .unwrap()
+            .get("dev")
+            .unwrap()
+            .is_none(),
+        "a rejected upsert must not create or mutate the profile"
+    );
+}
+
+/// `max_output_tokens` is REAL but owned by the profile-gateway contract —
+/// it gets a dedicated typed error pointing at the owner instead of a
+/// generic "unknown field".
+#[tokio::test]
+async fn llm_upsert_rejects_max_output_tokens_as_owned_elsewhere() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    let error = raw_profile_llm_upsert(
+        &state,
+        &RpcRequest::new(
+            "u-foreign".to_string(),
+            APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "selection": {
+                    "family_id": "custom",
+                    "model_id": "fixture-model",
+                    "route": { "route_id": "fixture", "base_url": "http://127.0.0.1:9/v1" },
+                    "max_output_tokens": 4096
+                },
+                "set_primary": true
+            }),
+        ),
+        None,
+    )
+    .await
+    .expect_err("max_output_tokens is owned by the gateway contract");
+    let data = error.data.as_ref().expect("typed error data");
+    assert_eq!(data["kind"], json!("llm_param_owned_elsewhere"));
+    assert_eq!(
+        data["rejected_fields"][0],
+        json!("selection.max_output_tokens")
+    );
+    let owner = data["owners"][0]["owner"].as_str().unwrap();
+    assert!(
+        owner.contains("gateway") && owner.contains("max_output_tokens"),
+        "the error must point at the owning contract: {owner}"
+    );
+    assert!(
+        state
+            .profile_store
+            .as_ref()
+            .unwrap()
+            .get("dev")
+            .unwrap()
+            .is_none(),
+        "a foreign-field rejection must not create or mutate the profile"
+    );
+}
+
+/// Out-of-range and non-finite typed values return a typed
+/// `llm_param_out_of_range` / `llm_param_non_finite` without mutating the
+/// prior configuration.
+#[tokio::test]
+async fn llm_upsert_rejects_out_of_range_and_non_finite_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    for (field, value, kind) in [
+        ("temperature", json!(3.5), "llm_param_out_of_range"),
+        ("temperature", json!(-0.1), "llm_param_out_of_range"),
+        ("top_p", json!(1.5), "llm_param_out_of_range"),
+        ("context_window", json!(0), "llm_param_out_of_range"),
+    ] {
+        let error = raw_profile_llm_upsert(
+            &state,
+            &RpcRequest::new(
+                "u-range".to_string(),
+                APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+                json!({
+                    "profile_id": "dev",
+                    "selection": {
+                        "family_id": "custom",
+                        "model_id": "fixture-model",
+                        "route": { "route_id": "fixture", "base_url": "http://127.0.0.1:9/v1" },
+                        field: value
+                    },
+                    "set_primary": true
+                }),
+            ),
+            None,
+        )
+        .await
+        .expect_err("{field}={value} must be rejected");
+        let data = error.data.as_ref().expect("typed error data");
+        assert_eq!(data["kind"], json!(kind), "{field}={value}");
+        assert_eq!(data["field"], json!(format!("selection.{field}")));
+    }
+    // Non-finite guard: exercised directly (JSON cannot carry NaN/Inf).
+    let error = validate_llm_inference_fields(&RawLlmSelection {
+        temperature: Some(f64::NAN),
+        ..Default::default()
+    })
+    .expect_err("NaN temperature must be rejected");
+    assert_eq!(
+        error.data.as_ref().unwrap()["kind"],
+        json!("llm_param_non_finite")
+    );
+}
+
+/// Known typed inference fields round-trip: upsert → durable store →
+/// list/read; a re-upsert WITHOUT them clears the prior override
+/// (`absent ≡ null ≡ inherit`), and routing metadata outside the schema
+/// (`cost_per_m`/`strong`) survives the same-address edit.
+#[tokio::test]
+async fn llm_upsert_round_trips_typed_inference_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    let route = json!({ "route_id": "fixture", "base_url": "http://127.0.0.1:9/v1" });
+    raw_profile_llm_upsert(
+        &state,
+        &RpcRequest::new(
+            "u-rt1".to_string(),
+            APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "selection": {
+                    "family_id": "custom",
+                    "model_id": "fixture-model",
+                    "route": route,
+                    "temperature": 0.2,
+                    "top_p": 0.9,
+                    "context_window": 16384,
+                    "reasoning_effort": "high",
+                    "model_hints": { "uses_completion_tokens": true }
+                },
+                "set_primary": true
+            }),
+        ),
+        None,
+    )
+    .await
+    .expect("typed upsert");
+    // Routing metadata arrives OUTSIDE the RPC (QoS/routing research owns
+    // it) — written straight to the durable selection.
+    let mut profile = state
+        .profile_store
+        .as_ref()
+        .unwrap()
+        .get("dev")
+        .unwrap()
+        .unwrap();
+    {
+        let primary = profile
+            .config
+            .llm
+            .as_mut()
+            .unwrap()
+            .primary
+            .as_mut()
+            .unwrap();
+        primary.cost_per_m = Some(1.5);
+        primary.strong = Some(true);
+    }
+    state
+        .profile_store
+        .as_ref()
+        .unwrap()
+        .save(&profile)
+        .expect("seed routing metadata");
+
+    let profile = state
+        .profile_store
+        .as_ref()
+        .unwrap()
+        .get("dev")
+        .unwrap()
+        .unwrap();
+    let primary = profile
+        .config
+        .llm
+        .as_ref()
+        .unwrap()
+        .primary
+        .as_ref()
+        .unwrap();
+    assert_eq!(primary.temperature, Some(0.2));
+    assert_eq!(primary.top_p, Some(0.9));
+    assert_eq!(primary.context_window, Some(16384));
+    assert_eq!(
+        primary.reasoning_effort,
+        Some(octos_llm::ReasoningEffort::High)
+    );
+    assert!(primary.model_hints.as_ref().unwrap().uses_completion_tokens);
+
+    // The list projection round-trips every configured field — and stays
+    // truthful: a client must be able to tell saved values from inherited.
+    let listed = profile_llm_list_result(&state, "dev", Some(&profile));
+    let primary_json = listed["primary"].as_object().expect("primary object");
+    assert_eq!(primary_json["context_window"], json!(16384));
+    assert!(
+        primary_json["temperature"].as_f64().unwrap() - 0.2 < 1e-6,
+        "got {}",
+        primary_json["temperature"]
+    );
+    assert!(
+        primary_json["top_p"].as_f64().unwrap() - 0.9 < 1e-6,
+        "got {}",
+        primary_json["top_p"]
+    );
+    assert_eq!(primary_json["reasoning_effort"], json!("high"));
+    assert_eq!(
+        primary_json["model_hints"]["uses_completion_tokens"],
+        json!(true)
+    );
+    assert_eq!(primary_json["cost_per_m"], json!(1.5));
+
+    // Re-upsert the same address WITHOUT the inference fields: absent ≡
+    // inherit, so the overrides clear — but the out-of-schema routing
+    // metadata (cost_per_m/strong) survives the edit.
+    raw_profile_llm_upsert(
+        &state,
+        &RpcRequest::new(
+            "u-rt2".to_string(),
+            APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "selection": {
+                    "family_id": "custom",
+                    "model_id": "fixture-model",
+                    "route": route
+                },
+                "set_primary": true
+            }),
+        ),
+        None,
+    )
+    .await
+    .expect("clearing re-upsert");
+    let profile = state
+        .profile_store
+        .as_ref()
+        .unwrap()
+        .get("dev")
+        .unwrap()
+        .unwrap();
+    let primary = profile
+        .config
+        .llm
+        .as_ref()
+        .unwrap()
+        .primary
+        .as_ref()
+        .unwrap();
+    assert_eq!(
+        primary.temperature, None,
+        "absent ≡ inherit: override cleared"
+    );
+    assert_eq!(primary.top_p, None);
+    assert_eq!(primary.context_window, None);
+    assert_eq!(primary.reasoning_effort, None);
+    assert_eq!(primary.cost_per_m, Some(1.5), "routing metadata survives");
+    assert_eq!(primary.strong, Some(true));
+    let listed = profile_llm_list_result(&state, "dev", Some(&profile));
+    assert!(
+        listed["primary"].get("temperature").is_none(),
+        "an unconfigured field must be absent (not null) so list output is \
+         unchanged for unconfigured users"
+    );
+}
+
+/// Each configured model carries its OWN parameter set: a fallback's
+/// inference defaults are independent of the primary's, so a
+/// primary/fallback switch cannot leak parameters across models.
+#[tokio::test]
+async fn llm_upsert_keeps_inference_params_per_model_without_leakage() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    let upsert = |id: &str, model: &str, extra: Value| {
+        let mut selection = json!({
+            "family_id": "custom",
+            "model_id": model,
+            "route": { "route_id": "fixture", "base_url": "http://127.0.0.1:9/v1" }
+        });
+        let extra = extra.as_object().unwrap().clone();
+        for (key, value) in extra {
+            selection[key] = value;
+        }
+        RpcRequest::new(
+            id.to_string(),
+            APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "selection": selection,
+                "set_primary": id == "primary",
+            }),
+        )
+    };
+    raw_profile_llm_upsert(
+        &state,
+        &upsert(
+            "primary",
+            "model-a",
+            json!({ "temperature": 0.2, "context_window": 8192 }),
+        ),
+        None,
+    )
+    .await
+    .expect("primary upsert");
+    raw_profile_llm_upsert(
+        &state,
+        &upsert(
+            "fallback",
+            "model-b",
+            json!({ "temperature": 0.9, "reasoning_effort": "max" }),
+        ),
+        None,
+    )
+    .await
+    .expect("fallback upsert");
+
+    let profile = state
+        .profile_store
+        .as_ref()
+        .unwrap()
+        .get("dev")
+        .unwrap()
+        .unwrap();
+    let llm = profile.config.llm.as_ref().unwrap();
+    assert_eq!(llm.primary.as_ref().unwrap().temperature, Some(0.2));
+    assert_eq!(llm.primary.as_ref().unwrap().context_window, Some(8192));
+    assert_eq!(llm.primary.as_ref().unwrap().reasoning_effort, None);
+    assert_eq!(llm.fallbacks[0].temperature, Some(0.9));
+    assert_eq!(
+        llm.fallbacks[0].reasoning_effort,
+        Some(octos_llm::ReasoningEffort::Max)
+    );
+    assert_eq!(llm.fallbacks[0].context_window, None, "no cross-model leak");
+}
+
 /// Key requirement mirrors the runtime factory, not just the registry
 /// flag: an `anthropic`/`responses` api_type override needs a key even
 /// on a registry-keyless family, and a family the registry doesn't know
@@ -28903,7 +29300,13 @@ async fn appui_no_cwd_workspace_does_not_become_a_transcript_store_hint() {
         .opened
         .workspace_root
         .expect("Tier-3 workspace root is still exposed for tools and UI");
-    assert_ne!(workspace_root, profile_runtime.data_dir);
+    // `workspace_root` is a `String` on the wire and `data_dir` a `PathBuf`:
+    // compare in the same domain (pre-existing compile break that blocked all
+    // `--features api` local test runs; surfaced while adding #2166 tests).
+    assert_ne!(
+        std::path::PathBuf::from(&workspace_root),
+        profile_runtime.data_dir
+    );
 
     let sessions = resolve_sessions_for_lookup(&state, None, Some(profile_id), &session_id)
         .await

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -12175,18 +12175,13 @@ async fn raw_profile_llm_upsert(
     // schema (`cost_per_m`, `strong` — owned by routing research / QoS) must
     // not be silently destroyed by an endpoint edit: carry the prior
     // same-address values forward instead of resetting them.
-    if let Some(prior) = profile
-        .config
-        .llm
-        .as_ref()
-        .map(|llm| {
-            llm.fallbacks
-                .iter()
-                .chain(llm.primary.iter())
-                .find(|existing| same_llm_selection_address(existing, &selection))
-        })
-        .flatten()
-    {
+    let prior_same_address = profile.config.llm.as_ref().and_then(|llm| {
+        llm.fallbacks
+            .iter()
+            .chain(llm.primary.iter())
+            .find(|existing| same_llm_selection_address(existing, &selection))
+    });
+    if let Some(prior) = prior_same_address {
         selection.cost_per_m = prior.cost_per_m;
         selection.strong = prior.strong;
     }

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -7773,7 +7773,12 @@ struct RawProfileSkillsRemoveParams {
     name: String,
 }
 
+/// One provider route on the AppUI `profile/llm/*` wire (#2166 typed
+/// schema). Unknown keys are rejected by [`reject_unknown_llm_upsert_fields`]
+/// before serde sees them (so the error lists EVERY rejected field), and
+/// `deny_unknown_fields` here is the belt-and-braces second layer.
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawLlmRoute {
     #[serde(default)]
     route_id: Option<String>,
@@ -7787,7 +7792,29 @@ struct RawLlmRoute {
     api_type: Option<String>,
 }
 
+/// The typed main-model selection + inference-parameter schema shared by
+/// `profile/llm/upsert`, `profile/llm/test`, and `profile/llm/fetch_models`
+/// (#2166). Test and Save parse the identical shape, so a payload that
+/// probes successfully is byte-for-byte the payload that persists.
+///
+/// Absent/null semantics for every optional inference field: `absent ≡
+/// null ≡ inherit` (clear any prior override — the upsert payload is the
+/// COMPLETE inference configuration for the addressed selection); an
+/// explicit value is an override. Omitted fields always mean "defer to the
+/// next tier of the precedence chain", never "silently keep serving a value
+/// the caller cannot see in the list response".
+///
+/// Ownership (what this schema deliberately does NOT accept):
+/// - `max_output_tokens` → owned by the profile gateway contract
+///   (`[gateway] max_output_tokens`); rejected with
+///   `kind: "llm_param_owned_elsewhere"`.
+/// - Per-session reasoning overrides → owned by the durable
+///   session/turn contract (`ui_protocol_reasoning_effort.rs`); this schema
+///   only sets the per-MODEL default tier.
+/// - Arbitrary provider request-body keys → owned by the gateway
+///   `llm_sampling_params` passthrough (#2176); rejected here as unknown.
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawLlmSelection {
     #[serde(default)]
     family_id: Option<String>,
@@ -7795,9 +7822,29 @@ struct RawLlmSelection {
     model_id: Option<String>,
     #[serde(default)]
     route: RawLlmRoute,
+    /// Typed compatibility metadata (mirrors
+    /// [`octos_llm::openai::ModelHints`]) — never a request-body bag.
+    #[serde(default)]
+    model_hints: Option<octos_llm::openai::ModelHints>,
+    /// Local runtime context budget override (#2142). Reaches the runtime
+    /// `ContextWindowOverride` via the durable selection; NOT an upstream
+    /// request field.
+    #[serde(default)]
+    context_window: Option<u32>,
+    /// Per-model default sampling temperature (finite, 0.0..=2.0).
+    #[serde(default)]
+    temperature: Option<f64>,
+    /// Per-model default nucleus-sampling ceiling (finite, 0.0..=1.0).
+    #[serde(default)]
+    top_p: Option<f64>,
+    /// Per-model default reasoning effort (the session/turn override tier
+    /// wins over this).
+    #[serde(default)]
+    reasoning_effort: Option<octos_llm::ReasoningEffort>,
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawProfileLlmSelectParams {
     #[serde(default)]
     profile_id: Option<String>,
@@ -7811,7 +7858,11 @@ struct RawProfileLlmSelectParams {
     route_id: Option<String>,
 }
 
+/// Typed AppUI `profile/llm/upsert` / `test` / `fetch_models` params
+/// (#2166). Unknown keys are rejected with their full dotted paths —
+/// `never return applied:true after discarding requested settings`.
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawProfileLlmUpsertParams {
     #[serde(default)]
     profile_id: Option<String>,
@@ -7820,6 +7871,211 @@ struct RawProfileLlmUpsertParams {
     api_key: Option<Value>,
     #[serde(default)]
     set_primary: bool,
+}
+
+/// Known keys per container level of the AppUI LLM schema (#2166). The
+/// pre-pass in [`reject_unknown_llm_upsert_fields`] walks these so ONE
+/// error can name every rejected field instead of only the first.
+const LLM_UPSERT_KNOWN_TOP: &[&str] = &["profile_id", "selection", "api_key", "set_primary"];
+const LLM_SELECTION_KNOWN: &[&str] = &[
+    "family_id",
+    "model_id",
+    "route",
+    "model_hints",
+    "context_window",
+    "temperature",
+    "top_p",
+    "reasoning_effort",
+];
+const LLM_ROUTE_KNOWN: &[&str] = &["route_id", "label", "base_url", "api_key_env", "api_type"];
+const LLM_MODEL_HINTS_KNOWN: &[&str] = &[
+    "uses_completion_tokens",
+    "fixed_temperature",
+    "lacks_vision",
+    "merge_system_messages",
+    "reasoning_style",
+];
+/// Fields a client may plausibly send on this RPC that are REAL but owned
+/// by a different contract tier. They get a dedicated typed error pointing
+/// at the owner instead of a generic "unknown field".
+const LLM_FOREIGN_FIELDS: &[(&str, &str)] = &[
+    (
+        "selection.max_output_tokens",
+        "profile gateway `max_output_tokens` ([gateway] max_output_tokens in the \
+         profile config) — a per-model output cap is not part of the AppUI model \
+         schema",
+    ),
+    (
+        "max_output_tokens",
+        "profile gateway `max_output_tokens` ([gateway] max_output_tokens in the \
+         profile config)",
+    ),
+];
+
+/// Pre-pass for the AppUI LLM mutation RPCs (#2166): collect EVERY unknown
+/// field (with its dotted path) and every foreign-owned field BEFORE any
+/// store mutation, so the caller gets one typed `invalid_params` naming all
+/// of them and the prior configuration is untouched. serde's
+/// `deny_unknown_fields` (on the structs above) remains as the second
+/// layer for shapes this walk does not model.
+fn reject_unknown_llm_upsert_fields(params: &Value) -> Result<(), RpcError> {
+    let Some(obj) = params.as_object() else {
+        return Ok(()); // non-object falls through to serde's own type error
+    };
+    let selection_obj = obj.get("selection").and_then(Value::as_object);
+    let contains_foreign = |path: &str| match path.split_once('.') {
+        Some(("selection", key)) => {
+            selection_obj.is_some_and(|selection| selection.contains_key(key))
+        }
+        _ => obj.contains_key(path),
+    };
+    let mut unknown: Vec<String> = obj
+        .keys()
+        .filter(|key| !LLM_UPSERT_KNOWN_TOP.contains(&key.as_str()))
+        .filter(|key| {
+            !LLM_FOREIGN_FIELDS
+                .iter()
+                .any(|(path, _)| *path == key.as_str())
+        })
+        .map(String::clone)
+        .collect();
+
+    if let Some(selection) = selection_obj {
+        for key in selection.keys() {
+            let path = format!("selection.{key}");
+            if LLM_FOREIGN_FIELDS.iter().any(|(known, _)| *known == path) {
+                continue;
+            }
+            if !LLM_SELECTION_KNOWN.contains(&key.as_str()) {
+                unknown.push(path);
+            }
+        }
+        if let Some(route) = selection.get("route").and_then(Value::as_object) {
+            unknown.extend(
+                route
+                    .keys()
+                    .filter(|key| !LLM_ROUTE_KNOWN.contains(&key.as_str()))
+                    .map(|key| format!("selection.route.{key}")),
+            );
+        }
+        if let Some(hints) = selection.get("model_hints").and_then(Value::as_object) {
+            unknown.extend(
+                hints
+                    .keys()
+                    .filter(|key| !LLM_MODEL_HINTS_KNOWN.contains(&key.as_str()))
+                    .map(|key| format!("selection.model_hints.{key}")),
+            );
+        }
+    }
+
+    let foreign: Vec<&str> = LLM_FOREIGN_FIELDS
+        .iter()
+        .filter(|(path, _)| contains_foreign(path))
+        .map(|(path, _)| *path)
+        .collect();
+
+    if !foreign.is_empty() {
+        let owners: Vec<Value> = foreign
+            .iter()
+            .map(|path| {
+                let owner = LLM_FOREIGN_FIELDS
+                    .iter()
+                    .find(|(known, _)| known == path)
+                    .map(|(_, owner)| *owner)
+                    .unwrap_or("another configuration contract");
+                json!({ "field": path, "owner": owner })
+            })
+            .collect();
+        return Err(RpcError::invalid_params(format!(
+            "field(s) {} belong to a different configuration contract and are not \
+             accepted by profile/llm/upsert",
+            foreign.join(", ")
+        ))
+        .with_data(json!({
+            "kind": "llm_param_owned_elsewhere",
+            "rejected_fields": foreign,
+            "owners": owners,
+        })));
+    }
+
+    if !unknown.is_empty() {
+        unknown.sort();
+        return Err(RpcError::invalid_params(format!(
+            "unknown field(s): {} — profile/llm/upsert accepts a typed schema and \
+             never silently discards fields",
+            unknown.join(", ")
+        ))
+        .with_data(json!({
+            "kind": "llm_unknown_fields",
+            "rejected_fields": unknown,
+        })));
+    }
+    Ok(())
+}
+
+/// Range/finite validation for the typed inference fields (#2166): runs
+/// BEFORE any store mutation, so an invalid value leaves the prior
+/// configuration untouched. (JSON cannot carry NaN/Inf, but the guard keeps
+/// the invariant local to the schema instead of trusting the transport.)
+fn validate_llm_inference_fields(selection: &RawLlmSelection) -> Result<(), RpcError> {
+    fn check_f64_range(
+        value: Option<f64>,
+        field: &str,
+        range: &str,
+        min: f64,
+        max: f64,
+    ) -> Result<(), RpcError> {
+        let Some(value) = value else {
+            return Ok(());
+        };
+        if !value.is_finite() {
+            return Err(RpcError::invalid_params(format!(
+                "selection.{field} must be a finite number"
+            ))
+            .with_data(json!({
+                "kind": "llm_param_non_finite",
+                "field": format!("selection.{field}"),
+            })));
+        }
+        if !(min..=max).contains(&value) {
+            return Err(RpcError::invalid_params(format!(
+                "selection.{field} must be in {range}, got {value}"
+            ))
+            .with_data(json!({
+                "kind": "llm_param_out_of_range",
+                "field": format!("selection.{field}"),
+                "range": range,
+            })));
+        }
+        Ok(())
+    }
+    check_f64_range(selection.temperature, "temperature", "0.0..=2.0", 0.0, 2.0)?;
+    check_f64_range(selection.top_p, "top_p", "0.0..=1.0", 0.0, 1.0)?;
+    if selection.context_window == Some(0) {
+        return Err(
+            RpcError::invalid_params("selection.context_window must be >= 1 token").with_data(
+                json!({
+                    "kind": "llm_param_out_of_range",
+                    "field": "selection.context_window",
+                    "range": ">=1",
+                }),
+            ),
+        );
+    }
+    Ok(())
+}
+
+/// Shared param pipeline for `profile/llm/upsert` / `test` /
+/// `fetch_models`: unknown-field pre-pass → typed deserialize (with
+/// `deny_unknown_fields`) → range validation. One place so Test and Save
+/// can never drift.
+fn parse_llm_selection_params(
+    request: &RpcRequest<Value>,
+) -> Result<RawProfileLlmUpsertParams, RpcError> {
+    reject_unknown_llm_upsert_fields(&request.params)?;
+    let params: RawProfileLlmUpsertParams = parse_raw_params(request)?;
+    validate_llm_inference_fields(&params.selection)?;
+    Ok(params)
 }
 
 /// `profile/llm/delete`: remove one configured model (primary or fallback) by
@@ -9008,7 +9264,7 @@ fn configured_provider_json(
     let model_id = selection.model_id.clone();
     let route_id = route.route_id.clone();
     let api_key_env = route.api_key_env.clone();
-    json!({
+    let mut provider = json!({
         "provider": family_id.clone().unwrap_or_default(),
         "model": model_id.clone().unwrap_or_default(),
         "family_id": family_id,
@@ -9022,7 +9278,38 @@ fn configured_provider_json(
             .is_some_and(|key| env_vars.get(key).is_some_and(|value| !value.is_empty())),
         "selected": selected,
         "available": true,
-    })
+    });
+    // #2166 typed inference schema round-trip: echo back every configured
+    // inference/routing field so a client can distinguish "saved" from
+    // "inherited". Keys are added ONLY when configured — a selection with no
+    // overrides serializes exactly as before #2166 (unconfigured default
+    // behavior unchanged), and `null` on the wire always means the same as
+    // an absent key: inherit.
+    let object = provider
+        .as_object_mut()
+        .expect("configured_provider_json builds an object");
+    if let Some(context_window) = selection.context_window {
+        object.insert("context_window".into(), json!(context_window));
+    }
+    if let Some(temperature) = selection.temperature {
+        object.insert("temperature".into(), json!(temperature));
+    }
+    if let Some(top_p) = selection.top_p {
+        object.insert("top_p".into(), json!(top_p));
+    }
+    if let Some(reasoning_effort) = selection.reasoning_effort {
+        object.insert("reasoning_effort".into(), json!(reasoning_effort));
+    }
+    if let Some(model_hints) = selection.model_hints.clone() {
+        object.insert("model_hints".into(), json!(model_hints));
+    }
+    if let Some(cost_per_m) = selection.cost_per_m {
+        object.insert("cost_per_m".into(), json!(cost_per_m));
+    }
+    if let Some(strong) = selection.strong {
+        object.insert("strong".into(), json!(strong));
+    }
+    provider
 }
 
 fn permission_profile_supported_selections(
@@ -11840,7 +12127,7 @@ async fn raw_profile_llm_upsert(
     request: &RpcRequest<Value>,
     connection_profile_id: Option<&str>,
 ) -> Result<Value, RpcError> {
-    let params: RawProfileLlmUpsertParams = parse_raw_params(request)?;
+    let params: RawProfileLlmUpsertParams = parse_llm_selection_params(request)?;
     let profile_id =
         raw_scoped_llm_profile_id(params.profile_id.clone(), None, connection_profile_id)?;
     let store = profile_store(state)?;
@@ -11868,12 +12155,41 @@ async fn raw_profile_llm_upsert(
         profile.config.env_vars.insert(api_key_env.clone(), api_key);
     }
 
-    let selection = crate::profiles::LlmModelSelectionConfig {
+    // #2166 typed inference schema: the upsert payload is the COMPLETE
+    // inference configuration for the addressed selection — every optional
+    // field is `absent ≡ null ≡ inherit` (a re-upsert without it CLEARS a
+    // prior override), an explicit value is an override. Rejected/unknown
+    // fields never reach this point (parse_llm_selection_params).
+    let mut selection = crate::profiles::LlmModelSelectionConfig {
         family_id: Some(family_id),
         model_id: Some(model_id),
         route: Some(route),
+        model_hints: params.selection.model_hints,
+        context_window: params.selection.context_window,
+        temperature: params.selection.temperature.map(|value| value as f32),
+        top_p: params.selection.top_p.map(|value| value as f32),
+        reasoning_effort: params.selection.reasoning_effort,
         ..Default::default()
     };
+    // #2166: routing/QoS metadata that is deliberately OUTSIDE the AppUI
+    // schema (`cost_per_m`, `strong` — owned by routing research / QoS) must
+    // not be silently destroyed by an endpoint edit: carry the prior
+    // same-address values forward instead of resetting them.
+    if let Some(prior) = profile
+        .config
+        .llm
+        .as_ref()
+        .map(|llm| {
+            llm.fallbacks
+                .iter()
+                .chain(llm.primary.iter())
+                .find(|existing| same_llm_selection_address(existing, &selection))
+        })
+        .flatten()
+    {
+        selection.cost_per_m = prior.cost_per_m;
+        selection.strong = prior.strong;
+    }
 
     let mut llm = profile.config.llm.take().unwrap_or_default();
     if params.set_primary || llm.primary.is_none() {
@@ -12160,7 +12476,7 @@ async fn raw_profile_llm_test(
     request: &RpcRequest<Value>,
     connection_profile_id: Option<&str>,
 ) -> Result<Value, RpcError> {
-    let params: RawProfileLlmUpsertParams = parse_raw_params(request)?;
+    let params: RawProfileLlmUpsertParams = parse_llm_selection_params(request)?;
     let profile_id =
         raw_scoped_llm_profile_id(params.profile_id.clone(), None, connection_profile_id)?;
     let profile = state
@@ -12300,7 +12616,7 @@ async fn raw_profile_llm_fetch_models(
     request: &RpcRequest<Value>,
     connection_profile_id: Option<&str>,
 ) -> Result<Value, RpcError> {
-    let params: RawProfileLlmUpsertParams = parse_raw_params(request)?;
+    let params: RawProfileLlmUpsertParams = parse_llm_selection_params(request)?;
     let profile_id =
         raw_scoped_llm_profile_id(params.profile_id.clone(), None, connection_profile_id)?;
     let profile = state

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -45,6 +45,25 @@ pub struct Config {
     #[serde(default)]
     pub context_window: Option<u32>,
 
+    /// #2166: the configured PRIMARY model's typed inference defaults,
+    /// flattened out of `LlmModelSelectionConfig` by `config_from_profile`
+    /// so session bootstrap can compose them AHEAD of the profile-gateway
+    /// knobs (`gateway.llm_temperature` / `gateway.reasoning_effort` /
+    /// `gateway.llm_sampling_params`). Ownership stays with the durable
+    /// model selection; these are read-only projections. `None` = inherit.
+    /// Range validation lives on the AppUI wire schema (#2166).
+    #[serde(default)]
+    pub model_temperature: Option<f32>,
+    /// #2166: primary model default `top_p`. At runtime it overrides a
+    /// same-named `top_p` key in `gateway.llm_sampling_params` (#2176);
+    /// every other sampler key in that map is untouched.
+    #[serde(default)]
+    pub model_top_p: Option<f32>,
+    /// #2166: primary model default reasoning effort. Precedence:
+    /// session/turn override → this → `gateway.reasoning_effort` → none.
+    #[serde(default)]
+    pub model_reasoning_effort: Option<octos_llm::ReasoningEffort>,
+
     /// Custom base URL for the API endpoint.
     #[serde(default)]
     pub base_url: Option<String>,

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -840,6 +840,27 @@ pub struct LlmModelSelectionConfig {
     /// Whether this is considered a strong model for large tool-heavy runs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strong: Option<bool>,
+    /// Per-model default sampling temperature (#2166 AppUI typed inference
+    /// schema). `None` = inherit: the runtime falls through to the profile
+    /// gateway `llm_temperature`, then the provider's own default.
+    /// Validated on the AppUI wire (finite, 0.0..=2.0) before persistence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// Per-model default `top_p` (nucleus sampling) (#2166). `None` =
+    /// inherit. Unlike `temperature` there is no typed `ChatConfig` field
+    /// yet, so at runtime it rides the sampler passthrough channel: it
+    /// overrides a same-named `top_p` key in the profile gateway
+    /// `llm_sampling_params` map (#2176). Validated on the AppUI wire
+    /// (finite, 0.0..=1.0) before persistence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    /// Per-model default reasoning effort for thinking models (#2166). This
+    /// is the *model default* tier of the documented reasoning-precedence
+    /// chain: a per-session/turn override
+    /// (`ui_protocol_reasoning_effort.rs`) wins over it, and it in turn wins
+    /// over the profile gateway `reasoning_effort`. `None` = inherit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<octos_llm::ReasoningEffort>,
     /// Operator override for the effective context window, in tokens. When
     /// set it takes precedence over BOTH the static catalog and the runtime
     /// probe (#2135): the provider is wrapped in `ContextWindowOverride` as
@@ -848,7 +869,8 @@ pub struct LlmModelSelectionConfig {
     /// a server advertises (e.g. cap a 262K llama-server at 16384 to bound
     /// KV/compaction) or to correct a mis-probed backend. `None` = defer to
     /// probe/catalog. Applies to the primary and to each fallback
-    /// independently. (#2142, split from #2127.)
+    /// independently. (#2142, split from #2127.) Exposed through the AppUI
+    /// typed inference schema by #2166.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_window: Option<u32>,
 }
@@ -1222,6 +1244,11 @@ impl LlmModelSelectionConfig {
             // #2142: a selection that pins ONLY a context_window override is
             // meaningful — it must not be collapsed as "empty" and dropped.
             && self.context_window.is_none()
+            // #2166: same for the typed inference defaults — a selection
+            // carrying only sampling/reasoning defaults is meaningful.
+            && self.temperature.is_none()
+            && self.top_p.is_none()
+            && self.reasoning_effort.is_none()
     }
 }
 
@@ -2765,6 +2792,12 @@ pub(crate) fn config_from_profile(
         model: primary.and_then(|selection| selection.model_id.clone()),
         // #2142: operator override of the primary's effective context window.
         context_window: primary.and_then(|selection| selection.context_window),
+        // #2166: primary model's typed inference defaults (sampling /
+        // reasoning), projected for the session-bootstrap precedence chain:
+        // model default → profile-gateway knob → provider default.
+        model_temperature: primary.and_then(|selection| selection.temperature),
+        model_top_p: primary.and_then(|selection| selection.top_p),
+        model_reasoning_effort: primary.and_then(|selection| selection.reasoning_effort),
         base_url: primary.and_then(|selection| {
             selection
                 .route
@@ -4066,6 +4099,10 @@ mod tests {
                         strong: Some(true),
                         // #2142: operator window override on the primary.
                         context_window: Some(16_384),
+                        // #2166: typed inference defaults (unset here).
+                        temperature: None,
+                        top_p: None,
+                        reasoning_effort: None,
                     }),
                     fallbacks: vec![LlmModelSelectionConfig {
                         family_id: Some("minimax".into()),
@@ -4089,6 +4126,10 @@ mod tests {
                         // #2142: a DIFFERENT per-fallback window override —
                         // must project independently of the primary's.
                         context_window: Some(8_192),
+                        // #2166: typed inference defaults (unset here).
+                        temperature: None,
+                        top_p: None,
+                        reasoning_effort: None,
                     }],
                 }),
                 ..Default::default()

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -569,26 +569,51 @@ impl SessionRuntime {
             // (greedy temperature=0.0, no sampler, 16384 max output) — dropping
             // the local-model repetition-collapse mitigations. Each is `None`
             // unless the operator set it, so cloud sessions are unchanged.
+            //
+            // #2166 precedence (documented contract): the CONFIGURED MODEL's
+            // typed inference defaults win over the profile-gateway knobs,
+            // which win over the provider defaults —
+            //   session/turn override → model default → gateway knob → none.
+            // The session/turn tier is applied per turn in the AppUI turn
+            // path (ui_protocol_reasoning_effort.rs) and sits on top of
+            // whatever this bootstrap composition produced.
             chat_max_tokens: profile
                 .config
                 .gateway
                 .as_ref()
                 .and_then(|g| g.max_output_tokens),
-            chat_temperature: profile
-                .config
-                .gateway
-                .as_ref()
-                .and_then(|g| g.llm_temperature),
-            chat_sampling_params: profile
-                .config
-                .gateway
-                .as_ref()
-                .and_then(|g| g.llm_sampling_params.clone()),
-            reasoning_effort: profile
-                .config
-                .gateway
-                .as_ref()
-                .and_then(|g| g.reasoning_effort),
+            chat_temperature: profile.config.model_temperature.or_else(|| {
+                profile
+                    .config
+                    .gateway
+                    .as_ref()
+                    .and_then(|g| g.llm_temperature)
+            }),
+            chat_sampling_params: {
+                let mut sampling = profile
+                    .config
+                    .gateway
+                    .as_ref()
+                    .and_then(|g| g.llm_sampling_params.clone());
+                // #2166 × #2176 coordination: the typed per-model `top_p`
+                // default overrides a same-named `top_p` key in the gateway
+                // sampler passthrough map; every OTHER passthrough key
+                // (`repeat_penalty`, …) is untouched. The passthrough stays
+                // the escape hatch for params octos does not model.
+                if let Some(top_p) = profile.config.model_top_p {
+                    sampling
+                        .get_or_insert_with(serde_json::Map::new)
+                        .insert("top_p".into(), serde_json::json!(top_p));
+                }
+                sampling
+            },
+            reasoning_effort: profile.config.model_reasoning_effort.or_else(|| {
+                profile
+                    .config
+                    .gateway
+                    .as_ref()
+                    .and_then(|g| g.reasoning_effort)
+            }),
             ..Default::default()
         })
         // M11-F regression fix (#891): propagate the pre-assembled
@@ -1293,6 +1318,71 @@ mod tests {
             Some(serde_json::json!(1.1))
         );
         assert_eq!(cfg.reasoning_effort, Some(octos_llm::ReasoningEffort::High));
+    }
+
+    #[tokio::test]
+    async fn session_agent_prefers_model_inference_defaults_over_gateway_knobs() {
+        // #2166 precedence, pinned: the CONFIGURED PRIMARY model's typed
+        // inference defaults win over the profile-gateway knobs —
+        //   session/turn override → model default → gateway knob → none —
+        // and the #2176 gateway sampler passthrough stays intact except for
+        // the same-named `top_p` key, which the typed model default
+        // overrides. (The session/turn tier is applied per turn on top of
+        // this composition by ui_protocol_reasoning_effort.rs.)
+        let dir = tempfile::tempdir().unwrap();
+        let mut profile = make_profile(dir.path().to_path_buf()).await;
+        {
+            let cfg = Arc::get_mut(&mut profile).unwrap();
+            cfg.config.model_temperature = Some(0.4);
+            cfg.config.model_top_p = Some(0.9);
+            cfg.config.model_reasoning_effort = Some(octos_llm::ReasoningEffort::High);
+            let mut sp = serde_json::Map::new();
+            sp.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+            sp.insert("top_p".to_string(), serde_json::json!(0.8));
+            cfg.config.gateway = Some(crate::config::GatewayConfig {
+                max_output_tokens: Some(32768),
+                llm_temperature: Some(0.7),
+                llm_sampling_params: Some(sp),
+                reasoning_effort: Some(octos_llm::ReasoningEffort::Low),
+                ..Default::default()
+            });
+        }
+        let rt = SessionRuntime::bootstrap(&profile, SessionKey::new("appui", "gw3"), None)
+            .await
+            .expect("bootstrap");
+        let cfg = rt.agent.agent_config();
+        // Model default beats the gateway knob.
+        assert_eq!(
+            cfg.chat_temperature,
+            Some(0.4),
+            "model default must win over gateway llm_temperature"
+        );
+        assert_eq!(
+            cfg.reasoning_effort,
+            Some(octos_llm::ReasoningEffort::High),
+            "model default must win over gateway reasoning_effort"
+        );
+        // Typed model top_p overrides the same-named passthrough key…
+        let top_p = cfg
+            .chat_sampling_params
+            .as_ref()
+            .and_then(|m| m.get("top_p"))
+            .and_then(|value| value.as_f64())
+            .expect("typed top_p rides the sampler map");
+        assert!(
+            (top_p - 0.9).abs() < 1e-6,
+            "typed model top_p must win over the gateway passthrough key: {top_p}"
+        );
+        // …while UNRELATED passthrough keys are untouched.
+        assert_eq!(
+            cfg.chat_sampling_params
+                .as_ref()
+                .and_then(|m| m.get("repeat_penalty").cloned()),
+            Some(serde_json::json!(1.1)),
+            "the #2176 passthrough stays intact for params octos does not model"
+        );
+        // Gateway-only fields still thread through unchanged.
+        assert_eq!(cfg.chat_max_tokens, Some(32768));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Part of #2166

## Problem

`RawLlmSelection` / `RawProfileLlmUpsertParams` had no `deny_unknown_fields` and no inference fields at all: a client could submit `temperature`, `top_p`, `max_output_tokens`, `context_window`, or a nested reasoning object on `profile/llm/upsert`, receive `applied: true`, and present values that were silently discarded. The durable `LlmModelSelectionConfig` — including the #2142 `context_window` override and `model_hints` — was unreachable from AppUI.

## Typed schema (shared by `profile/llm/upsert`, `profile/llm/test`, `profile/llm/fetch_models`)

Test and Save parse the identical shape, so a payload that probes successfully is byte-for-byte the payload that persists. Every optional field follows **`absent ≡ null ≡ inherit`**: the upsert payload is the *complete* inference configuration for the addressed selection; a re-upsert without a field clears the prior override.

| field | type | validation | durable target | runtime effect |
|---|---|---|---|---|
| `selection.family_id` / `model_id` | string | required | selection address | unchanged |
| `selection.route` | `{route_id, label, base_url, api_key_env, api_type}` | — | `LlmRouteConfig` | unchanged |
| `selection.model_hints` | `{uses_completion_tokens, fixed_temperature, lacks_vision, merge_system_messages, reasoning_style}` | typed enum/bools | `model_hints` (existing) | provider request shaping (existing) |
| `selection.context_window` | u32 | ≥ 1 | `context_window` (#2142, existing) | `ContextWindowOverride` outermost layer — local budgeting/compaction truth, **not** an upstream request field |
| `selection.temperature` | f64 | finite, 0.0–2.0 | `temperature` (new) | per-model sampling default |
| `selection.top_p` | f64 | finite, 0.0–1.0 | `top_p` (new) | rides the sampler passthrough map (no typed `ChatConfig` field exists) |
| `selection.reasoning_effort` | enum `none/low/medium/high/max` | typed enum | `reasoning_effort` (new) | per-**model default** tier of the reasoning chain |

### Ownership rules (what the schema deliberately does NOT accept)

- **`max_output_tokens`** → owned by the **profile gateway** contract (`[gateway] max_output_tokens`). Sending it returns `invalid_params` / `kind: "llm_param_owned_elsewhere"` with the owner named — never `applied: true`.
- **Per-session / per-turn reasoning overrides** → owned by the durable session contract (`ui_protocol_reasoning_effort.rs`). This schema sets only the per-model default tier.
- **Arbitrary provider request-body keys** → owned by the gateway `llm_sampling_params` passthrough (#2176). Rejected here as unknown; no loose JSON passthrough is added.

### Precedence (documented + pinned by tests)

```
session/turn override  →  configured model default  →  profile-gateway knob  →  provider/catalog default
(ui_protocol_reasoning    LlmModelSelectionConfig      gateway.llm_temperature /     (None)
 _effort.rs, per turn)    temperature/top_p/           reasoning_effort /
                          reasoning_effort             llm_sampling_params
```

Composition happens at `SessionRuntime::bootstrap`; the session/turn tier stays in the existing per-turn path on top of it. **#2176 coordination:** the gateway `llm_sampling_params` map remains the escape hatch for params octos does not model (`repeat_penalty`, …). A typed per-model `top_p` overrides only its same-named key in that map; every other passthrough key is untouched.

### Rejection behavior

One pre-pass collects **every** unknown key with its dotted path (`selection.temperature2`, `selection.inference`, `selection.route.bogus`, …) and returns one typed `invalid_params` with `kind: "llm_unknown_fields"` + `rejected_fields: [...]` — **before any store mutation**, so the prior configuration is never touched by a rejected request. serde `deny_unknown_fields` on the raw structs remains as the second layer. Range/non-finite violations return `kind: "llm_param_out_of_range"` / `"llm_param_non_finite"` with the field name and range.

### List/read round-trip

`profile/llm/list` echoes every configured inference/routing field per selection — primary and each fallback independently, so switching models switches their parameter sets. Keys are emitted **only when configured**: a selection without overrides serializes exactly as before this change (unconfigured output shape unchanged). Routing metadata outside the schema (`cost_per_m`, `strong`, owned by routing/QoS) now survives a same-address re-upsert instead of being silently reset.

## Unconfigured default behavior

Every new durable field is `Option` + `#[serde(default)]` + `skip_serializing_if`; profiles that never set them bootstrap exactly as before. `max_output_tokens` ownership is unchanged (gateway-only). `ci.yml` is untouched.

## Tests

- unknown fields rejected with every field named; store untouched (profile not even created)
- `selection.max_output_tokens` rejected with `llm_param_owned_elsewhere` + owner pointer
- out-of-range / non-finite values rejected with typed kinds, no mutation
- known fields round-trip through store **and** `profile/llm/list`; absent clears; `cost_per_m`/`strong` survive the edit
- per-model parameter isolation (no primary ↔ fallback leakage)
- runtime precedence: model default > gateway knob; typed `top_p` overrides only its passthrough key; `repeat_penalty` intact; gateway-only threads through
- pre-existing gateway-only tests stay green (unconfigured behavior unchanged)

## Notes

- Also fixes a pre-existing `--features api` test-compile break (`String` vs `PathBuf` `assert_ne!`) that blocked compiling the api-gated test module locally; it does not affect CI, which runs `cargo test -p octos-cli --lib` without the feature.
- Known limitation (documented in code): typed inference defaults apply to the **selected primary**; a mid-turn failover to a fallback keeps the primary's sampling defaults until the next runtime rebuild. Per-fallback values persist and apply after `profile/llm/select` promotion.
- Follow-ups for later PRs (not required by the issue's core contract): a normalized effective-config projection in `list`, and capability metadata per model/route for UI control hiding.