### PR TITLE
fix(llm): protocol- and provider-aware model discovery for fetch_models

### DIFF
--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -1201,10 +1201,41 @@ pub async fn provider_models(
             "base_url targets a link-local/metadata address".into(),
         ));
     }
-    let models = fetch_provider_models(&req.provider, &api_key, req.base_url.as_deref())
-        .await
-        .unwrap_or_default();
-    Ok(Json(models))
+    // Protocol-aware discovery shared with the AppUI `profile/llm/
+    // fetch_models` surface — the strategy resolves from the route (api_type
+    // override, then the family's declared protocol), never from the literal
+    // family id, so the two clients cannot drift.
+    let discovery = octos_llm::discovery::resolve_model_discovery(
+        Some(&req.provider),
+        req.api_type.as_deref(),
+    );
+    let outcome = octos_llm::discovery::discover_models(
+        discovery,
+        &api_key,
+        req.base_url.as_deref(),
+        Some(&req.provider),
+    )
+    .await;
+    match outcome {
+        // Success — including an empty catalog, which is data, not an error.
+        octos_llm::discovery::DiscoveryOutcome::Discovered(models) => Ok(Json(models)),
+        // Advisory: this family has no model-list endpoint. Not an error —
+        // manual model-id entry, Test, and Save stay fully available, and the
+        // dashboard treats an empty list as "nothing to suggest".
+        octos_llm::discovery::DiscoveryOutcome::Unsupported(_) => Ok(Json(Vec::new())),
+        other => Err((
+            if other.status_label() == "rate_limited" {
+                StatusCode::TOO_MANY_REQUESTS
+            } else {
+                StatusCode::BAD_GATEWAY
+            },
+            format!(
+                "{}: {}",
+                other.status_label(),
+                other.message().unwrap_or_default()
+            ),
+        )),
+    }
 }
 
 /// Fetch available models from a provider's /v1/models endpoint.
@@ -1232,49 +1263,6 @@ fn base_url_targets_link_local(base_url: &str) -> bool {
         }
         Err(_) => false,
     }
-}
-
-pub(crate) async fn fetch_provider_models(
-    provider: &str,
-    api_key: &str,
-    base_url: Option<&str>,
-) -> Option<Vec<String>> {
-    let base = base_url
-        .map(|u| u.trim_end_matches('/').to_string())
-        .or_else(|| {
-            octos_llm::registry::lookup(provider)
-                .and_then(|e| e.default_base_url.map(|u| u.to_string()))
-        })?;
-    let base_trimmed = base.trim_end_matches("/v1").trim_end_matches("/v1/");
-    let url = if provider == "anthropic" {
-        format!("{base}/v1/models")
-    } else {
-        format!("{base_trimmed}/v1/models")
-    };
-    let client = reqwest::Client::new();
-    let mut req = client.get(&url).timeout(std::time::Duration::from_secs(10));
-    if provider == "anthropic" {
-        req = req
-            .header("x-api-key", api_key)
-            .header("anthropic-version", "2023-06-01");
-    } else if !api_key.is_empty() {
-        // Keyless families pass an empty key — suppress the header instead of
-        // sending a literal `Bearer ` (mirrors test_provider's factory path).
-        req = req.header("Authorization", format!("Bearer {api_key}"));
-    }
-    let resp = req.send().await.ok()?;
-    if !resp.status().is_success() {
-        return None;
-    }
-    let body: serde_json::Value = resp.json().await.ok()?;
-    body.get("data").and_then(|d| d.as_array()).map(|arr| {
-        let mut ids: Vec<String> = arr
-            .iter()
-            .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(|s| s.to_string()))
-            .collect();
-        ids.sort();
-        ids
-    })
 }
 
 /// Merge a request body's `config` object into an existing profile config.
@@ -1400,6 +1388,10 @@ pub struct TestProviderRequest {
     pub api_key_env: Option<String>,
     #[serde(default)]
     pub base_url: Option<String>,
+    /// Route protocol override for model discovery (`"anthropic"` switches the
+    /// listing strategy); absent means the family's declared protocol.
+    #[serde(default)]
+    pub api_type: Option<String>,
     #[serde(default)]
     pub profile_id: Option<String>,
 }

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -1205,10 +1205,8 @@ pub async fn provider_models(
     // fetch_models` surface — the strategy resolves from the route (api_type
     // override, then the family's declared protocol), never from the literal
     // family id, so the two clients cannot drift.
-    let discovery = octos_llm::discovery::resolve_model_discovery(
-        Some(&req.provider),
-        req.api_type.as_deref(),
-    );
+    let discovery =
+        octos_llm::discovery::resolve_model_discovery(Some(&req.provider), req.api_type.as_deref());
     let outcome = octos_llm::discovery::discover_models(
         discovery,
         &api_key,

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -8626,7 +8626,7 @@ async fn profile_llm_fetch_models_requires_family_id() {
 }
 
 #[tokio::test]
-async fn profile_llm_fetch_models_returns_empty_with_reason_when_provider_unreachable() {
+async fn profile_llm_fetch_models_returns_typed_reason_when_provider_unreachable() {
     let state = Arc::new(AppState::empty_for_tests());
     let request = RpcRequest::new(
         "1",
@@ -8649,7 +8649,253 @@ async fn profile_llm_fetch_models_returns_empty_with_reason_when_provider_unreac
         .expect("fetch_models result");
 
     assert_eq!(result["models"], json!([]));
-    assert_eq!(result["reason"], json!("provider_unavailable"));
+    // Typed, distinguishable failure — not the old collapsed
+    // `provider_unavailable` that hid auth/protocol/manual-entry differences.
+    assert_eq!(result["status"], json!("endpoint_unreachable"));
+    assert_eq!(result["reason"], json!("endpoint_unreachable"));
+    assert!(result["message"].is_string());
+}
+
+/// One captured discovery request: path plus the auth-relevant headers.
+struct CapturedDiscoveryRequest {
+    path: String,
+    authorization: Option<String>,
+    x_api_key: Option<String>,
+}
+
+/// Raw-TCP loopback fixture for fetch_models: serves a fixed JSON status/body
+/// for every request and records path + auth headers, so tests can pin the
+/// EXACT wire behavior (no Bearer on Anthropic-protocol families, no
+/// duplicated version segments on versioned roots).
+async fn spawn_discovery_fixture(
+    status_line: &'static str,
+    body: &'static str,
+) -> (
+    String,
+    Arc<tokio::sync::Mutex<Vec<CapturedDiscoveryRequest>>>,
+) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let recorded = captured.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            // Read until the END OF HEADERS — a single read can return a
+            // partial request, and answering before the client finished
+            // sending makes the close reset the connection mid-request.
+            let mut raw = Vec::new();
+            let mut chunk = [0_u8; 2048];
+            loop {
+                match socket.read(&mut chunk).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(read) => {
+                        raw.extend_from_slice(&chunk[..read]);
+                        if raw.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                }
+            }
+            let request = String::from_utf8_lossy(&raw).to_string();
+            let mut lines = request.split("\r\n");
+            let request_line = lines.next().unwrap_or_default().to_string();
+            let path = request_line
+                .split_whitespace()
+                .nth(1)
+                .unwrap_or_default()
+                .to_string();
+            let header = |name: &str| -> Option<String> {
+                lines.clone().find_map(|line| {
+                    let (key, value) = line.split_once(':')?;
+                    key.eq_ignore_ascii_case(name)
+                        .then(|| value.trim().to_string())
+                })
+            };
+            recorded.lock().await.push(CapturedDiscoveryRequest {
+                path,
+                authorization: header("authorization"),
+                x_api_key: header("x-api-key"),
+            });
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\
+                 Connection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+        }
+    });
+    (format!("http://{address}"), captured)
+}
+
+#[tokio::test]
+async fn profile_llm_fetch_models_zai_never_gets_a_bearer_v1_models_probe() {
+    let (root, captured) = spawn_discovery_fixture(
+        "200 OK",
+        r#"{"data":[{"id":"glm-5.2"},{"id":"glm-4.7"}]}"#,
+    )
+    .await;
+    let state = Arc::new(AppState::empty_for_tests());
+    // Saved AppUI routes default api_type to "openai" — exactly the shape
+    // that used to force the Bearer /v1/models probe onto zai.
+    let request = RpcRequest::new(
+        "1",
+        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+        json!({
+            "selection": {
+                "family_id": "zai",
+                "route": {
+                    "route_id": "official",
+                    "base_url": format!("{root}/api/anthropic"),
+                    "api_type": "openai"
+                }
+            },
+            "api_key": "zai-secret-key"
+        }),
+    );
+
+    let result = raw_profile_llm_fetch_models(&state, &request, Some("ada"))
+        .await
+        .expect("fetch_models result");
+
+    assert_eq!(result["status"], json!("discovered"));
+    assert_eq!(result["models"], json!(["glm-4.7", "glm-5.2"]));
+    let requests = captured.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/api/anthropic/v1/models");
+    assert!(
+        requests[0].authorization.is_none(),
+        "zai speaks the Anthropic Messages protocol — never a Bearer probe"
+    );
+    assert_eq!(requests[0].x_api_key.as_deref(), Some("zai-secret-key"));
+}
+
+#[tokio::test]
+async fn profile_llm_fetch_models_does_not_duplicate_version_segments_on_v4_roots() {
+    let (root, captured) = spawn_discovery_fixture("200 OK", r#"{"data":[{"id":"glm-5.2"}]}"#).await;
+    let state = Arc::new(AppState::empty_for_tests());
+    let request = RpcRequest::new(
+        "1",
+        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+        json!({
+            "selection": {
+                "family_id": "zhipu",
+                "route": {
+                    "route_id": "official",
+                    "base_url": format!("{root}/api/paas/v4")
+                }
+            },
+            "api_key": "zhipu-key"
+        }),
+    );
+
+    let result = raw_profile_llm_fetch_models(&state, &request, Some("ada"))
+        .await
+        .expect("fetch_models result");
+
+    assert_eq!(result["status"], json!("discovered"));
+    let requests = captured.lock().await;
+    assert_eq!(requests[0].path, "/api/paas/v4/models");
+    assert_ne!(requests[0].path, "/api/paas/v4/v1/models");
+}
+
+#[tokio::test]
+async fn profile_llm_fetch_models_reports_unsupported_for_manual_only_families() {
+    let (root, captured) = spawn_discovery_fixture("200 OK", r#"{"data":[]}"#).await;
+    let state = Arc::new(AppState::empty_for_tests());
+    let request = RpcRequest::new(
+        "1",
+        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+        json!({
+            "selection": {
+                "family_id": "vertex",
+                "route": {
+                    "route_id": "official",
+                    "base_url": root
+                }
+            },
+            "api_key": "sa-json-credential"
+        }),
+    );
+
+    let result = raw_profile_llm_fetch_models(&state, &request, Some("ada"))
+        .await
+        .expect("fetch_models result");
+
+    assert_eq!(result["status"], json!("unsupported"));
+    assert_eq!(result["models"], json!([]));
+    assert!(
+        result["message"].as_str().is_some_and(|m| m.contains("manually")),
+        "unsupported must point at manual model-id entry"
+    );
+    assert!(
+        captured.lock().await.is_empty(),
+        "manual-only families must never be probed"
+    );
+}
+
+#[tokio::test]
+async fn profile_llm_fetch_models_distinguishes_auth_failures_from_unavailability() {
+    let (root, _) = spawn_discovery_fixture("401 Unauthorized", r#"{"error":{}}"#).await;
+    let state = Arc::new(AppState::empty_for_tests());
+    let request = RpcRequest::new(
+        "1",
+        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+        json!({
+            "selection": {
+                "family_id": "custom",
+                "route": {
+                    "route_id": "custom",
+                    "base_url": format!("{root}/v1"),
+                    "api_type": "openai"
+                }
+            },
+            "api_key": "sk-wrong"
+        }),
+    );
+
+    let result = raw_profile_llm_fetch_models(&state, &request, Some("ada"))
+        .await
+        .expect("fetch_models result");
+
+    assert_eq!(result["models"], json!([]));
+    assert_eq!(result["status"], json!("authentication_failed"));
+    assert_eq!(result["reason"], json!("authentication_failed"));
+}
+
+#[tokio::test]
+async fn profile_llm_fetch_models_keeps_empty_catalogs_distinguishable_from_failures() {
+    let (root, _) = spawn_discovery_fixture("200 OK", r#"{"data":[]}"#).await;
+    let state = Arc::new(AppState::empty_for_tests());
+    let request = RpcRequest::new(
+        "1",
+        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+        json!({
+            "selection": {
+                "family_id": "custom",
+                "route": {
+                    "route_id": "custom",
+                    "base_url": format!("{root}/v1"),
+                    "api_type": "openai"
+                }
+            },
+            "api_key": "sk-fine"
+        }),
+    );
+
+    let result = raw_profile_llm_fetch_models(&state, &request, Some("ada"))
+        .await
+        .expect("fetch_models result");
+
+    // An empty successful catalog is data, not `provider_unavailable`.
+    assert_eq!(result["status"], json!("discovered"));
+    assert_eq!(result["models"], json!([]));
+    assert!(result.get("reason").is_none());
+    assert!(result.get("message").is_none());
 }
 
 #[tokio::test]

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -8734,11 +8734,8 @@ async fn spawn_discovery_fixture(
 
 #[tokio::test]
 async fn profile_llm_fetch_models_zai_never_gets_a_bearer_v1_models_probe() {
-    let (root, captured) = spawn_discovery_fixture(
-        "200 OK",
-        r#"{"data":[{"id":"glm-5.2"},{"id":"glm-4.7"}]}"#,
-    )
-    .await;
+    let (root, captured) =
+        spawn_discovery_fixture("200 OK", r#"{"data":[{"id":"glm-5.2"},{"id":"glm-4.7"}]}"#).await;
     let state = Arc::new(AppState::empty_for_tests());
     // Saved AppUI routes default api_type to "openai" — exactly the shape
     // that used to force the Bearer /v1/models probe onto zai.
@@ -8776,7 +8773,8 @@ async fn profile_llm_fetch_models_zai_never_gets_a_bearer_v1_models_probe() {
 
 #[tokio::test]
 async fn profile_llm_fetch_models_does_not_duplicate_version_segments_on_v4_roots() {
-    let (root, captured) = spawn_discovery_fixture("200 OK", r#"{"data":[{"id":"glm-5.2"}]}"#).await;
+    let (root, captured) =
+        spawn_discovery_fixture("200 OK", r#"{"data":[{"id":"glm-5.2"}]}"#).await;
     let state = Arc::new(AppState::empty_for_tests());
     let request = RpcRequest::new(
         "1",
@@ -8829,7 +8827,9 @@ async fn profile_llm_fetch_models_reports_unsupported_for_manual_only_families()
     assert_eq!(result["status"], json!("unsupported"));
     assert_eq!(result["models"], json!([]));
     assert!(
-        result["message"].as_str().is_some_and(|m| m.contains("manually")),
+        result["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("manually")),
         "unsupported must point at manual model-id entry"
     );
     assert!(

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -12322,6 +12322,10 @@ async fn raw_profile_llm_fetch_models(
     let family_id = nonempty(params.selection.family_id)
         .ok_or_else(|| RpcError::invalid_params("selection.family_id is required"))?;
     let base_url = nonempty(params.selection.route.base_url);
+    // The route's protocol override feeds strategy resolution — ignoring it
+    // here is what forced Anthropic-protocol families onto the OpenAI/Bearer
+    // /v1/models probe.
+    let api_type = nonempty(params.selection.route.api_type);
     let api_key_env = nonempty(params.selection.route.api_key_env)
         .or_else(|| dashboard_family_api_key_env(&family_id));
 
@@ -12343,28 +12347,47 @@ async fn raw_profile_llm_fetch_models(
             return Ok(json!({
                 "profile_id": profile_id,
                 "family_id": family_id,
+                "api_type": api_type,
                 "models": [],
+                "status": "no_api_key",
                 "reason": "no_api_key",
             }));
         }
     };
 
-    let models =
-        crate::api::admin::fetch_provider_models(&family_id, &api_key, base_url.as_deref())
-            .await
-            .unwrap_or_default();
-    let reason = if models.is_empty() {
-        Some("provider_unavailable")
-    } else {
-        None
-    };
+    // Protocol-aware discovery, shared verbatim with the admin REST
+    // `/api/my/provider-models` surface: the strategy resolves from the route
+    // (api_type override, then the family's declared protocol), and the typed
+    // outcome keeps "enter the model id manually" distinguishable from
+    // "credential/endpoint invalid" — instead of collapsing every failure
+    // into an empty list + `provider_unavailable`.
+    let discovery = octos_llm::discovery::resolve_model_discovery(
+        Some(&family_id),
+        api_type.as_deref(),
+    );
+    let outcome = octos_llm::discovery::discover_models(
+        discovery,
+        &api_key,
+        base_url.as_deref(),
+        Some(&family_id),
+    )
+    .await;
+    let status = outcome.status_label();
     let mut result = json!({
         "profile_id": profile_id,
         "family_id": family_id,
-        "models": models,
+        "api_type": api_type,
+        "models": outcome.models().unwrap_or(&[]),
+        // Typed status: discovered | unsupported | authentication_failed |
+        // endpoint_unreachable | invalid_response | rate_limited.
+        "status": status,
     });
-    if let (Some(reason), Value::Object(object)) = (reason, &mut result) {
-        object.insert("reason".into(), Value::String(reason.into()));
+    if let Some(message) = outcome.message() {
+        // Safe, redacted provider message (never contains the credential).
+        result["message"] = Value::String(message.to_string());
+        // `reason` mirrors `status` on failures for clients still reading the
+        // old collapsed field.
+        result["reason"] = Value::String(status.to_string());
     }
     Ok(result)
 }

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -12361,10 +12361,8 @@ async fn raw_profile_llm_fetch_models(
     // outcome keeps "enter the model id manually" distinguishable from
     // "credential/endpoint invalid" — instead of collapsing every failure
     // into an empty list + `provider_unavailable`.
-    let discovery = octos_llm::discovery::resolve_model_discovery(
-        Some(&family_id),
-        api_type.as_deref(),
-    );
+    let discovery =
+        octos_llm::discovery::resolve_model_discovery(Some(&family_id), api_type.as_deref());
     let outcome = octos_llm::discovery::discover_models(
         discovery,
         &api_key,

--- a/crates/octos-llm/src/discovery.rs
+++ b/crates/octos-llm/src/discovery.rs
@@ -1,0 +1,708 @@
+//! Protocol- and provider-aware model discovery.
+//!
+//! `profile/llm/fetch_models` (and the admin REST `/api/my/provider-models`
+//! surface) used to switch on the literal family id `anthropic` and synthesize
+//! a Bearer-authenticated `<base>/v1/models` probe for everything else. That
+//! mis-probed Anthropic-protocol families whose ids differ (zai, zai-coding),
+//! duplicated version segments on versioned OpenAI-compatible roots
+//! (`.../v4` → `.../v4/v1/models`), and collapsed every failure mode into one
+//! empty list.
+//!
+//! Instead, each registry entry declares its discovery capability
+//! ([`ModelDiscovery`]) and the HTTP probe resolves from the selected ROUTE —
+//! the same override rules the inference path applies in
+//! `create_provider_with_api_type`: an `api_type` of `anthropic` forces the
+//! Anthropic Messages strategy, everything else follows the family's declared
+//! protocol (unknown families fall back to OpenAI-compatible, exactly like the
+//! runtime's custom-provider fallback). URL joining is relative to the
+//! configured API root — no heuristic version stripping/appending.
+//!
+//! Discovery is ADVISORY: `Unsupported` or a discovery-only 404 must never
+//! mark a configured model unavailable and must never block manual model-id
+//! entry, Test, or Save. The typed [`DiscoveryOutcome`] keeps "enter the model
+//! id manually" distinguishable from "the credential/endpoint is invalid".
+
+use std::time::Duration;
+
+/// The wire protocol a discovery strategy speaks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscoveryProtocol {
+    /// Anthropic Messages listing: `GET {root}/v1/models` with `x-api-key`
+    /// and `anthropic-version` headers; response `{data: [{id: ...}]}`.
+    AnthropicMessages,
+    /// OpenAI-compatible listing: `GET {root}/models` with `Authorization:
+    /// Bearer` (header suppressed for keyless families); response
+    /// `{data: [{id: ...}]}`.
+    OpenAICompatible,
+    /// Google Gemini listing: `GET {root}/models` with `x-goog-api-key`;
+    /// response `{models: [{name: "models/..."}]}`.
+    GeminiList,
+}
+
+/// A provider family's declared model-discovery capability. Stored on every
+/// registry [`crate::registry::ProviderEntry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelDiscovery {
+    /// Discovery is supported with the protocol-specific request strategy.
+    Supported(DiscoveryProtocol),
+    /// The family intentionally has no model-list endpoint — manual model id
+    /// only. The payload is a stable, key-free reason for UIs to surface.
+    Unsupported(&'static str),
+}
+
+/// Shorthand for registry entries: Anthropic Messages discovery.
+pub const ANTHROPIC_MODELS: ModelDiscovery =
+    ModelDiscovery::Supported(DiscoveryProtocol::AnthropicMessages);
+/// Shorthand for registry entries: OpenAI-compatible discovery.
+pub const OPENAI_MODELS: ModelDiscovery =
+    ModelDiscovery::Supported(DiscoveryProtocol::OpenAICompatible);
+/// Shorthand for registry entries: Gemini listing discovery.
+pub const GEMINI_MODELS: ModelDiscovery = ModelDiscovery::Supported(DiscoveryProtocol::GeminiList);
+
+/// The typed result of one discovery attempt. Every failure carries a safe,
+/// redacted message (never a credential) so callers can show it verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveryOutcome {
+    /// The endpoint answered with a model catalog (possibly empty — an empty
+    /// successful catalog is NOT a failure and stays distinguishable).
+    Discovered(Vec<String>),
+    /// No model-list endpoint: declared unsupported by the family, or the
+    /// endpoint answered 404. Manual model-id entry remains the path.
+    Unsupported(String),
+    /// The credential was rejected (HTTP 401/403).
+    AuthenticationFailed(String),
+    /// The endpoint could not be reached (transport error, timeout, no API
+    /// root) or answered with another non-success status.
+    EndpointUnreachable(String),
+    /// The endpoint answered but the body was not a valid catalog.
+    InvalidResponse(String),
+    /// The provider rate-limited discovery (HTTP 429).
+    RateLimited(String),
+}
+
+impl DiscoveryOutcome {
+    /// Stable machine-readable label shared by the AppUI RPC and the admin
+    /// REST surface (single mapping — the two clients cannot drift).
+    pub fn status_label(&self) -> &'static str {
+        match self {
+            DiscoveryOutcome::Discovered(_) => "discovered",
+            DiscoveryOutcome::Unsupported(_) => "unsupported",
+            DiscoveryOutcome::AuthenticationFailed(_) => "authentication_failed",
+            DiscoveryOutcome::EndpointUnreachable(_) => "endpoint_unreachable",
+            DiscoveryOutcome::InvalidResponse(_) => "invalid_response",
+            DiscoveryOutcome::RateLimited(_) => "rate_limited",
+        }
+    }
+
+    /// The discovered model ids; `None` when discovery did not succeed.
+    pub fn models(&self) -> Option<&[String]> {
+        match self {
+            DiscoveryOutcome::Discovered(models) => Some(models),
+            _ => None,
+        }
+    }
+
+    /// The safe, redacted human-readable message for non-`discovered`
+    /// outcomes; `None` on success.
+    pub fn message(&self) -> Option<&str> {
+        match self {
+            DiscoveryOutcome::Discovered(_) => None,
+            DiscoveryOutcome::Unsupported(message)
+            | DiscoveryOutcome::AuthenticationFailed(message)
+            | DiscoveryOutcome::EndpointUnreachable(message)
+            | DiscoveryOutcome::InvalidResponse(message)
+            | DiscoveryOutcome::RateLimited(message) => Some(message),
+        }
+    }
+
+    /// Whether this outcome means "discovery could not help, but inference
+    /// and manual model-id entry are unaffected" (advisory failure).
+    pub fn is_advisory(&self) -> bool {
+        matches!(self, DiscoveryOutcome::Unsupported(_))
+    }
+}
+
+/// Resolve the discovery strategy for a selected route.
+///
+/// Mirrors `create_provider_with_api_type`'s precedence exactly: an explicit
+/// `api_type: "anthropic"` overrides any family (the runtime bypasses the
+/// registry for that case), and for every other `api_type` the registered
+/// family's own factory — hence its declared discovery — rules. Unknown or
+/// `custom` families fall back to the OpenAI-compatible strategy, matching the
+/// runtime's custom-provider default. The protocol is never inferred from a
+/// single literal family id.
+pub fn resolve_model_discovery(family: Option<&str>, api_type: Option<&str>) -> ModelDiscovery {
+    if api_type == Some("anthropic") {
+        return ANTHROPIC_MODELS;
+    }
+    match family
+        .map(str::trim)
+        .filter(|f| !f.is_empty())
+        .and_then(crate::registry::lookup)
+    {
+        Some(entry) => entry.model_discovery,
+        // Unknown family / `custom` without an anthropic override: the runtime
+        // builds an OpenAI-compatible provider, so discovery matches that.
+        None => OPENAI_MODELS,
+    }
+}
+
+/// Join the models-listing URL relative to the configured API root.
+///
+/// The root is the API root exactly as providers' own default base URLs spell
+/// it (`https://api.openai.com/v1`, `https://open.bigmodel.cn/api/paas/v4`,
+/// `https://api.z.ai/api/anthropic`); the strategy appends only its declared
+/// path. No version segments are stripped or re-added heuristically, so a
+/// `/v4` root can never turn into `/v4/v1/models`.
+pub fn models_url(root: &str, protocol: DiscoveryProtocol) -> String {
+    let root = root.trim().trim_end_matches('/');
+    match protocol {
+        DiscoveryProtocol::AnthropicMessages => format!("{root}/v1/models"),
+        DiscoveryProtocol::OpenAICompatible | DiscoveryProtocol::GeminiList => {
+            format!("{root}/models")
+        }
+    }
+}
+
+/// Run one discovery attempt against the resolved strategy.
+///
+/// `api_key` may be empty for keyless families — the auth header is then
+/// suppressed rather than sent as a literal `Bearer ` (mirroring the
+/// connection-test path). `base_url` wins over the family's registered
+/// default root. Never includes the credential in any returned message.
+pub async fn discover_models(
+    discovery: ModelDiscovery,
+    api_key: &str,
+    base_url: Option<&str>,
+    family: Option<&str>,
+) -> DiscoveryOutcome {
+    let protocol = match discovery {
+        ModelDiscovery::Unsupported(reason) => {
+            return DiscoveryOutcome::Unsupported(reason.to_string());
+        }
+        ModelDiscovery::Supported(protocol) => protocol,
+    };
+    let root = base_url
+        .map(str::trim)
+        .filter(|root| !root.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            family
+                .map(str::trim)
+                .filter(|family| !family.is_empty())
+                .and_then(crate::registry::lookup)
+                .and_then(|entry| entry.default_base_url)
+                .map(str::to_string)
+        });
+    let Some(root) = root else {
+        return DiscoveryOutcome::EndpointUnreachable(
+            "no API root configured for model discovery — set base_url or enter the model id \
+             manually"
+                .into(),
+        );
+    };
+    let url = models_url(&root, protocol);
+    let mut request = reqwest::Client::new()
+        .get(&url)
+        .timeout(Duration::from_secs(10));
+    match protocol {
+        DiscoveryProtocol::AnthropicMessages => {
+            request = request
+                .header("x-api-key", api_key)
+                .header("anthropic-version", "2023-06-01");
+        }
+        DiscoveryProtocol::GeminiList => {
+            if !api_key.is_empty() {
+                request = request.header("x-goog-api-key", api_key);
+            }
+        }
+        DiscoveryProtocol::OpenAICompatible => {
+            // Keyless families pass an empty key — suppress the header instead
+            // of sending a literal `Bearer ` (mirrors test_provider).
+            if !api_key.is_empty() {
+                request = request.header("Authorization", format!("Bearer {api_key}"));
+            }
+        }
+    }
+
+    let response = match request.send().await {
+        Ok(response) => response,
+        Err(error) => {
+            return DiscoveryOutcome::EndpointUnreachable(format!(
+                "model listing at {url} is unreachable: {error}"
+            ));
+        }
+    };
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return DiscoveryOutcome::AuthenticationFailed(format!(
+            "the provider rejected the credential for model discovery (HTTP {status}) — check the \
+             API key"
+        ));
+    }
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return DiscoveryOutcome::RateLimited(format!(
+            "the provider rate-limited model discovery (HTTP {status}) — retry later"
+        ));
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        // A discovery-only 404 is advisory: inference can be perfectly fine
+        // while the family publishes no model-list endpoint.
+        return DiscoveryOutcome::Unsupported(format!(
+            "no model-list endpoint at {url} (HTTP 404) — enter the model id manually; inference \
+             is unaffected"
+        ));
+    }
+    if !status.is_success() {
+        return DiscoveryOutcome::EndpointUnreachable(format!(
+            "model listing at {url} returned HTTP {status}"
+        ));
+    }
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(error) => {
+            return DiscoveryOutcome::InvalidResponse(format!(
+                "reading the model-listing response failed: {error}"
+            ));
+        }
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(&body) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            return DiscoveryOutcome::InvalidResponse(
+                "model listing returned a non-JSON body".into(),
+            );
+        }
+    };
+    let mut ids = match protocol {
+        DiscoveryProtocol::AnthropicMessages | DiscoveryProtocol::OpenAICompatible => parsed
+            .get("data")
+            .and_then(serde_json::Value::as_array)
+            .map(|models| {
+                models
+                    .iter()
+                    .filter_map(|model| model.get("id").and_then(serde_json::Value::as_str))
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            }),
+        DiscoveryProtocol::GeminiList => parsed
+            .get("models")
+            .and_then(serde_json::Value::as_array)
+            .map(|models| {
+                models
+                    .iter()
+                    .filter_map(|model| model.get("name").and_then(serde_json::Value::as_str))
+                    .map(|name| {
+                        // Gemini names entries "models/gemini-2.0-flash";
+                        // surface the bare model id callers configure.
+                        name.strip_prefix("models/").unwrap_or(name).to_string()
+                    })
+                    .collect::<Vec<_>>()
+            }),
+    };
+    match ids.as_mut() {
+        Some(ids) => {
+            ids.sort();
+            ids.dedup();
+            DiscoveryOutcome::Discovered(std::mem::take(ids))
+        }
+        None => DiscoveryOutcome::InvalidResponse(format!(
+            "model listing at {url} returned an unexpected response shape"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Strategy resolution ─────────────────────────────────────────────
+
+    #[test]
+    fn should_use_native_anthropic_strategy_for_zai_family_without_literal_id_match() {
+        // The registry entry — not a `provider == "anthropic"` literal —
+        // declares the protocol, so the Anthropic-protocol zai family resolves
+        // to the Anthropic Messages strategy even though its id differs.
+        assert_eq!(resolve_model_discovery(Some("zai"), None), ANTHROPIC_MODELS);
+        assert_eq!(
+            resolve_model_discovery(Some("zai-coding"), None),
+            ANTHROPIC_MODELS
+        );
+    }
+
+    #[test]
+    fn should_resolve_family_alias_to_the_same_strategy_as_the_canonical_family() {
+        for alias in ["z.ai", "z.ai-coding", "glm-coding"] {
+            let canonical = match alias {
+                "z.ai" => "zai",
+                _ => "zai-coding",
+            };
+            assert_eq!(
+                resolve_model_discovery(Some(alias), None),
+                resolve_model_discovery(Some(canonical), None),
+                "alias {alias} must resolve like {canonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_apply_route_api_type_anthropic_override_over_the_native_strategy() {
+        // The runtime's `create_provider_with_api_type` bypasses the registry
+        // for `api_type: "anthropic"`; discovery mirrors that override.
+        assert_eq!(
+            resolve_model_discovery(Some("openai"), Some("anthropic")),
+            ANTHROPIC_MODELS
+        );
+        // And a registered Anthropic-protocol family stays on-strategy.
+        assert_eq!(
+            resolve_model_discovery(Some("zai"), Some("anthropic")),
+            ANTHROPIC_MODELS
+        );
+    }
+
+    #[test]
+    fn should_keep_native_strategy_when_api_type_is_not_the_anthropic_override() {
+        // Mirrors inference: for registered families only `api_type:
+        // "anthropic"` changes protocol — "openai" on zai still constructs
+        // AnthropicProvider, so discovery must NOT take the bait either
+        // (saved AppUI routes default api_type to "openai").
+        assert_eq!(
+            resolve_model_discovery(Some("zai"), Some("openai")),
+            ANTHROPIC_MODELS
+        );
+        assert_eq!(
+            resolve_model_discovery(Some("zhipu"), Some("openai")),
+            OPENAI_MODELS
+        );
+        assert_eq!(
+            resolve_model_discovery(Some("anthropic"), Some("openai")),
+            // The literal anthropic family's native protocol is Messages, but
+            // its route explicitly says the openai override… which for a
+            // registered family is ignored at runtime — native rules.
+            ANTHROPIC_MODELS
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_openai_strategy_for_unknown_and_custom_families() {
+        assert_eq!(resolve_model_discovery(Some("custom"), None), OPENAI_MODELS);
+        assert_eq!(
+            resolve_model_discovery(Some("custom"), Some("openai")),
+            OPENAI_MODELS
+        );
+        assert_eq!(
+            resolve_model_discovery(Some("custom"), Some("anthropic")),
+            ANTHROPIC_MODELS
+        );
+        assert_eq!(
+            resolve_model_discovery(Some("not-a-family"), None),
+            OPENAI_MODELS
+        );
+        assert_eq!(resolve_model_discovery(None, None), OPENAI_MODELS);
+    }
+
+    #[test]
+    fn should_declare_unsupported_discovery_for_vertex() {
+        let discovery = resolve_model_discovery(Some("vertex"), None);
+        match discovery {
+            ModelDiscovery::Unsupported(reason) => {
+                assert!(
+                    reason.contains("manually"),
+                    "reason must point at manual entry"
+                );
+            }
+            other => panic!("vertex must be manual-only, got {other:?}"),
+        }
+    }
+
+    // ── URL joining ─────────────────────────────────────────────────────
+
+    #[test]
+    fn should_join_openai_models_relative_to_the_api_root_without_version_duplication() {
+        // The /v4 regression: a versioned root must never become /v4/v1/models.
+        assert_eq!(
+            models_url(
+                "https://open.bigmodel.cn/api/paas/v4",
+                DiscoveryProtocol::OpenAICompatible
+            ),
+            "https://open.bigmodel.cn/api/paas/v4/models"
+        );
+        assert_eq!(
+            models_url(
+                "https://api.openai.com/v1/",
+                DiscoveryProtocol::OpenAICompatible
+            ),
+            "https://api.openai.com/v1/models"
+        );
+        assert_eq!(
+            models_url(
+                "https://my-gateway.example.com",
+                DiscoveryProtocol::OpenAICompatible
+            ),
+            "https://my-gateway.example.com/models"
+        );
+    }
+
+    #[test]
+    fn should_join_anthropic_models_relative_to_the_api_root() {
+        assert_eq!(
+            models_url(
+                "https://api.z.ai/api/anthropic",
+                DiscoveryProtocol::AnthropicMessages
+            ),
+            "https://api.z.ai/api/anthropic/v1/models"
+        );
+        assert_eq!(
+            models_url(
+                "https://api.anthropic.com",
+                DiscoveryProtocol::AnthropicMessages
+            ),
+            "https://api.anthropic.com/v1/models"
+        );
+    }
+
+    // ── HTTP executor against a loopback fixture ────────────────────────
+
+    /// One captured request: path + auth-relevant headers.
+    struct Captured {
+        path: String,
+        authorization: Option<String>,
+        x_api_key: Option<String>,
+    }
+
+    /// Raw-TCP loopback fixture: serves a scripted response for every
+    /// connection and records each request. One accepted connection per
+    /// `Connection: close` request keeps the protocol trivially correct.
+    async fn spawn_fixture(
+        status_line: &'static str,
+        body: &'static str,
+    ) -> (String, std::sync::Arc<tokio::sync::Mutex<Vec<Captured>>>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let captured = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let recorded = captured.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                // Read until the END OF HEADERS — a single read can return a
+                // partial request, and answering before the client finished
+                // sending makes the close reset the connection mid-request.
+                let mut raw = Vec::new();
+                let mut chunk = [0_u8; 2048];
+                loop {
+                    match socket.read(&mut chunk).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => {
+                            raw.extend_from_slice(&chunk[..read]);
+                            if raw.windows(4).any(|w| w == b"\r\n\r\n") {
+                                break;
+                            }
+                        }
+                    }
+                }
+                let request = String::from_utf8_lossy(&raw).to_string();
+                let mut lines = request.split("\r\n");
+                let request_line = lines.next().unwrap_or_default().to_string();
+                let path = request_line
+                    .split_whitespace()
+                    .nth(1)
+                    .unwrap_or_default()
+                    .to_string();
+                let header = |name: &str| -> Option<String> {
+                    lines.clone().find_map(|line| {
+                        let (key, value) = line.split_once(':')?;
+                        key.eq_ignore_ascii_case(name)
+                            .then(|| value.trim().to_string())
+                    })
+                };
+                recorded.lock().await.push(Captured {
+                    path,
+                    authorization: header("authorization"),
+                    x_api_key: header("x-api-key"),
+                });
+                let response = format!(
+                    "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: \
+                     {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        (format!("http://{address}"), captured)
+    }
+
+    #[tokio::test]
+    async fn should_probe_anthropic_protocol_for_zai_without_bearer_or_v1_models() {
+        let (root, captured) =
+            spawn_fixture("200 OK", r#"{"data":[{"id":"glm-4.7"},{"id":"glm-5.2"}]}"#).await;
+        // Base root exactly as the zai family spells it (no /v1 suffix).
+        let url = format!("{root}/api/anthropic");
+        let outcome = discover_models(
+            resolve_model_discovery(Some("zai"), Some("openai")),
+            "zai-key-secret",
+            Some(&url),
+            Some("zai"),
+        )
+        .await;
+
+        assert_eq!(outcome.status_label(), "discovered");
+        assert_eq!(
+            outcome.models(),
+            Some(vec!["glm-4.7".to_string(), "glm-5.2".to_string()].as_slice())
+        );
+        let requests = captured.lock().await;
+        assert_eq!(requests.len(), 1);
+        let only = &requests[0];
+        // The strategy-derived path, NOT a synthesized /v1/models off the
+        // root, and Anthropic header semantics — never `Authorization: Bearer`.
+        assert_eq!(only.path, "/api/anthropic/v1/models");
+        assert!(
+            only.authorization.is_none(),
+            "zai must never get a Bearer probe"
+        );
+        assert_eq!(only.x_api_key.as_deref(), Some("zai-key-secret"));
+    }
+
+    #[tokio::test]
+    async fn should_not_duplicate_version_segments_for_versioned_openai_roots() {
+        let (root, captured) = spawn_fixture("200 OK", r#"{"data":[{"id":"glm-5.2"}]}"#).await;
+        let url = format!("{root}/api/paas/v4");
+        let outcome = discover_models(
+            resolve_model_discovery(Some("zhipu"), None),
+            "zhipu-key",
+            Some(&url),
+            Some("zhipu"),
+        )
+        .await;
+
+        assert_eq!(outcome.status_label(), "discovered");
+        let requests = captured.lock().await;
+        assert_eq!(requests[0].path, "/api/paas/v4/models");
+        assert_ne!(requests[0].path, "/api/paas/v4/v1/models");
+        assert_eq!(
+            requests[0].authorization.as_deref(),
+            Some("Bearer zhipu-key")
+        );
+    }
+
+    #[tokio::test]
+    async fn should_map_401_to_authentication_failed_and_404_to_unsupported() {
+        let (root, _) = spawn_fixture("401 Unauthorized", r#"{"error":{}}"#).await;
+        let outcome = discover_models(
+            OPENAI_MODELS,
+            "bad-key",
+            Some(&format!("{root}/v1")),
+            Some("openai"),
+        )
+        .await;
+        assert_eq!(outcome.status_label(), "authentication_failed");
+
+        let (root, _) = spawn_fixture("404 Not Found", "nope").await;
+        let outcome = discover_models(
+            OPENAI_MODELS,
+            "k",
+            Some(&format!("{root}/v1")),
+            Some("openai"),
+        )
+        .await;
+        assert_eq!(outcome.status_label(), "unsupported");
+        assert!(outcome.is_advisory());
+        assert!(outcome.message().is_some_and(|m| m.contains("manually")));
+    }
+
+    #[tokio::test]
+    async fn should_map_rate_limit_transport_and_malformed_responses_distinctly() {
+        let (root, _) = spawn_fixture("429 Too Many Requests", "{}").await;
+        let outcome = discover_models(
+            OPENAI_MODELS,
+            "k",
+            Some(&format!("{root}/v1")),
+            Some("openai"),
+        )
+        .await;
+        assert_eq!(outcome.status_label(), "rate_limited");
+
+        // Nothing listens on port 1 — transport failure, not an auth problem.
+        let outcome = discover_models(
+            OPENAI_MODELS,
+            "k",
+            Some("http://127.0.0.1:1/v1"),
+            Some("openai"),
+        )
+        .await;
+        assert_eq!(outcome.status_label(), "endpoint_unreachable");
+
+        let (root, _) = spawn_fixture("200 OK", "<html>not json</html>").await;
+        let outcome = discover_models(
+            OPENAI_MODELS,
+            "k",
+            Some(&format!("{root}/v1")),
+            Some("openai"),
+        )
+        .await;
+        assert_eq!(outcome.status_label(), "invalid_response");
+
+        // Shape mismatch: 200 + JSON without the expected array.
+        let (root, _) = spawn_fixture("200 OK", r#"{"models":"bogus"}"#).await;
+        let outcome = discover_models(
+            OPENAI_MODELS,
+            "k",
+            Some(&format!("{root}/v1")),
+            Some("openai"),
+        )
+        .await;
+        assert_eq!(outcome.status_label(), "invalid_response");
+    }
+
+    #[tokio::test]
+    async fn should_keep_empty_successful_catalogs_distinguishable_from_failures() {
+        let (root, _) = spawn_fixture("200 OK", r#"{"data":[]}"#).await;
+        let outcome = discover_models(
+            OPENAI_MODELS,
+            "k",
+            Some(&format!("{root}/v1")),
+            Some("openai"),
+        )
+        .await;
+        assert_eq!(outcome, DiscoveryOutcome::Discovered(Vec::new()));
+        assert_eq!(outcome.status_label(), "discovered");
+        assert!(outcome.message().is_none());
+    }
+
+    #[tokio::test]
+    async fn should_return_declared_unsupported_without_any_outbound_request() {
+        let (root, captured) = spawn_fixture("200 OK", r#"{"data":[]}"#).await;
+        let outcome = discover_models(
+            resolve_model_discovery(Some("vertex"), None),
+            "sa-json",
+            Some(&root),
+            Some("vertex"),
+        )
+        .await;
+        assert_eq!(outcome.status_label(), "unsupported");
+        assert!(outcome.models().is_none());
+        assert!(
+            outcome.message().is_some_and(|m| m.contains("manually")),
+            "unsupported must explain the manual path"
+        );
+        assert!(
+            captured.lock().await.is_empty(),
+            "manual-only families must never be probed"
+        );
+    }
+
+    #[test]
+    fn should_build_gemini_models_url_relative_to_the_versioned_root() {
+        assert_eq!(
+            models_url(
+                "https://generativelanguage.googleapis.com/v1beta",
+                DiscoveryProtocol::GeminiList
+            ),
+            "https://generativelanguage.googleapis.com/v1beta/models"
+        );
+    }
+}

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -13,6 +13,7 @@ pub mod content_classifier;
 pub mod context;
 mod context_override;
 pub mod credential_pool;
+pub mod discovery;
 pub mod embedding;
 mod failover;
 mod fallback;

--- a/crates/octos-llm/src/registry/anthropic.rs
+++ b/crates/octos-llm/src/registry/anthropic.rs
@@ -17,6 +17,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &["claude"],
+    model_discovery: crate::discovery::ANTHROPIC_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/dashscope.rs
+++ b/crates/octos-llm/src/registry/dashscope.rs
@@ -17,6 +17,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &["qwen"],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/deepseek.rs
+++ b/crates/octos-llm/src/registry/deepseek.rs
@@ -17,6 +17,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &["deepseek"],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/gemini.rs
+++ b/crates/octos-llm/src/registry/gemini.rs
@@ -17,6 +17,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &["gemini"],
+    model_discovery: crate::discovery::GEMINI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/groq.rs
+++ b/crates/octos-llm/src/registry/groq.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     // Groq hosts many open-source models — llama and mixtral are common.
     detect_patterns: &["llama", "mixtral"],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/local.rs
+++ b/crates/octos-llm/src/registry/local.rs
@@ -36,6 +36,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     // User-loaded models — nothing to pattern-match.
     detect_patterns: &[],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/minimax.rs
+++ b/crates/octos-llm/src/registry/minimax.rs
@@ -17,6 +17,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &["minimax"],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/mod.rs
+++ b/crates/octos-llm/src/registry/mod.rs
@@ -141,6 +141,12 @@ pub struct ProviderEntry {
     pub requires_model: bool,
     /// Substrings in a model name that identify this provider (for auto-detection).
     pub detect_patterns: &'static [&'static str],
+    /// Declared model-discovery capability: which protocol-specific listing
+    /// strategy the family speaks, or that it has no model-list endpoint and
+    /// only accepts manual model ids. Consumed by
+    /// [`crate::discovery::resolve_model_discovery`] — the protocol is never
+    /// inferred from the family id string.
+    pub model_discovery: crate::discovery::ModelDiscovery,
     /// Factory function with full control over provider construction.
     pub create: fn(CreateParams) -> Result<Arc<dyn LlmProvider>>,
 }

--- a/crates/octos-llm/src/registry/moonshot.rs
+++ b/crates/octos-llm/src/registry/moonshot.rs
@@ -17,6 +17,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &["kimi", "moonshot"],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/moonshot_coding.rs
+++ b/crates/octos-llm/src/registry/moonshot_coding.rs
@@ -26,6 +26,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // `kimi-for-coding`) must not be silently routed to the regular `moonshot`
     // endpoint, which would reject a coding-plan key.
     detect_patterns: &[],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/nvidia.rs
+++ b/crates/octos-llm/src/registry/nvidia.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     // Nvidia NIM hosts many models — no simple detect pattern.
     detect_patterns: &[],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/ollama.rs
+++ b/crates/octos-llm/src/registry/ollama.rs
@@ -19,6 +19,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     // Ollama hosts user-pulled models — no detect pattern.
     detect_patterns: &[],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/openai.rs
+++ b/crates/octos-llm/src/registry/openai.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &["gpt"],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/openrouter.rs
+++ b/crates/octos-llm/src/registry/openrouter.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     // OpenRouter hosts many models — no simple detect pattern.
     detect_patterns: &[],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/r9s.rs
+++ b/crates/octos-llm/src/registry/r9s.rs
@@ -19,6 +19,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     // R9S hosts many providers — no simple detect pattern.
     detect_patterns: &[],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/vertex.rs
+++ b/crates/octos-llm/src/registry/vertex.rs
@@ -28,6 +28,9 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &[],
+    model_discovery: crate::discovery::ModelDiscovery::Unsupported(
+        "Vertex AI lists models through project-scoped, service-account APIs - enter the model id manually",
+    ),
     create,
 };
 

--- a/crates/octos-llm/src/registry/vllm.rs
+++ b/crates/octos-llm/src/registry/vllm.rs
@@ -19,6 +19,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: true,
     // vLLM hosts user-deployed models — no detect pattern.
     detect_patterns: &[],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/zai.rs
+++ b/crates/octos-llm/src/registry/zai.rs
@@ -19,6 +19,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     // Z.AI hosts multiple model families — no simple detect pattern.
     detect_patterns: &[],
+    model_discovery: crate::discovery::ANTHROPIC_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/zai_coding.rs
+++ b/crates/octos-llm/src/registry/zai_coding.rs
@@ -26,6 +26,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // Selected explicitly by family — not auto-detected from a bare `glm-*`
     // model, which the regular `zai`/`zhipu` families already handle.
     detect_patterns: &[],
+    model_discovery: crate::discovery::ANTHROPIC_MODELS,
     create,
 };
 

--- a/crates/octos-llm/src/registry/zhipu.rs
+++ b/crates/octos-llm/src/registry/zhipu.rs
@@ -17,6 +17,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_base_url: false,
     requires_model: false,
     detect_patterns: &["glm"],
+    model_discovery: crate::discovery::OPENAI_MODELS,
     create,
 };
 


### PR DESCRIPTION
## Summary

Model discovery for `profile/llm/fetch_models` (and the admin REST `/api/my/provider-models` surface) no longer switches on the literal family id `anthropic` and no longer synthesizes a Bearer-authenticated `<base>/v1/models` probe for everything else.

Discovery is now a typed, provider/protocol-aware capability resolved from the selected **route**, and it is strictly advisory: discovery failure never marks a configured model unavailable and never blocks manual model-id entry, Test, or Save.

## What changed

- **Registry-declared capability** (`octos-llm`): every `ProviderEntry` declares `model_discovery` — a protocol-specific strategy (`AnthropicMessages`, `OpenAICompatible`, `GeminiList`) or `Unsupported(reason)` for manual-model-id-only families (currently `vertex`, whose service-account auth has no simple listing endpoint).
- **Route resolution mirrors inference** (`octos_llm::discovery::resolve_model_discovery`): only `route.api_type == "anthropic"` overrides the family's declared protocol — exactly the precedence `create_provider_with_api_type` applies at inference time. The protocol is never inferred from the family id string, so `zai` / `zai-coding` (Anthropic Messages families, ids notwithstanding) resolve to the Anthropic strategy even when a saved AppUI route carries the historical `api_type: "openai"` default. Family aliases resolve to the same strategy as their canonical family.
- **Root-relative URL joining**: the listing URL is joined to the configured API root with no heuristic version stripping/appending, so a `/v4` root (zhipu) becomes `/api/paas/v4/models`, never `/api/paas/v4/v1/models`.
- **Typed outcome** (`DiscoveryOutcome`): `discovered` / `unsupported` / `authentication_failed` / `endpoint_unreachable` / `invalid_response` / `rate_limited`, each with a safe redacted message (never the credential). An empty successful catalog is `discovered` with no error, distinguishable from every failure.
- **Both surfaces share one implementation**: the AppUI RPC now echoes `api_type` + `status` (+ `message`/`reason` on failures) instead of collapsing everything into `models: []` + `provider_unavailable`; the REST handler keeps its `string[]` success shape for dashboard compatibility and maps `unsupported` to an empty list (advisory) while surfacing auth/rate/transport failures as typed errors. Discovery-only 404 maps to `unsupported` (manual entry, inference unaffected).

## Behavior preservation

- Literal `anthropic` family: `<root>/v1/models` with `x-api-key` + `anthropic-version` — unchanged.
- Literal OpenAI-compatible families with `/v1` roots: `<root>/models` with `Authorization: Bearer` — unchanged for registered roots (all of which already include the version segment).
- Keyless families still list without an auth header; link-local base URLs are still refused before any outbound request.
- No CI changes.

## Tests

`octos-llm` (15 new):
- zai/zai-coding resolve to the Anthropic strategy without any literal id match; aliases match their canonical family.
- `api_type: "anthropic"` overrides any family; non-anthropic `api_type` values keep the native strategy (mirrors inference); unknown/custom families fall back to OpenAI-compatible.
- URL joining: `/v4` roots never duplicate version segments; `/v1` and bare roots join correctly.
- Loopback fixture: zai probe hits `/api/anthropic/v1/models` with `x-api-key` and **no** Bearer header; 401/404/429/transport/malformed/empty-catalog stay distinguishable; `vertex` is never probed.

`octos-cli` AppUI fixtures (8, incl. updated legacy tests):
- `zai` never receives a Bearer `/v1/models` request; `/v4` roots never get `/v4/v1/models`; manual-only families return typed `unsupported` with zero outbound requests; 401 → `authentication_failed`; empty catalogs stay `discovered` with no reason.

Local: `cargo test -p octos-llm` 578 passed; `cargo test -p octos-cli --lib --features api` ui_protocol 826 passed + admin 64 passed; `cargo fmt --check` and clippy clean for touched code.

Fixes #2165