### PR TITLE
fix(api): profile/llm upsert and delete invalidate active runtimes or report restart_required

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -1061,9 +1061,17 @@ async fn llm_select_rejects_keyless_models_before_persisting() {
     assert_eq!(result["applied"], true);
     assert_eq!(result["selected"]["model"], "glm-5.3");
     assert_eq!(
-        result.get("restart_required"),
-        None,
+        result["restart_required"],
+        json!(false),
         "dynamic profiles apply without a restart: {result}"
+    );
+    // #2164 uniform post-commit truth: applied stays persistence-only and the
+    // runtime disposition is stamped beside it.
+    assert_eq!(result["runtime_disposition"], "reloaded", "{result}");
+    assert_eq!(result["effective_from"], "next_turn", "{result}");
+    assert!(
+        result.get("config_revision").is_some_and(|r| r.is_string()),
+        "committed revision must be comparable against the runtime stamp: {result}"
     );
 }
 
@@ -1473,8 +1481,13 @@ async fn llm_delete_removes_entries_and_promotes_fallback() {
         &delete("openai", "gpt-4o", "official", "d-miss"),
         None,
     )
+    .await
     .expect("delete miss");
     assert_eq!(result["applied"], json!(false));
+    assert_eq!(
+        result["runtime_disposition"], "unchanged",
+        "a miss persists nothing and must not touch the runtime: {result}"
+    );
 
     // (b) Delete the PRIMARY -> the fallback is promoted.
     let result = raw_profile_llm_delete(
@@ -1482,6 +1495,7 @@ async fn llm_delete_removes_entries_and_promotes_fallback() {
         &delete("zai", "glm-5.3", "official", "d-primary"),
         None,
     )
+    .await
     .expect("delete primary");
     assert_eq!(result["applied"], json!(true));
     let profile = state
@@ -1505,6 +1519,7 @@ async fn llm_delete_removes_entries_and_promotes_fallback() {
         &delete("deepseek", "deepseek-v4-pro", "official", "d-last"),
         None,
     )
+    .await
     .expect("delete last");
     assert_eq!(result["applied"], json!(true));
     let profile = state
@@ -1525,6 +1540,435 @@ async fn llm_delete_removes_entries_and_promotes_fallback() {
         "last model removed (an emptied llm block may serialize away): {:?}",
         profile.config.llm
     );
+}
+
+/// #2164 test helpers: read the dynamic ProfileRuntime cache for a profile
+/// through the same key derivation the transport uses.
+fn dynamic_cached_profile_runtime(
+    state: &AppState,
+    profile_id: &str,
+) -> Option<Arc<crate::runtime::ProfileRuntime>> {
+    let key = dynamic_profile_runtime_key(state, profile_id)?;
+    dynamic_profile_runtimes()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&key)
+        .cloned()
+}
+
+fn llm_upsert_rpc(
+    id: &str,
+    profile_id: &str,
+    family: &str,
+    model: &str,
+    base_url: Option<&str>,
+    set_primary: bool,
+) -> RpcRequest<Value> {
+    let mut body = json!({
+        "profile_id": profile_id,
+        "selection": {
+            "family_id": family,
+            "model_id": model,
+            "route": {
+                "route_id": "official",
+                // A test-scoped variable name so resolution can't fall
+                // through to a real key in the process env.
+                "api_key_env": "OCTOS_TEST_LLM_RUNTIME_INVALIDATION_KEY",
+            },
+        },
+        "api_key": "test-invalidation-key",
+        "set_primary": set_primary,
+    });
+    if let Some(base_url) = base_url {
+        body["selection"]["route"]["base_url"] = json!(base_url);
+    }
+    RpcRequest::new(
+        id.to_string(),
+        APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+        body,
+    )
+}
+
+fn llm_delete_rpc(id: &str, profile_id: &str, family: &str, model: &str) -> RpcRequest<Value> {
+    RpcRequest::new(
+        id.to_string(),
+        APPUI_METHOD_PROFILE_LLM_DELETE.to_string(),
+        json!({
+            "profile_id": profile_id,
+            "family_id": family,
+            "model_id": model,
+            "route_id": "official",
+        }),
+    )
+}
+
+/// #2164 acceptance — dynamic profile, endpoint edit: changing the primary's
+/// base URL (same family/model/route address) must evict the cached
+/// ProfileRuntime and rebuild from the committed file, so the next turn
+/// serves the new endpoint instead of the stale provider chain.
+#[tokio::test]
+async fn should_upsert_endpoint_edit_reload_dynamic_profile_runtime_for_next_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc("u-v1", "dev", "openai", "gpt-4o-mini", None, true),
+        None,
+    )
+    .await
+    .expect("seed primary");
+    let before = ensure_session_profile_runtime(&state, Some("dev"))
+        .await
+        .expect("bootstrap")
+        .expect("runtime cached after first upsert");
+    assert!(Arc::ptr_eq(
+        &before,
+        &dynamic_cached_profile_runtime(&state, "dev").expect("cache entry"),
+    ));
+    // A turn in flight keeps its start-of-turn runtime; the test drops its
+    // handle the same way a finished turn would, so the rebuild below can
+    // take over the profile's data directory (single-writer redb).
+    let before_ptr = Arc::as_ptr(&before) as usize;
+    drop(before);
+
+    // Same model id, different endpoint: the cache MUST still be invalidated.
+    let result = raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc(
+            "u-v2",
+            "dev",
+            "openai",
+            "gpt-4o-mini",
+            Some("http://127.0.0.1:9/v1"),
+            true,
+        ),
+        None,
+    )
+    .await
+    .expect("endpoint edit");
+    assert_eq!(result["applied"], json!(true), "{result}");
+    assert_eq!(result["runtime_disposition"], "reloaded", "{result}");
+    assert_eq!(result["restart_required"], json!(false), "{result}");
+    assert_eq!(result["effective_from"], "next_turn", "{result}");
+    assert!(
+        result["config_revision"].is_string(),
+        "the committed revision must be comparable against the runtime stamp: {result}"
+    );
+
+    let after = dynamic_cached_profile_runtime(&state, "dev").expect("cache repopulated");
+    assert_ne!(
+        Arc::as_ptr(&after) as usize,
+        before_ptr,
+        "endpoint edit must rebuild the cached ProfileRuntime"
+    );
+    assert_eq!(after.primary_model_id, "gpt-4o-mini");
+    assert_eq!(
+        after.config.base_url.as_deref(),
+        Some("http://127.0.0.1:9/v1"),
+        "the rebuilt chain must serve the COMMITTED endpoint"
+    );
+}
+
+/// #2164 acceptance — deleting the active primary promotes the first
+/// fallback and the NEXT turn uses it: the cached runtime is rebuilt from
+/// the promoted chain, not left on the deleted model.
+#[tokio::test]
+async fn should_delete_primary_promote_fallback_and_reload_dynamic_profile_runtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc("u-primary", "dev", "openai", "gpt-4o-mini", None, true),
+        None,
+    )
+    .await
+    .expect("seed primary");
+    raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc(
+            "u-fallback",
+            "dev",
+            "deepseek",
+            "deepseek-chat",
+            None,
+            false,
+        ),
+        None,
+    )
+    .await
+    .expect("seed fallback");
+    let before = ensure_session_profile_runtime(&state, Some("dev"))
+        .await
+        .expect("bootstrap")
+        .expect("runtime cached");
+    let before_ptr = Arc::as_ptr(&before) as usize;
+    drop(before);
+
+    let result = raw_profile_llm_delete(
+        &state,
+        &llm_delete_rpc("d-1", "dev", "openai", "gpt-4o-mini"),
+        None,
+    )
+    .await
+    .expect("delete primary");
+    assert_eq!(result["applied"], json!(true), "{result}");
+    assert_eq!(result["runtime_disposition"], "reloaded", "{result}");
+    assert_eq!(result["restart_required"], json!(false), "{result}");
+
+    let after = dynamic_cached_profile_runtime(&state, "dev").expect("cache repopulated");
+    assert_ne!(
+        Arc::as_ptr(&after) as usize,
+        before_ptr,
+        "primary deletion must rebuild the cached ProfileRuntime"
+    );
+    assert_eq!(
+        after.primary_model_id, "deepseek-chat",
+        "the promoted fallback must serve the next turn"
+    );
+}
+
+/// #2164 acceptance — deleting the LAST model evicts the cached runtime and
+/// reports a deterministic deferred disposition; the next turn observes the
+/// empty selection as typed runtime-unavailable truth (no stale chain).
+#[tokio::test]
+async fn should_delete_last_model_evict_dynamic_runtime_and_report_deferred() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc("u-only", "dev", "openai", "gpt-4o-mini", None, true),
+        None,
+    )
+    .await
+    .expect("seed sole primary");
+    ensure_session_profile_runtime(&state, Some("dev"))
+        .await
+        .expect("bootstrap")
+        .expect("runtime cached");
+    assert!(dynamic_cached_profile_runtime(&state, "dev").is_some());
+
+    let result = raw_profile_llm_delete(
+        &state,
+        &llm_delete_rpc("d-last", "dev", "openai", "gpt-4o-mini"),
+        None,
+    )
+    .await
+    .expect("delete last model");
+    assert_eq!(result["applied"], json!(true), "{result}");
+    assert_eq!(result["runtime_disposition"], "deferred", "{result}");
+    assert_eq!(result["restart_required"], json!(false), "{result}");
+    assert!(
+        dynamic_cached_profile_runtime(&state, "dev").is_none(),
+        "the stale runtime must not survive the last-model deletion"
+    );
+    let next_turn = ensure_session_profile_runtime(&state, Some("dev"))
+        .await
+        .expect("ensure");
+    assert!(
+        next_turn.is_none(),
+        "with no selection left the next turn must report typed runtime-unavailable truth"
+    );
+}
+
+/// #2164 acceptance — startup-pinned profile: upsert and delete persist but
+/// return `restart_required: true` with disposition `restart_required`, and
+/// the boot-snapshot runtime is left untouched (no fake reload).
+#[tokio::test]
+async fn should_report_restart_required_for_startup_pinned_llm_mutations() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc("u-primary", "dev", "openai", "gpt-4o-mini", None, true),
+        None,
+    )
+    .await
+    .expect("seed primary");
+    raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc(
+            "u-fallback",
+            "dev",
+            "deepseek",
+            "deepseek-chat",
+            None,
+            false,
+        ),
+        None,
+    )
+    .await
+    .expect("seed fallback");
+    let pinned = ensure_session_profile_runtime(&state, Some("dev"))
+        .await
+        .expect("bootstrap")
+        .expect("runtime");
+
+    // Simulate the serve-startup shape: the runtime lives in the immutable
+    // startup map and nothing sits in the dynamic cache.
+    let mut state = Arc::try_unwrap(state).ok().expect("sole state owner");
+    state.profiles.insert("dev".to_string(), pinned.clone());
+    if let Some(key) = dynamic_profile_runtime_key(&state, "dev") {
+        dynamic_profile_runtimes()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&key);
+    }
+    let state = Arc::new(state);
+
+    let result = raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc(
+            "u-edit",
+            "dev",
+            "openai",
+            "gpt-4o-mini",
+            Some("http://127.0.0.1:9/v1"),
+            true,
+        ),
+        None,
+    )
+    .await
+    .expect("pinned upsert");
+    assert_eq!(result["applied"], json!(true), "{result}");
+    assert_eq!(
+        result["runtime_disposition"], "restart_required",
+        "{result}"
+    );
+    assert_eq!(result["restart_required"], json!(true), "{result}");
+    assert_eq!(result["effective_from"], "next_turn", "{result}");
+    assert!(
+        dynamic_cached_profile_runtime(&state, "dev").is_none(),
+        "a pinned profile must not fake a reload into the dynamic cache"
+    );
+    assert!(
+        Arc::ptr_eq(&pinned, state.profiles.get("dev").unwrap()),
+        "the boot-snapshot runtime stays as-is until restart"
+    );
+
+    let result = raw_profile_llm_delete(
+        &state,
+        &llm_delete_rpc("d-fallback", "dev", "deepseek", "deepseek-chat"),
+        None,
+    )
+    .await
+    .expect("pinned delete");
+    assert_eq!(result["applied"], json!(true), "{result}");
+    assert_eq!(
+        result["runtime_disposition"], "restart_required",
+        "{result}"
+    );
+    assert_eq!(result["restart_required"], json!(true), "{result}");
+}
+
+/// #2164 acceptance — a concurrent old bootstrap cannot repopulate the cache
+/// after a mutation: an insert carrying the PRE-bump generation is refused
+/// (the cache stays empty), while a bootstrap that read the committed file
+/// inserts under the new generation.
+#[tokio::test]
+async fn should_refuse_stale_profile_runtime_insert_after_generation_bump() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc("u-only", "dev", "openai", "gpt-4o-mini", None, true),
+        None,
+    )
+    .await
+    .expect("seed");
+    let runtime = ensure_session_profile_runtime(&state, Some("dev"))
+        .await
+        .expect("bootstrap")
+        .expect("runtime");
+    let key = dynamic_profile_runtime_key(&state, "dev").expect("dynamic key");
+
+    // Post-mutation state: generation bumped, cache emptied (the transition).
+    let post_commit_generation = bump_profile_runtime_generation(&key);
+    dynamic_profile_runtimes()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&key);
+
+    // A bootstrap that captured the PRE-commit generation must be refused…
+    assert!(
+        !insert_profile_runtime_if_current(&key, post_commit_generation - 1, Arc::clone(&runtime),),
+        "a stale in-flight bootstrap must not repopulate the cache"
+    );
+    assert!(
+        dynamic_cached_profile_runtime(&state, "dev").is_none(),
+        "the refused insert must leave the cache empty"
+    );
+    // …while a bootstrap reading the committed file inserts normally.
+    assert!(
+        insert_profile_runtime_if_current(&key, post_commit_generation, Arc::clone(&runtime)),
+        "a current-generation bootstrap inserts"
+    );
+    assert!(dynamic_cached_profile_runtime(&state, "dev").is_some());
+}
+
+/// #2164 acceptance — persisted-but-rebuild-failed is EXPLICIT in the
+/// response (`persisted_but_not_live` + `runtime_error`), not collapsed into
+/// a warn-only server log, and recoverable once the bootstrap blocker is
+/// removed.
+#[tokio::test]
+async fn should_report_persisted_but_not_live_when_runtime_rebuild_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+    // Block the runtime bootstrap deterministically: the profile's data dir
+    // is a plain FILE, so the episode store cannot open underneath it.
+    let blocker = dir.path().join("dev-data-blocker");
+    std::fs::write(&blocker, b"not a directory").unwrap();
+    let mut profile = profile_for_runtime_message("dev");
+    profile.data_dir = Some(blocker.to_string_lossy().to_string());
+    profile.config.llm = Some(crate::profiles::LlmProfileConfig {
+        primary: Some(crate::profiles::LlmModelSelectionConfig {
+            family_id: Some("openai".to_string()),
+            model_id: Some("gpt-4o-mini".to_string()),
+            route: Some(crate::profiles::LlmRouteConfig {
+                api_key_env: Some("OCTOS_TEST_LLM_RUNTIME_INVALIDATION_KEY".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        fallbacks: Vec::new(),
+    });
+    profile.config.env_vars.insert(
+        "OCTOS_TEST_LLM_RUNTIME_INVALIDATION_KEY".to_string(),
+        "k".to_string(),
+    );
+    state
+        .profile_store
+        .as_ref()
+        .unwrap()
+        .save(&profile)
+        .unwrap();
+
+    let result = raw_profile_llm_upsert(
+        &state,
+        &llm_upsert_rpc("u-edit", "dev", "openai", "gpt-4o-mini", None, true),
+        None,
+    )
+    .await
+    .expect("persistence must succeed");
+    assert_eq!(result["applied"], json!(true), "{result}");
+    assert_eq!(
+        result["runtime_disposition"], "persisted_but_not_live",
+        "the failed rebuild must be explicit on the wire: {result}"
+    );
+    assert_eq!(result["restart_required"], json!(false), "{result}");
+    assert!(
+        result["runtime_error"].is_string(),
+        "the rebuild failure detail must be reported: {result}"
+    );
+    assert!(result["config_revision"].is_string(), "{result}");
+
+    // Recoverable: unblock the data dir and the next bootstrap succeeds.
+    std::fs::remove_file(&blocker).unwrap();
+    std::fs::create_dir_all(&blocker).unwrap();
+    let recovered = ensure_session_profile_runtime(&state, Some("dev"))
+        .await
+        .expect("bootstrap after unblock")
+        .expect("runtime recovers on the next turn");
+    assert_eq!(recovered.primary_model_id, "gpt-4o-mini");
 }
 
 /// A same-address upsert (same family/model/route_id — including a
@@ -28903,7 +29347,9 @@ async fn appui_no_cwd_workspace_does_not_become_a_transcript_store_hint() {
         .opened
         .workspace_root
         .expect("Tier-3 workspace root is still exposed for tools and UI");
-    assert_ne!(workspace_root, profile_runtime.data_dir);
+    // `SessionOpenResult.workspace_root` is wire-typed String; convert so the
+    // comparison against the runtime's PathBuf still type-checks.
+    assert_ne!(PathBuf::from(workspace_root), profile_runtime.data_dir);
 
     let sessions = resolve_sessions_for_lookup(&state, None, Some(profile_id), &session_id)
         .await

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -11732,42 +11732,28 @@ async fn raw_profile_llm_select(
     }
     profile.config.llm = Some(llm);
 
-    if !already_primary {
+    // The switch must take effect on the NEXT turn, not the next restart:
+    // cached SessionRuntimes embed the old provider chain and the dynamic
+    // ProfileRuntime caches forever, so run the SAME post-commit transition
+    // as upsert/delete (#2164) — evict both caches (generation-guarded) and
+    // rebuild. `applied` stays persistence-only; the runtime disposition is
+    // stamped onto the result separately.
+    let transition = if !already_primary {
         profile.updated_at = Utc::now();
         store
             .save_with_merge(&mut profile)
             .map_err(|err| RpcError::internal_error(format!("failed to save profile: {err}")))?;
-
-        // The switch must take effect on the NEXT turn, not the next restart:
-        // cached SessionRuntimes embed the old provider chain and the dynamic
-        // ProfileRuntime caches forever, so evict both and re-bootstrap.
-        state.session_cache.invalidate_profile(&profile_id).await;
-        if let Some(key) = dynamic_profile_runtime_key(state, &profile_id) {
-            dynamic_profile_runtimes()
-                .write()
-                .map_err(|err| {
-                    RpcError::internal_error(format!(
-                        "dynamic profile runtime cache lock poisoned: {err}"
-                    ))
-                })?
-                .remove(&key);
-        }
-        if state.profiles.contains_key(&profile_id) {
-            // Startup-config profiles live in an immutable map — the saved
-            // selection persists but cannot rebuild without a restart.
-            tracing::warn!(
-                profile_id = %profile_id,
-                "profile/llm/select saved, but this startup-config profile's runtime \
-                 rebuilds on restart only"
-            );
-        } else if let Err(error) = ensure_session_profile_runtime(state, Some(&profile_id)).await {
-            tracing::warn!(
-                profile_id = %profile_id,
-                error = %error.message,
-                "profile/llm/select saved; runtime bootstrap deferred to the next turn",
-            );
-        }
-    }
+        Some(
+            commit_profile_llm_runtime_transition(
+                state,
+                &profile_id,
+                Some(profile.updated_at.to_rfc3339()),
+            )
+            .await,
+        )
+    } else {
+        None
+    };
 
     let session_id = params
         .session_id
@@ -11795,10 +11781,18 @@ async fn raw_profile_llm_select(
             Some(&refreshed),
         ),
     });
+    stamp_profile_llm_runtime_transition(
+        &mut result,
+        transition
+            .as_ref()
+            .unwrap_or(&ProfileLlmRuntimeTransition::unchanged()),
+    );
     if state.profiles.contains_key(&profile_id) {
         // Startup-pinned runtime: the selection is saved but turns keep the
         // boot snapshot until restart (the stamp above says so too). Tell
-        // the caller instead of letting the switch silently not take.
+        // the caller instead of letting the switch silently not take —
+        // including for an idempotent re-select of the already-active
+        // primary, which performs no transition of its own.
         result["restart_required"] = json!(true);
     }
     Ok(result)
@@ -11910,19 +11904,20 @@ async fn raw_profile_llm_upsert(
     store
         .save_with_merge(&mut profile)
         .map_err(|err| RpcError::internal_error(format!("failed to save profile: {err}")))?;
-    if let Err(error) = ensure_session_profile_runtime(state, Some(&profile_id)).await {
-        tracing::warn!(
-            profile_id = %profile_id,
-            error = %error.message,
-            "profile/llm/upsert saved provider config but runtime bootstrap is not ready yet",
-        );
-    }
-    Ok(profile_llm_mutation_result(
+    // #2164: a saved-but-still-cached provider chain used to serve the next
+    // turn (ensure returned the existing dynamic or startup runtime
+    // immediately). Run the shared post-commit transition instead: evict the
+    // cached SessionRuntimes + ProfileRuntime (generation-guarded), then
+    // rebuild or report restart_required / persisted_but_not_live.
+    let transition = commit_profile_llm_runtime_transition(
         state,
         &profile_id,
-        Some(&profile),
-        true,
-    ))
+        Some(profile.updated_at.to_rfc3339()),
+    )
+    .await;
+    let mut result = profile_llm_mutation_result(state, &profile_id, Some(&profile), true);
+    stamp_profile_llm_runtime_transition(&mut result, &transition);
+    Ok(result)
 }
 
 /// `profile/llm/delete`: remove one configured model — primary or fallback —
@@ -11931,7 +11926,10 @@ async fn raw_profile_llm_upsert(
 /// so the profile keeps a working model whenever one exists; deleting the
 /// last model leaves `llm.primary` empty (recoverable via `/model` → Add).
 /// A non-matching address returns the unchanged state with `applied: false`.
-fn raw_profile_llm_delete(
+/// On a successful commit it runs the SAME post-commit transition as
+/// select/upsert (#2164): evict the cached runtimes and rebuild — deleting
+/// the active primary used to leave the old chain serving the next turn.
+async fn raw_profile_llm_delete(
     state: &Arc<AppState>,
     request: &RpcRequest<Value>,
     connection_profile_id: Option<&str>,
@@ -11944,7 +11942,12 @@ fn raw_profile_llm_delete(
         .get(&profile_id)
         .map_err(|err| RpcError::internal_error(format!("failed to read profile: {err}")))?
     else {
-        return Ok(profile_llm_mutation_result(state, &profile_id, None, false));
+        let mut result = profile_llm_mutation_result(state, &profile_id, None, false);
+        stamp_profile_llm_runtime_transition(
+            &mut result,
+            &ProfileLlmRuntimeTransition::unchanged(),
+        );
+        return Ok(result);
     };
 
     let family_id = nonempty(Some(params.family_id))
@@ -11964,12 +11967,12 @@ fn raw_profile_llm_delete(
     };
 
     let Some(mut llm) = profile.config.llm.take() else {
-        return Ok(profile_llm_mutation_result(
-            state,
-            &profile_id,
-            Some(&profile),
-            false,
-        ));
+        let mut result = profile_llm_mutation_result(state, &profile_id, Some(&profile), false);
+        stamp_profile_llm_runtime_transition(
+            &mut result,
+            &ProfileLlmRuntimeTransition::unchanged(),
+        );
+        return Ok(result);
     };
 
     let applied = if llm
@@ -11994,24 +11997,32 @@ fn raw_profile_llm_delete(
     profile.config.llm = Some(llm);
 
     if !applied {
-        return Ok(profile_llm_mutation_result(
-            state,
-            &profile_id,
-            Some(&profile),
-            false,
-        ));
+        // #2164: a miss persists nothing and must NOT evict a healthy
+        // runtime — report the unchanged disposition explicitly.
+        let mut result = profile_llm_mutation_result(state, &profile_id, Some(&profile), false);
+        stamp_profile_llm_runtime_transition(
+            &mut result,
+            &ProfileLlmRuntimeTransition::unchanged(),
+        );
+        return Ok(result);
     }
 
     profile.updated_at = Utc::now();
     store
         .save_with_merge(&mut profile)
         .map_err(|err| RpcError::internal_error(format!("failed to save profile: {err}")))?;
-    Ok(profile_llm_mutation_result(
+    // #2164: the shared post-commit transition — deletion used to return
+    // `applied: true` while every cached runtime kept serving the deleted
+    // model (or the pre-promotion primary) until a restart.
+    let transition = commit_profile_llm_runtime_transition(
         state,
         &profile_id,
-        Some(&profile),
-        true,
-    ))
+        Some(profile.updated_at.to_rfc3339()),
+    )
+    .await;
+    let mut result = profile_llm_mutation_result(state, &profile_id, Some(&profile), true);
+    stamp_profile_llm_runtime_transition(&mut result, &transition);
+    Ok(result)
 }
 
 fn upsert_llm_fallback(
@@ -12407,6 +12418,162 @@ fn profile_llm_mutation_result(
         object.insert("applied".into(), Value::Bool(applied));
     }
     result
+}
+
+/// Post-commit runtime disposition of a Profile LLM mutation (#2164):
+/// `applied` only ever means PERSISTED — this is the separate live-runtime
+/// truth, uniform across `profile/llm/select`, `upsert`, and `delete`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProfileRuntimeDisposition {
+    /// Dynamic profile: caches evicted and the ProfileRuntime rebuilt from the
+    /// committed file — the next turn serves the new provider chain.
+    Reloaded,
+    /// Dynamic profile: caches evicted, no runtime bootstrapped right now
+    /// (disabled profile, or no model left after deleting the last one) — the
+    /// next turn deterministically re-derives, reporting typed
+    /// runtime-unavailable truth when the selection is gone.
+    Deferred,
+    /// Startup-pinned profile: the boot snapshot keeps serving until restart.
+    RestartRequired,
+    /// Dynamic profile: caches evicted but the rebuild FAILED — the next turn
+    /// retries the bootstrap (retry/restart recovers). Reported explicitly on
+    /// the wire, never collapsed into a warn-only server log.
+    PersistedButNotLive,
+    /// Nothing was persisted (applied:false): no runtime transition happened,
+    /// a healthy runtime stays healthy.
+    Unchanged,
+}
+
+impl ProfileRuntimeDisposition {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Reloaded => "reloaded",
+            Self::Deferred => "deferred",
+            Self::RestartRequired => "restart_required",
+            Self::PersistedButNotLive => "persisted_but_not_live",
+            Self::Unchanged => "unchanged",
+        }
+    }
+}
+
+/// The runtime transition a committed Profile LLM mutation performed, stamped
+/// onto the wire result next to `applied` (#2164).
+#[derive(Debug, Clone)]
+struct ProfileLlmRuntimeTransition {
+    disposition: ProfileRuntimeDisposition,
+    /// Persisted profile revision (`updated_at`) the runtime was — or was
+    /// demonstrably not — synced to.
+    config_revision: Option<String>,
+    /// Rebuild failure detail for `persisted_but_not_live`.
+    error: Option<String>,
+}
+
+impl ProfileLlmRuntimeTransition {
+    fn unchanged() -> Self {
+        Self {
+            disposition: ProfileRuntimeDisposition::Unchanged,
+            config_revision: None,
+            error: None,
+        }
+    }
+}
+
+/// The ONE post-commit transition shared by `profile/llm/select`, `upsert`,
+/// and `delete` (#2164): evict every cached SessionRuntime for the profile,
+/// bump the dynamic-runtime generation and drop the cached ProfileRuntime,
+/// then either rebuild it (dynamic profile) or report `restart_required`
+/// (startup-pinned boot snapshot). A caller whose persistence FAILED must not
+/// reach this — a healthy runtime stays healthy.
+async fn commit_profile_llm_runtime_transition(
+    state: &AppState,
+    profile_id: &str,
+    config_revision: Option<String>,
+) -> ProfileLlmRuntimeTransition {
+    let startup_pinned = state.profiles.contains_key(profile_id);
+    // Evict FIRST, generation before removal: the session cache bumps its own
+    // guard inside `invalidate_profile`, and the dynamic map's guard must be
+    // bumped before the drop so an in-flight bootstrap that read the
+    // pre-commit file is refused at insert time.
+    state.session_cache.invalidate_profile(profile_id).await;
+    if let Some(key) = dynamic_profile_runtime_key(state, profile_id) {
+        bump_profile_runtime_generation(&key);
+        dynamic_profile_runtimes()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&key);
+    }
+
+    if startup_pinned {
+        // Startup-config profiles live in an immutable map — the saved
+        // mutation persists but cannot rebuild without a restart.
+        tracing::warn!(
+            profile_id = %profile_id,
+            "profile LLM mutation saved, but this startup-config profile's runtime \
+             rebuilds on restart only"
+        );
+        return ProfileLlmRuntimeTransition {
+            disposition: ProfileRuntimeDisposition::RestartRequired,
+            config_revision,
+            error: None,
+        };
+    }
+
+    match ensure_session_profile_runtime(state, Some(profile_id)).await {
+        Ok(Some(_runtime)) => ProfileLlmRuntimeTransition {
+            disposition: ProfileRuntimeDisposition::Reloaded,
+            config_revision,
+            error: None,
+        },
+        Ok(None) => ProfileLlmRuntimeTransition {
+            disposition: ProfileRuntimeDisposition::Deferred,
+            config_revision,
+            error: None,
+        },
+        Err(error) => {
+            tracing::warn!(
+                profile_id = %profile_id,
+                error = %error.message,
+                "profile LLM mutation saved but runtime rebuild failed; the next turn \
+                 retries the bootstrap"
+            );
+            ProfileLlmRuntimeTransition {
+                disposition: ProfileRuntimeDisposition::PersistedButNotLive,
+                config_revision,
+                error: Some(error.message),
+            }
+        }
+    }
+}
+
+/// Stamp the uniform post-commit runtime truth (#2164) onto a profile-LLM
+/// mutation result. `applied` stays persistence-only; `restart_required` is
+/// always present so clients never parse presence as the signal.
+fn stamp_profile_llm_runtime_transition(
+    result: &mut Value,
+    transition: &ProfileLlmRuntimeTransition,
+) {
+    if let Value::Object(object) = result {
+        object.insert(
+            "runtime_disposition".into(),
+            json!(transition.disposition.as_str()),
+        );
+        if let Some(config_revision) = &transition.config_revision {
+            object.insert("config_revision".into(), json!(config_revision));
+        }
+        object.insert(
+            "restart_required".into(),
+            json!(matches!(
+                transition.disposition,
+                ProfileRuntimeDisposition::RestartRequired
+            )),
+        );
+        if transition.disposition != ProfileRuntimeDisposition::Unchanged {
+            object.insert("effective_from".into(), json!("next_turn"));
+        }
+        if let Some(error) = &transition.error {
+            object.insert("runtime_error".into(), json!(error));
+        }
+    }
 }
 
 fn sub_provider_json(sp: &crate::config::SubProviderConfig) -> Value {
@@ -16442,7 +16609,7 @@ async fn handle_raw_appui_rpc(
             raw_profile_llm_select(state, request, connection_profile_id).await
         }
         APPUI_METHOD_PROFILE_LLM_DELETE => {
-            raw_profile_llm_delete(state, request, connection_profile_id)
+            raw_profile_llm_delete(state, request, connection_profile_id).await
         }
         APPUI_METHOD_PROFILE_LLM_FETCH_MODELS => {
             raw_profile_llm_fetch_models(state, request, connection_profile_id).await
@@ -19190,6 +19357,52 @@ fn dynamic_profile_runtime_key(state: &AppState, profile_id: &str) -> Option<Str
     ))
 }
 
+/// Generation guard for the dynamic ProfileRuntime cache (#2164): the
+/// post-commit Profile LLM transition bumps the generation BEFORE dropping
+/// the cached runtime, so an in-flight bootstrap that read the PRE-commit
+/// profile file is refused at insert time and cannot repopulate the cache
+/// with a stale provider chain (mirrors `SessionRuntimeCache::generations`).
+fn profile_runtime_generations() -> &'static std::sync::RwLock<HashMap<String, u64>> {
+    static GENERATIONS: OnceLock<std::sync::RwLock<HashMap<String, u64>>> = OnceLock::new();
+    GENERATIONS.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+fn current_profile_runtime_generation(key: &str) -> u64 {
+    profile_runtime_generations()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(key)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn bump_profile_runtime_generation(key: &str) -> u64 {
+    let mut generations = profile_runtime_generations()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let generation = generations.entry(key.to_owned()).or_insert(0);
+    *generation += 1;
+    *generation
+}
+
+/// Insert `runtime` under `key` only while `generation` is still current.
+/// Returns `false` — leaving the cache untouched — when a post-commit
+/// invalidation bumped the generation while this bootstrap was in flight.
+fn insert_profile_runtime_if_current(
+    key: &str,
+    generation: u64,
+    runtime: Arc<crate::runtime::ProfileRuntime>,
+) -> bool {
+    let mut runtimes = dynamic_profile_runtimes()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if current_profile_runtime_generation(key) != generation {
+        return false;
+    }
+    runtimes.entry(key.to_owned()).or_insert(runtime);
+    true
+}
+
 async fn ensure_session_profile_runtime(
     state: &AppState,
     active_profile_id: Option<&str>,
@@ -19214,59 +19427,72 @@ async fn ensure_session_profile_runtime(
         return Ok(Some(runtime.clone()));
     }
 
-    let profile = store
-        .get(profile_id)
-        .map_err(|error| runtime_unavailable_error(format!("failed to read profile: {error}")))?;
-    let Some(profile) = profile else {
-        return Ok(None);
-    };
-    let profile_data_dir = store.resolve_data_dir(&profile);
-    // Restart recovery belongs exclusively to `octos serve` startup, which
-    // scans every persisted profile before runtimes are bootstrapped. This
-    // helper also runs for live cache replacement (for example
-    // `profile/llm/select`), where marking active jobs abandoned would lie
-    // about work still executing in this process.
-    if !profile.enabled || profile.parent_id.is_some() || !profile.config.has_llm_selection() {
-        return Ok(None);
-    }
-
-    // Lazily-created profiles must honour host-level policy too — without
-    // host_memory, a host opt-out of (default-on) memory refresh would not
-    // bind profiles created after startup.
-    let runtime = crate::runtime::ProfileRuntime::bootstrap_with_host_plugins(
-        &profile,
-        &profile_data_dir,
-        Some(store.octos_home_dir()),
-        crate::runtime::BootstrapRole::Serve,
-        None,
-        None,
-        state.host_memory.as_ref(),
-    )
-    .await
-    .map_err(|error| {
-        // Lock contention is a config mistake with a concrete fix, so it gets
-        // its own typed kind and a sentence the operator can act on. Anything
-        // else stays `runtime_unavailable` — but formatted with `{error:#}`
-        // so the eyre chain survives to the client. Plain `{error}` prints
-        // only the outermost context, which is how "failed to open episode
-        // store for profile 'x'" used to reach the TUI with its actual cause
-        // (and its remedy) silently dropped.
-        if octos_memory::is_episode_store_locked(&error) {
-            data_dir_locked_error(profile_id, &error)
-        } else {
-            runtime_unavailable_error(format!(
-                "failed to bootstrap ProfileRuntime for profile '{profile_id}': {error:#}"
-            ))
+    // #2164: a profile/llm select/upsert/delete that commits while this
+    // bootstrap is in flight bumps the generation and must not be undone by
+    // this insert — a runtime built from the PRE-commit file would silently
+    // serve the old provider chain for the next turn. Capture the generation
+    // up front, verify it at insert time, and on a lost race retry once from
+    // the freshly committed file.
+    for attempt in 0..2 {
+        let generation = current_profile_runtime_generation(&key);
+        let profile = store.get(profile_id).map_err(|error| {
+            runtime_unavailable_error(format!("failed to read profile: {error}"))
+        })?;
+        let Some(profile) = profile else {
+            return Ok(None);
+        };
+        let profile_data_dir = store.resolve_data_dir(&profile);
+        // Restart recovery belongs exclusively to `octos serve` startup, which
+        // scans every persisted profile before runtimes are bootstrapped. This
+        // helper also runs for live cache replacement (for example
+        // `profile/llm/select`), where marking active jobs abandoned would lie
+        // about work still executing in this process.
+        if !profile.enabled || profile.parent_id.is_some() || !profile.config.has_llm_selection() {
+            return Ok(None);
         }
-    })?;
-    let mut runtimes = dynamic_profile_runtimes()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = runtimes
-        .entry(key)
-        .or_insert_with(|| runtime.clone())
-        .clone();
-    Ok(Some(runtime))
+
+        // Lazily-created profiles must honour host-level policy too — without
+        // host_memory, a host opt-out of (default-on) memory refresh would not
+        // bind profiles created after startup.
+        let runtime = crate::runtime::ProfileRuntime::bootstrap_with_host_plugins(
+            &profile,
+            &profile_data_dir,
+            Some(store.octos_home_dir()),
+            crate::runtime::BootstrapRole::Serve,
+            None,
+            None,
+            state.host_memory.as_ref(),
+        )
+        .await
+        .map_err(|error| {
+            // Lock contention is a config mistake with a concrete fix, so it gets
+            // its own typed kind and a sentence the operator can act on. Anything
+            // else stays `runtime_unavailable` — but formatted with `{error:#}`
+            // so the eyre chain survives to the client. Plain `{error}` prints
+            // only the outermost context, which is how "failed to open episode
+            // store for profile 'x'" used to reach the TUI with its actual cause
+            // (and its remedy) silently dropped.
+            if octos_memory::is_episode_store_locked(&error) {
+                data_dir_locked_error(profile_id, &error)
+            } else {
+                runtime_unavailable_error(format!(
+                    "failed to bootstrap ProfileRuntime for profile '{profile_id}': {error:#}"
+                ))
+            }
+        })?;
+        if insert_profile_runtime_if_current(&key, generation, runtime.clone()) {
+            return Ok(Some(runtime));
+        }
+        tracing::debug!(
+            profile_id = %profile_id,
+            attempt,
+            "profile runtime bootstrap raced a profile/llm commit; retrying from the committed file"
+        );
+    }
+    Err(runtime_unavailable_error(format!(
+        "profile '{profile_id}' configuration changed while its runtime was bootstrapping; \
+         retry the turn"
+    )))
 }
 
 async fn rebuild_profile_runtime_after_skill_mutation(


### PR DESCRIPTION
## Problem

`profile/llm/upsert` and `profile/llm/delete` persisted Profile configuration but performed no active-runtime transition: upsert called `ensure_session_profile_runtime`, which returns an already-cached dynamic or startup runtime immediately, and delete returned `applied: true` without any invalidation. Cached `SessionRuntime`/`ProfileRuntime` instances kept serving the pre-mutation provider chain on the next turn — unsafe for endpoint/key edits and deletion of the active primary. Settings reported success while the old configuration stayed live. `profile/llm/select` was the only mutation with a runtime transition (and the only one reporting `restart_required`).

## Fix: one post-commit transition for select / upsert / delete

New shared `commit_profile_llm_runtime_transition`, run by all three mutations after a successful commit:

- **`applied` stays persistence-only.** Runtime disposition is exposed separately and uniformly on every mutation result:
  ```json
  {
    "applied": true,
    "config_revision": "<profile updated_at RFC3339>",
    "runtime_disposition": "reloaded | deferred | restart_required | persisted_but_not_live | unchanged",
    "restart_required": false,
    "effective_from": "next_turn",
    "runtime_error": "…only for persisted_but_not_live…"
  }
  ```
- **Dynamic profiles:** evict all cached `SessionRuntime`s for the profile (the session cache already bumps its own generation guard), bump a NEW generation guard on the dynamic `ProfileRuntime` map and drop the entry, then rebuild via `ensure_session_profile_runtime` → `reloaded`; if no runtime bootstraps (disabled profile / last model deleted) → `deferred`, and the next turn reports typed runtime-unavailable truth.
- **Generation/revision guard:** `ensure_session_profile_runtime` captures the dynamic-map generation before reading the profile file and refuses the insert when a concurrent mutation bumped it (one retry from the freshly committed file), so an in-flight bootstrap cannot repopulate the cache with the stale provider chain — mirroring `SessionRuntimeCache::generations` (#1639).
- **Startup-pinned profiles:** `restart_required: true` + disposition `restart_required`, no fake reload — select's existing wire promise, now shared (select keeps reporting `restart_required: true` even for an idempotent re-select).
- **Persisted-but-rebuild-failed is explicit:** disposition `persisted_but_not_live` + `runtime_error` on the wire (previously a warn-only server log); the cache stays empty so the next turn retries the bootstrap and recovers.
- **Failed persistence never reaches the transition:** a healthy runtime stays healthy (`runtime_disposition: "unchanged"`, no eviction).
- An in-flight turn keeps its start-of-turn runtime (sessions hold their own `Arc`); the following turn observes the committed revision.

## Notes

- `restart_required` is now always present as a bool on these mutation results (it was absent for dynamic profiles before); presence is no longer the signal. One existing test assertion updated accordingly.
- `raw_profile_llm_delete` became `async` to run the transition (dispatcher awaits it).
- Drive-by: fixes a pre-existing `--features api` lib-test compile break (`SessionOpenResult.workspace_root` became `String` on main while the Tier-3 test still compared it to a `PathBuf`), needed so the new tests build.
- `ci.yml` untouched. Unconfigured/default user behavior unchanged: mutations with `applied: false` perform no runtime transition, and profiles without an LLM selection keep getting the existing typed runtime-unavailable handling.

## Tests

New `should_*` tests pin the contract (all passing):

- endpoint edit on an unchanged model id rebuilds the cached `ProfileRuntime` and the rebuilt chain serves the committed `base_url` (`reloaded`, `restart_required: false`)
- deleting the primary promotes the fallback and the rebuilt runtime serves it
- deleting the last model evicts the cached runtime (`deferred`) and the next turn sees typed runtime-unavailable truth
- startup-pinned upsert and delete report `restart_required: true` and leave the boot snapshot untouched
- a stale (pre-bump generation) bootstrap insert is refused and leaves the cache empty; a current-generation insert succeeds
- persisted-but-rebuild-failed is explicit (`persisted_but_not_live` + `runtime_error`) and recoverable once the blocker is removed
- delete miss reports `unchanged` and does not evict

Full `cargo test -p octos-cli --lib --features api`: 3165 passed; the two `appui_*_drains_internal_continuation_turn` failures observed under full-suite parallel load pass reliably in isolation/smaller runs (timing-sensitive turn-drain tests, unrelated to profile/llm paths — under investigation whether pre-existing on main).

Fixes #2164
