### PR TITLE
feat(catalog): add glm-5.3-flash to the z.ai API and GLM Coding Plan

### DIFF
--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -198,6 +198,9 @@
     "models": [
       { "id": "glm-5.3", "input": 0.0, "output": 0.0, "max_output": 131072, "endpoints": [
         { "id": "zai-coding", "label": "GLM Coding Plan", "base_url": "https://api.z.ai/api/anthropic", "api_key_env": "ZAI_API_KEY" }
+      ] },
+      { "id": "glm-5.3-flash", "input": 0.0, "output": 0.0, "max_output": 131072, "endpoints": [
+        { "id": "zai-coding", "label": "GLM Coding Plan", "base_url": "https://api.z.ai/api/anthropic", "api_key_env": "ZAI_API_KEY" }
       ] }
     ]
   },
@@ -219,7 +222,8 @@
       { "id": "glm-5-turbo", "input": 1.0, "output": 0.4, "max_output": 131072 },
       { "id": "glm-5.1", "input": 0.5, "output": 2.0, "max_output": 131072 },
       { "id": "glm-4.7", "input": 0.3, "output": 1.2, "max_output": 8192 },
-      { "id": "glm-4.5-air", "input": 0.07, "output": 0.07, "max_output": 4096 }
+      { "id": "glm-4.5-air", "input": 0.07, "output": 0.07, "max_output": 4096 },
+      { "id": "glm-5.3-flash", "input": 0.15, "output": 0.5, "max_output": 131072 }
     ]
   },
   "nvidia": {

--- a/model_catalog.json
+++ b/model_catalog.json
@@ -1963,6 +1963,19 @@
       "ds_output": 0
     },
     {
+      "provider": "zai/glm-5.3-flash",
+      "type": "fast",
+      "cost_in": 0.15,
+      "cost_out": 0.5,
+      "context_window": 1000000,
+      "max_output": 131072,
+      "stability": 1.0,
+      "tool_avg_ms": 0,
+      "p95_ms": 0,
+      "score": 0.0,
+      "ds_output": 0
+    },
+    {
       "provider": "zhipu/glm-4-air",
       "type": "fast",
       "stability": 1.0,
@@ -2088,6 +2101,27 @@
       "provider": "zai-coding/glm-5.3",
       "type": "strong",
       "default": true,
+      "stability": 1.0,
+      "tool_avg_ms": 0,
+      "p95_ms": 0,
+      "score": 0.0,
+      "ds_output": 0,
+      "cost_in": 0.0,
+      "cost_out": 0.0,
+      "context_window": 200000,
+      "max_output": 131072,
+      "endpoints": [
+        {
+          "id": "zai-coding",
+          "label": "GLM Coding Plan",
+          "base_url": "https://api.z.ai/api/anthropic",
+          "api_key_env": "ZAI_API_KEY"
+        }
+      ]
+    },
+    {
+      "provider": "zai-coding/glm-5.3-flash",
+      "type": "fast",
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,


### PR DESCRIPTION
Two entries, mirroring the existing glm-5.3 pair.

**`zai/glm-5.3-flash`** — metered, `type: fast`, **$0.15/M input, $0.50/M output**. That is the **list** price from [docs.z.ai's pricing page](https://docs.z.ai/guides/overview/pricing); the $0.075/$0.25 you may see elsewhere is a launch promotion ending **2026-09-09 (UTC+8)**, and a catalog shouldn't carry a price that expires next week. Real numbers rather than `0.0` — zero and unknown are two different semantics, and zero pricing displays every metered request as free (the exact defect holding #1877).

**`zai-coding/glm-5.3-flash`** — GLM Coding Plan, same Anthropic endpoint as `zai-coding/glm-5.3`. `0.0/0.0` here is semantic (flat-fee subscription), matching the existing plan entry. **`glm-5.3` stays the plan's default** — promoting the new model would be a behaviour change nobody asked for.

`context_window`/`max_output` use the family serving values (1,000,000 / 131,072), matching `zai/glm-5.3`. The docs don't publish flash's window; OpenRouter reports 1,310,720 for its own gateway, but that's a different serving stack and was deliberately not copied.

**Also noticed, deliberately NOT changed here:** docs.z.ai lists GLM-5.3 itself at **$1.4/$4.4** while our catalog has `1.0/4.0`. Either our entry is stale or it reflects something the docs don't (negotiated tier?). Flagging for whoever owns that entry rather than silently repricing an existing model in a PR about a new one.

No registry change needed — the `zai`/`zai-coding` families resolve models from the catalog SSOT. Dashboard regenerated via `sync-dashboard-providers.py` (appended 2).

```
cargo test -p octos-llm --lib  => ok. 578 passed
cargo test -p octos-core --lib => ok. 358 passed
```

Sources: [docs.z.ai pricing](https://docs.z.ai/guides/overview/pricing), [OpenRouter GLM 5.3 Flash](https://openrouter.ai/z-ai/glm-5.3-flash)