### PR TITLE
feat(core): pi-shaped structured truncation report + grep per-line cap

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -2383,22 +2383,28 @@ impl Agent {
             //
             // The cut is a BACKSTOP: it is the one point every tool's output
             // funnels through, which is also the point that knows the least —
-            // `truncate_head_tail` receives a string and a number. On its own it
-            // leaves the model with `... [N bytes omitted] ...` and no way to
-            // reach what it lost, so the only recovery is re-running the call,
-            // which returns the same output cut the same way and spends the
-            // tokens the cap was meant to save.
+            // `truncate_head_tail_report` receives a string and a number. On
+            // its own it leaves the model with `... [N bytes omitted] ...` and
+            // no way to reach what it lost, so the only recovery is re-running
+            // the call, which returns the same output cut the same way and
+            // spends the tokens the cap was meant to save.
             //
             // `Tool::truncation_recovery` is the missing half: the tool still
             // knows its own arguments and whether it paginates, so it can name a
             // concrete next call. Tools with no resume path return None and get
             // no invented advice.
+            //
+            // The hook is handed `omitted_bytes` from the structured report —
+            // the same N the inline marker prints — instead of the legacy
+            // `untruncated_len - content.len()` re-derivation, which
+            // undercounted by the marker's own length and told the model two
+            // disagreeing numbers about one cut.
             let limit = octos_core::tool_output_limit(&tc_name);
-            let untruncated_len = content.len();
-            let mut content = octos_core::truncate_head_tail(&content, limit, 0.7);
-            if content.len() < untruncated_len {
+            let report = octos_core::truncate_head_tail_report(&content, limit, 0.7);
+            let mut content = report.content;
+            if report.truncated {
                 if let Some(recovery) = tools.get(&tc_name).and_then(|tool| {
-                    tool.truncation_recovery(&effective_args, untruncated_len - content.len())
+                    tool.truncation_recovery(&effective_args, report.omitted_bytes)
                 }) {
                     content.push('\n');
                     content.push_str(&recovery);

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6380,6 +6380,64 @@ async fn truncated_tool_output_reaches_the_model_with_its_recovery_advice() {
     );
 }
 
+/// Every `<digits> bytes omitted` count in `content`, in order of appearance.
+fn omitted_byte_counts(content: &str) -> Vec<u64> {
+    let mut counts = Vec::new();
+    for (idx, _) in content.match_indices(" bytes omitted") {
+        let digits: Vec<char> = content[..idx]
+            .chars()
+            .rev()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        let digits: String = digits.into_iter().rev().collect();
+        if !digits.is_empty() {
+            counts.push(digits.parse().expect("ascii digits"));
+        }
+    }
+    counts
+}
+
+/// The backstop's inline marker (`... [N bytes omitted] ...`) and the
+/// recovery advice the tool composes (`[N bytes omitted] Continue...`) are
+/// two tellings of the SAME cut and must carry the same byte count.
+///
+/// The legacy loop recomputed the recovery count as
+/// `untruncated_len - content.len()`, which undercounts by the length of the
+/// elision marker itself — the model was shown two numbers that never agreed.
+/// The structured `truncate_head_tail_report` hands both consumers the one
+/// `omitted_bytes` the split actually measured.
+#[tokio::test]
+async fn should_agree_on_omitted_bytes_between_marker_and_recovery_when_backstop_truncates() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut tools = ToolRegistry::with_builtins(dir.path());
+    tools.register(OverflowingPagedTool);
+
+    let provider: Arc<dyn LlmProvider> = Arc::new(CallsOverflowingToolThenEnds {
+        calls: AtomicUsize::new(0),
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("truncation-agree"), provider, tools, memory);
+
+    let result = agent.process_message("go", &[], vec![]).await.unwrap();
+    let tool_message = result
+        .messages
+        .iter()
+        .find(|m| m.role == MessageRole::Tool)
+        .expect("the turn must contain the tool result");
+
+    let counts = omitted_byte_counts(&tool_message.content);
+    assert_eq!(
+        counts.len(),
+        2,
+        "expected the elision marker and the recovery advice to each name a count; tail: {:?}",
+        &tool_message.content[tool_message.content.len().saturating_sub(300)..]
+    );
+    assert_eq!(
+        counts[0], counts[1],
+        "marker and recovery advice must agree on how much was omitted"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // #27d (R4) — malformed tool-call feedback buffer
 // ─────────────────────────────────────────────────────────────────────────

--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -72,6 +72,32 @@ fn default_limit() -> usize {
     50
 }
 
+/// Max chars kept from a single emitted match/context line — pi's
+/// `GREP_MAX_LINE_LENGTH` (`packages/coding-agent/src/core/tools/truncate.ts`).
+///
+/// Without this, one minified-JS line consumes the whole grep output budget
+/// (`octos_core::tool_output_limit("grep")`) blind: the backstop head/tail cut
+/// then elides every later match while the model sees mostly one giant line.
+const GREP_MAX_LINE_LENGTH: usize = 500;
+
+/// Cap one emitted line at [`GREP_MAX_LINE_LENGTH`] characters.
+///
+/// Cuts by char index (never inside a multi-byte UTF-8 char) and appends a
+/// suffix naming the original length, so the model knows what it lost —
+/// re-running the search cannot reveal more; `read_file` can.
+fn cap_match_line(line: &str) -> std::borrow::Cow<'_, str> {
+    match line.char_indices().nth(GREP_MAX_LINE_LENGTH) {
+        None => std::borrow::Cow::Borrowed(line),
+        Some((cut, _)) => {
+            let total_chars = GREP_MAX_LINE_LENGTH + line[cut..].chars().count();
+            std::borrow::Cow::Owned(format!(
+                "{}\u{2026} [line truncated, {total_chars} chars total]",
+                &line[..cut]
+            ))
+        }
+    }
+}
+
 #[async_trait]
 impl Tool for GrepTool {
     fn name(&self) -> &str {
@@ -79,7 +105,17 @@ impl Tool for GrepTool {
     }
 
     fn description(&self) -> &str {
-        "Search file contents using regex. Respects .gitignore. Use file_pattern to filter which files to search (e.g., '*.rs'). Use path to scope the search to a specific directory."
+        static DESCRIPTION: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+            format!(
+                "Search file contents using regex. Respects .gitignore. Use file_pattern to \
+                 filter which files to search (e.g., '*.rs'). Use path to scope the search to a \
+                 specific directory. Output is truncated beyond {} bytes (middle elided) and \
+                 each matched line beyond {GREP_MAX_LINE_LENGTH} chars, so prefer narrow \
+                 patterns and path/file_pattern filters over broad sweeps.",
+                octos_core::tool_output_limit("grep")
+            )
+        });
+        &DESCRIPTION
     }
 
     fn tags(&self) -> &[&str] {
@@ -144,7 +180,9 @@ impl Tool for GrepTool {
         levers.push("tighten the pattern");
         levers.push("lower limit and re-run");
         Some(format!(
-            "[{omitted_bytes} bytes omitted] Too many matches to return. Narrow the search: {}.",
+            "[{omitted_bytes} bytes omitted] Too many matches to return. Narrow the search: {}. \
+             Matched lines are already capped at {GREP_MAX_LINE_LENGTH} chars — re-running \
+             cannot reveal more of a long line; use read_file to see one in full.",
             levers.join(", ")
         ))
     }
@@ -404,12 +442,17 @@ fn run_grep(
                             "{} {:4}│ {}\n",
                             marker,
                             actual_line + 1,
-                            ctx_line
+                            cap_match_line(ctx_line)
                         ));
                     }
                     matches.push(ctx_output);
                 } else {
-                    matches.push(format!("{}:{}: {}", rel_path, line_num + 1, line.trim()));
+                    matches.push(format!(
+                        "{}:{}: {}",
+                        rel_path,
+                        line_num + 1,
+                        cap_match_line(line.trim())
+                    ));
                 }
             }
         }
@@ -908,6 +951,165 @@ mod tests {
         assert!(
             !already_scoped.contains("scope it with path"),
             "a lever already in use must not be suggested again: {already_scoped}"
+        );
+    }
+
+    // ── per-match-line cap (pi GREP_MAX_LINE_LENGTH port) ────────────────
+
+    /// One minified-JS line must not blow the whole 30KB grep budget: each
+    /// emitted match line is capped at 500 chars with a suffix naming the
+    /// original length. Driven through the REAL execute path.
+    #[tokio::test]
+    async fn should_cap_match_line_at_500_chars_when_line_is_longer() {
+        let dir = tempfile::tempdir().unwrap();
+        let long_line = format!("needle{}", "a".repeat(600)); // 606 chars
+        std::fs::write(
+            dir.path().join("minified.js"),
+            format!("{long_line}\nneedle short\n"),
+        )
+        .unwrap();
+
+        let tool = GrepTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({ "pattern": "needle" }))
+            .await
+            .unwrap();
+        assert!(result.success, "{}", result.output);
+        // Mutation guard: deleting the cap re-emits the full 600-char run.
+        assert!(
+            !result.output.contains(&"a".repeat(501)),
+            "match line emitted uncapped"
+        );
+        assert!(
+            result
+                .output
+                .contains(&format!("… [line truncated, {} chars total]", 606)),
+            "cap suffix must name the original length: {}",
+            result.output
+        );
+        // Exactly 500 chars of payload survive: "needle" + 494 'a's.
+        assert!(
+            result
+                .output
+                .contains(&format!("needle{}…", "a".repeat(494))),
+            "cap must keep exactly 500 chars: {}",
+            result.output
+        );
+        // A short sibling match is untouched.
+        assert!(result.output.contains("needle short"));
+    }
+
+    #[tokio::test]
+    async fn should_not_cap_match_line_when_exactly_500_chars() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = format!("needle{}", "b".repeat(494)); // exactly 500 chars
+        std::fs::write(dir.path().join("edge.txt"), format!("{line}\n")).unwrap();
+
+        let tool = GrepTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({ "pattern": "needle" }))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(
+            result.output.contains(&line),
+            "an exactly-at-limit line must pass through untouched: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("[line truncated"),
+            "no cap suffix at the boundary: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_cap_multibyte_match_line_at_char_boundary_when_over_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        // 6 + 600 = 606 chars, mostly 3-byte CJK: a byte-indexed cut would
+        // split a char and panic (or emit invalid UTF-8).
+        let line = format!("needle{}", "\u{754C}".repeat(600));
+        std::fs::write(dir.path().join("cjk.txt"), format!("{line}\n")).unwrap();
+
+        let tool = GrepTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({ "pattern": "needle" }))
+            .await
+            .unwrap();
+        assert!(result.success, "{}", result.output);
+        assert!(
+            result
+                .output
+                .contains("… [line truncated, 606 chars total]"),
+            "{}",
+            result.output
+        );
+        assert!(
+            result
+                .output
+                .contains(&format!("needle{}…", "\u{754C}".repeat(494))),
+            "the cap must count CHARS, not bytes: {}",
+            result.output
+        );
+        assert!(!result.output.contains(&"\u{754C}".repeat(495)));
+    }
+
+    #[tokio::test]
+    async fn should_cap_context_lines_when_context_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let long_neighbor = "c".repeat(700);
+        std::fs::write(
+            dir.path().join("ctx.txt"),
+            format!("{long_neighbor}\nneedle here\n"),
+        )
+        .unwrap();
+
+        let tool = GrepTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({ "pattern": "needle", "context": 1 }))
+            .await
+            .unwrap();
+        assert!(result.success, "{}", result.output);
+        assert!(
+            !result.output.contains(&"c".repeat(501)),
+            "context lines must be capped too: one long neighbour blows the budget just the same"
+        );
+        assert!(
+            result
+                .output
+                .contains("… [line truncated, 700 chars total]"),
+            "{}",
+            result.output
+        );
+    }
+
+    /// With the per-line cap in place, a long line can no longer be recovered
+    /// by re-running grep — the recovery advice must say so and point at
+    /// read_file instead.
+    #[test]
+    fn should_mention_per_line_cap_in_recovery_when_matches_overflow() {
+        let tool = GrepTool::new(std::path::Path::new("."));
+        let advice = tool
+            .truncation_recovery(&serde_json::json!({ "pattern": "x" }), 1_000)
+            .expect("grep always has narrowing available");
+        assert!(advice.contains("500 chars"), "{advice}");
+        assert!(advice.contains("read_file"), "{advice}");
+    }
+
+    /// pi-style truncation contract: the model is warned about the output cap
+    /// UP FRONT, in the tool description, using the real limits.
+    #[test]
+    fn should_state_truncation_contract_in_description_when_grep() {
+        let tool = GrepTool::new(std::path::Path::new("."));
+        let desc = tool.description();
+        let limit = octos_core::tool_output_limit("grep");
+        assert!(
+            desc.contains(&limit.to_string()),
+            "description must carry the real output cap ({limit}): {desc}"
+        );
+        assert!(
+            desc.contains("500"),
+            "description must carry the per-line cap: {desc}"
         );
     }
 }

--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -82,17 +82,21 @@ const GREP_MAX_LINE_LENGTH: usize = 500;
 
 /// Cap one emitted line at [`GREP_MAX_LINE_LENGTH`] characters.
 ///
-/// Cuts by char index (never inside a multi-byte UTF-8 char) and appends a
-/// suffix naming the original length, so the model knows what it lost —
-/// re-running the search cannot reveal more; `read_file` can.
-fn cap_match_line(line: &str) -> std::borrow::Cow<'_, str> {
-    match line.char_indices().nth(GREP_MAX_LINE_LENGTH) {
-        None => std::borrow::Cow::Borrowed(line),
+/// `display` is the text as it would be emitted (the plain match site trims
+/// it first); `raw_line` is the physical line it came from. The cap fires on
+/// `display` and cuts by char index (never inside a multi-byte UTF-8 char);
+/// the suffix names the RAW line's char count, so the same physical line
+/// reports the same `N chars total` at every emission site regardless of
+/// site-local trimming. Re-running the search cannot reveal more of the
+/// line; `read_file` can.
+fn cap_match_line<'a>(display: &'a str, raw_line: &str) -> std::borrow::Cow<'a, str> {
+    match display.char_indices().nth(GREP_MAX_LINE_LENGTH) {
+        None => std::borrow::Cow::Borrowed(display),
         Some((cut, _)) => {
-            let total_chars = GREP_MAX_LINE_LENGTH + line[cut..].chars().count();
+            let total_chars = raw_line.chars().count();
             std::borrow::Cow::Owned(format!(
                 "{}\u{2026} [line truncated, {total_chars} chars total]",
-                &line[..cut]
+                &display[..cut]
             ))
         }
     }
@@ -442,7 +446,7 @@ fn run_grep(
                             "{} {:4}│ {}\n",
                             marker,
                             actual_line + 1,
-                            cap_match_line(ctx_line)
+                            cap_match_line(ctx_line, ctx_line)
                         ));
                     }
                     matches.push(ctx_output);
@@ -451,7 +455,7 @@ fn run_grep(
                         "{}:{}: {}",
                         rel_path,
                         line_num + 1,
-                        cap_match_line(line.trim())
+                        cap_match_line(line.trim(), line)
                     ));
                 }
             }
@@ -1081,6 +1085,49 @@ mod tests {
             "{}",
             result.output
         );
+    }
+
+    /// The `N chars total` suffix must name the RAW physical line's char
+    /// count at BOTH emission sites. The plain match site trims before
+    /// capping; counting the trimmed text there while the context site
+    /// counts the raw line makes the same physical line report two different
+    /// totals depending on the `context` argument.
+    #[tokio::test]
+    async fn should_report_same_chars_total_with_and_without_context_when_line_capped() {
+        let dir = tempfile::tempdir().unwrap();
+        // Raw 606 chars: 100 leading spaces + "needle" + 500 'a's (trimmed: 506).
+        let raw_line = format!("{}needle{}", " ".repeat(100), "a".repeat(500));
+        std::fs::write(dir.path().join("indent.txt"), format!("{raw_line}\n")).unwrap();
+
+        let tool = GrepTool::new(dir.path());
+        let plain = tool
+            .execute(&serde_json::json!({ "pattern": "needle" }))
+            .await
+            .unwrap();
+        let with_context = tool
+            .execute(&serde_json::json!({ "pattern": "needle", "context": 1 }))
+            .await
+            .unwrap();
+        assert!(plain.success && with_context.success);
+
+        let total_of = |output: &str| -> String {
+            let start = output
+                .find("[line truncated, ")
+                .expect("cap suffix must be present")
+                + "[line truncated, ".len();
+            output[start..]
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .collect()
+        };
+        let plain_total = total_of(&plain.output);
+        let ctx_total = total_of(&with_context.output);
+        assert_eq!(
+            plain_total, ctx_total,
+            "same physical line must report the same total at both emission sites\nplain: {}\nctx: {}",
+            plain.output, with_context.output
+        );
+        assert_eq!(plain_total, "606", "the total is the RAW line's char count");
     }
 
     /// With the per-line cap in place, a long line can no longer be recovered

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -642,7 +642,7 @@ pub trait Tool: Send + Sync {
     /// Truncation happens in the execution loop, at the one point every tool's
     /// output funnels through — which is also the point that knows the least.
     /// By then the result is a plain `String`: the helper doing the cutting
-    /// (`truncate_head_tail(s, max_len, head_ratio)`) receives a string and a
+    /// (`truncate_head_tail_report(s, max_len, head_ratio)`) receives a string and a
     /// number and cannot know which tool produced it, whether that tool paginates,
     /// or what the parameter is called.
     ///

--- a/crates/octos-agent/src/tools/web_fetch.rs
+++ b/crates/octos-agent/src/tools/web_fetch.rs
@@ -71,7 +71,15 @@ impl Tool for WebFetchTool {
     }
 
     fn description(&self) -> &str {
-        "Fetch a URL and extract its content as markdown or plain text."
+        static DESCRIPTION: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+            format!(
+                "Fetch a URL and extract its content as markdown or plain text. Output beyond \
+                 {} bytes is truncated with a '[N bytes omitted]' middle marker, regardless of \
+                 max_chars.",
+                octos_core::tool_output_limit("web_fetch")
+            )
+        });
+        &DESCRIPTION
     }
 
     fn tags(&self) -> &[&str] {
@@ -468,6 +476,19 @@ mod tests {
             result.output.contains("allowlist"),
             "refusal must be the allowlist (no network hit): {}",
             result.output,
+        );
+    }
+
+    /// pi-style truncation contract: the model is warned about the output cap
+    /// UP FRONT, in the tool description, using the real limit.
+    #[test]
+    fn should_state_truncation_contract_in_description_when_web_fetch() {
+        let tool = WebFetchTool::new();
+        let desc = tool.description();
+        let limit = octos_core::tool_output_limit("web_fetch");
+        assert!(
+            desc.contains(&limit.to_string()),
+            "description must carry the real output cap ({limit}): {desc}"
         );
     }
 }

--- a/crates/octos-core/src/lib.rs
+++ b/crates/octos-core/src/lib.rs
@@ -50,6 +50,6 @@ pub use types::{
 };
 pub use ui_protocol::{EventEnvelope, TurnContext};
 pub use utils::{
-    SAFE_FILENAME_MAX_BYTES, safe_filename, tool_output_limit, truncate_head_tail, truncate_utf8,
-    truncated_utf8,
+    SAFE_FILENAME_MAX_BYTES, TruncatedBy, TruncationReport, safe_filename, tool_output_limit,
+    truncate_head_tail, truncate_head_tail_report, truncate_utf8, truncated_utf8,
 };

--- a/crates/octos-core/src/utils.rs
+++ b/crates/octos-core/src/utils.rs
@@ -77,13 +77,6 @@ pub struct TruncationReport {
     /// Exact number of input bytes dropped between head and tail — the same
     /// `N` printed in the elision marker. `0` when not truncated.
     pub omitted_bytes: usize,
-    /// pi's `firstLineExceedsLimit` flags the head-truncation case where not
-    /// even the FIRST LINE fits the byte budget. A head/tail byte split has
-    /// no lines, so the honest analogue reported here: `true` when
-    /// truncation kept ZERO head bytes — `max_len` (minus the marker
-    /// overhead reservation) was too small for even one leading char to
-    /// survive, and `content` is effectively just the marker.
-    pub first_segment_exceeds_limit: bool,
     /// The applied byte limit, as passed.
     pub max_len: usize,
     /// The applied head fraction, after clamping to `[0.1, 0.9]`.
@@ -120,7 +113,6 @@ pub fn truncate_head_tail_report(s: &str, max_len: usize, head_ratio: f32) -> Tr
         total_bytes,
         output_bytes: total_bytes,
         omitted_bytes: 0,
-        first_segment_exceeds_limit: false,
         max_len,
         head_ratio,
     };
@@ -164,7 +156,6 @@ pub fn truncate_head_tail_report(s: &str, max_len: usize, head_ratio: f32) -> Tr
         truncated_by: Some(TruncatedBy::Bytes),
         total_bytes,
         omitted_bytes: omitted,
-        first_segment_exceeds_limit: head_end == 0,
         max_len,
         head_ratio,
     }
@@ -477,7 +468,6 @@ mod tests {
         assert_eq!(r.total_bytes, 100);
         assert_eq!(r.output_bytes, 100);
         assert_eq!(r.omitted_bytes, 0);
-        assert!(!r.first_segment_exceeds_limit);
         assert_eq!(r.max_len, 100);
     }
 
@@ -497,7 +487,6 @@ mod tests {
             "report and inline marker must agree on the omitted count: {}",
             r.content
         );
-        assert!(!r.first_segment_exceeds_limit);
     }
 
     #[test]
@@ -570,18 +559,20 @@ mod tests {
         }
     }
 
+    /// Degenerate regime: `max_len` below the marker overhead reservation
+    /// keeps zero payload bytes — the emitted content is only the elision
+    /// marker (and, pre-existing behaviour, longer than `max_len` itself).
+    /// The report must still be internally consistent: everything omitted,
+    /// marker N accurate. Unreachable through `tool_output_limit` (>= 20K).
     #[test]
-    fn should_flag_first_segment_exceeds_limit_when_budget_below_marker_overhead() {
-        // max_len below the separator overhead: no payload byte survives and
-        // the emitted content is only the elision marker — the head/tail
-        // analogue of pi's firstLineExceedsLimit (see the field doc).
+    fn should_emit_only_marker_when_budget_below_marker_overhead() {
         let s = "z".repeat(100);
         let r = truncate_head_tail_report(&s, 10, 0.7);
         assert!(r.truncated);
-        assert!(r.first_segment_exceeds_limit);
         assert_eq!(r.omitted_bytes, 100);
         assert_eq!(r.content, "\n\n... [100 bytes omitted] ...\n\n");
         assert_eq!(r.truncated_by, Some(TruncatedBy::Bytes));
+        assert_eq!(r.output_bytes, r.content.len());
     }
 
     #[test]

--- a/crates/octos-core/src/utils.rs
+++ b/crates/octos-core/src/utils.rs
@@ -29,17 +29,105 @@ pub fn truncated_utf8(s: &str, max_len: usize, suffix: &str) -> String {
     format!("{}{}", &s[..limit], suffix)
 }
 
+/// Which limit cut the output in a [`TruncationReport`].
+///
+/// Modeled on pi's `TruncationResult.truncatedBy` (`"lines" | "bytes" |
+/// null`, `packages/coding-agent/src/core/tools/truncate.ts`).
+/// [`truncate_head_tail_report`] cuts purely by bytes, so today it only ever
+/// emits [`TruncatedBy::Bytes`]; [`TruncatedBy::Lines`] is declared for
+/// future line-count-based truncation helpers rather than invented here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TruncatedBy {
+    /// The byte limit (`max_len`) was hit.
+    Bytes,
+    /// A line-count limit was hit. Not produced by any octos-core helper
+    /// yet — see the enum-level doc.
+    Lines,
+}
+
+/// Structured result of a head/tail truncation, modeled on pi's
+/// `TruncationResult` (`packages/coding-agent/src/core/tools/truncate.ts`).
+///
+/// [`truncate_head_tail`] keeps only [`TruncationReport::content`] and throws
+/// the rest away; callers that need to ADVISE the model about the cut (how
+/// much is gone, which limit fired) use [`truncate_head_tail_report`] and
+/// read it from here instead of re-deriving it from string lengths — the
+/// re-derivation `total - content.len()` undercounts by the elision marker's
+/// own length.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TruncationReport {
+    /// The (possibly truncated) output. When truncated this embeds the
+    /// `\n\n... [N bytes omitted] ...\n\n` elision marker between the kept
+    /// head and tail.
+    pub content: String,
+    /// Whether any input bytes were dropped.
+    pub truncated: bool,
+    /// Which limit fired; `None` when not truncated. Only
+    /// [`TruncatedBy::Bytes`] is reachable from
+    /// [`truncate_head_tail_report`].
+    pub truncated_by: Option<TruncatedBy>,
+    /// Byte length of the original input.
+    pub total_bytes: usize,
+    /// Byte length of `content`. When truncated this INCLUDES the elision
+    /// marker, so `output_bytes != total_bytes - omitted_bytes` — the marker
+    /// adds ~30 bytes. In the degenerate `max_len`-below-marker-overhead
+    /// regime it can even exceed `max_len` (pre-existing
+    /// [`truncate_head_tail`] behaviour, unchanged).
+    pub output_bytes: usize,
+    /// Exact number of input bytes dropped between head and tail — the same
+    /// `N` printed in the elision marker. `0` when not truncated.
+    pub omitted_bytes: usize,
+    /// pi's `firstLineExceedsLimit` flags the head-truncation case where not
+    /// even the FIRST LINE fits the byte budget. A head/tail byte split has
+    /// no lines, so the honest analogue reported here: `true` when
+    /// truncation kept ZERO head bytes — `max_len` (minus the marker
+    /// overhead reservation) was too small for even one leading char to
+    /// survive, and `content` is effectively just the marker.
+    pub first_segment_exceeds_limit: bool,
+    /// The applied byte limit, as passed.
+    pub max_len: usize,
+    /// The applied head fraction, after clamping to `[0.1, 0.9]`.
+    pub head_ratio: f32,
+}
+
 /// Truncate output with head/tail split, preserving both ends.
 ///
 /// When `s` exceeds `max_len`, keeps `head_ratio` fraction from the start and
 /// the remainder from the end, joined by a separator line showing omitted bytes.
 /// Both split points are UTF-8 safe.
+///
+/// Thin wrapper over [`truncate_head_tail_report`] keeping the legacy
+/// `String` surface — one implementation, two surfaces.
 pub fn truncate_head_tail(s: &str, max_len: usize, head_ratio: f32) -> String {
-    if s.len() <= max_len {
-        return s.to_string();
-    }
+    truncate_head_tail_report(s, max_len, head_ratio).content
+}
 
+/// [`truncate_head_tail`] returning a structured [`TruncationReport`]
+/// instead of a bare `String`.
+///
+/// The `content` field is byte-identical to what [`truncate_head_tail`]
+/// returns for the same inputs; the rest of the report tells the caller what
+/// the cut did (`omitted_bytes`, `truncated_by`, the applied limits) without
+/// re-deriving it from string lengths.
+pub fn truncate_head_tail_report(s: &str, max_len: usize, head_ratio: f32) -> TruncationReport {
+    let total_bytes = s.len();
     let head_ratio = head_ratio.clamp(0.1, 0.9);
+
+    let untruncated = |content: String| TruncationReport {
+        content,
+        truncated: false,
+        truncated_by: None,
+        total_bytes,
+        output_bytes: total_bytes,
+        omitted_bytes: 0,
+        first_segment_exceeds_limit: false,
+        max_len,
+        head_ratio,
+    };
+
+    if s.len() <= max_len {
+        return untruncated(s.to_string());
+    }
 
     // Estimate separator overhead conservatively (handles large omitted counts)
     // "\n\n... [99999 bytes omitted] ...\n\n" is ~40 bytes max
@@ -59,14 +147,27 @@ pub fn truncate_head_tail(s: &str, max_len: usize, head_ratio: f32) -> String {
         tail_start += 1;
     }
 
-    // Avoid overlap
+    // Defensive overlap guard: the budgets cannot overlap by construction
+    // (head + tail <= max_len - 50 < s.len() here), but if they ever did the
+    // input passes through whole — reported honestly as "not truncated".
     if head_end >= tail_start {
-        return s.to_string();
+        return untruncated(s.to_string());
     }
 
     let omitted = tail_start - head_end;
     let sep = format!("\n\n... [{omitted} bytes omitted] ...\n\n");
-    format!("{}{}{}", &s[..head_end], sep, &s[tail_start..])
+    let content = format!("{}{}{}", &s[..head_end], sep, &s[tail_start..]);
+    TruncationReport {
+        output_bytes: content.len(),
+        content,
+        truncated: true,
+        truncated_by: Some(TruncatedBy::Bytes),
+        total_bytes,
+        omitted_bytes: omitted,
+        first_segment_exceeds_limit: head_end == 0,
+        max_len,
+        head_ratio,
+    }
 }
 
 /// Default per-tool output limits (max chars). Tools not listed use the global default.
@@ -219,6 +320,20 @@ mod tests {
         assert!(result.len() <= 150); // 100 + separator overhead
     }
 
+    /// Characterization pin: the exact legacy string emitted by
+    /// `truncate_head_tail`, captured BEFORE the structured-report refactor.
+    /// The refactor must keep the wrapper byte-identical.
+    #[test]
+    fn should_emit_exact_legacy_marker_when_truncating() {
+        let s = format!("{}{}", "h".repeat(100), "t".repeat(100));
+        let expect = format!(
+            "{}\n\n... [150 bytes omitted] ...\n\n{}",
+            "h".repeat(25),
+            "t".repeat(25)
+        );
+        assert_eq!(truncate_head_tail(&s, 100, 0.5), expect);
+    }
+
     #[test]
     fn test_head_tail_preserves_utf8() {
         let s = format!("{}{}", "\u{4F60}".repeat(50), "\u{597D}".repeat(50));
@@ -348,5 +463,134 @@ mod tests {
     #[test]
     fn should_return_placeholder_when_input_empty() {
         assert_eq!(safe_filename(""), "_");
+    }
+
+    // ── structured truncation report (pi TruncationResult port) ──────────
+
+    #[test]
+    fn should_report_untruncated_when_input_at_exact_limit() {
+        let s = "a".repeat(100);
+        let r = truncate_head_tail_report(&s, 100, 0.7);
+        assert!(!r.truncated);
+        assert_eq!(r.truncated_by, None);
+        assert_eq!(r.content, s);
+        assert_eq!(r.total_bytes, 100);
+        assert_eq!(r.output_bytes, 100);
+        assert_eq!(r.omitted_bytes, 0);
+        assert!(!r.first_segment_exceeds_limit);
+        assert_eq!(r.max_len, 100);
+    }
+
+    #[test]
+    fn should_report_bytes_truncation_when_one_byte_over_limit() {
+        let s = "a".repeat(101);
+        let r = truncate_head_tail_report(&s, 100, 0.7);
+        assert!(r.truncated);
+        assert_eq!(r.truncated_by, Some(TruncatedBy::Bytes));
+        assert_eq!(r.total_bytes, 101);
+        assert_eq!(r.max_len, 100);
+        assert_eq!(r.output_bytes, r.content.len());
+        assert!(r.omitted_bytes > 0);
+        assert!(
+            r.content
+                .contains(&format!("... [{} bytes omitted] ...", r.omitted_bytes)),
+            "report and inline marker must agree on the omitted count: {}",
+            r.content
+        );
+        assert!(!r.first_segment_exceeds_limit);
+    }
+
+    #[test]
+    fn should_report_untruncated_when_input_empty() {
+        let r = truncate_head_tail_report("", 0, 0.7);
+        assert!(!r.truncated);
+        assert_eq!(r.truncated_by, None);
+        assert_eq!(r.content, "");
+        assert_eq!(r.total_bytes, 0);
+        assert_eq!(r.output_bytes, 0);
+        assert_eq!(r.omitted_bytes, 0);
+    }
+
+    #[test]
+    fn should_keep_utf8_boundaries_when_multibyte_chars_straddle_the_cut() {
+        // 4-byte scalars; the byte budgets land mid-char, so both split points
+        // must back off to char boundaries instead of panicking.
+        let s = "\u{1F980}".repeat(200); // 800 bytes
+        let r = truncate_head_tail_report(&s, 101, 0.7);
+        assert!(r.truncated);
+        let marker = format!("\n\n... [{} bytes omitted] ...\n\n", r.omitted_bytes);
+        let (head, tail) = r
+            .content
+            .split_once(&marker)
+            .expect("truncated content must contain the elision marker");
+        assert!(
+            head.chars().all(|c| c == '\u{1F980}'),
+            "head must hold only whole chars: {head:?}"
+        );
+        assert!(
+            tail.chars().all(|c| c == '\u{1F980}'),
+            "tail must hold only whole chars: {tail:?}"
+        );
+        assert_eq!(r.total_bytes, 800);
+        assert_eq!(r.output_bytes, r.content.len());
+        // Whole chars only: kept payload + omitted covers the input exactly.
+        assert_eq!(head.len() + tail.len() + r.omitted_bytes, r.total_bytes);
+    }
+
+    /// Wrapper equivalence: `truncate_head_tail` must be a thin projection of
+    /// the report — one implementation, two surfaces. Property-style over
+    /// fixtures crossing the limit from both sides, multi-byte content, and
+    /// out-of-range ratios.
+    #[test]
+    fn should_match_wrapper_content_when_report_and_wrapper_share_inputs() {
+        let fixtures: Vec<String> = vec![
+            String::new(),
+            "short".to_string(),
+            "a".repeat(99),
+            "a".repeat(100),
+            "a".repeat(101),
+            "x".repeat(10_000),
+            "\u{1F980}".repeat(400),
+            "\u{4F60}\u{597D}\u{4E16}\u{754C}".repeat(500),
+            format!("head\n{}\ntail", "mid ".repeat(2_000)),
+        ];
+        for s in &fixtures {
+            for max_len in [0usize, 10, 49, 50, 51, 100, 1_000, 30_000] {
+                for ratio in [0.0f32, 0.3, 0.5, 0.7, 0.9, 1.5] {
+                    let report = truncate_head_tail_report(s, max_len, ratio);
+                    assert_eq!(
+                        truncate_head_tail(s, max_len, ratio),
+                        report.content,
+                        "wrapper and report must share one implementation \
+                         (len={}, max_len={max_len}, ratio={ratio})",
+                        s.len(),
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn should_flag_first_segment_exceeds_limit_when_budget_below_marker_overhead() {
+        // max_len below the separator overhead: no payload byte survives and
+        // the emitted content is only the elision marker — the head/tail
+        // analogue of pi's firstLineExceedsLimit (see the field doc).
+        let s = "z".repeat(100);
+        let r = truncate_head_tail_report(&s, 10, 0.7);
+        assert!(r.truncated);
+        assert!(r.first_segment_exceeds_limit);
+        assert_eq!(r.omitted_bytes, 100);
+        assert_eq!(r.content, "\n\n... [100 bytes omitted] ...\n\n");
+        assert_eq!(r.truncated_by, Some(TruncatedBy::Bytes));
+    }
+
+    #[test]
+    fn should_clamp_reported_head_ratio_when_ratio_out_of_range() {
+        let s = "a".repeat(300);
+        let hi = truncate_head_tail_report(&s, 100, 5.0);
+        assert_eq!(hi.head_ratio, 0.9);
+        assert_eq!(hi.content, truncate_head_tail(&s, 100, 5.0));
+        let lo = truncate_head_tail_report(&s, 100, -1.0);
+        assert_eq!(lo.head_ratio, 0.1);
     }
 }


### PR DESCRIPTION
Reference design: pi's `packages/coding-agent/src/core/tools/truncate.ts` — its truncation helper returns a structured `TruncationResult`; octos's `truncate_head_tail` returned a bare `String` and threw away everything a caller needs to advise the model about the cut.

## Part 1 — structured truncation result (octos-core)

New `octos_core::truncate_head_tail_report(s, max_len, head_ratio) -> TruncationReport`:

```rust
pub enum TruncatedBy { Bytes, Lines }

pub struct TruncationReport {
    pub content: String,
    pub truncated: bool,
    pub truncated_by: Option<TruncatedBy>, // only Bytes reachable today (doc'd)
    pub total_bytes: usize,
    pub output_bytes: usize,               // len of content, marker included
    pub omitted_bytes: usize,              // the exact N the marker prints
    pub max_len: usize,                    // applied limits
    pub head_ratio: f32,                   // as applied (clamped to [0.1, 0.9])
}
```

`truncate_head_tail` is now a thin wrapper over the report (one implementation, two surfaces). Byte-identity of the legacy surface is pinned by a golden characterization test captured **before** the refactor, plus a property-style wrapper-equivalence test over fixtures (empty / at-limit / one-over / 10K ASCII / 4-byte emoji / CJK / mixed) x limits x ratios.

Where pi's shape did not transfer (said in docs rather than invented):

- `totalLines` / `outputLines` / `maxLines` — pi cuts line-wise; the head/tail split cuts purely by bytes, so line counts would be fabricated. Not shipped; `TruncatedBy::Lines` is declared for future line-based helpers and documented as unreachable today.
- `lastLinePartial` — a tail-truncation edge case; a middle-elision split makes both segments deliberately partial at the cut, so the flag is meaningless here. Not shipped.
- `firstLineExceedsLimit` — **not shipped** (review H3): a bytes-only head/tail split has no line awareness, so any analogue would be a different concept wearing pi's name; it could never fire under real `tool_output_limit`s (all >= 20K vs the ~60-byte degenerate threshold), the genuine oversized-line signal already lives where lines exist (the read-paging probe's `max_line_bytes` check and the windowed read_file work building on it), and no consumer reads it — so the field is dropped rather than exported as misuse surface. The degenerate small-limit regime (content is only the elision marker, which can exceed `max_len`; pre-existing behaviour) stays pinned on the content itself by `should_emit_only_marker_when_budget_below_marker_overhead`.

### Migrated call site: the execution-loop backstop

`Agent` per-tool output truncation (`crates/octos-agent/src/agent/execution.rs`) now consumes the report: `Tool::truncation_recovery` (#2124) receives `report.omitted_bytes` instead of re-deriving `untruncated_len - content.len()`, which undercounts by the marker's own length.

Emitted text before/after (120KB output under the 50KB cap; marker itself is byte-identical, the recovery suffix's N changes):

```text
before:  ... [70050 bytes omitted] ...     <- inline marker
         [70017 bytes omitted] Continue with page: 1.   <- recovery advice

after:   ... [70050 bytes omitted] ...
         [70050 bytes omitted] Continue with page: 1.
```

The model previously saw two disagreeing numbers about one cut. Non-truncated path is byte-identical. One micro-delta: the recovery gate is now `report.truncated` rather than `content.len() < untruncated_len`; they diverge only when the marker is longer than the bytes it saves (`max_len` under ~30 bytes — production limits are >= 20K, unreachable at this call site). The second `truncate_head_tail` call site (hook-feedback path, execution.rs:570) intentionally stays on the wrapper.

Tracking note (pre-existing on main, unchanged here, flagged in review as tracking-only): the approved-tool after-hook path (execution.rs:561/:570) neither caps ordinary approved results nor supplies `truncation_recovery` metadata — noted so it isn't lost; not load-bearing for this change.

## Part 2 — grep per-line cap

pi caps each grep match line at 500 chars (`GREP_MAX_LINE_LENGTH`); octos's grep emitted matching lines unbounded — one minified-JS line could blow the whole 30KB budget blind. Both emission sites (plain matches and `context` lines) now cap at 500 **chars** (char-indexed, UTF-8-safe) with a `… [line truncated, N chars total]` suffix.

`N` is the **raw physical line's** char count at BOTH sites (review H4): the plain match site trims before capping, and counting the trimmed text there while the context site counted the raw line made the same physical line report two different totals (506 vs 606) depending on the `context` argument. `cap_match_line(display, raw_line)` fires the cap on the emitted text but always names the raw total; pinned by a test that greps the same line with and without `context` and asserts one total, observed failing (506 vs 606) before the fix.

`truncation_recovery` updated accordingly:

```text
before:  [N bytes omitted] Too many matches to return. Narrow the search: <levers>.
after:   [N bytes omitted] Too many matches to return. Narrow the search: <levers>. Matched
         lines are already capped at 500 chars — re-running cannot reveal more of a long
         line; use read_file to see one in full.
```

("Too many matches" also becomes *accurate* — pre-cap, a single giant line could trigger the backstop with one match.)

## Part 3 — truncation contract in descriptions

`grep` and `web_fetch` descriptions each gained one sentence stating the cap up front, formatted from `octos_core::tool_output_limit` at first use (LazyLock) so the numbers cannot drift from the real limits:

- grep: "Output is truncated beyond 30000 bytes (middle elided) and each matched line beyond 500 chars, so prefer narrow patterns and path/file_pattern filters over broad sweeps."
- web_fetch: "Output beyond 40000 bytes is truncated with a '[N bytes omitted]' middle marker, regardless of max_chars."

read_file/shell descriptions untouched (owned by parallel work).

## TDD

RED first, all failures observed before implementing (the loop test failed with exactly the predicted 33-byte disagreement: `left: 70050, right: 70017`; the grep cap tests are the deleted-cap mutant by construction — same code state, same failure; the H4 consistency test observed failing 506 vs 606 pre-fix).

New tests:
- octos-core: `should_emit_exact_legacy_marker_when_truncating` (golden pin, green pre-refactor), `should_report_untruncated_when_input_at_exact_limit`, `should_report_bytes_truncation_when_one_byte_over_limit`, `should_report_untruncated_when_input_empty`, `should_keep_utf8_boundaries_when_multibyte_chars_straddle_the_cut`, `should_match_wrapper_content_when_report_and_wrapper_share_inputs`, `should_emit_only_marker_when_budget_below_marker_overhead`, `should_clamp_reported_head_ratio_when_ratio_out_of_range`
- grep (real execute path, fixture files): `should_cap_match_line_at_500_chars_when_line_is_longer`, `should_not_cap_match_line_when_exactly_500_chars`, `should_cap_multibyte_match_line_at_char_boundary_when_over_limit`, `should_cap_context_lines_when_context_requested`, `should_report_same_chars_total_with_and_without_context_when_line_capped`, `should_mention_per_line_cap_in_recovery_when_matches_overflow`, `should_state_truncation_contract_in_description_when_grep`
- web_fetch: `should_state_truncation_contract_in_description_when_web_fetch`
- loop: `should_agree_on_omitted_bytes_between_marker_and_recovery_when_backstop_truncates`

## Verification (after review fixes)

```text
cargo test -p octos-core --lib   -> ok. 366 passed; 0 failed; 1 ignored
cargo test -p octos-agent --lib  -> ok. 2705 passed; 0 failed; 3 ignored
cargo clippy -p octos-core -p octos-agent --all-targets -- -D warnings -> clean
cargo fmt --all -- --check       -> clean
```
