### PR TITLE
feat(shell): spool over-cap output to a file the model can grep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,13 @@ jobs:
       - name: serve wiring guards (octos-cli)
         run: cargo test -p octos-cli --features api commands::serve::tests
 
+      # The workspace/artifact pane exclusion list lives in the `api`-gated
+      # transport module (same reason as the §6 guard) — without an explicit
+      # filter this guard never runs (#2029). It pins `.octos` (sessions,
+      # #1638 shell output spools) out of the recursive pane walks.
+      - name: Artifact pane exclusions (octos-cli)
+        run: cargo test -p octos-cli --features api artifact_pane
+
       # The goal-completion verifier's ledger-evidence fold lives in the
       # `api`-gated goal_tool module, so the unfeatured runs above never compile
       # it. Guards the peer-goal convergence fix (#1989): a genuinely-complete

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6380,6 +6380,134 @@ async fn truncated_tool_output_reaches_the_model_with_its_recovery_advice() {
     );
 }
 
+/// Scripted provider: one `shell` call with the given command, then EndTurn.
+struct CallsShellThenEnds {
+    calls: AtomicUsize,
+    command: &'static str,
+}
+
+#[async_trait]
+impl LlmProvider for CallsShellThenEnds {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> Result<ChatResponse> {
+        let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        Ok(if call == 0 {
+            ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![ToolCall {
+                    id: "call_shell".to_string(),
+                    name: "shell".to_string(),
+                    arguments: serde_json::json!({ "command": self.command }),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: LlmTokenUsage::default(),
+                provider_index: None,
+            }
+        } else {
+            ChatResponse {
+                content: Some("done".to_string()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: LlmTokenUsage::default(),
+                provider_index: None,
+            }
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "test-model"
+    }
+
+    fn provider_name(&self) -> &str {
+        "test-provider"
+    }
+}
+
+/// Drive the REAL loop path (dispatch → sanitize → backstop) for one shell
+/// command and return the tool message the model received.
+#[cfg(unix)]
+async fn shell_tool_message_through_loop(command: &'static str) -> (tempfile::TempDir, Message) {
+    let dir = tempfile::tempdir().unwrap();
+    let tools = ToolRegistry::with_builtins(dir.path());
+    let provider: Arc<dyn LlmProvider> = Arc::new(CallsShellThenEnds {
+        calls: AtomicUsize::new(0),
+        command,
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("shell-spool-loop"), provider, tools, memory);
+    let result = agent.process_message("go", &[], vec![]).await.unwrap();
+    let message = result
+        .messages
+        .iter()
+        .find(|m| m.role == MessageRole::Tool)
+        .expect("the turn must contain the shell tool result")
+        .clone();
+    (dir, message)
+}
+
+/// #1638 golden through the REAL loop: a small shell output must reach the
+/// model byte-identical — sanitize is a no-op on clean text and the backstop
+/// must not touch it. The in-tool unit golden proves the tool; this proves
+/// the sanitize+backstop interplay around it.
+#[cfg(unix)]
+#[tokio::test]
+async fn small_shell_output_reaches_the_model_byte_identical_through_the_loop() {
+    let (_dir, tool_message) = shell_tool_message_through_loop("echo hi").await;
+    assert_eq!(
+        tool_message.content, "hi\n\n\nExit code: 0",
+        "small shell output must arrive unchanged through dispatch + sanitize + backstop"
+    );
+}
+
+/// #1638 golden through the REAL loop: a spooled shell result must arrive
+/// with its footer intact — under the cap (so the loop backstop never fired)
+/// and without any backstop recovery advice appended.
+#[cfg(unix)]
+#[tokio::test]
+async fn spooled_shell_output_reaches_the_model_with_footer_intact_through_the_loop() {
+    let (dir, tool_message) = shell_tool_message_through_loop(
+        "awk 'BEGIN { for (i = 1; i <= 12000; i++) print \"line \" i }'",
+    )
+    .await;
+    let limit = octos_core::tool_output_limit("shell");
+    assert!(
+        tool_message.content.len() <= limit,
+        "the assembled result must fit the {limit}B cap, got {}",
+        tool_message.content.len()
+    );
+    assert!(
+        tool_message.content.contains("Full output: "),
+        "the spool footer must survive the loop: {}",
+        &tool_message.content[tool_message.content.len().saturating_sub(300)..]
+    );
+    // Backstop-fired evidence must be ABSENT: the tool sized its result so
+    // the loop never re-cut it and never appended recovery advice.
+    assert!(
+        !tool_message
+            .content
+            .contains("Re-run with output redirected"),
+        "backstop recovery advice implies the loop re-cut the result"
+    );
+    assert!(
+        !tool_message.content.contains("was saved to"),
+        "backstop recovery advice implies the loop re-cut the result"
+    );
+    // The spool named by the footer exists inside the workspace.
+    let marker = "Full output: ";
+    let start = tool_message.content.rfind(marker).unwrap() + marker.len();
+    let rest = &tool_message.content[start..];
+    let path = std::path::PathBuf::from(&rest[..rest.find(']').unwrap()]);
+    assert!(path.starts_with(dir.path()), "spool inside the workspace");
+    assert!(path.exists(), "footer must name a real file");
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // #27d (R4) — malformed tool-call feedback buffer
 // ─────────────────────────────────────────────────────────────────────────

--- a/crates/octos-agent/src/sandbox/bwrap.rs
+++ b/crates/octos-agent/src/sandbox/bwrap.rs
@@ -27,6 +27,13 @@ pub struct BwrapSandbox {
 }
 
 impl Sandbox for BwrapSandbox {
+    fn workspace_scratch_writable(&self) -> bool {
+        // A #1976 fence already degraded `workspace_write` to `false` at
+        // construction (`fence_degraded_workspace_write`), so this single
+        // flag covers both the read-only profile and the fenced one.
+        self.workspace_write
+    }
+
     fn supports_repo_git_write(&self) -> bool {
         // bwrap can `--bind <repo>/.git <repo>/.git` (rw) and read-binds the
         // system dirs, so a Host-granted worker gets both the `.git` write AND the

--- a/crates/octos-agent/src/sandbox/docker.rs
+++ b/crates/octos-agent/src/sandbox/docker.rs
@@ -38,6 +38,24 @@ impl Sandbox for DockerSandbox {
         true
     }
 
+    fn workspace_scratch_writable(&self) -> bool {
+        // `:ro` mounts promise the shell a read-only workspace (a #1976
+        // fence degrades ReadWrite to ReadOnly at construction —
+        // `fence_degraded_docker`), so the harness must not spool into it.
+        // `None` never mounts the workspace at all: nothing was promised
+        // about the host tree, which other tools keep writing normally.
+        self.config.mount_mode != MountMode::ReadOnly
+    }
+
+    fn workspace_remap_root(&self) -> Option<&Path> {
+        // Commands see the cwd bind-mounted at /workspace (`wrap_command`);
+        // with no mount there is no in-container view at all.
+        match self.config.mount_mode {
+            MountMode::ReadWrite | MountMode::ReadOnly => Some(Path::new("/workspace")),
+            MountMode::None => None,
+        }
+    }
+
     fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
         let mut cmd = Command::new("docker");
         cmd.arg("run").arg("--rm");

--- a/crates/octos-agent/src/sandbox/landlock.rs
+++ b/crates/octos-agent/src/sandbox/landlock.rs
@@ -25,6 +25,13 @@ pub struct LinuxContainerSandbox {
 }
 
 impl Sandbox for LinuxContainerSandbox {
+    fn workspace_scratch_writable(&self) -> bool {
+        // A #1976 fence already degraded `workspace_write` to `false` at
+        // construction (`fence_degraded_workspace_write`), so this single
+        // flag covers both the read-only profile and the fenced one.
+        self.workspace_write
+    }
+
     fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
         let Some(helper_path) = find_sandbox_helper_path() else {
             tracing::error!("octos-sandbox helper not found, refusing unsandboxed Linux command");

--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -183,6 +183,14 @@ pub struct MacosSandbox {
 }
 
 impl Sandbox for MacosSandbox {
+    fn workspace_scratch_writable(&self) -> bool {
+        // Same predicate as `workspace_scratch_writable` in `wrap_command`
+        // (#1976): a read-only workspace or a write fence means the shell
+        // was promised an immutable tree outside the grants — the harness
+        // must not spool into it either.
+        self.workspace_write && self.write_allow_globs.is_none()
+    }
+
     fn supports_repo_git_write(&self) -> bool {
         // A `(subpath "<repo>/.git")` rule grants the `.git` WRITE, but
         // `git commit` must also READ `<repo>/.git`. That read only holds under an

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -466,6 +466,30 @@ pub trait Sandbox: Send + Sync {
     fn supports_repo_git_write(&self) -> bool {
         false
     }
+
+    /// Whether the HARNESS may create scratch files inside the workspace on
+    /// this profile (#1638 shell output spools).
+    ///
+    /// `false` when the profile promises the shell a read-only workspace
+    /// (`workspace_write: false`) or fences writes to an allowlist (#1976
+    /// `write_allow_globs`): the operator declared the tree immutable
+    /// outside the grants, and the harness must not mutate what the sandbox
+    /// forbids the shell to — a host-side spool write would do exactly that.
+    /// Real backends override from their own write posture; the default
+    /// `true` matches [`NoSandbox`] and custom sandboxes (no promise made).
+    fn workspace_scratch_writable(&self) -> bool {
+        true
+    }
+
+    /// The path at which SHELL COMMANDS see the workspace root, when this
+    /// backend remaps it — Docker bind-mounts the cwd at a fixed
+    /// in-container path (`/workspace`), so a host-absolute path in a tool
+    /// result is unusable by the model's next command there. `None` (the
+    /// default, every non-remapping backend) = commands see host paths
+    /// unchanged.
+    fn workspace_remap_root(&self) -> Option<&Path> {
+        None
+    }
 }
 
 /// No-op sandbox: executes commands directly.

--- a/crates/octos-agent/src/sandbox/windows.rs
+++ b/crates/octos-agent/src/sandbox/windows.rs
@@ -57,6 +57,13 @@ impl Sandbox for AppContainerSandbox {
         find_sandbox_helper().is_none()
     }
 
+    fn workspace_scratch_writable(&self) -> bool {
+        // A #1976 fence already degraded `workspace_write` to `false` at
+        // construction (`fence_degraded_workspace_write`), so this single
+        // flag covers both the read-only profile and the fenced one.
+        self.workspace_write
+    }
+
     fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
         // Find the helper binary next to our own executable
         let helper = find_sandbox_helper();

--- a/crates/octos-agent/src/tools/send_file.rs
+++ b/crates/octos-agent/src/tools/send_file.rs
@@ -244,6 +244,30 @@ impl Tool for SendFileTool {
             raw_path.to_path_buf()
         };
 
+        // #1638 — shell output spools (`.octos/tmp/shell/`) are internal
+        // working state: the complete sanitized output of a command, kept
+        // only so the model can grep past its own output cap. They are
+        // never deliverables, so refuse BEFORE any allowlist logic — the
+        // allowlist would otherwise admit them as ordinary workspace files.
+        // Checked on both the lexical path and its canonical form (a
+        // symlink must not disguise a spool as something else, nor vice
+        // versa); applies with or without a configured `base_dir`.
+        let canonical_probe = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if octos_core::is_shell_spool_path(&path)
+            || octos_core::is_shell_spool_path(&canonical_probe)
+        {
+            return Ok(ToolResult {
+                output: format!(
+                    "Refusing to send '{}': shell output spool files (.octos/tmp/shell/) are \
+                     internal working state, not deliverables. If the user needs this content, \
+                     copy the relevant part into a new file and send that instead.",
+                    path.display()
+                ),
+                success: false,
+                ..Default::default()
+            });
+        }
+
         // Step 2: containment check against the send_file allowlist
         // (base_dir + /tmp/ + extra_allowed_dirs). The unified resolver
         // already verified containment for `up/...`/`pf/...` handles
@@ -428,6 +452,50 @@ mod tests {
         assert_eq!(msg.content, "Here is the file");
         assert_eq!(msg.media.len(), 1);
         assert_eq!(msg.media[0], path);
+    }
+
+    #[tokio::test]
+    async fn should_refuse_send_when_path_is_shell_spool() {
+        let (tx, _rx) = mpsc::channel(16);
+        let base = tempfile::tempdir().unwrap();
+        let spool_dir = base.path().join(".octos").join("tmp").join("shell");
+        std::fs::create_dir_all(&spool_dir).unwrap();
+        let spool = spool_dir.join("output-0000000000001-0000.log");
+        std::fs::write(&spool, "full command output\n").unwrap();
+
+        let tool = SendFileTool::new(tx).with_base_dir(base.path());
+        tool.set_context("telegram", "12345");
+
+        // Spool files are internal working state (complete command output
+        // kept only so the model can grep past its cap) — never outbound.
+        let result = tool
+            .execute(&serde_json::json!({
+                "file_path": spool.to_string_lossy(),
+            }))
+            .await
+            .unwrap();
+        assert!(
+            !result.success,
+            "shell spool files must not be sendable: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("spool"),
+            "refusal should say why: {}",
+            result.output
+        );
+
+        // Control: a sibling file outside the spool subtree still sends —
+        // the deny is targeted, not a blanket workspace block.
+        let report = base.path().join("report.txt");
+        std::fs::write(&report, "report\n").unwrap();
+        let ok = tool
+            .execute(&serde_json::json!({
+                "file_path": report.to_string_lossy(),
+            }))
+            .await
+            .unwrap();
+        assert!(ok.success, "non-spool file must still send: {}", ok.output);
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -67,13 +67,17 @@ pub struct ShellTool {
     /// deadline. `None` = no extra cap (only the outer `[1, 600]s` clamp
     /// applies) — unchanged behaviour for every existing caller.
     max_timeout: Option<Duration>,
-    /// Recent output spools, newest first: `(command, spool path)` for the
-    /// last [`SPOOL_KEEP`] commands whose output exceeded the per-tool cap
-    /// and was written to a full-output file (#1638). Consulted by
+    /// Recent output spools, newest first: `(command, host path, display
+    /// path)` for the last [`SPOOL_KEEP`] commands whose LATEST invocation
+    /// exceeded the per-tool cap and was spooled (#1638). Consulted by
     /// [`Tool::truncation_recovery`] so that if the execution-loop backstop
-    /// still cuts a result, the recovery advice can name the exact file
-    /// holding the complete output.
-    spools: std::sync::Mutex<std::collections::VecDeque<(String, PathBuf)>>,
+    /// still cuts a result, the advice can name the exact file holding the
+    /// complete output. Every new invocation of a command first FORGETS its
+    /// entry ([`Self::forget_spool`]) so a stale spool from a previous run
+    /// is never offered as this run's output; the host path is re-checked
+    /// for existence at advice time (another session sharing the workspace
+    /// may have pruned the file).
+    spools: std::sync::Mutex<std::collections::VecDeque<(String, PathBuf, String)>>,
 }
 
 impl ShellTool {
@@ -97,12 +101,25 @@ impl ShellTool {
 
     /// Record a freshly written spool for `command` (newest first, bounded to
     /// [`SPOOL_KEEP`] entries; a re-run of the same command replaces its
-    /// older entry).
-    fn remember_spool(&self, command: &str, path: PathBuf) {
+    /// older entry). `display` is the path as commands see it
+    /// ([`command_visible_path`] — remapped under Docker), used verbatim in
+    /// recovery advice; `host` is what existence checks run against.
+    fn remember_spool(&self, command: &str, host: PathBuf, display: String) {
         let mut spools = self.spools.lock().unwrap_or_else(|p| p.into_inner());
-        spools.retain(|(c, _)| c != command);
-        spools.push_front((command.to_owned(), path));
+        spools.retain(|(c, _, _)| c != command);
+        // Tidy entries whose files another session's prune already removed.
+        spools.retain(|(_, h, _)| h.exists());
+        spools.push_front((command.to_owned(), host, display));
         spools.truncate(SPOOL_KEEP);
+    }
+
+    /// Drop any recorded spool for `command`. Called at the start of every
+    /// new foreground invocation: whatever a previous run spooled no longer
+    /// describes THIS run, so recovery advice must never name it (the run
+    /// may end small, time out, or fail to spawn — none of which re-spool).
+    fn forget_spool(&self, command: &str) {
+        let mut spools = self.spools.lock().unwrap_or_else(|p| p.into_inner());
+        spools.retain(|(c, _, _)| c != command);
     }
 
     /// Cap the effective per-command timeout at `cap_secs` (a hard CEILING).
@@ -872,65 +889,155 @@ fn background_label(command: &str) -> String {
 // harness-write territory (sessions, `.octos/work`, validator outcomes), and
 // a `*` gitignore inside the spool dir keeps the files out of `git status`
 // and out of the #28a change receipt. (Docker with a mounted workspace
-// remaps the path to `/workspace`; the harness-side `grep`/`read_file`
-// tools still resolve the host path.)
+// remaps the path — the footer and recovery advice print the in-container
+// view via `Sandbox::workspace_remap_root`; the harness-side `grep`/
+// `read_file` tools still resolve the host path.)
 //
-// Lifecycle: newest SPOOL_KEEP files per workspace; older ones are deleted
-// on the next spool write. No daemon.
+// Security posture (codex review round 2):
+// - The stream is SANITIZED before persisting: the spool holds the same
+//   redacted bytes the model sees, never the raw secrets the loop-level
+//   sanitizer exists to destroy.
+// - The spool is NOT written at all when the sandbox profile promises a
+//   read-only or write-fenced workspace (`Sandbox::workspace_scratch_writable`)
+//   — the harness must not mutate from the host what the sandbox forbids
+//   the shell to mutate.
+// - File creation goes through the #1976 `open_confined` component-wise
+//   O_NOFOLLOW walk (dir 0700 / file 0600 on Unix; on Windows there is no
+//   mode bit story — content protection is the workspace's own ACLs, and
+//   the non-Unix walk degrades to open_confined's documented ancestor-scan
+//   fallback).
+// - Outbound sweep surfaces (send_file, artifact-contract globs, the UI
+//   panes) exclude the spool subtree via `octos_core::is_shell_spool_path`.
+//
+// Lifecycle: newest SPOOL_KEEP files per workspace directory; older ones are
+// deleted on the next spool write, never the file just written. No daemon.
 // ---------------------------------------------------------------------------
 
-/// Byte budget reserved for everything appended after the inline view (exit
-/// code suffix, sandbox-denial hint, #28a change receipt, warn nudge) so the
-/// assembled result stays within the execution loop's per-tool cap and the
-/// backstop never re-cuts the spool footer away.
-const SPOOL_TAIL_RESERVE: usize = 2_048;
-
-/// Retention bound: newest spool files kept per workspace.
+/// Retention bound: spool files kept per workspace (the freshly written one
+/// included).
 const SPOOL_KEEP: usize = 16;
 
+/// Minimum inline-view budget worth spooling for. If the assembled suffixes
+/// (receipt, hint, exit code) leave less room than this, a head+tail view
+/// would be useless — fall back to the historic cut instead.
+const SPOOL_MIN_VIEW: usize = 1_024;
+
 /// Monotonic per-process suffix so two spools written within the same
-/// millisecond cannot collide on a filename.
+/// millisecond cannot collide on a filename (and so a cross-process
+/// `create_new` collision can retry with the next number).
 static SHELL_SPOOL_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// Workspace-local directory holding full-output spool files.
-fn spool_dir(cwd: &Path) -> PathBuf {
-    cwd.join(".octos").join("tmp").join("shell")
+/// Workspace-relative spool directory (`.octos/tmp/shell` — the components
+/// [`octos_core::SHELL_SPOOL_COMPONENTS`], which the outbound sweep
+/// exclusions match on).
+fn spool_rel_dir() -> PathBuf {
+    let [a, b, c] = octos_core::SHELL_SPOOL_COMPONENTS;
+    Path::new(a).join(b).join(c)
 }
 
-/// Write `full` to a fresh spool file under [`spool_dir`], pruning the dir to
-/// [`SPOOL_KEEP`] files. Returns `None` on any I/O failure (unwritable
-/// filesystem): the caller falls back to the historic truncate-only path.
-fn write_spool(cwd: &Path, full: &str) -> Option<PathBuf> {
-    let dir = spool_dir(cwd);
-    std::fs::create_dir_all(&dir).ok()?;
-    // Keep spools invisible to `git status` (and thereby to the #28a change
-    // receipt): a `*` gitignore inside the dir ignores everything in it,
-    // itself included.
-    let gitignore = dir.join(".gitignore");
-    if !gitignore.exists() {
-        let _ = std::fs::write(&gitignore, "*\n");
+/// The spool path as SHELL COMMANDS will see it: remapped under
+/// [`Sandbox::workspace_remap_root`] when the backend mounts the workspace
+/// elsewhere (Docker: `/workspace`), the host path otherwise. Remapped paths
+/// join with `/` — they name an in-container Unix path even from a Windows
+/// host.
+fn command_visible_path(sandbox: &dyn Sandbox, spool: &Path, cwd: &Path) -> String {
+    if let Some(remap) = sandbox.workspace_remap_root() {
+        if let Ok(rel) = spool.strip_prefix(cwd) {
+            let mut s = remap.to_string_lossy().into_owned();
+            for comp in rel.components() {
+                s.push('/');
+                s.push_str(&comp.as_os_str().to_string_lossy());
+            }
+            return s;
+        }
     }
+    spool.display().to_string()
+}
+
+/// Write the (already sanitized) `full` stream to a fresh spool file under
+/// `<cwd>/.octos/tmp/shell/`, pruning the directory to [`SPOOL_KEEP`] files.
+/// Returns `None` on any I/O failure — including a symlinked path component
+/// — and the caller falls back to the historic truncate-only path.
+///
+/// Every create goes through the #1976 [`open_confined`] component-wise
+/// `O_NOFOLLOW` walk: intermediate dirs are created from the parent's fd and
+/// never through a symlink, so a pre-planted `.octos/tmp/shell` symlink
+/// fails `ELOOP` instead of redirecting the write outside the workspace.
+/// (Non-Unix uses open_confined's documented ancestor-scan fallback.)
+fn write_spool(cwd: &Path, full: &str) -> Option<PathBuf> {
+    use crate::tools::write_grant::{ConfinedLeaf, open_confined};
+
+    let rel_dir = spool_rel_dir();
+
+    // `*` gitignore first (its walk also creates the dir chain): keeps
+    // spools out of `git status` and thereby out of the #28a change receipt.
+    match open_confined(cwd, &rel_dir.join(".gitignore"), ConfinedLeaf::CreateNew) {
+        Ok(mut file) => {
+            let _ = std::io::Write::write_all(&mut file, b"*\n");
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(_) => return None,
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Owner-only spool dir. A path-based chmod could follow a swapped-in
+        // symlink, so re-check it is a real dir first — the same residual
+        // race class as open_confined's non-Unix fallback; the CREATE path
+        // above remains the race-free boundary.
+        let dir = cwd.join(&rel_dir);
+        if std::fs::symlink_metadata(&dir).is_ok_and(|m| m.file_type().is_dir()) {
+            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+
     let millis = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .unwrap_or(0);
-    let seq = SHELL_SPOOL_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    // Fixed-width stamp: lexicographic filename order == recency order, which
-    // is what `prune_spools` sorts by.
-    let path = dir.join(format!("output-{millis:013}-{seq:04}.log"));
-    // `create_new`: never write through a pre-existing file or symlink.
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
-        .ok()?;
-    std::io::Write::write_all(&mut file, full.as_bytes()).ok()?;
-    prune_spools(&dir);
-    Some(path)
+    // Fixed-width stamp: lexicographic filename order == recency order,
+    // which is what `prune_spools` sorts by.
+    for _ in 0..4 {
+        let seq = SHELL_SPOOL_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let rel = rel_dir.join(format!("output-{millis:013}-{seq:04}.log"));
+        let mut file = match open_confined(cwd, &rel, ConfinedLeaf::CreateNew) {
+            Ok(file) => file,
+            // Another octos process on the same workspace took this name:
+            // retry with the next sequence number rather than silently
+            // disabling the spool.
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return None,
+        };
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            // fchmod on the open handle — race-free owner-only file.
+            let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+        }
+        if std::io::Write::write_all(&mut file, full.as_bytes()).is_err() {
+            return None;
+        }
+        let path = cwd.join(&rel);
+        prune_spools(&cwd.join(&rel_dir), &path);
+        return Some(path);
+    }
+    None
 }
 
-/// Delete the oldest `output-*.log` files beyond [`SPOOL_KEEP`].
-fn prune_spools(dir: &Path) {
+/// Delete the oldest `output-*.log` files beyond [`SPOOL_KEEP`] — never
+/// `keep`, the spool just written. Excluding `keep` from the candidates
+/// means a directory crowded with future-stamped names (which sort "newer"
+/// than any honest stamp) can never make this call delete the file whose
+/// path the caller is about to hand back. Runs only right after
+/// [`open_confined`] validated the directory chain; the remaining swap
+/// window matches open_confined's documented non-Unix residual, and the
+/// re-check below refuses to operate through a symlinked dir at all.
+fn prune_spools(dir: &Path, keep: &Path) {
+    if !std::fs::symlink_metadata(dir).is_ok_and(|m| m.file_type().is_dir()) {
+        return;
+    }
+    let keep_name = keep.file_name();
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -938,15 +1045,19 @@ fn prune_spools(dir: &Path) {
         .filter_map(|e| e.ok())
         .map(|e| e.file_name())
         .filter(|n| {
+            if keep_name == Some(n.as_os_str()) {
+                return false;
+            }
             let n = n.to_string_lossy();
             n.starts_with("output-") && n.ends_with(".log")
         })
         .collect();
-    if names.len() <= SPOOL_KEEP {
+    let others_keep = SPOOL_KEEP.saturating_sub(1);
+    if names.len() <= others_keep {
         return;
     }
     names.sort();
-    let excess = names.len() - SPOOL_KEEP;
+    let excess = names.len() - others_keep;
     for name in names.into_iter().take(excess) {
         let _ = std::fs::remove_file(dir.join(name));
     }
@@ -970,12 +1081,12 @@ fn count_lines(s: &str) -> usize {
 /// ranges are exact; when a single line overflows its budget the cut is
 /// byte-based and the footer switches to a byte-range form rather than
 /// reporting line numbers that would be lies.
-fn spooled_view(full: &str, budget: usize, spool_path: &Path) -> String {
+fn spooled_view(full: &str, budget: usize, footer_path: &str) -> String {
     let total_lines = count_lines(full);
-    let path_disp = spool_path.display().to_string();
+    let path_disp = footer_path;
     // Conservative allowance for the omission marker + footer (digits
-    // included): marker ≤ 40B, footer ≤ 120B + path.
-    let overhead = 160 + path_disp.len();
+    // included): marker ≤ 50B, footer ≤ 140B + path.
+    let overhead = 220 + path_disp.len();
     let avail = budget.saturating_sub(overhead);
     let head_budget = avail * 7 / 10;
     let tail_budget = avail - head_budget;
@@ -1055,7 +1166,7 @@ impl Tool for ShellTool {
         // instead of re-running a big command.
         static DESC: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
             format!(
-                "Execute a shell command and return the output. Use this to run tests, build code, or interact with the filesystem. Output over {}KB is truncated to head and tail; when that happens the full output is saved to a temp file named in the result footer — grep or read that file instead of re-running the command.",
+                "Execute a shell command and return the output. Use this to run tests, build code, or interact with the filesystem. Output over {}KB is truncated to head and tail; when that happens the full output is saved to a file under the workspace (.octos/tmp/shell/) named in the result footer — grep or read that file instead of re-running the command.",
                 octos_core::tool_output_limit("shell") / 1000
             )
         });
@@ -1063,25 +1174,32 @@ impl Tool for ShellTool {
     }
 
     /// Belt-and-braces for the execution loop's truncation backstop (#2124):
-    /// the tool already keeps its own result under the cap by spooling, but
-    /// if the backstop still fires (e.g. a large #28a receipt pushed the
-    /// total over), the advice names the spool file holding the complete
-    /// output. Without a recorded spool the honest resume path is a re-run
-    /// redirected to a file.
+    /// the tool sizes its own result to fit the cap, but if the backstop
+    /// still fires the advice names the spool file holding the complete
+    /// output — provided that spool was written by THIS invocation
+    /// (`forget_spool` clears stale entries at the start of every run) and
+    /// still exists on disk (another session sharing the workspace may have
+    /// pruned it). Otherwise the honest resume path is a re-run redirected
+    /// to a file.
     fn truncation_recovery(
         &self,
         args: &serde_json::Value,
         omitted_bytes: usize,
     ) -> Option<String> {
         let command = args.get("command").and_then(serde_json::Value::as_str)?;
-        let spools = self.spools.lock().unwrap_or_else(|p| p.into_inner());
-        Some(match spools.iter().find(|(c, _)| c == command) {
-            Some((_, path)) => format!(
+        let recorded = {
+            let spools = self.spools.lock().unwrap_or_else(|p| p.into_inner());
+            spools
+                .iter()
+                .find(|(c, _, _)| c == command)
+                .map(|(_, host, display)| (host.clone(), display.clone()))
+        };
+        Some(match recorded {
+            Some((host, display)) if host.exists() => format!(
                 "[{omitted_bytes} bytes omitted] The complete output of this command was saved \
-                 to {} — grep or read_file that file instead of re-running the command.",
-                path.display()
+                 to {display} — grep or read_file that file instead of re-running the command."
             ),
-            None => format!(
+            _ => format!(
                 "[{omitted_bytes} bytes omitted] Re-run with output redirected to a file (e.g. \
                  `<command> > out.log 2>&1`), then grep or read the file instead of re-running \
                  for the full output."
@@ -1326,6 +1444,13 @@ impl Tool for ShellTool {
             timeout_duration = timeout_duration.min(cap);
         }
 
+        // A NEW invocation of this command starts here: whatever spool an
+        // earlier run recorded no longer describes it. Forget first; a fresh
+        // spool (in the completion arm) re-records. This keeps
+        // `truncation_recovery` from naming a stale file when this run ends
+        // small, times out, or fails to spawn.
+        self.forget_spool(&input.command);
+
         // Execute command (through sandbox).
         // Spawn the child, grab its PID, then timeout on wait_with_output().
         // If timeout fires, kill by PID to prevent orphaned processes.
@@ -1375,56 +1500,43 @@ impl Tool for ShellTool {
                     result_text = "(no output)".to_string();
                 }
 
-                // Sandbox-denial scan runs on the FULL text (the denial line
-                // may be exactly what truncation cuts); the hint is appended
-                // after truncation so it survives the cut.
+                // Sandbox-denial scan runs on the FULL raw text (the denial
+                // line may be exactly what truncation cuts); the hint is part
+                // of the suffixes below so it always survives the cut.
                 let denial_hint = crate::sandbox::sandbox_denial_hint(
                     !self.sandbox.is_noop(),
                     output.status.success(),
                     &result_text,
                 );
 
-                let exit_suffix = format!("\n\nExit code: {exit_code}");
+                // Sanitize the FULL stream ONCE, here, so the spool file and
+                // every derived view hold the same redacted bytes — the
+                // loop's own sanitize pass is a no-op on already-redacted
+                // text. Without this the model-visible copy was redacted
+                // while the on-disk spool durably kept the secrets the
+                // sanitizer exists to destroy (codex review round 2), and
+                // the footer's byte offsets described a string the loop was
+                // about to rewrite.
+                let mut result_text = crate::sanitize::sanitize_tool_output(&result_text);
 
-                // #1638 — over the per-tool cap the middle of the output (where
-                // test failures live) used to be gone forever. Spool the FULL
-                // stream to a workspace-local file and return head + tail + a
-                // footer naming the file, sized so the execution loop's
-                // backstop never re-cuts the result. If the spool cannot be
-                // written (unwritable filesystem), fall back to the historic
-                // in-tool tail cut and let the backstop apply as before.
-                let limit = octos_core::tool_output_limit(self.name());
-                if result_text.len() > limit {
-                    match write_spool(effective_cwd, &result_text) {
-                        Some(spool_path) => {
-                            let budget =
-                                limit.saturating_sub(exit_suffix.len() + SPOOL_TAIL_RESERVE);
-                            let view = spooled_view(&result_text, budget, &spool_path);
-                            self.remember_spool(&input.command, spool_path);
-                            result_text = view;
-                        }
-                        None => {
-                            const MAX_OUTPUT: usize = 50000;
-                            octos_core::truncate_utf8(
-                                &mut result_text,
-                                MAX_OUTPUT - exit_suffix.len(),
-                                "\n... (output truncated)",
-                            );
-                        }
-                    }
-                }
-
-                result_text.push_str(&exit_suffix);
+                // Assemble EVERY suffix before any size decision: exit code,
+                // sandbox-denial hint, #28a change receipt, #28b warn nudge.
+                // The spool/truncation decision is then made on the FINAL
+                // assembled size, so a large receipt can never push the
+                // result back over the cap behind the decision's back and
+                // wake the loop backstop. (The receipt's AFTER snapshot runs
+                // before the spool write; the spool dir is gitignored, so it
+                // never appears in a receipt either way.)
+                let mut suffixes = format!("\n\nExit code: {exit_code}");
                 if let Some(hint) = denial_hint {
-                    result_text.push_str(hint);
+                    suffixes.push_str(hint);
                 }
-
-                // #28a — file-change receipt: AFTER snapshot + diff,
-                // appended ONCE to THIS result's tail (never the system
-                // prompt, never a history rewrite — prompt-cache stable).
+                // #28a — file-change receipt: AFTER snapshot + diff, appended
+                // ONCE to THIS result's tail (never the system prompt, never
+                // a history rewrite — prompt-cache stable).
                 let receipt = diff_to_receipt(dirty_before, snapshot_dirty_paths(effective_cwd));
                 if let Some(receipt) = receipt.as_deref() {
-                    result_text.push_str(receipt);
+                    suffixes.push_str(receipt);
                     // #28b — warn knob: nudge ONLY when files actually
                     // changed (files_changed > 0), sharing the receipt's
                     // AFTER snapshot (no second git-status scan). Zero
@@ -1432,11 +1544,51 @@ impl Tool for ShellTool {
                     if self.bash_file_writes == BashFileWrites::Warn
                         && !receipt.trim_end().ends_with("files_changed: 0")
                     {
-                        result_text.push_str(
+                        suffixes.push_str(
                             "\nnote: prefer the edit_file / diff_edit tools for code changes (tool_policy.bash_file_writes=warn)",
                         );
                     }
                 }
+
+                // #1638 — over the per-tool cap the middle of the output
+                // (where test failures live) used to be gone forever. Spool
+                // the full sanitized stream to a workspace-local file and
+                // return head + tail + a footer naming the file, sized so
+                // view + suffixes fit the cap exactly and the loop backstop
+                // never re-cuts the result. No spool when the profile
+                // promises a read-only/fenced workspace, when the suffixes
+                // leave no useful room, or when the write fails — those fall
+                // back to the historic in-tool tail cut (loop backstop still
+                // applies, and `truncation_recovery` then gives the honest
+                // re-run-redirected advice: `forget_spool` above cleared any
+                // stale entry for this command).
+                let limit = octos_core::tool_output_limit(self.name());
+                let budget = limit.saturating_sub(suffixes.len());
+                if result_text.len() > budget {
+                    let mut spooled = false;
+                    if budget >= SPOOL_MIN_VIEW && self.sandbox.workspace_scratch_writable() {
+                        if let Some(spool_path) = write_spool(effective_cwd, &result_text) {
+                            let display = command_visible_path(
+                                self.sandbox.as_ref(),
+                                &spool_path,
+                                effective_cwd,
+                            );
+                            result_text = spooled_view(&result_text, budget, &display);
+                            self.remember_spool(&input.command, spool_path, display);
+                            spooled = true;
+                        }
+                    }
+                    if !spooled {
+                        const MAX_OUTPUT: usize = 50000;
+                        octos_core::truncate_utf8(
+                            &mut result_text,
+                            MAX_OUTPUT.saturating_sub(suffixes.len()),
+                            "\n... (output truncated)",
+                        );
+                    }
+                }
+
+                result_text.push_str(&suffixes);
 
                 Ok(ToolResult {
                     output: result_text,
@@ -3153,7 +3305,7 @@ mod spool_tests {
         // One giant unterminated line: no line boundary fits either budget,
         // so line numbers would be lies — the footer must switch to the
         // byte-range form and the view must still respect the budget.
-        let spool = std::path::Path::new("/tmp/spool-under-test.log");
+        let spool = "/tmp/spool-under-test.log";
         let full = "x".repeat(100_000);
         let view = spooled_view(&full, 5_000, spool);
         assert!(
@@ -3174,7 +3326,7 @@ mod spool_tests {
 
     #[test]
     fn should_keep_view_within_budget_when_line_data_spooled() {
-        let spool = std::path::Path::new("/tmp/spool-under-test.log");
+        let spool = "/tmp/spool-under-test.log";
         let full: String = (1..=5_000).map(|i| format!("entry number {i}\n")).collect();
         let budget = 8_000;
         let view = spooled_view(&full, budget, spool);
@@ -3203,5 +3355,318 @@ mod spool_tests {
             desc.contains("full output is saved"),
             "description states the spool contract: {desc}"
         );
+    }
+
+    // ── codex review round 2 ────────────────────────────────────────────
+
+    /// Sandbox stub for profiles that promise a read-only workspace: runs
+    /// commands directly (like NoSandbox) but reports scratch unwritable.
+    struct ReadOnlyWorkspaceSandbox;
+
+    impl crate::sandbox::Sandbox for ReadOnlyWorkspaceSandbox {
+        fn wrap_command(&self, shell_command: &str, cwd: &Path) -> tokio::process::Command {
+            let mut cmd = tokio::process::Command::new("sh");
+            cmd.arg("-c").arg(shell_command).current_dir(cwd);
+            cmd
+        }
+        fn workspace_scratch_writable(&self) -> bool {
+            false
+        }
+    }
+
+    /// Sandbox stub for backends that remap the workspace for commands
+    /// (Docker mounts the cwd at /workspace).
+    struct RemappingSandbox;
+
+    impl crate::sandbox::Sandbox for RemappingSandbox {
+        fn wrap_command(&self, shell_command: &str, cwd: &Path) -> tokio::process::Command {
+            let mut cmd = tokio::process::Command::new("sh");
+            cmd.arg("-c").arg(shell_command).current_dir(cwd);
+            cmd
+        }
+        fn workspace_remap_root(&self) -> Option<&Path> {
+            Some(Path::new("/workspace"))
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_sanitize_stream_before_persisting_spool() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path());
+        // A credential in the stream followed by >cap filler. Loop-level
+        // sanitization redacts what reaches the model; the spool must hold
+        // the SAME redacted stream — persisting the raw one would durably
+        // keep the secret the sanitizer exists to destroy.
+        let cmd = "echo sk-testsecretsecretsecret12345; awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"fill \" i }'";
+        let out = run(&tool, cmd);
+        assert!(out.success, "output: {}", out.output);
+        let path = footer_path(&out.output);
+        let spooled = std::fs::read_to_string(&path).expect("read spool");
+        assert!(
+            !spooled.contains("sk-testsecretsecretsecret12345"),
+            "raw credential persisted to disk — the spool must store the sanitized stream"
+        );
+        assert!(
+            spooled.contains("[credential-redacted]"),
+            "spool must carry the redaction marker: {}",
+            &spooled[..200]
+        );
+        assert!(
+            !out.output.contains("sk-testsecretsecretsecret12345"),
+            "inline view must be redacted too"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_restrict_spool_permissions_when_persisting() {
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path());
+        let out = run(
+            &tool,
+            "awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"perm \" i }'",
+        );
+        let path = footer_path(&out.output);
+        let file_mode = std::fs::metadata(&path)
+            .expect("spool metadata")
+            .permissions()
+            .mode();
+        assert_eq!(
+            file_mode & 0o777,
+            0o600,
+            "spool file must be owner-only (0600), got {:o}",
+            file_mode & 0o777
+        );
+        let dir_mode = std::fs::metadata(path.parent().expect("spool dir"))
+            .expect("dir metadata")
+            .permissions()
+            .mode();
+        assert_eq!(
+            dir_mode & 0o777,
+            0o700,
+            "spool dir must be owner-only (0700), got {:o}",
+            dir_mode & 0o777
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_not_spool_when_workspace_read_only() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path()).with_sandbox(Box::new(ReadOnlyWorkspaceSandbox));
+        let out = run(
+            &tool,
+            "awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"ro \" i }'",
+        );
+        assert!(out.success, "output: {}", out.output);
+        // The profile promised the model a read-only workspace: the harness
+        // must not mutate it from the host either. Historic cut instead.
+        assert!(
+            !temp.path().join(".octos").exists(),
+            "read-only workspace must not gain a spool dir"
+        );
+        assert!(
+            !out.output.contains("Full output:"),
+            "no footer without a spool: {}",
+            out.output
+        );
+        assert!(
+            out.output.contains("(output truncated)"),
+            "historic in-tool cut must apply: {}",
+            out.output
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_include_receipt_in_budget_when_receipt_present() {
+        // A large #28a receipt (20 long paths) must be part of the size the
+        // spool decision is made on — otherwise the execution loop's backstop
+        // re-cuts the assembled result and buries the footer.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cwd = temp.path();
+        std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(cwd)
+            .status()
+            .expect("git init");
+        let tool = ShellTool::new(cwd);
+        let long = "f".repeat(120);
+        let cmd = format!(
+            "i=1; while [ $i -le 20 ]; do echo x > {long}$i.txt; i=$((i+1)); done; \
+             awk 'BEGIN {{ for (i = 1; i <= 9000; i++) print \"z \" i }}'"
+        );
+        let out = run(&tool, &cmd);
+        assert!(out.success, "output: {}", out.output);
+        assert!(
+            out.output.contains("files_changed:"),
+            "receipt present: {}",
+            out.output
+        );
+        assert!(
+            out.output.contains("Full output: "),
+            "footer present: {}",
+            out.output
+        );
+        let limit = octos_core::tool_output_limit("shell");
+        assert!(
+            out.output.len() <= limit,
+            "assembled result (view + receipt + suffixes) must fit the {limit}B cap so the \
+             loop backstop never re-cuts it, got {}",
+            out.output.len()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_fall_back_to_generic_advice_when_spool_file_deleted() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path());
+        let cmd = "awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"del \" i }'";
+        let out = run(&tool, cmd);
+        let path = footer_path(&out.output);
+        std::fs::remove_file(&path).expect("delete spool");
+        let advice = tool
+            .truncation_recovery(&serde_json::json!({ "command": cmd }), 77)
+            .expect("advice");
+        assert!(
+            !advice.contains(&path.display().to_string()),
+            "advice must never name a deleted file: {advice}"
+        );
+        assert!(
+            advice.contains("2>&1"),
+            "fallback to the honest re-run advice: {advice}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_forget_stale_spool_when_command_reruns_without_spooling() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let big: String = (1..=9000).map(|i| format!("data {i}\n")).collect();
+        std::fs::write(temp.path().join("data.txt"), &big).expect("seed data");
+        let tool = ShellTool::new(temp.path());
+        let cmd = "cat data.txt";
+
+        // First run spools.
+        let out = run(&tool, cmd);
+        let path = footer_path(&out.output);
+        assert!(path.exists());
+
+        // Re-run the SAME command with small output: the latest invocation
+        // did not spool, so the old entry no longer describes this command.
+        std::fs::write(temp.path().join("data.txt"), "small\n").expect("shrink data");
+        let out2 = run(&tool, cmd);
+        assert!(!out2.output.contains("Full output:"), "{}", out2.output);
+        let advice = tool
+            .truncation_recovery(&serde_json::json!({ "command": cmd }), 55)
+            .expect("advice");
+        assert!(
+            !advice.contains(&path.display().to_string()),
+            "advice must not name a previous invocation's spool: {advice}"
+        );
+        assert!(advice.contains("2>&1"), "generic advice expected: {advice}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_keep_fresh_spool_when_future_stamped_files_crowd_the_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path().join(".octos").join("tmp").join("shell");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        // Future-stamped names sort NEWER than any real stamp: a
+        // lexicographic prune that trusts names would delete the fresh spool
+        // it is about to hand back.
+        for i in 0..16 {
+            std::fs::write(
+                dir.join(format!("output-9999999999999-{i:04}.log")),
+                "crowd\n",
+            )
+            .expect("seed");
+        }
+        let tool = ShellTool::new(temp.path());
+        let out = run(
+            &tool,
+            "awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"keep \" i }'",
+        );
+        let path = footer_path(&out.output);
+        assert!(
+            path.exists(),
+            "the fresh spool must survive its own prune: {}",
+            path.display()
+        );
+        let expected: String = (1..=9000).map(|i| format!("keep {i}\n")).collect();
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read spool"),
+            expected,
+            "the surviving file must be THIS run's output"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_refuse_spool_when_spool_dir_is_symlink() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        std::fs::create_dir_all(temp.path().join(".octos").join("tmp")).expect("mkdir");
+        std::os::unix::fs::symlink(
+            outside.path(),
+            temp.path().join(".octos").join("tmp").join("shell"),
+        )
+        .expect("plant symlink");
+        let tool = ShellTool::new(temp.path());
+        let out = run(
+            &tool,
+            "awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"sym \" i }'",
+        );
+        assert!(out.success, "output: {}", out.output);
+        // Nothing may be written through the planted symlink, and with no
+        // spool there is no footer — the historic cut applies.
+        assert_eq!(
+            std::fs::read_dir(outside.path())
+                .expect("read outside")
+                .count(),
+            0,
+            "a planted spool-dir symlink must not redirect writes outside the workspace"
+        );
+        assert!(
+            !out.output.contains("Full output:"),
+            "no footer without a spool: {}",
+            out.output
+        );
+        assert!(out.output.contains("(output truncated)"), "{}", out.output);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_emit_remapped_footer_path_when_sandbox_remaps_workspace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path()).with_sandbox(Box::new(RemappingSandbox));
+        let out = run(
+            &tool,
+            "awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"map \" i }'",
+        );
+        assert!(out.success, "output: {}", out.output);
+        // The footer must name the path AS COMMANDS SEE IT (Docker mounts
+        // the cwd at /workspace); a host-absolute path is unusable there.
+        assert!(
+            out.output
+                .contains("Full output: /workspace/.octos/tmp/shell/output-"),
+            "footer must use the remapped path: {}",
+            out.output
+        );
+        // The spool itself still lands on the host, under the workspace.
+        let host_dir = temp.path().join(".octos").join("tmp").join("shell");
+        let spool_count = std::fs::read_dir(&host_dir)
+            .expect("spool dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let n = e.file_name().to_string_lossy().into_owned();
+                n.starts_with("output-") && n.ends_with(".log")
+            })
+            .count();
+        assert_eq!(spool_count, 1, "exactly this run's spool on the host");
     }
 }

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -67,6 +67,13 @@ pub struct ShellTool {
     /// deadline. `None` = no extra cap (only the outer `[1, 600]s` clamp
     /// applies) — unchanged behaviour for every existing caller.
     max_timeout: Option<Duration>,
+    /// Recent output spools, newest first: `(command, spool path)` for the
+    /// last [`SPOOL_KEEP`] commands whose output exceeded the per-tool cap
+    /// and was written to a full-output file (#1638). Consulted by
+    /// [`Tool::truncation_recovery`] so that if the execution-loop backstop
+    /// still cuts a result, the recovery advice can name the exact file
+    /// holding the complete output.
+    spools: std::sync::Mutex<std::collections::VecDeque<(String, PathBuf)>>,
 }
 
 impl ShellTool {
@@ -84,7 +91,18 @@ impl ShellTool {
             task_ledger_path: None,
             background_allowed: true,
             max_timeout: None,
+            spools: std::sync::Mutex::new(std::collections::VecDeque::new()),
         }
+    }
+
+    /// Record a freshly written spool for `command` (newest first, bounded to
+    /// [`SPOOL_KEEP`] entries; a re-run of the same command replaces its
+    /// older entry).
+    fn remember_spool(&self, command: &str, path: PathBuf) {
+        let mut spools = self.spools.lock().unwrap_or_else(|p| p.into_inner());
+        spools.retain(|(c, _)| c != command);
+        spools.push_front((command.to_owned(), path));
+        spools.truncate(SPOOL_KEEP);
     }
 
     /// Cap the effective per-command timeout at `cap_secs` (a hard CEILING).
@@ -834,6 +852,197 @@ fn background_label(command: &str) -> String {
     label
 }
 
+// ---------------------------------------------------------------------------
+// Output spooling (#1638)
+//
+// A `shell` result over `octos_core::tool_output_limit("shell")` used to be
+// head/tail-cut with `[N bytes omitted]` — the omitted middle (where `cargo
+// test` / `npm test` failures live) was gone forever, and the model's only
+// recovery was re-running the command, paying the run AND the tokens again.
+// Instead, the FULL combined stream is written to a workspace-local spool
+// file and the inline result becomes head + tail + a footer naming the exact
+// line ranges shown, the total, and the file — so the model can grep/read
+// the file instead of re-running.
+//
+// Placement: `<workspace>/.octos/tmp/shell/`. The workspace is the ONE
+// location every sandbox backend lets the model's follow-up shell command
+// read: bwrap tmpfs-shadows host /tmp (`--tmpfs /tmp`), the macOS
+// restricted-read profile and Landlock grant the cwd, and NoSandbox reads
+// anything. `.octos/` inside the workspace is already established
+// harness-write territory (sessions, `.octos/work`, validator outcomes), and
+// a `*` gitignore inside the spool dir keeps the files out of `git status`
+// and out of the #28a change receipt. (Docker with a mounted workspace
+// remaps the path to `/workspace`; the harness-side `grep`/`read_file`
+// tools still resolve the host path.)
+//
+// Lifecycle: newest SPOOL_KEEP files per workspace; older ones are deleted
+// on the next spool write. No daemon.
+// ---------------------------------------------------------------------------
+
+/// Byte budget reserved for everything appended after the inline view (exit
+/// code suffix, sandbox-denial hint, #28a change receipt, warn nudge) so the
+/// assembled result stays within the execution loop's per-tool cap and the
+/// backstop never re-cuts the spool footer away.
+const SPOOL_TAIL_RESERVE: usize = 2_048;
+
+/// Retention bound: newest spool files kept per workspace.
+const SPOOL_KEEP: usize = 16;
+
+/// Monotonic per-process suffix so two spools written within the same
+/// millisecond cannot collide on a filename.
+static SHELL_SPOOL_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Workspace-local directory holding full-output spool files.
+fn spool_dir(cwd: &Path) -> PathBuf {
+    cwd.join(".octos").join("tmp").join("shell")
+}
+
+/// Write `full` to a fresh spool file under [`spool_dir`], pruning the dir to
+/// [`SPOOL_KEEP`] files. Returns `None` on any I/O failure (unwritable
+/// filesystem): the caller falls back to the historic truncate-only path.
+fn write_spool(cwd: &Path, full: &str) -> Option<PathBuf> {
+    let dir = spool_dir(cwd);
+    std::fs::create_dir_all(&dir).ok()?;
+    // Keep spools invisible to `git status` (and thereby to the #28a change
+    // receipt): a `*` gitignore inside the dir ignores everything in it,
+    // itself included.
+    let gitignore = dir.join(".gitignore");
+    if !gitignore.exists() {
+        let _ = std::fs::write(&gitignore, "*\n");
+    }
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let seq = SHELL_SPOOL_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    // Fixed-width stamp: lexicographic filename order == recency order, which
+    // is what `prune_spools` sorts by.
+    let path = dir.join(format!("output-{millis:013}-{seq:04}.log"));
+    // `create_new`: never write through a pre-existing file or symlink.
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .ok()?;
+    std::io::Write::write_all(&mut file, full.as_bytes()).ok()?;
+    prune_spools(&dir);
+    Some(path)
+}
+
+/// Delete the oldest `output-*.log` files beyond [`SPOOL_KEEP`].
+fn prune_spools(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut names: Vec<std::ffi::OsString> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
+        .filter(|n| {
+            let n = n.to_string_lossy();
+            n.starts_with("output-") && n.ends_with(".log")
+        })
+        .collect();
+    if names.len() <= SPOOL_KEEP {
+        return;
+    }
+    names.sort();
+    let excess = names.len() - SPOOL_KEEP;
+    for name in names.into_iter().take(excess) {
+        let _ = std::fs::remove_file(dir.join(name));
+    }
+}
+
+/// Count lines the way `str::lines` does: a trailing newline does not open a
+/// final empty line.
+fn count_lines(s: &str) -> usize {
+    if s.is_empty() {
+        return 0;
+    }
+    let newlines = s.bytes().filter(|&b| b == b'\n').count();
+    newlines + usize::from(!s.ends_with('\n'))
+}
+
+/// Head + tail view of a spooled output, within `budget` bytes, ending in a
+/// pi-style footer that names the exact line ranges shown, the total, and
+/// the spool file holding the complete stream.
+///
+/// Head and tail are cut on line boundaries whenever one fits, so the footer
+/// ranges are exact; when a single line overflows its budget the cut is
+/// byte-based and the footer switches to a byte-range form rather than
+/// reporting line numbers that would be lies.
+fn spooled_view(full: &str, budget: usize, spool_path: &Path) -> String {
+    let total_lines = count_lines(full);
+    let path_disp = spool_path.display().to_string();
+    // Conservative allowance for the omission marker + footer (digits
+    // included): marker ≤ 40B, footer ≤ 120B + path.
+    let overhead = 160 + path_disp.len();
+    let avail = budget.saturating_sub(overhead);
+    let head_budget = avail * 7 / 10;
+    let tail_budget = avail - head_budget;
+
+    // Head: largest prefix within budget, preferring to end on a line
+    // boundary (newline included).
+    let mut head_end = head_budget.min(full.len());
+    while head_end > 0 && !full.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+    let head_aligned = match full[..head_end].rfind('\n') {
+        Some(i) => {
+            head_end = i + 1;
+            true
+        }
+        None => false,
+    };
+
+    // Tail: largest suffix within budget, preferring to start at a line
+    // start.
+    let mut tail_start = full.len().saturating_sub(tail_budget).max(head_end);
+    while tail_start < full.len() && !full.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+    let tail_aligned = if tail_start == 0 || full[..tail_start].ends_with('\n') {
+        true
+    } else {
+        match full[tail_start..].find('\n') {
+            // Skip past the partial first line — unless that newline is the
+            // very last byte (the whole tail slice was one partial line).
+            Some(i) if tail_start + i + 1 < full.len() => {
+                tail_start += i + 1;
+                true
+            }
+            _ => false,
+        }
+    };
+
+    let head = &full[..head_end];
+    let tail = &full[tail_start..];
+    let omitted = tail_start - head_end;
+
+    let footer = if head_aligned && tail_aligned && !head.is_empty() && !tail.is_empty() {
+        // Both cuts landed on line boundaries: head shows complete lines
+        // 1..=head_lines, tail shows the last tail_lines lines.
+        let head_lines = count_lines(head);
+        let tail_lines = count_lines(tail);
+        let tail_first = total_lines - tail_lines + 1;
+        format!(
+            "\n\n[Showing lines 1-{head_lines} and {tail_first}-{total_lines} of {total_lines}. Full output: {path_disp}]"
+        )
+    } else {
+        format!(
+            "\n\n[Showing first {head_end} and last {} bytes of {} ({total_lines} lines). Full output: {path_disp}]",
+            tail.len(),
+            full.len()
+        )
+    };
+
+    let mut view = String::with_capacity(head.len() + tail.len() + footer.len() + 48);
+    view.push_str(head);
+    view.push_str(&format!("\n\n... [{omitted} bytes omitted] ...\n\n"));
+    view.push_str(tail);
+    view.push_str(&footer);
+    view
+}
+
 #[async_trait]
 impl Tool for ShellTool {
     fn name(&self) -> &str {
@@ -841,7 +1050,43 @@ impl Tool for ShellTool {
     }
 
     fn description(&self) -> &str {
-        "Execute a shell command and return the output. Use this to run tests, build code, or interact with the filesystem."
+        // The spool contract is part of the tool contract (pi's bash wording
+        // as the model): warned up front, the model greps the named file
+        // instead of re-running a big command.
+        static DESC: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+            format!(
+                "Execute a shell command and return the output. Use this to run tests, build code, or interact with the filesystem. Output over {}KB is truncated to head and tail; when that happens the full output is saved to a temp file named in the result footer — grep or read that file instead of re-running the command.",
+                octos_core::tool_output_limit("shell") / 1000
+            )
+        });
+        &DESC
+    }
+
+    /// Belt-and-braces for the execution loop's truncation backstop (#2124):
+    /// the tool already keeps its own result under the cap by spooling, but
+    /// if the backstop still fires (e.g. a large #28a receipt pushed the
+    /// total over), the advice names the spool file holding the complete
+    /// output. Without a recorded spool the honest resume path is a re-run
+    /// redirected to a file.
+    fn truncation_recovery(
+        &self,
+        args: &serde_json::Value,
+        omitted_bytes: usize,
+    ) -> Option<String> {
+        let command = args.get("command").and_then(serde_json::Value::as_str)?;
+        let spools = self.spools.lock().unwrap_or_else(|p| p.into_inner());
+        Some(match spools.iter().find(|(c, _)| c == command) {
+            Some((_, path)) => format!(
+                "[{omitted_bytes} bytes omitted] The complete output of this command was saved \
+                 to {} — grep or read_file that file instead of re-running the command.",
+                path.display()
+            ),
+            None => format!(
+                "[{omitted_bytes} bytes omitted] Re-run with output redirected to a file (e.g. \
+                 `<command> > out.log 2>&1`), then grep or read the file instead of re-running \
+                 for the full output."
+            ),
+        })
     }
 
     fn tags(&self) -> &[&str] {
@@ -1139,14 +1384,35 @@ impl Tool for ShellTool {
                     &result_text,
                 );
 
-                // Truncate if too long (reserve space for exit code suffix)
                 let exit_suffix = format!("\n\nExit code: {exit_code}");
-                const MAX_OUTPUT: usize = 50000;
-                octos_core::truncate_utf8(
-                    &mut result_text,
-                    MAX_OUTPUT - exit_suffix.len(),
-                    "\n... (output truncated)",
-                );
+
+                // #1638 — over the per-tool cap the middle of the output (where
+                // test failures live) used to be gone forever. Spool the FULL
+                // stream to a workspace-local file and return head + tail + a
+                // footer naming the file, sized so the execution loop's
+                // backstop never re-cuts the result. If the spool cannot be
+                // written (unwritable filesystem), fall back to the historic
+                // in-tool tail cut and let the backstop apply as before.
+                let limit = octos_core::tool_output_limit(self.name());
+                if result_text.len() > limit {
+                    match write_spool(effective_cwd, &result_text) {
+                        Some(spool_path) => {
+                            let budget =
+                                limit.saturating_sub(exit_suffix.len() + SPOOL_TAIL_RESERVE);
+                            let view = spooled_view(&result_text, budget, &spool_path);
+                            self.remember_spool(&input.command, spool_path);
+                            result_text = view;
+                        }
+                        None => {
+                            const MAX_OUTPUT: usize = 50000;
+                            octos_core::truncate_utf8(
+                                &mut result_text,
+                                MAX_OUTPUT - exit_suffix.len(),
+                                "\n... (output truncated)",
+                            );
+                        }
+                    }
+                }
 
                 result_text.push_str(&exit_suffix);
                 if let Some(hint) = denial_hint {
@@ -2662,5 +2928,280 @@ mod change_receipt_tests {
             .filter(|l| l.trim_start().starts_with("many/"))
             .count();
         assert_eq!(listed_count, 20, "exactly 20 listed (cap): {receipt}");
+    }
+}
+
+#[cfg(test)]
+mod spool_tests {
+    use super::*;
+
+    fn run(tool: &ShellTool, command: &str) -> ToolResult {
+        tokio::runtime::Runtime::new()
+            .expect("rt")
+            .block_on(tool.execute(&serde_json::json!({ "command": command })))
+            .expect("execute")
+    }
+
+    /// Extract the spool path named by the footer's `Full output: <path>]`.
+    fn footer_path(output: &str) -> std::path::PathBuf {
+        let marker = "Full output: ";
+        let start = output
+            .rfind(marker)
+            .expect("footer must name the spool file")
+            + marker.len();
+        let rest = &output[start..];
+        let end = rest.find(']').expect("footer must close with ]");
+        std::path::PathBuf::from(&rest[..end])
+    }
+
+    #[cfg(unix)]
+    // POSIX shell command shapes (awk) — same convention as the #34e gates above.
+    #[test]
+    fn should_spool_full_output_with_footer_when_output_exceeds_cap() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path());
+        // Deterministic >cap output: 12000 numbered lines (~130KB vs the 30KB cap).
+        let cmd = "awk 'BEGIN { for (i = 1; i <= 12000; i++) print \"line \" i }'";
+        let out = run(&tool, cmd);
+        assert!(out.success, "output: {}", out.output);
+
+        // The inline view fits the per-tool cap so the loop backstop never
+        // re-cuts it (which would bury the footer under `[bytes omitted]`).
+        let limit = octos_core::tool_output_limit("shell");
+        assert!(
+            out.output.len() <= limit,
+            "inline view must fit the {limit}B cap, got {}",
+            out.output.len()
+        );
+
+        // Head and tail both survive the cut.
+        assert!(
+            out.output.contains("line 1\n"),
+            "head lost: {}",
+            &out.output[..200]
+        );
+        assert!(out.output.contains("line 12000"), "tail lost");
+
+        // pi-style footer: exact line ranges shown, the total, and the file.
+        assert!(
+            out.output.contains("[Showing lines 1-"),
+            "footer must name the shown ranges: {}",
+            out.output
+        );
+        assert!(
+            out.output.contains(" of 12000. Full output: "),
+            "footer must name the total line count: {}",
+            out.output
+        );
+
+        // The named file exists and holds the COMPLETE stream byte-for-byte.
+        let path = footer_path(&out.output);
+        assert!(path.exists(), "spool file must exist: {}", path.display());
+        let expected: String = (1..=12000).map(|i| format!("line {i}\n")).collect();
+        let spooled = std::fs::read_to_string(&path).expect("read spool");
+        assert_eq!(
+            spooled, expected,
+            "spool must hold the full untruncated output"
+        );
+
+        // Inside the workspace: the one location every sandbox backend lets a
+        // follow-up sandboxed shell command read (bwrap tmpfs-shadows host
+        // /tmp; macOS/Landlock restricted profiles always grant the cwd).
+        assert!(
+            path.starts_with(temp.path()),
+            "spool must live under the workspace: {}",
+            path.display()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_report_line_ranges_matching_shown_content_when_spooled() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path());
+        let out = run(
+            &tool,
+            "awk 'BEGIN { for (i = 1; i <= 12000; i++) print \"line \" i }'",
+        );
+        assert!(out.success, "output: {}", out.output);
+
+        // Parse `[Showing lines 1-H and T-12000 of 12000. Full output: ...]`.
+        let tag = "[Showing lines 1-";
+        let at = out.output.rfind(tag).expect("line-range footer") + tag.len();
+        let rest = &out.output[at..];
+        let h: usize = rest[..rest.find(' ').expect("space after head range")]
+            .parse()
+            .expect("head end line number");
+        let rest = &rest[rest.find("and ").expect("and") + 4..];
+        let t: usize = rest[..rest.find('-').expect("dash")]
+            .parse()
+            .expect("tail start line number");
+
+        // The ranges must be TRUE: the head really ends at line H (marker
+        // follows) and the tail really resumes at line T.
+        assert!(
+            out.output.contains(&format!("line {h}\n\n\n... [")),
+            "head must end exactly at line {h}: {}",
+            out.output
+        );
+        assert!(
+            out.output.contains(&format!("] ...\n\nline {t}\n")),
+            "tail must resume exactly at line {t}: {}",
+            out.output
+        );
+        assert!(h < t && t <= 12000, "sane ranges: h={h} t={t}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_return_output_unchanged_and_no_spool_when_output_under_cap() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path());
+        let out = run(&tool, "echo hi");
+        assert!(out.success);
+        // Byte-identical to the historic small-output shape (stdout keeps its
+        // trailing newline, then the exit-code suffix): no footer, no marker,
+        // nothing appended.
+        assert_eq!(out.output, "hi\n\n\nExit code: 0");
+        // And no spool artifacts created for it.
+        assert!(
+            !temp.path().join(".octos").exists(),
+            "small output must not create a spool dir"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_name_spool_path_in_truncation_recovery_when_backstop_fires() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path());
+        let cmd = "awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"row \" i }'";
+        let out = run(&tool, cmd);
+        let path = footer_path(&out.output);
+
+        // Belt-and-braces (#2124 hook): if the loop backstop still cuts the
+        // result, the advice names the spool holding the full output.
+        let advice = tool
+            .truncation_recovery(&serde_json::json!({ "command": cmd }), 4321)
+            .expect("shell must offer recovery advice after spooling");
+        assert!(
+            advice.contains(&path.display().to_string()),
+            "advice must name the spool path: {advice}"
+        );
+        assert!(
+            advice.contains("4321"),
+            "advice names omitted bytes: {advice}"
+        );
+    }
+
+    #[test]
+    fn should_advise_rerun_with_redirect_when_no_spool_recorded_for_command() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ShellTool::new(temp.path());
+        let advice = tool
+            .truncation_recovery(&serde_json::json!({ "command": "echo hi" }), 100)
+            .expect("generic advice when no spool exists");
+        assert!(
+            advice.contains("2>&1"),
+            "fallback advice suggests redirecting to a file: {advice}"
+        );
+        assert!(
+            advice.contains("100"),
+            "advice names omitted bytes: {advice}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_prune_spool_dir_to_capacity_when_spools_accumulate() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Seed the spool dir with MORE than the retention cap of old spools
+        // (all created by THIS test in its own tempdir).
+        let dir = temp.path().join(".octos").join("tmp").join("shell");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        for i in 0..20 {
+            std::fs::write(
+                dir.join(format!("output-0000000000000-{i:04}.log")),
+                "old\n",
+            )
+            .expect("seed spool");
+        }
+        let tool = ShellTool::new(temp.path());
+        let out = run(
+            &tool,
+            "awk 'BEGIN { for (i = 1; i <= 9000; i++) print \"p \" i }'",
+        );
+        let new_path = footer_path(&out.output);
+        assert!(new_path.exists(), "fresh spool must survive pruning");
+        let count = std::fs::read_dir(&dir)
+            .expect("read spool dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let n = e.file_name().to_string_lossy().into_owned();
+                n.starts_with("output-") && n.ends_with(".log")
+            })
+            .count();
+        // Retention bound: keep the newest 16 spools per workspace.
+        assert!(
+            count <= 16,
+            "spool dir must stay bounded, got {count} files"
+        );
+    }
+
+    #[test]
+    fn should_use_byte_footer_when_single_line_exceeds_budget() {
+        // One giant unterminated line: no line boundary fits either budget,
+        // so line numbers would be lies — the footer must switch to the
+        // byte-range form and the view must still respect the budget.
+        let spool = std::path::Path::new("/tmp/spool-under-test.log");
+        let full = "x".repeat(100_000);
+        let view = spooled_view(&full, 5_000, spool);
+        assert!(
+            view.contains("[Showing first "),
+            "byte-form footer expected: {view}"
+        );
+        assert!(
+            view.contains("bytes of 100000 (1 lines). Full output: "),
+            "byte-form footer names totals: {view}"
+        );
+        assert!(!view.contains("[Showing lines"), "no fake line ranges");
+        assert!(
+            view.len() <= 5_000,
+            "view must fit budget, got {}",
+            view.len()
+        );
+    }
+
+    #[test]
+    fn should_keep_view_within_budget_when_line_data_spooled() {
+        let spool = std::path::Path::new("/tmp/spool-under-test.log");
+        let full: String = (1..=5_000).map(|i| format!("entry number {i}\n")).collect();
+        let budget = 8_000;
+        let view = spooled_view(&full, budget, spool);
+        assert!(
+            view.len() <= budget,
+            "view must fit budget {budget}, got {}",
+            view.len()
+        );
+        assert!(view.starts_with("entry number 1\n"), "head preserved");
+        assert!(view.contains("entry number 5000"), "tail preserved");
+        assert!(
+            view.contains(" of 5000. Full output: "),
+            "line footer: {view}"
+        );
+    }
+
+    #[test]
+    fn should_state_spool_contract_in_description() {
+        let tool = ShellTool::new("/tmp");
+        let desc = tool.description();
+        assert!(
+            desc.contains("truncated"),
+            "description warns about truncation: {desc}"
+        );
+        assert!(
+            desc.contains("full output is saved"),
+            "description states the spool contract: {desc}"
+        );
     }
 }

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -395,6 +395,13 @@ fn resolve_glob_matches(
         if !path.is_file() {
             continue;
         }
+        // #1638 — shell output spools are internal working state (complete
+        // command output kept so the model can grep past its cap), never
+        // deliverable artifacts. Globbing ignores gitignore, so a broad
+        // pattern like `**/*.log` would otherwise bundle them.
+        if octos_core::is_shell_spool_path(&path) {
+            continue;
+        }
         if started_at.is_some() {
             let modified = std::fs::metadata(&path)
                 .and_then(|meta| meta.modified())
@@ -870,6 +877,28 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use crate::{Tool, ToolRegistry, ToolResult, WorkspacePolicy, write_workspace_policy};
+
+    #[test]
+    fn should_exclude_shell_spool_files_from_artifact_globs() {
+        // Spool files hold complete command output (#1638) and are internal
+        // working state; a contract glob like `**/*.log` must never surface
+        // them as deliverable artifacts.
+        let ws = tempfile::tempdir().unwrap();
+        std::fs::write(ws.path().join("keep.log"), "artifact\n").unwrap();
+        let spool_dir = ws.path().join(".octos").join("tmp").join("shell");
+        std::fs::create_dir_all(&spool_dir).unwrap();
+        std::fs::write(spool_dir.join("output-0000000000001-0000.log"), "spool\n").unwrap();
+
+        let matches = resolve_glob_matches(ws.path(), "**/*.log", None).expect("glob");
+        assert!(
+            matches.iter().any(|p| p.ends_with("keep.log")),
+            "real artifacts still match: {matches:?}"
+        );
+        assert!(
+            matches.iter().all(|p| !octos_core::is_shell_spool_path(p)),
+            "shell spool files must not surface as artifacts: {matches:?}"
+        );
+    }
 
     #[derive(Clone, Default)]
     struct CaptureSendFileTool {

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -19981,7 +19981,31 @@ fn parse_git_history_line(line: &str) -> Option<UiGitHistoryItem> {
 }
 
 fn should_skip_pane_dir(label: &str) -> bool {
-    matches!(label, ".git" | "target" | "node_modules")
+    matches!(label, ".git" | "target" | "node_modules" | ".octos")
+}
+
+#[cfg(test)]
+mod artifact_pane_exclusion_tests {
+    use super::should_skip_pane_dir;
+
+    /// `.octos` is the harness's workspace-local data dir — sessions,
+    /// validator outcomes, and #1638 shell output spools (complete command
+    /// output). The workspace/artifact panes enumerate every file under the
+    /// workspace recursively; surfacing that internal state (and offering
+    /// spools as openable artifacts) leaks working data the user never
+    /// produced. Runs in CI via the `artifact_pane` filter step (api-gated
+    /// module — an unmatched filter never runs, #2029).
+    #[test]
+    fn should_skip_octos_internal_dir_when_walking_panes() {
+        assert!(should_skip_pane_dir(".octos"));
+        // The existing exclusions stay.
+        assert!(should_skip_pane_dir(".git"));
+        assert!(should_skip_pane_dir("target"));
+        assert!(should_skip_pane_dir("node_modules"));
+        // Real project content still walks.
+        assert!(!should_skip_pane_dir("src"));
+        assert!(!should_skip_pane_dir("docs"));
+    }
 }
 
 fn format_size(bytes: u64) -> String {

--- a/crates/octos-core/src/lib.rs
+++ b/crates/octos-core/src/lib.rs
@@ -50,6 +50,6 @@ pub use types::{
 };
 pub use ui_protocol::{EventEnvelope, TurnContext};
 pub use utils::{
-    SAFE_FILENAME_MAX_BYTES, safe_filename, tool_output_limit, truncate_head_tail, truncate_utf8,
-    truncated_utf8,
+    SAFE_FILENAME_MAX_BYTES, SHELL_SPOOL_COMPONENTS, is_shell_spool_path, safe_filename,
+    tool_output_limit, truncate_head_tail, truncate_utf8, truncated_utf8,
 };

--- a/crates/octos-core/src/utils.rs
+++ b/crates/octos-core/src/utils.rs
@@ -1,5 +1,34 @@
 //! Shared utility functions.
 
+/// Workspace-relative components of the shell tool's full-output spool
+/// directory (#1638): `<workspace>/.octos/tmp/shell`.
+pub const SHELL_SPOOL_COMPONENTS: [&str; 3] = [".octos", "tmp", "shell"];
+
+/// True when `path` contains the shell spool directory component run
+/// (`.octos/tmp/shell`) anywhere along it.
+///
+/// Spool files hold complete (sanitized) command output and exist ONLY so
+/// the model can grep past its own output cap — they are internal working
+/// state, not user artifacts. Every surface that sweeps workspace files
+/// outward (the `send_file` allowlist, artifact-contract globbing, the UI
+/// artifact pane) uses this predicate to keep them out of outbound bundles.
+/// Component-wise matching is separator- and canonicalization-independent,
+/// so the same check holds on Windows paths and on partially resolved ones.
+pub fn is_shell_spool_path(path: &std::path::Path) -> bool {
+    let names: Vec<&std::ffi::OsStr> = path
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(name) => Some(name),
+            _ => None,
+        })
+        .collect();
+    names.windows(SHELL_SPOOL_COMPONENTS.len()).any(|w| {
+        w.iter()
+            .zip(SHELL_SPOOL_COMPONENTS.iter())
+            .all(|(seen, want)| *seen == std::ffi::OsStr::new(want))
+    })
+}
+
 /// Truncate a string in-place at a UTF-8 safe boundary, appending a suffix.
 ///
 /// Does nothing if `s.len() <= max_len`.
@@ -226,6 +255,25 @@ mod tests {
         // Should not panic or produce invalid UTF-8
         assert!(result.is_char_boundary(0));
         assert!(result.contains("bytes omitted"));
+    }
+
+    #[test]
+    fn should_match_spool_component_run_when_checking_shell_spool_paths() {
+        use std::path::Path;
+        assert!(is_shell_spool_path(Path::new(
+            "/ws/.octos/tmp/shell/output-1-0.log"
+        )));
+        assert!(is_shell_spool_path(Path::new(".octos/tmp/shell/x.log")));
+        assert!(is_shell_spool_path(Path::new(
+            "/deep/nested/ws/.octos/tmp/shell"
+        )));
+        // Partial runs and lookalikes do not match.
+        assert!(!is_shell_spool_path(Path::new(
+            "/ws/.octos/tmp/other/x.log"
+        )));
+        assert!(!is_shell_spool_path(Path::new("/ws/.octos/shell/x.log")));
+        assert!(!is_shell_spool_path(Path::new("/ws/tmp/shell/x.log")));
+        assert!(!is_shell_spool_path(Path::new("/ws/src/main.rs")));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`shell` output over its 30KB cap (`octos_core::tool_output_limit("shell")`) is head/tail-cut by the execution loop with `[N bytes omitted]` — the omitted middle is gone forever. For `cargo test` / `npm test` runs the middle is where the failures live, and the model's only recovery is re-running the command, paying the run AND the tokens again. #2124 gave `read_file`/`grep` recovery advice; shell was deferred because its real recovery is spooling.

## Change (shell tool only)

When a foreground command's combined stream (stdout + stderr) plus its appended suffixes would exceed the cap, the FULL **sanitized** stream is written to `<workspace>/.octos/tmp/shell/output-<millis>-<seq>.log` and the inline result becomes head + tail + a pi-style footer:

```
[Showing lines 1-1710 and 10896-12000 of 12000. Full output: /path/to/ws/.octos/tmp/shell/output-…-0000.log]
```

The model then greps/reads the file instead of re-running. Head and tail are cut on line boundaries so the footer ranges are exact; a single line too big for its budget switches the footer to a byte-range form rather than reporting line numbers that would be lies.

Reference: the pi harness — `packages/coding-agent/src/core/tools/bash.ts` (footer at ~436-440: `[Showing lines X-Y of Z. Full output: /tmp/...]`) and `output-accumulator.ts` (keeps a display tail, opens a temp file when the full output must survive). Pi's up-front description warning ("If truncated, full output is saved to a temp file") is adopted in shell's `description()`, which also names the location (`.octos/tmp/shell/`).

## Security posture (adversarial review round)

- **Sanitize-before-persist.** The stream runs through `sanitize_tool_output` (API keys, bearer tokens, secret assignments, long hex, data URIs, injection defusing) IN the tool, before the spool write and before the view/footer are computed. The spool, the inline view, and the footer's offsets all describe the same redacted bytes; the loop's own sanitize pass is a no-op on them. The on-disk copy can no longer keep credentials the model-visible copy had redacted. Mutation-verified: dropping the in-tool sanitize fails `should_sanitize_stream_before_persisting_spool` on the "raw credential persisted" assertion.
- **Owner-only permissions.** Spool dir `0700`, files `0600` via fchmod on the open handle (Unix). Windows has no mode-bit story — content protection there is the workspace's own ACLs (stated, not pretended away).
- **Outbound sweep exclusions** via `octos_core::is_shell_spool_path` (component-run match on `.octos/tmp/shell`, separator- and canonicalization-independent): `send_file` refuses spool paths before any allowlist logic (lexical AND canonical form), artifact-contract globbing (`resolve_glob_matches`) skips them, and the UI workspace/artifact panes skip `.octos` entirely (`should_skip_pane_dir`). The pane guard is `api`-gated, so it gets its own explicit CI filter step (`artifact_pane`) — an unmatched filter never runs (#2029).
- **No spooling on read-only or write-fenced profiles.** New `Sandbox::workspace_scratch_writable()` — macOS: `workspace_write && write_allow_globs.is_none()` (the same predicate its TMPDIR placement uses); bwrap/Landlock/AppContainer: `workspace_write` (a #1976 fence already degrades it to false at construction); Docker: `mount_mode != ReadOnly`. When false, the harness does not mutate from the host a workspace the sandbox told the shell is immutable — the historic in-tool cut applies instead. Mutation-verified: dropping the gate fails `should_not_spool_when_workspace_read_only`.
- **Symlink hardening.** All spool creates go through the #1976 `open_confined` component-wise `O_NOFOLLOW` walk (`tools/write_grant.rs`): a pre-planted `.octos/tmp/shell` symlink fails `ELOOP` instead of redirecting writes outside the workspace, and with no spool created, prune never runs either. Prune additionally re-checks the dir is a real directory and never deletes the file just written, so a dir crowded with future-stamped names cannot evict the spool whose path is being returned. Cross-process `create_new` collisions retry with the next sequence number. Non-Unix degrades to `open_confined`'s documented ancestor-scan fallback. The prune-time path-based deletes retain a narrow post-walk swap race — the same documented residual class as `open_confined`'s non-Unix mode; the create path is the race-free boundary.

## Budgeting (backstop never re-cuts)

All suffixes — exit code, sandbox-denial hint, #28a change receipt (unbounded-ish: up to 20 paths), warn nudge — are assembled FIRST; the spool decision and the head/tail view are computed from `limit − suffixes.len()`, on the sanitized final representation. So the assembled result fits the cap exactly, the loop backstop never fires on a spooled result, and the at-cap boundary case collapses into the same arithmetic. Pinned by `should_include_receipt_in_budget_when_receipt_present` (20 long-named files + >cap output ⇒ total ≤ 30000 with footer AND receipt present) and by two loop-path goldens driving the real dispatch→sanitize→backstop pipeline (`small_shell_output_reaches_the_model_byte_identical_through_the_loop`, `spooled_shell_output_reaches_the_model_with_footer_intact_through_the_loop`).

## Recovery advice that can't lie

`Tool::truncation_recovery` (the #2124 hook) as belt-and-braces if the backstop still fires: it names the spool only when (a) it was written by the LATEST invocation of that command — every new invocation forgets its registry entry up front, covering small reruns, timeouts, and spawn failures — and (b) the host file still exists (a sibling session sharing the workspace may have pruned it; registries are per-session, the directory is shared). Otherwise the honest fallback: re-run redirected to a file. Under Docker, footers and advice print the in-container path (`Sandbox::workspace_remap_root` → `/workspace/...`).

## Why `<workspace>/.octos/tmp/shell/` and not the OS temp dir

A spool the sandbox then blocks reading is worse than useless. The workspace is the one location every sandbox backend lets the model's follow-up `shell` call read:

- **bwrap** mounts `--tmpfs /tmp` and `--tmpfs /var/tmp` (`sandbox/bwrap.rs`), so a host `std::env::temp_dir()` spool would be invisible; the workspace is bound at its own path (reads work under ro-bind too — though read-only profiles no longer spool at all, see above).
- **macOS seatbelt** default profile allows `(allow file-read*)` globally; the restricted-read profile grants `(allow file-read* (subpath "<cwd>"))` (`sandbox/macos.rs`) — verified live with a `sandbox-exec` probe of the equivalent restricted profile: a spool under the workspace greps fine, a file in host `/tmp` gets `Operation not permitted`.
- **Landlock** grants the cwd.
- **Windows / NoSandbox**: no restriction; the footer prints the path via `Path::display()` (native separators), and no Unix-only APIs are used outside `#[cfg(unix)]` blocks.
- **Docker** with a mounted workspace sees it at `/workspace` — the footer/advice print that in-container path; the harness-side `grep`/`read_file` tools keep working on the host path either way.

`.octos/` inside the workspace is already established harness-write territory (session transcripts, `.octos/work`, `validator_outcomes.jsonl`). A `*` gitignore written inside the spool dir keeps the files out of `git status` and thereby out of the #28a change receipt.

## Lifecycle bound

Newest 16 spools per workspace directory; older `output-*.log` files are deleted on the next spool write — never the file just written (fixed-width millis+seq stamp makes lexicographic order = recency order). No daemon, no timers.

## Known pre-existing limitation (tracking only)

stdout/stderr interleaving was already lost before this change — `wait_with_output` captures the two streams separately and the result concatenates them (`stdout` + `--- stderr ---` + `stderr`); the spool preserves exactly that concatenated view, not the original interleaving.

## Not included (checked, separate code paths)

`coding_tools.rs` `BashTool` (`bash`) and `ExecCommandTool` (`exec_command`) do NOT share ShellTool's output path — they assemble output through their own local `truncate_output()` helper (`coding_tools.rs:65`, used at `:568` and `:2111`); they share only the 28a receipt module and the command-policy judge. Per scope, this PR covers `shell` alone.

## Tests (TDD, red first)

`tools/shell.rs::spool_tests` through the real `execute` path, plus loop-path goldens in `agent/loop_runner_tests.rs`, `octos-core` predicate tests, and one guard per sweep surface:

- `should_spool_full_output_with_footer_when_output_exceeds_cap` (spool byte-equals the full stream; mutation-checked: removing the spool write fails it)
- `should_report_line_ranges_matching_shown_content_when_spooled`
- `should_return_output_unchanged_and_no_spool_when_output_under_cap`
- `should_sanitize_stream_before_persisting_spool` (mutation-checked)
- `should_restrict_spool_permissions_when_persisting`
- `should_not_spool_when_workspace_read_only` (mutation-checked)
- `should_include_receipt_in_budget_when_receipt_present`
- `should_fall_back_to_generic_advice_when_spool_file_deleted`
- `should_forget_stale_spool_when_command_reruns_without_spooling`
- `should_keep_fresh_spool_when_future_stamped_files_crowd_the_dir`
- `should_refuse_spool_when_spool_dir_is_symlink`
- `should_emit_remapped_footer_path_when_sandbox_remaps_workspace`
- `should_name_spool_path_in_truncation_recovery_when_backstop_fires`
- `should_advise_rerun_with_redirect_when_no_spool_recorded_for_command`
- `should_prune_spool_dir_to_capacity_when_spools_accumulate`
- `should_use_byte_footer_when_single_line_exceeds_budget` / `should_keep_view_within_budget_when_line_data_spooled`
- `should_state_spool_contract_in_description`
- `small_shell_output_reaches_the_model_byte_identical_through_the_loop` / `spooled_shell_output_reaches_the_model_with_footer_intact_through_the_loop` (real loop)
- `should_match_spool_component_run_when_checking_shell_spool_paths` (octos-core)
- `should_refuse_send_when_path_is_shell_spool` (send_file, with a non-spool control)
- `should_exclude_shell_spool_files_from_artifact_globs` (workspace contract)
- `should_skip_octos_internal_dir_when_walking_panes` (UI panes, api-gated, new CI filter step)

## Verification

- `cargo test -p octos-agent --lib` — 2718 passed; 0 failed; 3 ignored
- `cargo test -p octos-core --lib` — 359 passed; 0 failed; 1 ignored
- `cargo test -p octos-cli --features api --lib artifact_pane` — 1 passed
- `cargo clippy -p octos-agent --all-targets -- -D warnings` — clean
- `cargo clippy -p octos-core --all-targets -- -D warnings` — clean
- `cargo clippy -p octos-cli --features api --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Refs #1638
