### PR TITLE
feat(tools): flag-gated windowed read_file + partial-view write guard

### DIFF
--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -50,10 +50,23 @@ use octos_core::{PathClassification, SessionScope};
 #[derive(Debug, Clone)]
 pub struct ToolInputError(String);
 
+/// Upper bound on a [`ToolInputError`]'s model-facing message. The message can
+/// embed caller-controlled content (unknown parameter names), so it is bounded
+/// at construction — well under every tool's output limit (`tool_output_limit`
+/// min is 20_000) — so an armed tool's `Err` can never exceed the cap and be
+/// mangled by the execution loop's blind head/tail cut (#2193 R4). Real
+/// validation messages are a few hundred bytes.
+pub(crate) const TOOL_INPUT_ERROR_MAX_BYTES: usize = 4096;
+
 impl ToolInputError {
-    /// Build an input-validation error from a model-facing message.
+    /// Build an input-validation error from a model-facing message, bounded to
+    /// [`TOOL_INPUT_ERROR_MAX_BYTES`] so caller-supplied content (e.g. a
+    /// pathological unknown-parameter name) cannot make the error exceed the
+    /// tool-output cap.
     pub fn new(message: impl Into<String>) -> Self {
-        Self(message.into())
+        let mut message = message.into();
+        octos_core::truncate_utf8(&mut message, TOOL_INPUT_ERROR_MAX_BYTES, "…[truncated]");
+        Self(message)
     }
 }
 

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1349,6 +1349,95 @@ pub async fn read_no_follow(path: &Path) -> std::io::Result<String> {
     .unwrap_or_else(|e| Err(std::io::Error::other(e)))
 }
 
+/// Open a file read-only, atomically rejecting symlinks (O_NOFOLLOW on Unix).
+///
+/// SECURITY: the flags here MUST match [`read_no_follow`]'s open exactly.
+#[cfg(unix)]
+fn open_no_follow_ro(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_no_follow_ro(path: &Path) -> std::io::Result<std::fs::File> {
+    if path.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "symlink rejected",
+        ));
+    }
+    std::fs::OpenOptions::new().read(true).open(path)
+}
+
+/// The descriptor-derived facts an armed windowed read needs beyond the bytes.
+pub(crate) struct ReadMeta {
+    /// [`crate::tools::read_window::ViewEpoch`] taken from the SAME descriptor
+    /// the bytes came from — not a separate path stat — so it describes the
+    /// exact inode whose bytes were shown (#2193 R4, read-side TOCTOU).
+    /// `None` only if the descriptor's metadata was unavailable, which never
+    /// authorizes a write.
+    pub epoch: Option<crate::tools::read_window::ViewEpoch>,
+    /// The returned content is a DECODE of the on-disk bytes (PDF text
+    /// extraction), not the bytes themselves — so a whole-file rewrite
+    /// reconstructed from it can never be faithful, and the view must never be
+    /// allowed to reach COMPLETE (#2193 R4, PDF false-COMPLETE).
+    pub transformed: bool,
+}
+
+/// Like [`read_no_follow`] but also returns the [`ReadMeta`] the armed
+/// windowed-read ledger needs. Kept as a distinct entry point so the many
+/// non-armed `read_no_follow` callers pay nothing for the extra `fstat`.
+pub(crate) async fn read_no_follow_with_meta(path: &Path) -> std::io::Result<(String, ReadMeta)> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || {
+        use std::io::{Read, Seek, SeekFrom};
+        let mut file = open_no_follow_ro(&path)?;
+        // fstat the DESCRIPTOR (not a re-resolution of the path): binds the
+        // epoch to the exact inode these bytes are read from.
+        let epoch = file
+            .metadata()
+            .ok()
+            .and_then(|m| crate::tools::read_window::ViewEpoch::from_metadata(&m));
+        // Same PDF handling as read_no_follow, reading the rest from the SAME
+        // O_NOFOLLOW descriptor (seek back to 0), never by re-opening the path.
+        let mut magic = [0u8; 5];
+        let n = file.read(&mut magic)?;
+        file.seek(SeekFrom::Start(0))?;
+        if n >= 5 && &magic == b"%PDF-" {
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)?;
+            match pdf_extract::extract_text_from_mem(&bytes) {
+                Ok(text) => Ok((
+                    text,
+                    ReadMeta {
+                        epoch,
+                        transformed: true,
+                    },
+                )),
+                Err(err) => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("pdf extraction failed: {err}"),
+                )),
+            }
+        } else {
+            let mut content = String::with_capacity(n);
+            file.read_to_string(&mut content)?;
+            Ok((
+                content,
+                ReadMeta {
+                    epoch,
+                    transformed: false,
+                },
+            ))
+        }
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+}
+
 /// Write content to a file, atomically rejecting symlinks via O_NOFOLLOW on Unix.
 ///
 /// Eliminates the TOCTOU race between `reject_symlink` and `tokio::fs::write`.
@@ -1387,8 +1476,8 @@ pub(crate) enum CheckedWrite {
     /// The opened descriptor matched the authorizing epoch and was truncated
     /// and rewritten.
     Written,
-    /// The opened descriptor's `(mtime, size)` no longer matched what
-    /// authorized the write — nothing was written.
+    /// The opened descriptor's epoch (mtime/size/ctime/inode) no longer
+    /// matched what authorized the write — nothing was written.
     EpochChanged {
         /// The descriptor's actual epoch at open time.
         found: crate::tools::read_window::ViewEpoch,
@@ -1435,12 +1524,12 @@ pub(crate) async fn write_no_follow_checked(
             }
         }
         let mut file = opts.open(&path)?;
-        // fstat the DESCRIPTOR itself (not a re-resolution of the path).
+        // fstat the DESCRIPTOR itself (not a re-resolution of the path). The
+        // epoch binds mtime/size/ctime/inode, so a same-size replacement that
+        // forged mtime is caught by the ctime (or inode) mismatch.
         let meta = file.metadata()?;
-        let found = crate::tools::read_window::ViewEpoch {
-            mtime: meta.modified()?,
-            size: meta.len(),
-        };
+        let found = crate::tools::read_window::ViewEpoch::from_metadata(&meta)
+            .ok_or_else(|| std::io::Error::other("descriptor metadata unavailable"))?;
         if found != expected {
             return Ok(CheckedWrite::EpochChanged { found });
         }
@@ -1503,16 +1592,71 @@ mod nofollow_tests {
     // external replacement in the narrow authorize→truncate window is caught
     // on the exact opened object, not a re-resolved path.
     #[tokio::test]
+    async fn checked_write_refuses_a_same_size_same_mtime_content_swap() {
+        // #2193 R4 (codex H2): the (mtime,size)-only epoch authorized an
+        // overwrite of content the model never saw when a replacement kept the
+        // size and FORGED the mtime back. The epoch now also binds ctime, and
+        // forging mtime with `set_modified` is itself what bumps ctime — so the
+        // swap is caught. Under the old epoch this returned `Written` (RED).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"AAAAAAAAAA").unwrap(); // 10 bytes
+        let meta = std::fs::metadata(&path).unwrap();
+        let mtime = meta.modified().unwrap();
+        let authorized = crate::tools::read_window::ViewEpoch::from_metadata(&meta).unwrap();
+
+        std::fs::write(&path, b"BBBBBBBBBB").unwrap(); // same size, new content
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+        let now = std::fs::metadata(&path).unwrap();
+        assert_eq!(now.len(), authorized.size, "size still matches");
+        assert_eq!(now.modified().unwrap(), mtime, "mtime forged back to match");
+
+        let result = write_no_follow_checked(&path, b"CCCCCCCCCC", authorized)
+            .await
+            .unwrap();
+        assert!(
+            matches!(result, CheckedWrite::EpochChanged { .. }),
+            "same-size, same-mtime content swap must be refused (ctime binding)",
+        );
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            b"BBBBBBBBBB",
+            "the swapped-in bytes must be intact — never blind-clobbered",
+        );
+    }
+
+    #[tokio::test]
+    async fn read_with_meta_reports_untransformed_epoch_from_the_read_fd() {
+        // #2193 R4 (codex H2b/H6): the armed ledger needs the epoch taken from
+        // the READ descriptor (not a separate path stat), and transformed=false
+        // for ordinary text.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hello.txt");
+        std::fs::write(&path, b"hello world\n").unwrap();
+        let (content, meta) = read_no_follow_with_meta(&path).await.unwrap();
+        assert_eq!(content, "hello world\n");
+        assert!(!meta.transformed, "plain text is not a transform");
+        let epoch = meta.epoch.expect("descriptor epoch");
+        assert_eq!(epoch.size, 12);
+        let independent =
+            crate::tools::read_window::ViewEpoch::from_metadata(&std::fs::metadata(&path).unwrap())
+                .unwrap();
+        assert_eq!(epoch, independent, "epoch describes the exact inode read");
+    }
+
+    #[tokio::test]
     async fn write_no_follow_checked_writes_when_epoch_matches() {
         use crate::tools::read_window::ViewEpoch;
         let dir = tempfile::TempDir::new().unwrap();
         let file = dir.path().join("f.txt");
         std::fs::write(&file, "original").unwrap();
         let meta = std::fs::metadata(&file).unwrap();
-        let epoch = ViewEpoch {
-            mtime: meta.modified().unwrap(),
-            size: meta.len(),
-        };
+        let epoch = ViewEpoch::from_metadata(&meta).unwrap();
 
         let outcome = write_no_follow_checked(&file, b"rebuilt", epoch)
             .await
@@ -1531,10 +1675,7 @@ mod nofollow_tests {
         let file = dir.path().join("f.txt");
         std::fs::write(&file, "original small").unwrap();
         let meta = std::fs::metadata(&file).unwrap();
-        let authorized = ViewEpoch {
-            mtime: meta.modified().unwrap(),
-            size: meta.len(),
-        };
+        let authorized = ViewEpoch::from_metadata(&meta).unwrap();
 
         // The file is replaced (new size ⇒ new epoch) in the window between
         // the guard authorizing against `authorized` and this write opening

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -767,6 +767,7 @@ pub trait Tool: Send + Sync {
 // Tool registry (extracted to its own module)
 /// Observe-only probe for the read-paging decision (changes no behaviour).
 pub(crate) mod read_paging_probe;
+pub(crate) mod read_window;
 mod registry;
 pub use registry::ToolRegistry;
 

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1604,6 +1604,9 @@ mod nofollow_tests {
     // (mtime, size) no longer matches what authorized the write — so an
     // external replacement in the narrow authorize→truncate window is caught
     // on the exact opened object, not a re-resolved path.
+    // Unix-only: off-Unix the epoch has no ctime, so the documented weaker
+    // (mtime,size) fallback cannot detect a same-size/same-mtime swap.
+    #[cfg(unix)]
     #[tokio::test]
     async fn checked_write_refuses_a_same_size_same_mtime_content_swap() {
         // #2193 R4 (codex H2): the (mtime,size)-only epoch authorized an

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1381,6 +1381,78 @@ pub async fn write_no_follow(path: &Path, content: &[u8]) -> std::io::Result<()>
     .unwrap_or_else(|e| Err(std::io::Error::other(e)))
 }
 
+/// Outcome of an epoch-bound overwrite ([`write_no_follow_checked`]).
+#[derive(Debug)]
+pub(crate) enum CheckedWrite {
+    /// The opened descriptor matched the authorizing epoch and was truncated
+    /// and rewritten.
+    Written,
+    /// The opened descriptor's `(mtime, size)` no longer matched what
+    /// authorized the write — nothing was written.
+    EpochChanged {
+        /// The descriptor's actual epoch at open time.
+        found: crate::tools::read_window::ViewEpoch,
+    },
+}
+
+/// Overwrite an EXISTING file, but only if the descriptor we open still
+/// matches `expected` (#1638 R1 — TOCTOU).
+///
+/// The armed write guard authorizes an overwrite against a *stat of the path*.
+/// A plain `write_no_follow` then opens the path AGAIN and truncates whatever
+/// it resolves to — so an external replacement in that narrow authorize→open
+/// window is silently clobbered. This binds the authorization to the exact
+/// opened inode: it opens WITHOUT `O_TRUNC`, `fstat`s the descriptor, and only
+/// truncates + writes when that descriptor's `(mtime, size)` still equals the
+/// epoch that authorized the write. `O_NOFOLLOW` still rejects a symlink swap;
+/// operating on the validated descriptor (not a re-resolved path) closes the
+/// race even against a same-name inode swap after validation.
+pub(crate) async fn write_no_follow_checked(
+    path: &Path,
+    content: &[u8],
+    expected: crate::tools::read_window::ViewEpoch,
+) -> std::io::Result<CheckedWrite> {
+    let path = path.to_owned();
+    let content = content.to_owned();
+    tokio::task::spawn_blocking(move || {
+        use std::io::Write;
+        let mut opts = std::fs::OpenOptions::new();
+        // No create, no truncate — we must inspect the descriptor before
+        // destroying its contents.
+        opts.write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.custom_flags(libc::O_NOFOLLOW);
+        }
+        #[cfg(not(unix))]
+        {
+            if path.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "symlink rejected",
+                ));
+            }
+        }
+        let mut file = opts.open(&path)?;
+        // fstat the DESCRIPTOR itself (not a re-resolution of the path).
+        let meta = file.metadata()?;
+        let found = crate::tools::read_window::ViewEpoch {
+            mtime: meta.modified()?,
+            size: meta.len(),
+        };
+        if found != expected {
+            return Ok(CheckedWrite::EpochChanged { found });
+        }
+        // The validated descriptor is the one we truncate and rewrite.
+        file.set_len(0)?;
+        file.write_all(&content)?;
+        Ok(CheckedWrite::Written)
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+}
+
 // #1976 note: `create_only` (`O_CREAT|O_EXCL`) enforcement moved into the
 // component-wise confined `openat` walk in `tools::write_grant::open_confined`
 // (which also closes the ancestor-symlink TOCTOU a whole-path lexical open
@@ -1422,6 +1494,65 @@ mod nofollow_tests {
 
         let content = read_no_follow(&file).await.unwrap();
         assert_eq!(content, "hello");
+    }
+
+    // R1 (#1638): the epoch-bound writer closes the TOCTOU between the write
+    // guard's authorizing stat and the truncating open. It fstat's the
+    // descriptor it is about to truncate and refuses if that inode's
+    // (mtime, size) no longer matches what authorized the write — so an
+    // external replacement in the narrow authorize→truncate window is caught
+    // on the exact opened object, not a re-resolved path.
+    #[tokio::test]
+    async fn write_no_follow_checked_writes_when_epoch_matches() {
+        use crate::tools::read_window::ViewEpoch;
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("f.txt");
+        std::fs::write(&file, "original").unwrap();
+        let meta = std::fs::metadata(&file).unwrap();
+        let epoch = ViewEpoch {
+            mtime: meta.modified().unwrap(),
+            size: meta.len(),
+        };
+
+        let outcome = write_no_follow_checked(&file, b"rebuilt", epoch)
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, CheckedWrite::Written),
+            "a matching epoch must write"
+        );
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "rebuilt");
+    }
+
+    #[tokio::test]
+    async fn write_no_follow_checked_refuses_a_replaced_inode() {
+        use crate::tools::read_window::ViewEpoch;
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("f.txt");
+        std::fs::write(&file, "original small").unwrap();
+        let meta = std::fs::metadata(&file).unwrap();
+        let authorized = ViewEpoch {
+            mtime: meta.modified().unwrap(),
+            size: meta.len(),
+        };
+
+        // The file is replaced (new size ⇒ new epoch) in the window between
+        // the guard authorizing against `authorized` and this write opening
+        // the descriptor.
+        std::fs::write(&file, "REPLACED with different, important, longer content").unwrap();
+
+        let outcome = write_no_follow_checked(&file, b"model rebuild", authorized)
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, CheckedWrite::EpochChanged { .. }),
+            "a replaced inode must be refused, not truncated"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&file).unwrap(),
+            "REPLACED with different, important, longer content",
+            "the descriptor the guard did not authorize must be left intact"
+        );
     }
 
     /// Pins the PDF auto-extract path (mini5 invoice regression

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -230,6 +230,28 @@ impl Tool for ReadFileTool {
         ctx: &ToolContext,
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
+        let mut result = self.execute_capped_inner(ctx, args).await?;
+        // #2193 R4: ONE release-enforced cap over every armed return (success
+        // and early errors), so no caller-controlled path or message can slip
+        // past the loop's blind head/tail cut. Byte-mode also clamps to the
+        // tighter window bound inside; this is the uniform outer backstop.
+        if self.window_armed() {
+            octos_core::truncate_utf8(
+                &mut result.output,
+                octos_core::tool_output_limit(self.name()),
+                "",
+            );
+        }
+        Ok(result)
+    }
+}
+
+impl ReadFileTool {
+    async fn execute_capped_inner(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: ReadFileInput =
             super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
@@ -391,8 +413,8 @@ impl Tool for ReadFileTool {
         // #2131 refusal (a byte read is bounded by construction).
         if let Some(requested_offset) = input.byte_offset {
             use super::read_window::WINDOW_MAX_BYTES;
-            let content = match super::read_no_follow(&path).await {
-                Ok(c) => c,
+            let (content, read_meta) = match super::read_no_follow_with_meta(&path).await {
+                Ok(cm) => cm,
                 Err(e) => return Ok(super::file_io_error(e, &input.path)),
             };
             let total = content.len();
@@ -441,12 +463,17 @@ impl Tool for ReadFileTool {
             // mangling the footer in a release build.
             output = clamp_armed_return(output);
             let session = ctx.parent_session_key.clone().unwrap_or_default();
-            let epoch = current_mtime.map(|mtime| super::read_window::ViewEpoch {
-                mtime,
-                size: file_size as u64,
-            });
             let tainted = crate::sanitize::sanitize_tool_output(&output) != output;
-            super::read_window::record_view(&session, &path, epoch, start_b, end_b, total, tainted);
+            super::read_window::record_view(
+                &session,
+                &path,
+                read_meta.epoch,
+                start_b,
+                end_b,
+                total,
+                tainted,
+                read_meta.transformed,
+            );
             return Ok(ToolResult {
                 output,
                 success: true,
@@ -480,8 +507,8 @@ impl Tool for ReadFileTool {
         }
 
         // Read file (O_NOFOLLOW atomically rejects symlinks, no TOCTOU race)
-        let content = match super::read_no_follow(&path).await {
-            Ok(c) => c,
+        let (content, read_meta) = match super::read_no_follow_with_meta(&path).await {
+            Ok(cm) => cm,
             Err(e) => return Ok(super::file_io_error(e, &input.path)),
         };
 
@@ -692,10 +719,6 @@ impl Tool for ReadFileTool {
         // placeholders for real content.
         if window_armed {
             let session = ctx.parent_session_key.clone().unwrap_or_default();
-            let epoch = current_mtime.map(|mtime| super::read_window::ViewEpoch {
-                mtime,
-                size: file_size as u64,
-            });
             let byte_start = line_start_byte_offset(&content, start + 1);
             let byte_end = if included_end >= total_lines {
                 content.len()
@@ -706,11 +729,12 @@ impl Tool for ReadFileTool {
             super::read_window::record_view(
                 &session,
                 &path,
-                epoch,
+                read_meta.epoch,
                 byte_start,
                 byte_end,
                 content.len(),
                 tainted,
+                read_meta.transformed,
             );
         }
 

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -809,6 +809,34 @@ mod tests {
     use super::*;
     use crate::tools::ConcurrencyClass;
 
+    #[tokio::test]
+    async fn armed_read_caps_an_oversized_malformed_argument_error() {
+        // #2193 R4 (codex round 4): an armed tool's Err path must be bounded
+        // too — a pathological caller-controlled unknown-parameter name must
+        // not exceed the tool-output cap and get mangled by the loop's blind
+        // head/tail cut. The error stays a ToolInputError (downcastable).
+        let tool = ReadFileTool::new("/tmp").with_window_enforcement(true);
+        let big_key = "k".repeat(60_000);
+        let mut map = serde_json::Map::new();
+        map.insert(big_key, serde_json::json!(1));
+        map.insert("path".to_string(), serde_json::json!("f.txt"));
+        let err = match tool.execute(&serde_json::Value::Object(map)).await {
+            Ok(_) => panic!("an unknown parameter must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.chain()
+                .any(|src| src.is::<crate::tools::ToolInputError>()),
+            "the error identity must stay ToolInputError: {err:#}",
+        );
+        let rendered = format!("{err}");
+        assert!(
+            rendered.len() <= crate::tools::TOOL_INPUT_ERROR_MAX_BYTES + 64,
+            "armed malformed-arg error must be capped (got {} bytes)",
+            rendered.len(),
+        );
+    }
+
     #[test]
     fn read_file_tool_is_safe() {
         // read_file is read-only and side-effect-free — the M8.8 default

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -76,6 +76,15 @@ struct ReadFileInput {
     /// `limit: 100` as "stop at line 100".
     #[serde(default)]
     limit: Option<usize>,
+    /// #1638: raw byte mode — 0-indexed byte position to start from. For
+    /// content line offsets cannot reach: a single line larger than the
+    /// window. Mutually exclusive with the line parameters.
+    #[serde(default)]
+    byte_offset: Option<usize>,
+    /// #1638: maximum bytes to return in raw byte mode (clamped to the
+    /// window). Requires `byte_offset`.
+    #[serde(default)]
+    byte_limit: Option<usize>,
 }
 
 /// Resolve the effective `(start_line, end_line)` pair from the three
@@ -115,8 +124,9 @@ impl Tool for ReadFileTool {
     // where they are always current.
     fn description(&self) -> &str {
         "Read the contents of a file. Returns the file content with line numbers. Large results \
-         are truncated to a bounded window and the message names the exact call (offset/limit) \
-         to continue — page forward until no continuation notice remains."
+         are truncated to a bounded window and the message names the exact call to continue \
+         (offset/limit, or byte_offset for raw byte paging of very long lines) — page forward \
+         until no continuation notice remains."
     }
 
     fn tags(&self) -> &[&str] {
@@ -142,6 +152,14 @@ impl Tool for ReadFileTool {
                 "limit": {
                     "type": "integer",
                     "description": "Optional maximum number of lines to read, starting at start_line (alternative to end_line — do not provide both)"
+                },
+                "byte_offset": {
+                    "type": "integer",
+                    "description": "Raw byte mode: 0-indexed byte position to start reading from. Returns file bytes without line numbers — for single lines too long to page by line offset. Do not combine with start_line/end_line/limit."
+                },
+                "byte_limit": {
+                    "type": "integer",
+                    "description": "Raw byte mode: maximum bytes to return (default and cap: the read window). Requires byte_offset."
                 }
             },
             "required": ["path"]
@@ -224,6 +242,34 @@ impl Tool for ReadFileTool {
                 }
             };
 
+        // #1638: raw byte mode is a distinct coordinate system — mixing it
+        // with line parameters is ambiguous and rejected, like end_line+limit.
+        if input.byte_offset.is_some() || input.byte_limit.is_some() {
+            let message = if input.start_line.is_some()
+                || input.end_line.is_some()
+                || input.limit.is_some()
+            {
+                Some(
+                    "Provide either line parameters (start_line/end_line/limit) or byte \
+                     parameters (byte_offset/byte_limit), not both."
+                        .to_string(),
+                )
+            } else if input.byte_offset.is_none() {
+                Some("'byte_limit' requires 'byte_offset'.".to_string())
+            } else if input.byte_limit == Some(0) {
+                Some("'byte_limit' must be at least 1.".to_string())
+            } else {
+                None
+            };
+            if let Some(message) = message {
+                return Ok(ToolResult {
+                    output: message,
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        }
+
         // Phase 2-C of the SessionScope migration: when the host has
         // threaded a scope through `ToolContext`, use it as the single
         // source of truth for base_dir + path classification. Reads are
@@ -286,7 +332,13 @@ impl Tool for ReadFileTool {
         // We store the user-supplied range verbatim so the comparison here is
         // exact (without needing to know the file's total line count).
         let requested_range = user_range(start_line, end_line);
-        if let (Some(cache), Some(mtime)) = (ctx.file_state_cache.as_ref(), current_mtime) {
+        // #1638: a byte-mode request is NOT a line-range request — the cache
+        // stores line ranges, so a stored complete entry must never answer a
+        // byte request with the [FILE_UNCHANGED] stub (the byte branch below
+        // also never stores into the cache).
+        if input.byte_offset.is_none()
+            && let (Some(cache), Some(mtime)) = (ctx.file_state_cache.as_ref(), current_mtime)
+        {
             if let Some(entry) = cache.get(&path, mtime) {
                 if cache_matches_request(&entry, requested_range) {
                     return Ok(ToolResult {
@@ -302,6 +354,82 @@ impl Tool for ReadFileTool {
         // `OCTOS_READ_WINDOW=1` (production). Resolved once — every armed
         // branch below keys off this.
         let window_armed = self.window_armed();
+
+        // #1638: raw byte mode. Bypasses the M8.4 cache in BOTH directions —
+        // the cache's view ranges are line ranges, so a byte request must
+        // never be answered with a line-range [FILE_UNCHANGED] stub, and a
+        // byte view must never be stored as one — and bypasses the #2131
+        // refusal (a byte read is bounded by construction). Works unarmed
+        // too: the schema is static, so an advertised parameter always
+        // works; only the ledger recording is armed-gated.
+        if let Some(requested_offset) = input.byte_offset {
+            use super::read_window::{FOOTER_RESERVE, WINDOW_MAX_BYTES};
+            let content = match super::read_no_follow(&path).await {
+                Ok(c) => c,
+                Err(e) => return Ok(super::file_io_error(e, &input.path)),
+            };
+            let total = content.len();
+            if requested_offset >= total {
+                return Ok(ToolResult {
+                    output: format!(
+                        "byte_offset {requested_offset} is beyond the end of file ({total} bytes)"
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+            // Snap the start BACK to a UTF-8 boundary (re-serving at most 3
+            // bytes; never leaving a gap), the end back likewise, and
+            // guarantee at least one whole character of progress.
+            let mut start_b = requested_offset;
+            while start_b > 0 && !content.is_char_boundary(start_b) {
+                start_b -= 1;
+            }
+            let want = input
+                .byte_limit
+                .unwrap_or(WINDOW_MAX_BYTES)
+                .min(WINDOW_MAX_BYTES);
+            let mut end_b = start_b.saturating_add(want).min(total);
+            while end_b > start_b && !content.is_char_boundary(end_b) {
+                end_b -= 1;
+            }
+            if end_b <= start_b {
+                end_b = start_b + 1;
+                while end_b < total && !content.is_char_boundary(end_b) {
+                    end_b += 1;
+                }
+            }
+            let mut output = content[start_b..end_b].to_string();
+            if end_b < total {
+                output.push_str(&format!(
+                    "\n\n[read_file window: bytes {start_b}-{} of {total} (raw byte mode). \
+                     Continue with byte_offset: {end_b}.]",
+                    end_b - 1
+                ));
+            }
+            debug_assert!(
+                output.len() <= WINDOW_MAX_BYTES + FOOTER_RESERVE,
+                "byte-mode output + footer must stay within the reserve so the loop \
+                 backstop can never fire (got {} bytes)",
+                output.len()
+            );
+            if window_armed {
+                let session = ctx.parent_session_key.clone().unwrap_or_default();
+                let epoch = current_mtime.map(|mtime| super::read_window::ViewEpoch {
+                    mtime,
+                    size: file_size as u64,
+                });
+                let tainted = crate::sanitize::sanitize_tool_output(&output) != output;
+                super::read_window::record_view(
+                    &session, &path, epoch, start_b, end_b, total, tainted,
+                );
+            }
+            return Ok(ToolResult {
+                output,
+                success: true,
+                ..Default::default()
+            });
+        }
 
         // #2131 part 4: budget-aware reads. An UNBOUNDED read of a file larger
         // than the tool-output budget would be truncated on the way in and then
@@ -410,27 +538,39 @@ impl Tool for ReadFileTool {
             if window_armed && output.len() + formatted.len() > WINDOW_MAX_BYTES {
                 if idx == 0 {
                     // The first line of the window alone exceeds the whole
-                    // byte budget: line offsets cannot page within a line
-                    // (there is deliberately no byte-resume parameter — see
-                    // the read_window module docs), so hand the model an
-                    // exact shell command for the line instead, pi-style.
+                    // byte budget: line offsets cannot page within a line,
+                    // so hand the model the IN-TOOL byte-mode continuation.
+                    // Never a shell fallback — shell output is capped at
+                    // 30,000 bytes (tool_output_limit("shell")) and the loop
+                    // sanitizer redacts exactly what giant lines are made
+                    // of, so shell advice is self-defeating end to end.
+                    // Nothing is recorded in the view ledger here (the model
+                    // received no bytes); the fail-closed write guard treats
+                    // that absence as refuse-and-read-first. NOTE: no
+                    // caller-controlled text (path spellings are unbounded)
+                    // — the model knows the path from its own call.
+                    let line_start = line_start_byte_offset(&content, line_num);
                     let mut advice = format!(
                         "[read_file window: line {n} is {len} bytes — larger than the \
-                         {WINDOW_MAX_BYTES}-byte window, and read_file cannot page within a \
-                         line. Fetch it with the shell tool: sed -n '{n}p' '{p}' | head -c \
-                         {WINDOW_MAX_BYTES}, then advance with | tail -c +{next_byte}.",
+                         {WINDOW_MAX_BYTES}-byte window, and lines cannot be split across \
+                         line-mode pages. Read it in raw byte mode with byte_offset: \
+                         {line_start} (returns bytes without line numbers; follow the \
+                         byte_offset each footer names).",
                         n = line_num,
                         len = line.len(),
-                        p = input.path,
-                        next_byte = WINDOW_MAX_BYTES + 1,
                     );
                     if line_num < total_lines {
                         advice.push_str(&format!(
-                            " Continue with offset: {} for the lines after it.",
+                            " Lines after it resume at offset: {}.",
                             line_num + 1
                         ));
                     }
                     advice.push(']');
+                    debug_assert!(
+                        advice.len() <= octos_core::tool_output_limit("read_file"),
+                        "the giant-line advice must stay under the loop cap (got {} bytes)",
+                        advice.len()
+                    );
                     return Ok(ToolResult {
                         output: advice,
                         success: true,
@@ -520,16 +660,36 @@ impl Tool for ReadFileTool {
             }
         }
 
-        // #1638 (c): feed the partial-view ledger that backs write_file's
+        // #1638 (c): feed the view ledger that backs write_file's fail-closed
         // overwrite guard. Armed only — a disarmed read records nothing, so
-        // arming later never refuses on evidence gathered while off.
+        // arming later never trusts evidence gathered while off. Coverage is
+        // recorded in BYTES (the emitted line range converted to its raw byte
+        // span) so line-mode and byte-mode pages stitch in one coordinate
+        // system, and the view is TAINTED when the loop sanitizer would alter
+        // the output — the model then never received these exact bytes, and a
+        // whole-file rewrite from them would substitute redaction
+        // placeholders for real content.
         if window_armed {
+            let session = ctx.parent_session_key.clone().unwrap_or_default();
+            let epoch = current_mtime.map(|mtime| super::read_window::ViewEpoch {
+                mtime,
+                size: file_size as u64,
+            });
+            let byte_start = line_start_byte_offset(&content, start + 1);
+            let byte_end = if included_end >= total_lines {
+                content.len()
+            } else {
+                line_start_byte_offset(&content, included_end + 1)
+            };
+            let tainted = crate::sanitize::sanitize_tool_output(&output) != output;
             super::read_window::record_view(
+                &session,
                 &path,
-                current_mtime,
-                start + 1,
-                included_end,
-                total_lines,
+                epoch,
+                byte_start,
+                byte_end,
+                content.len(),
+                tainted,
             );
         }
 
@@ -539,6 +699,18 @@ impl Tool for ReadFileTool {
             ..Default::default()
         })
     }
+}
+
+/// Byte offset (into the raw content) where 1-indexed `line` starts.
+///
+/// Counted over `split_inclusive('\n')` so `\r\n` and a missing trailing
+/// newline are handled exactly; `line` past EOF returns `content.len()`.
+fn line_start_byte_offset(content: &str, line: usize) -> usize {
+    content
+        .split_inclusive('\n')
+        .take(line.saturating_sub(1))
+        .map(str::len)
+        .sum()
 }
 
 /// Encode the user-supplied (start_line, end_line) pair as a cache range.
@@ -1696,12 +1868,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_advise_shell_for_a_single_line_larger_than_the_window_when_armed() {
+    async fn should_advise_byte_mode_for_a_single_line_larger_than_the_window_when_armed() {
         // A line bigger than the whole byte window cannot be paged by line
-        // offset. Mirroring pi's `firstLineExceedsLimit`: no content, an
-        // exact shell command for the line, and the offset that continues
-        // past it. There is deliberately NO byte-resume parameter — see
-        // read_window.rs module docs.
+        // offset — the answer is the IN-TOOL raw byte mode, never a shell
+        // fallback: shell output is capped at 30,000 bytes
+        // (tool_output_limit("shell")), so a `head -c 49152` could never
+        // arrive intact even if advised.
         let dir = tempfile::tempdir().unwrap();
         let giant = format!("short first\n{}\nafter line", "G".repeat(60_000));
         std::fs::write(dir.path().join("giant_armed.txt"), &giant).unwrap();
@@ -1725,7 +1897,8 @@ mod tests {
             page1.output
         );
 
-        // Page two starts AT the giant line: advice, not content.
+        // Page two starts AT the giant line: advice naming the byte-mode
+        // continuation, not content.
         let page2 = tool
             .execute(&serde_json::json!({"path": "giant_armed.txt", "offset": 2}))
             .await
@@ -1733,7 +1906,7 @@ mod tests {
         assert!(page2.success, "{}", page2.output);
         assert!(
             !page2.output.contains("GGGG"),
-            "a line larger than the window is never returned inline"
+            "a line larger than the window is never returned inline by line mode"
         );
         assert!(
             page2.output.contains("line 2 is 60000 bytes"),
@@ -1741,8 +1914,14 @@ mod tests {
             page2.output
         );
         assert!(
-            page2.output.contains("sed -n '2p'") && page2.output.contains("head -c"),
-            "the advice hands the model an exact shell command: {}",
+            page2.output.contains("byte_offset: 12"),
+            "the advice names the exact byte offset where the line starts: {}",
+            page2.output
+        );
+        assert!(
+            !page2.output.contains("sed"),
+            "no shell fallback — it cannot survive the shell tool's own \
+             30,000-byte cap: {}",
             page2.output
         );
         assert!(
@@ -1751,6 +1930,176 @@ mod tests {
             page2.output
         );
         assert!(page2.output.len() <= octos_core::tool_output_limit("read_file"));
+
+        // And the advised byte-mode call actually returns the line's bytes.
+        let bytes = tool
+            .execute(
+                &serde_json::json!({"path": "giant_armed.txt", "byte_offset": 12, "byte_limit": 20}),
+            )
+            .await
+            .unwrap();
+        assert!(bytes.success, "{}", bytes.output);
+        assert!(
+            bytes.output.starts_with(&"G".repeat(20)),
+            "raw byte mode returns the giant line's bytes without a gutter: {}",
+            octos_core::truncated_utf8(&bytes.output, 120, "...")
+        );
+        assert!(
+            bytes.output.contains("byte_offset: 32"),
+            "the byte-mode footer names the exact next byte: {}",
+            bytes.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_page_raw_bytes_with_byte_offset() {
+        // The raw byte mode itself: exact slices, an exact continuation,
+        // no footer at EOF, UTF-8 boundary snapping, and clean errors for
+        // out-of-range or ambiguous parameters. Available unarmed too — the
+        // schema is static, so an advertised parameter must always work.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("bytes.txt"), "abcdefghij").unwrap();
+        let tool = ReadFileTool::new(dir.path());
+
+        let first = tool
+            .execute(&serde_json::json!({"path": "bytes.txt", "byte_offset": 0, "byte_limit": 4}))
+            .await
+            .unwrap();
+        assert!(first.success, "{}", first.output);
+        assert!(
+            first.output.starts_with("abcd") && !first.output.starts_with("abcde"),
+            "exactly the requested slice: {}",
+            first.output
+        );
+        assert!(
+            first.output.contains("bytes 0-3 of 10") && first.output.contains("byte_offset: 4"),
+            "the footer names the actual range, the total, and the next \
+             call: {}",
+            first.output
+        );
+
+        let rest = tool
+            .execute(&serde_json::json!({"path": "bytes.txt", "byte_offset": 4}))
+            .await
+            .unwrap();
+        assert!(rest.success, "{}", rest.output);
+        assert_eq!(
+            rest.output, "efghij",
+            "reading to EOF returns the remainder with NO footer — footer \
+             absence is the completion signal"
+        );
+
+        // UTF-8: an offset inside a multi-byte char snaps BACK to the char
+        // boundary (re-serving at most 3 bytes; never leaving a gap).
+        std::fs::write(dir.path().join("utf8.txt"), "αβγ").unwrap();
+        let snapped = tool
+            .execute(&serde_json::json!({"path": "utf8.txt", "byte_offset": 3}))
+            .await
+            .unwrap();
+        assert!(snapped.success, "{}", snapped.output);
+        assert_eq!(
+            snapped.output, "βγ",
+            "offset 3 is inside β (bytes 2..4) — snap back to 2, never split \
+             a character"
+        );
+
+        // Out of range and ambiguous parameter combinations are clean errors.
+        let beyond = tool
+            .execute(&serde_json::json!({"path": "bytes.txt", "byte_offset": 100}))
+            .await
+            .unwrap();
+        assert!(!beyond.success);
+        assert!(
+            beyond.output.contains("beyond"),
+            "past-EOF byte_offset is a clean, explained error: {}",
+            beyond.output
+        );
+
+        let mixed = tool
+            .execute(&serde_json::json!({"path": "bytes.txt", "byte_offset": 0, "start_line": 1}))
+            .await
+            .unwrap();
+        assert!(!mixed.success);
+        assert!(
+            mixed.output.contains("not both"),
+            "line and byte parameters are mutually exclusive: {}",
+            mixed.output
+        );
+
+        let orphan_limit = tool
+            .execute(&serde_json::json!({"path": "bytes.txt", "byte_limit": 4}))
+            .await
+            .unwrap();
+        assert!(
+            !orphan_limit.success,
+            "byte_limit without byte_offset must be rejected: {}",
+            orphan_limit.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_not_serve_file_unchanged_for_a_byte_mode_read() {
+        // The M8.4 cache stores LINE ranges; a byte-mode request must bypass
+        // it entirely — a cached complete entry must not answer a byte
+        // request with the [FILE_UNCHANGED] stub, and a byte read must not
+        // poison the line-range cache.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("cached.txt"), "one\ntwo\nthree\n").unwrap();
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let cache = Arc::new(FileStateCache::new());
+        let ctx = ctx_with_cache(cache.clone());
+
+        let full = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "cached.txt"}))
+            .await
+            .unwrap();
+        assert!(full.success && !full.output.contains("[FILE_UNCHANGED]"));
+
+        let bytes = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "cached.txt", "byte_offset": 0, "byte_limit": 3}),
+            )
+            .await
+            .unwrap();
+        assert!(bytes.success, "{}", bytes.output);
+        assert!(
+            !bytes.output.contains("[FILE_UNCHANGED]"),
+            "a byte-mode read must never be answered from the line-range \
+             cache: {}",
+            bytes.output
+        );
+        assert!(bytes.output.starts_with("one"), "{}", bytes.output);
+    }
+
+    #[tokio::test]
+    async fn should_keep_every_armed_return_under_the_loop_cap_for_a_pathological_path() {
+        // Path SPELLINGS are caller-controlled and unbounded — a spelling
+        // made of thousands of `./` components resolves to a normal file but
+        // would blow the output budget if any armed return interpolated it
+        // raw. Every armed return must stay under the loop cap regardless.
+        let dir = tempfile::tempdir().unwrap();
+        let giant = format!("{}\nafter", "G".repeat(60_000));
+        std::fs::write(dir.path().join("g.txt"), &giant).unwrap();
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let pathological = format!("{}g.txt", "./".repeat(25_000)); // 50,005 chars
+
+        let advice = tool
+            .execute(&serde_json::json!({"path": pathological}))
+            .await
+            .unwrap();
+        assert!(advice.success, "{}", advice.output);
+        assert!(
+            advice.output.contains("byte_offset: 0"),
+            "the giant-first-line advice still names the byte continuation: {}",
+            advice.output
+        );
+        assert!(
+            advice.output.len() <= octos_core::tool_output_limit("read_file"),
+            "an armed return may never exceed the loop cap, whatever the \
+             path spelling: {} bytes",
+            advice.output.len()
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -116,17 +116,23 @@ impl Tool for ReadFileTool {
         "read_file"
     }
 
-    // #1638 (d): the description is static while window arming is dynamic, so
-    // it states the truncation contract that holds in EVERY mode — unarmed
-    // reads are already truncated with continuation advice by the execution
-    // loop (#2124) or refused with a range hint (#2131), and armed reads
-    // carry the window footer. The mode-specific numbers live in the footer,
-    // where they are always current.
+    // #1638 R6: the tool spec (description + schema) is serialized into the
+    // LLM prompt-cache prefix for EVERY session, so it must be byte-identical
+    // to origin/main when the flag is OFF, or arming one process would bust
+    // the prefix for all of them. Both are therefore conditional on the arm:
+    // unarmed returns exactly the origin strings; armed adds the windowing
+    // contract and the byte-mode parameters. (`window_armed()` reads the
+    // per-instance override or `OCTOS_READ_WINDOW`, both stable for a process,
+    // so `specs()` sees a consistent answer.)
     fn description(&self) -> &str {
-        "Read the contents of a file. Returns the file content with line numbers. Large results \
-         are truncated to a bounded window and the message names the exact call to continue \
-         (offset/limit, or byte_offset for raw byte paging of very long lines) — page forward \
-         until no continuation notice remains."
+        if self.window_armed() {
+            "Read the contents of a file. Returns the file content with line numbers. Large \
+             results are truncated to a bounded window and the message names the exact call to \
+             continue (offset/limit, or byte_offset for raw byte paging of very long lines) — \
+             page forward until no continuation notice remains."
+        } else {
+            "Read the contents of a file. Returns the file content with line numbers."
+        }
     }
 
     fn tags(&self) -> &[&str] {
@@ -134,34 +140,45 @@ impl Tool for ReadFileTool {
     }
 
     fn input_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Path to the file to read (relative to working directory; alias: filePath)"
-                },
-                "start_line": {
-                    "type": "integer",
-                    "description": "Optional starting line number (1-indexed; alias: offset)"
-                },
-                "end_line": {
-                    "type": "integer",
-                    "description": "Optional ending line number (1-indexed, inclusive)"
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Optional maximum number of lines to read, starting at start_line (alternative to end_line — do not provide both)"
-                },
-                "byte_offset": {
+        // Origin/main properties — MUST stay byte-identical when unarmed.
+        let mut properties = serde_json::json!({
+            "path": {
+                "type": "string",
+                "description": "Path to the file to read (relative to working directory; alias: filePath)"
+            },
+            "start_line": {
+                "type": "integer",
+                "description": "Optional starting line number (1-indexed; alias: offset)"
+            },
+            "end_line": {
+                "type": "integer",
+                "description": "Optional ending line number (1-indexed, inclusive)"
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Optional maximum number of lines to read, starting at start_line (alternative to end_line — do not provide both)"
+            }
+        });
+        if self.window_armed() {
+            let props = properties.as_object_mut().expect("object literal");
+            props.insert(
+                "byte_offset".to_string(),
+                serde_json::json!({
                     "type": "integer",
                     "description": "Raw byte mode: 0-indexed byte position to start reading from. Returns file bytes without line numbers — for single lines too long to page by line offset. Do not combine with start_line/end_line/limit."
-                },
-                "byte_limit": {
+                }),
+            );
+            props.insert(
+                "byte_limit".to_string(),
+                serde_json::json!({
                     "type": "integer",
                     "description": "Raw byte mode: maximum bytes to return (default and cap: the read window). Requires byte_offset."
-                }
-            },
+                }),
+            );
+        }
+        serde_json::json!({
+            "type": "object",
+            "properties": properties,
             "required": ["path"]
         })
     }
@@ -242,10 +259,26 @@ impl Tool for ReadFileTool {
                 }
             };
 
+        // #1638 R6: byte mode is part of the ARMED feature. It is resolved
+        // once here so the schema/description gating and the execution gating
+        // agree.
+        let window_armed = self.window_armed();
+
         // #1638: raw byte mode is a distinct coordinate system — mixing it
         // with line parameters is ambiguous and rejected, like end_line+limit.
         if input.byte_offset.is_some() || input.byte_limit.is_some() {
-            let message = if input.start_line.is_some()
+            // R6: unarmed, byte mode is not advertised in the schema and must
+            // not execute. Reject rather than silently fall through to a line
+            // read (which would drop the caller's intent). The LLM never hits
+            // this — the schema omits the parameters when unarmed — so this
+            // only guards manual/legacy callers.
+            let message = if !window_armed {
+                Some(
+                    "byte_offset/byte_limit are only available when windowed reads are enabled \
+                     (OCTOS_READ_WINDOW=1)."
+                        .to_string(),
+                )
+            } else if input.start_line.is_some()
                 || input.end_line.is_some()
                 || input.limit.is_some()
             {
@@ -350,20 +383,14 @@ impl Tool for ReadFileTool {
             }
         }
 
-        // #1638: windowed-read enforcement, armed per instance (tests) or by
-        // `OCTOS_READ_WINDOW=1` (production). Resolved once — every armed
-        // branch below keys off this.
-        let window_armed = self.window_armed();
-
-        // #1638: raw byte mode. Bypasses the M8.4 cache in BOTH directions —
-        // the cache's view ranges are line ranges, so a byte request must
-        // never be answered with a line-range [FILE_UNCHANGED] stub, and a
-        // byte view must never be stored as one — and bypasses the #2131
-        // refusal (a byte read is bounded by construction). Works unarmed
-        // too: the schema is static, so an advertised parameter always
-        // works; only the ledger recording is armed-gated.
+        // #1638 R6 (armed-only): raw byte mode. Reached only when armed —
+        // unarmed byte params were rejected above. Bypasses the M8.4 cache in
+        // BOTH directions (the cache's view ranges are line ranges, so a byte
+        // request must never be answered with a line-range [FILE_UNCHANGED]
+        // stub, and a byte view must never be stored as one) and bypasses the
+        // #2131 refusal (a byte read is bounded by construction).
         if let Some(requested_offset) = input.byte_offset {
-            use super::read_window::{FOOTER_RESERVE, WINDOW_MAX_BYTES};
+            use super::read_window::WINDOW_MAX_BYTES;
             let content = match super::read_no_follow(&path).await {
                 Ok(c) => c,
                 Err(e) => return Ok(super::file_io_error(e, &input.path)),
@@ -407,23 +434,19 @@ impl Tool for ReadFileTool {
                     end_b - 1
                 ));
             }
-            debug_assert!(
-                output.len() <= WINDOW_MAX_BYTES + FOOTER_RESERVE,
-                "byte-mode output + footer must stay within the reserve so the loop \
-                 backstop can never fire (got {} bytes)",
-                output.len()
-            );
-            if window_armed {
-                let session = ctx.parent_session_key.clone().unwrap_or_default();
-                let epoch = current_mtime.map(|mtime| super::read_window::ViewEpoch {
-                    mtime,
-                    size: file_size as u64,
-                });
-                let tainted = crate::sanitize::sanitize_tool_output(&output) != output;
-                super::read_window::record_view(
-                    &session, &path, epoch, start_b, end_b, total, tainted,
-                );
-            }
+            // R5: enforce the loop-cap at RUNTIME (not debug_assert, which
+            // release builds drop). Sized to fit under the cap by
+            // construction, so this never actually cuts; it is the real
+            // backstop that keeps the loop's blind head/tail cut from ever
+            // mangling the footer in a release build.
+            output = clamp_armed_return(output);
+            let session = ctx.parent_session_key.clone().unwrap_or_default();
+            let epoch = current_mtime.map(|mtime| super::read_window::ViewEpoch {
+                mtime,
+                size: file_size as u64,
+            });
+            let tainted = crate::sanitize::sanitize_tool_output(&output) != output;
+            super::read_window::record_view(&session, &path, epoch, start_b, end_b, total, tainted);
             return Ok(ToolResult {
                 output,
                 success: true,
@@ -566,13 +589,12 @@ impl Tool for ReadFileTool {
                         ));
                     }
                     advice.push(']');
-                    debug_assert!(
-                        advice.len() <= octos_core::tool_output_limit("read_file"),
-                        "the giant-line advice must stay under the loop cap (got {} bytes)",
-                        advice.len()
-                    );
+                    // R5: real runtime clamp (release builds drop
+                    // debug_assert). The advice interpolates no unbounded
+                    // caller input, so it is already short; the clamp is the
+                    // enforced guarantee.
                     return Ok(ToolResult {
-                        output: advice,
+                        output: clamp_armed_return(advice),
                         success: true,
                         ..Default::default()
                     });
@@ -601,12 +623,11 @@ impl Tool for ReadFileTool {
                     "\n[read_file window: showing lines {shown_from}-{included_end} of \
                      {total_lines} — {limit_clause}. Continue with offset: {next_offset}.]"
                 ));
-                debug_assert!(
-                    output.len() <= WINDOW_MAX_BYTES + super::read_window::FOOTER_RESERVE,
-                    "armed window + footer must stay within its reserve so the loop \
-                     backstop can never fire (got {} bytes)",
-                    output.len()
-                );
+                // R5: real runtime clamp (release builds drop debug_assert).
+                // The window body is bounded to WINDOW_MAX_BYTES and the
+                // footer to well under FOOTER_RESERVE, so this never cuts in
+                // practice; it is the enforced backstop.
+                output = clamp_armed_return(output);
             }
             None => {
                 // Add file info
@@ -699,6 +720,20 @@ impl Tool for ReadFileTool {
             ..Default::default()
         })
     }
+}
+
+/// R5: clamp an ARMED `read_file` return as a real runtime operation. Every
+/// armed window/byte/advice return is sized to fit within
+/// `WINDOW_MAX_BYTES + FOOTER_RESERVE` by construction, so this never cuts in
+/// practice — it is the release-build enforcement that a `debug_assert` (which
+/// release builds drop) cannot provide. The tripwire test pins
+/// `WINDOW_MAX_BYTES + FOOTER_RESERVE <= tool_output_limit("read_file")`, so
+/// clamping to that tighter bound also keeps every armed return under the
+/// loop's blind head/tail backstop (#2124), which must never mangle a footer.
+fn clamp_armed_return(mut output: String) -> String {
+    let bound = super::read_window::WINDOW_MAX_BYTES + super::read_window::FOOTER_RESERVE;
+    octos_core::truncate_utf8(&mut output, bound, "");
+    output
 }
 
 /// Byte offset (into the raw content) where 1-indexed `line` starts.
@@ -1599,6 +1634,108 @@ mod tests {
     // process-global counts (#2077/#2126 lesson).
     // -----------------------------------------------------------------------
 
+    /// R6: the UNARMED tool must be byte-for-byte the origin/main tool at the
+    /// WIRE — same name, description, and input schema — because every enabled
+    /// tool's ToolSpec is serialized into the LLM prompt-cache prefix
+    /// (registry.rs `specs()`). A changed unarmed spec would invalidate that
+    /// prefix for every session on the planet, armed or not, defeating the
+    /// "flag-gated, zero blast radius" premise. This golden is the exact
+    /// origin/main ToolSpec JSON; only the ARMED tool may differ from it.
+    fn read_file_origin_toolspec() -> serde_json::Value {
+        serde_json::json!({
+            "name": "read_file",
+            "description": "Read the contents of a file. Returns the file content with line numbers.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the file to read (relative to working directory; alias: filePath)"
+                    },
+                    "start_line": {
+                        "type": "integer",
+                        "description": "Optional starting line number (1-indexed; alias: offset)"
+                    },
+                    "end_line": {
+                        "type": "integer",
+                        "description": "Optional ending line number (1-indexed, inclusive)"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Optional maximum number of lines to read, starting at start_line (alternative to end_line — do not provide both)"
+                    }
+                },
+                "required": ["path"]
+            }
+        })
+    }
+
+    fn read_file_toolspec(tool: &ReadFileTool) -> serde_json::Value {
+        serde_json::json!({
+            "name": tool.name(),
+            "description": tool.description(),
+            "input_schema": tool.input_schema(),
+        })
+    }
+
+    #[test]
+    fn unarmed_read_file_toolspec_is_byte_identical_to_origin_main() {
+        let tool = ReadFileTool::new("/tmp").with_window_enforcement(false);
+        let spec = read_file_toolspec(&tool);
+        assert_eq!(
+            spec,
+            read_file_origin_toolspec(),
+            "the UNARMED read_file ToolSpec must equal origin/main exactly — no \
+             byte_offset/byte_limit in the schema, no windowing sentence in the \
+             description — or the prompt-cache prefix changes for every session"
+        );
+        // The wire is the serialized string; pin it too (serde_json sorts
+        // keys, so this is deterministic).
+        assert_eq!(
+            serde_json::to_string(&spec).unwrap(),
+            serde_json::to_string(&read_file_origin_toolspec()).unwrap(),
+            "serialized unarmed spec must match origin byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn armed_read_file_toolspec_advertises_byte_mode() {
+        // The armed spec is ALLOWED to differ — byte mode is part of the
+        // armed feature — and it must actually carry the byte parameters.
+        let tool = ReadFileTool::new("/tmp").with_window_enforcement(true);
+        let spec = read_file_toolspec(&tool);
+        assert_ne!(
+            spec,
+            read_file_origin_toolspec(),
+            "the armed spec differs from origin by design"
+        );
+        let props = spec["input_schema"]["properties"].as_object().unwrap();
+        assert!(
+            props.contains_key("byte_offset") && props.contains_key("byte_limit"),
+            "armed schema advertises byte mode: {props:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unarmed_byte_params_are_rejected_not_silently_ignored() {
+        // byte mode is an armed-only capability. Unarmed, the schema does not
+        // advertise it, so the model never sends it; a manual caller that
+        // does must get a clear error, never a silent fall-through to a line
+        // read (which would drop its intent).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.txt"), "abcdef").unwrap();
+        let tool = ReadFileTool::new(dir.path()); // unarmed
+        let r = tool
+            .execute(&serde_json::json!({"path": "f.txt", "byte_offset": 0}))
+            .await
+            .unwrap();
+        assert!(
+            !r.success && r.output.contains("byte_offset"),
+            "unarmed byte_offset must be a clean rejection: {}",
+            r.output
+        );
+    }
+
     /// 1500 lines, 100 bytes of content each (distinct `row NNNNNN` prefixes),
     /// 151,500 content bytes total. With a 4-digit gutter each formatted line
     /// is 109 bytes, so the 49,152-byte window holds exactly 450 of them:
@@ -1955,11 +2092,12 @@ mod tests {
     async fn should_page_raw_bytes_with_byte_offset() {
         // The raw byte mode itself: exact slices, an exact continuation,
         // no footer at EOF, UTF-8 boundary snapping, and clean errors for
-        // out-of-range or ambiguous parameters. Available unarmed too — the
-        // schema is static, so an advertised parameter must always work.
+        // out-of-range or ambiguous parameters. R6: byte mode is part of the
+        // ARMED feature (unarmed the schema does not advertise it), so the
+        // tool is armed here.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("bytes.txt"), "abcdefghij").unwrap();
-        let tool = ReadFileTool::new(dir.path());
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
 
         let first = tool
             .execute(&serde_json::json!({"path": "bytes.txt", "byte_offset": 0, "byte_limit": 4}))

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -16,6 +16,11 @@ pub struct ReadFileTool {
     base_dir: PathBuf,
     /// Effective filesystem scope.
     filesystem_scope: FilesystemScope,
+    /// Windowed-read enforcement (#1638). `None` = the `OCTOS_READ_WINDOW`
+    /// env flag decides (production); `Some` = explicit, for tests — arming
+    /// changes output, so tests must not arm process-globally (see
+    /// `read_window::armed_from_env`).
+    window_enforcement: Option<bool>,
 }
 
 impl ReadFileTool {
@@ -24,6 +29,7 @@ impl ReadFileTool {
         Self {
             base_dir: base_dir.into(),
             filesystem_scope: FilesystemScope::Workspace,
+            window_enforcement: None,
         }
     }
 
@@ -31,6 +37,22 @@ impl ReadFileTool {
     pub fn with_filesystem_scope(mut self, filesystem_scope: FilesystemScope) -> Self {
         self.filesystem_scope = filesystem_scope;
         self
+    }
+
+    /// Test-only arming override for windowed-read enforcement, so no test
+    /// has to mutate the process environment (`set_var` is `unsafe` under
+    /// edition 2024 and this workspace denies unsafe) or leak armed
+    /// behaviour into parallel unarmed tests.
+    #[cfg(test)]
+    pub(crate) fn with_window_enforcement(mut self, armed: bool) -> Self {
+        self.window_enforcement = Some(armed);
+        self
+    }
+
+    /// Whether windowed-read enforcement is armed for this instance.
+    fn window_armed(&self) -> bool {
+        self.window_enforcement
+            .unwrap_or_else(super::read_window::armed_from_env)
     }
 }
 
@@ -85,8 +107,16 @@ impl Tool for ReadFileTool {
         "read_file"
     }
 
+    // #1638 (d): the description is static while window arming is dynamic, so
+    // it states the truncation contract that holds in EVERY mode — unarmed
+    // reads are already truncated with continuation advice by the execution
+    // loop (#2124) or refused with a range hint (#2131), and armed reads
+    // carry the window footer. The mode-specific numbers live in the footer,
+    // where they are always current.
     fn description(&self) -> &str {
-        "Read the contents of a file. Returns the file content with line numbers."
+        "Read the contents of a file. Returns the file content with line numbers. Large results \
+         are truncated to a bounded window and the message names the exact call (offset/limit) \
+         to continue — page forward until no continuation notice remains."
     }
 
     fn tags(&self) -> &[&str] {
@@ -268,12 +298,19 @@ impl Tool for ReadFileTool {
             }
         }
 
+        // #1638: windowed-read enforcement, armed per instance (tests) or by
+        // `OCTOS_READ_WINDOW=1` (production). Resolved once — every armed
+        // branch below keys off this.
+        let window_armed = self.window_armed();
+
         // #2131 part 4: budget-aware reads. An UNBOUNDED read of a file larger
         // than the tool-output budget would be truncated on the way in and then
         // evicted by compaction — forcing the exact re-read loop #2131 targets.
         // Return a range hint instead of accept-then-evict, so the model asks
         // for the slice it needs. A read that already names a range is honored.
-        if start_line.is_none() && end_line.is_none() {
+        // ARMED, the refusal is subsumed by the window: page one plus an exact
+        // continuation is strictly more useful than a hint with no content.
+        if start_line.is_none() && end_line.is_none() && !window_armed {
             let budget = octos_core::tool_output_limit("read_file");
             if file_size > budget {
                 return Ok(ToolResult {
@@ -356,42 +393,144 @@ impl Tool for ReadFileTool {
         let mut output = String::new();
         let line_num_width = end.to_string().len();
 
+        // #1638 armed window: emit whole formatted lines until either limit
+        // would be crossed. Unarmed (or armed and everything fits), this is
+        // byte-for-byte the loop that always ran.
+        use super::read_window::{WINDOW_MAX_BYTES, WINDOW_MAX_LINES, WindowClamp};
+        let mut clamp: Option<WindowClamp> = None;
+        let mut included_end = end; // exclusive 0-indexed == last emitted 1-indexed line
         for (idx, line) in lines[start..end].iter().enumerate() {
+            if window_armed && idx == WINDOW_MAX_LINES {
+                clamp = Some(WindowClamp::Lines);
+                included_end = start + idx;
+                break;
+            }
             let line_num = start + idx + 1;
-            output.push_str(&format!("{line_num:>line_num_width$}│ {line}\n"));
+            let formatted = format!("{line_num:>line_num_width$}│ {line}\n");
+            if window_armed && output.len() + formatted.len() > WINDOW_MAX_BYTES {
+                if idx == 0 {
+                    // The first line of the window alone exceeds the whole
+                    // byte budget: line offsets cannot page within a line
+                    // (there is deliberately no byte-resume parameter — see
+                    // the read_window module docs), so hand the model an
+                    // exact shell command for the line instead, pi-style.
+                    let mut advice = format!(
+                        "[read_file window: line {n} is {len} bytes — larger than the \
+                         {WINDOW_MAX_BYTES}-byte window, and read_file cannot page within a \
+                         line. Fetch it with the shell tool: sed -n '{n}p' '{p}' | head -c \
+                         {WINDOW_MAX_BYTES}, then advance with | tail -c +{next_byte}.",
+                        n = line_num,
+                        len = line.len(),
+                        p = input.path,
+                        next_byte = WINDOW_MAX_BYTES + 1,
+                    );
+                    if line_num < total_lines {
+                        advice.push_str(&format!(
+                            " Continue with offset: {} for the lines after it.",
+                            line_num + 1
+                        ));
+                    }
+                    advice.push(']');
+                    return Ok(ToolResult {
+                        output: advice,
+                        success: true,
+                        ..Default::default()
+                    });
+                }
+                clamp = Some(WindowClamp::Bytes);
+                included_end = start + idx;
+                break;
+            }
+            output.push_str(&formatted);
         }
 
-        // Add file info
-        if start > 0 || end < total_lines {
-            output.push_str(&format!(
-                "\n(showing lines {}-{} of {})",
-                start + 1,
-                end,
-                total_lines
-            ));
+        match clamp {
+            Some(kind) => {
+                // The advising footer: which limit fired, the range actually
+                // returned, the totals, and the exact next call.
+                let shown_from = start + 1;
+                let next_offset = included_end + 1;
+                let limit_clause = match kind {
+                    WindowClamp::Lines => format!("{WINDOW_MAX_LINES}-line limit hit"),
+                    WindowClamp::Bytes => format!(
+                        "{WINDOW_MAX_BYTES}-byte limit hit; file is {} bytes",
+                        content.len()
+                    ),
+                };
+                output.push_str(&format!(
+                    "\n[read_file window: showing lines {shown_from}-{included_end} of \
+                     {total_lines} — {limit_clause}. Continue with offset: {next_offset}.]"
+                ));
+                debug_assert!(
+                    output.len() <= WINDOW_MAX_BYTES + super::read_window::FOOTER_RESERVE,
+                    "armed window + footer must stay within its reserve so the loop \
+                     backstop can never fire (got {} bytes)",
+                    output.len()
+                );
+            }
+            None => {
+                // Add file info
+                if start > 0 || end < total_lines {
+                    output.push_str(&format!(
+                        "\n(showing lines {}-{} of {})",
+                        start + 1,
+                        end,
+                        total_lines
+                    ));
+                }
+            }
         }
 
-        // Truncate if too long
-        const MAX_OUTPUT: usize = 100000;
-        octos_core::truncate_utf8(&mut output, MAX_OUTPUT, "\n... (content truncated)");
+        // Truncate if too long. UNARMED ONLY: the armed path's advising
+        // window above bounds output to WINDOW_MAX_BYTES + a footer — under
+        // both this blind cut and the execution loop's 50,000-byte backstop
+        // (#2124), which must never fire on an armed read (a blind head/tail
+        // cut would mangle the very footer that names the continuation).
+        if !window_armed {
+            const MAX_OUTPUT: usize = 100000;
+            octos_core::truncate_utf8(&mut output, MAX_OUTPUT, "\n... (content truncated)");
+        }
 
         // M8.4: record this read in the file-state cache so a later read can
         // short-circuit to the `[FILE_UNCHANGED]` stub. Skip binary blobs —
         // we never want to serve an image/PDF body from the cache.
+        //
+        // #1638 (b): the recorded view is the view RETURNED, not the view
+        // requested. A clamped read stores its actual window, so an unbounded
+        // request can never hit a windowed entry and claim
+        // `[FILE_UNCHANGED] (full file cached)` against content the model
+        // was never shown.
+        let recorded_range = if clamp.is_some() {
+            Some(((start + 1) as u64, included_end as u64))
+        } else {
+            user_range(start_line, end_line)
+        };
         if let (Some(cache), Some(mtime)) = (ctx.file_state_cache.as_ref(), current_mtime) {
             let can_cache = !FileStateCache::has_binary_extension(&path)
                 && FileStateCache::is_text_cacheable(content.as_bytes());
             if can_cache {
-                let view_range = user_range(start_line, end_line);
                 cache.put(CacheEntry::new(
                     path.clone(),
                     mtime,
                     FileStateCache::content_hash(content.as_bytes()),
                     file_size,
-                    view_range.is_some(),
-                    view_range,
+                    recorded_range.is_some(),
+                    recorded_range,
                 ));
             }
+        }
+
+        // #1638 (c): feed the partial-view ledger that backs write_file's
+        // overwrite guard. Armed only — a disarmed read records nothing, so
+        // arming later never refuses on evidence gathered while off.
+        if window_armed {
+            super::read_window::record_view(
+                &path,
+                current_mtime,
+                start + 1,
+                included_end,
+                total_lines,
+            );
         }
 
         Ok(ToolResult {
@@ -1277,6 +1416,412 @@ mod tests {
         assert!(
             r2.output.contains("abcdefghij"),
             "the bounded slice returns content"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #1638: flag-gated windowed reads. Armed via `with_window_enforcement`
+    // per instance — never process-globally, because arming CHANGES read_file
+    // output and would leak into every unarmed test running in parallel.
+    // Every test here asserts on files it created itself (per-path), never on
+    // process-global counts (#2077/#2126 lesson).
+    // -----------------------------------------------------------------------
+
+    /// 1500 lines, 100 bytes of content each (distinct `row NNNNNN` prefixes),
+    /// 151,500 content bytes total. With a 4-digit gutter each formatted line
+    /// is 109 bytes, so the 49,152-byte window holds exactly 450 of them:
+    /// 450 x 109 = 49,050 fits, 451 would not.
+    fn wide_rows_file(dir: &tempfile::TempDir, name: &str) {
+        let content = (1..=1500)
+            .map(|i| format!("row {i:06}{}", "z".repeat(90)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.path().join(name), &content).unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_window_an_unbounded_read_of_a_big_file_when_armed() {
+        let dir = tempfile::tempdir().unwrap();
+        wide_rows_file(&dir, "big_armed.txt");
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let r = tool
+            .execute(&serde_json::json!({"path": "big_armed.txt"}))
+            .await
+            .unwrap();
+
+        assert!(
+            r.success,
+            "armed, the read returns page one instead of the unarmed refusal: {}",
+            r.output
+        );
+        assert!(r.output.contains("row 000001"), "page one starts at line 1");
+        assert!(
+            !r.output.contains("row 000451"),
+            "the byte limit stops the window at line 450"
+        );
+        assert!(
+            r.output.contains("showing lines 1-450 of 1500"),
+            "the footer names the actual range returned and the total: {}",
+            r.output
+        );
+        assert!(
+            r.output.contains("-byte limit"),
+            "the footer names WHICH limit fired (bytes, not lines): {}",
+            r.output
+        );
+        assert!(
+            r.output.contains("offset: 451"),
+            "the footer names the exact next call: {}",
+            r.output
+        );
+        assert!(
+            r.output.len() <= octos_core::tool_output_limit("read_file"),
+            "the tool's own advising cut must keep the loop's blind backstop from \
+             ever firing on an armed read: {} bytes",
+            r.output.len()
+        );
+        assert!(
+            !r.output.contains("... (content truncated)"),
+            "the internal blind cut must not fire on the armed path"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_fire_the_line_limit_first_on_a_many_short_lines_file_when_armed() {
+        let dir = tempfile::tempdir().unwrap();
+        let many = (1..=3000)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.path().join("many_armed.txt"), &many).unwrap();
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let r = tool
+            .execute(&serde_json::json!({"path": "many_armed.txt"}))
+            .await
+            .unwrap();
+
+        assert!(r.success, "{}", r.output);
+        assert!(
+            r.output.contains("line 2000"),
+            "line 2000 is the last shown"
+        );
+        assert!(!r.output.contains("line 2001"), "line 2001 is windowed off");
+        assert!(
+            r.output.contains("showing lines 1-2000 of 3000"),
+            "footer names the range and total: {}",
+            r.output
+        );
+        assert!(
+            r.output.contains("2000-line limit"),
+            "the footer names WHICH limit fired (lines, not bytes): {}",
+            r.output
+        );
+        assert!(r.output.contains("offset: 2001"), "{}", r.output);
+        assert!(r.output.len() <= octos_core::tool_output_limit("read_file"));
+    }
+
+    #[tokio::test]
+    async fn should_clamp_an_explicit_oversized_limit_when_armed() {
+        let dir = tempfile::tempdir().unwrap();
+        wide_rows_file(&dir, "clamp_armed.txt");
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let r = tool
+            .execute(&serde_json::json!({"path": "clamp_armed.txt", "offset": 1, "limit": 999999}))
+            .await
+            .unwrap();
+
+        assert!(r.success, "{}", r.output);
+        assert!(
+            r.output.contains("showing lines 1-450 of 1500") && r.output.contains("offset: 451"),
+            "an explicit range past the window is clamped with the same footer: {}",
+            r.output
+        );
+        assert!(r.output.len() <= octos_core::tool_output_limit("read_file"));
+    }
+
+    #[tokio::test]
+    async fn should_continue_from_a_later_offset_with_the_same_window_when_armed() {
+        // The continuation call the footer names must itself work and name
+        // the next one — that is what makes paging converge.
+        let dir = tempfile::tempdir().unwrap();
+        wide_rows_file(&dir, "page2_armed.txt");
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let r = tool
+            .execute(&serde_json::json!({"path": "page2_armed.txt", "offset": 451}))
+            .await
+            .unwrap();
+
+        assert!(r.success, "{}", r.output);
+        assert!(
+            r.output.contains("row 000451"),
+            "page two starts where told"
+        );
+        assert!(
+            r.output.contains("showing lines 451-900 of 1500") && r.output.contains("offset: 901"),
+            "page two names page three: {}",
+            r.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_return_small_files_whole_and_byte_identical_when_armed() {
+        // Arming must not touch anything that fits the window: same bytes as
+        // the unarmed goldens captured before this feature existed.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("golden_small.txt"), "alpha\nbeta\ngamma\n").unwrap();
+        let ten = (1..=10)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.path().join("golden_range.txt"), &ten).unwrap();
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let small = tool
+            .execute(&serde_json::json!({"path": "golden_small.txt"}))
+            .await
+            .unwrap();
+        assert!(small.success);
+        assert_eq!(
+            (
+                small.output.len(),
+                FileStateCache::content_hash(small.output.as_bytes())
+            ),
+            (32, 0xa9a1_582d_5fdd_6b1c),
+            "armed read of a small file must be byte-identical to unarmed: {:?}",
+            small.output
+        );
+
+        let range = tool
+            .execute(
+                &serde_json::json!({"path": "golden_range.txt", "start_line": 3, "end_line": 5}),
+            )
+            .await
+            .unwrap();
+        assert!(range.success);
+        assert_eq!(
+            (
+                range.output.len(),
+                FileStateCache::content_hash(range.output.as_bytes())
+            ),
+            (62, 0x7ca7_68c2_04c1_08d7),
+            "armed in-window explicit range must be byte-identical to unarmed: {:?}",
+            range.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_keep_unarmed_outputs_byte_identical_to_pre_change_goldens() {
+        // Golden compare against a capture taken on the pre-change tree
+        // (fnv-1a via FileStateCache::content_hash, plus exact lengths).
+        // Inputs are reconstructed deterministically; outputs embed only the
+        // relative path, so the hashes are stable across hosts.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = ReadFileTool::new(dir.path());
+
+        std::fs::write(dir.path().join("golden_small.txt"), "alpha\nbeta\ngamma\n").unwrap();
+        let ten = (1..=10)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.path().join("golden_range.txt"), &ten).unwrap();
+        std::fs::write(
+            dir.path().join("golden_big.txt"),
+            "0123456789abcdef\n".repeat(4000),
+        )
+        .unwrap();
+        let wide = (0..3000)
+            .map(|_| "x".repeat(40))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.path().join("golden_cut.txt"), &wide).unwrap();
+        let many = (1..=3000)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.path().join("golden_manylines.txt"), &many).unwrap();
+
+        // (args, success, output_len, fnv1a) captured pre-change:
+        let cases: Vec<(serde_json::Value, bool, usize, u64)> = vec![
+            (
+                serde_json::json!({"path": "golden_small.txt"}),
+                true,
+                32,
+                0xa9a1_582d_5fdd_6b1c,
+            ),
+            (
+                serde_json::json!({"path": "golden_range.txt", "start_line": 3, "end_line": 5}),
+                true,
+                62,
+                0x7ca7_68c2_04c1_08d7,
+            ),
+            // The #2131 refusal for an oversized unbounded read stays.
+            (
+                serde_json::json!({"path": "golden_big.txt"}),
+                false,
+                305,
+                0x1fb1_380c_4950_1cb6,
+            ),
+            // The internal blind 100KB cut stays on the unarmed path.
+            (
+                serde_json::json!({"path": "golden_cut.txt", "start_line": 1, "end_line": 3000}),
+                true,
+                100_024,
+                0xfd5e_1b93_81ff_e0b0,
+            ),
+            // >2000 lines unbounded stays a FULL read when unarmed.
+            (
+                serde_json::json!({"path": "golden_manylines.txt"}),
+                true,
+                52_893,
+                0x88cc_44e4_d1e6_85a3,
+            ),
+        ];
+        for (args, success, len, fnv) in cases {
+            let r = tool.execute(&args).await.unwrap();
+            assert_eq!(
+                (
+                    r.success,
+                    r.output.len(),
+                    FileStateCache::content_hash(r.output.as_bytes())
+                ),
+                (success, len, fnv),
+                "unarmed output changed for {args}: {:?}...",
+                octos_core::truncated_utf8(&r.output, 200, "")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn should_advise_shell_for_a_single_line_larger_than_the_window_when_armed() {
+        // A line bigger than the whole byte window cannot be paged by line
+        // offset. Mirroring pi's `firstLineExceedsLimit`: no content, an
+        // exact shell command for the line, and the offset that continues
+        // past it. There is deliberately NO byte-resume parameter — see
+        // read_window.rs module docs.
+        let dir = tempfile::tempdir().unwrap();
+        let giant = format!("short first\n{}\nafter line", "G".repeat(60_000));
+        std::fs::write(dir.path().join("giant_armed.txt"), &giant).unwrap();
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+
+        // Page one: the giant line does not fit after line 1, so the window
+        // stops before it and resumes AT it.
+        let page1 = tool
+            .execute(&serde_json::json!({"path": "giant_armed.txt"}))
+            .await
+            .unwrap();
+        assert!(page1.success, "{}", page1.output);
+        assert!(page1.output.contains("short first"));
+        assert!(
+            !page1.output.contains("GGGG"),
+            "the giant line must not leak into page one"
+        );
+        assert!(
+            page1.output.contains("showing lines 1-1 of 3") && page1.output.contains("offset: 2"),
+            "page one stops before the giant line and names it as the next offset: {}",
+            page1.output
+        );
+
+        // Page two starts AT the giant line: advice, not content.
+        let page2 = tool
+            .execute(&serde_json::json!({"path": "giant_armed.txt", "offset": 2}))
+            .await
+            .unwrap();
+        assert!(page2.success, "{}", page2.output);
+        assert!(
+            !page2.output.contains("GGGG"),
+            "a line larger than the window is never returned inline"
+        );
+        assert!(
+            page2.output.contains("line 2 is 60000 bytes"),
+            "the advice names the line and its full size: {}",
+            page2.output
+        );
+        assert!(
+            page2.output.contains("sed -n '2p'") && page2.output.contains("head -c"),
+            "the advice hands the model an exact shell command: {}",
+            page2.output
+        );
+        assert!(
+            page2.output.contains("offset: 3"),
+            "the advice names how to continue past the giant line: {}",
+            page2.output
+        );
+        assert!(page2.output.len() <= octos_core::tool_output_limit("read_file"));
+    }
+
+    #[tokio::test]
+    async fn should_not_cache_a_windowed_read_as_complete_when_armed() {
+        // (b) The file-state cache hazard: a windowed read recorded as "no
+        // range = complete file" would make the next unbounded read return
+        // `[FILE_UNCHANGED] (full file cached)` — a lie about a view the
+        // model never fully saw. The recorded view must be the RETURNED
+        // window, so an unbounded re-read re-pages instead of claiming
+        // completeness.
+        let dir = tempfile::tempdir().unwrap();
+        wide_rows_file(&dir, "cache_armed.txt");
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let cache = Arc::new(FileStateCache::new());
+        let ctx = ctx_with_cache(cache.clone());
+
+        let first = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "cache_armed.txt"}))
+            .await
+            .unwrap();
+        assert!(first.success, "{}", first.output);
+        assert!(first.output.contains("showing lines 1-450 of 1500"));
+
+        let second = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "cache_armed.txt"}))
+            .await
+            .unwrap();
+        assert!(second.success, "{}", second.output);
+        assert!(
+            !second.output.contains("[FILE_UNCHANGED]"),
+            "a windowed view must never satisfy an unbounded request as \
+             unchanged-complete: {}",
+            second.output
+        );
+        assert!(
+            second.output.contains("showing lines 1-450 of 1500"),
+            "the honest answer is the same first page again: {}",
+            second.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_still_serve_file_unchanged_for_a_repeated_in_window_range_when_armed() {
+        // Arming must not destroy the M8.4 cache win for ranges the model
+        // truly saw in full.
+        let dir = tempfile::tempdir().unwrap();
+        ten_lines_file(&dir);
+        let tool = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let cache = Arc::new(FileStateCache::new());
+        let ctx = ctx_with_cache(cache.clone());
+
+        let first = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "lines.txt", "start_line": 3, "end_line": 5}),
+            )
+            .await
+            .unwrap();
+        assert!(first.success && !first.output.contains("[FILE_UNCHANGED]"));
+
+        let second = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "lines.txt", "start_line": 3, "end_line": 5}),
+            )
+            .await
+            .unwrap();
+        assert!(
+            second.output.contains("[FILE_UNCHANGED]"),
+            "an identical fully-seen range still hits the cache when armed: {}",
+            second.output
         );
     }
 }

--- a/crates/octos-agent/src/tools/read_window.rs
+++ b/crates/octos-agent/src/tools/read_window.rs
@@ -75,13 +75,15 @@
 //! Coverage is tracked in BYTES — one coordinate system for line-mode reads
 //! (converted to their byte spans) and raw byte-mode reads, so paging past a
 //! giant line stitches naturally. The mark is a contiguous-from-byte-0
-//! high-water line keyed by an epoch of `(mtime, size)`: any epoch change
-//! resets coverage to the new read alone, and `write_file` re-validates the
-//! recorded epoch against the CURRENT file at write time, so a file replaced
-//! after reading refuses as stale instead of trusting dead coverage.
-//! Same-mtime-same-size replacement is not detectable by this scheme (no
-//! content hash in the epoch); it is also not detectable by the M8.4
-//! file-state cache today.
+//! high-water line keyed by an epoch of `(mtime, size, ctime, inode)` on Unix
+//! (`(mtime, size)` off-Unix): any epoch change resets coverage to the new
+//! read alone, and `write_file` re-validates the recorded epoch against the
+//! CURRENT file at write time, so a file replaced after reading refuses as
+//! stale instead of trusting dead coverage. A same-mtime-same-size IN-PLACE
+//! rewrite IS detected on Unix — ctime advances on any write and userspace
+//! cannot roll it back — and a rename-over swap is detected by the inode.
+//! (Off-Unix the scheme falls back to `(mtime, size)`, a documented weaker
+//! guarantee for this Unix-primary flag.)
 //!
 //! A view only counts if the model actually received the bytes: the recorded
 //! output is checked against `sanitize_tool_output` (the exact function the
@@ -207,7 +209,10 @@ impl ViewEpoch {
     /// inode, not a re-resolved path.
     pub(crate) fn from_metadata(meta: &std::fs::Metadata) -> Option<ViewEpoch> {
         let mtime = meta.modified().ok()?;
-        let (ctime, inode) = ctime_and_inode(meta);
+        // `None` fails closed: no epoch => the view never completes and the
+        // checked writers refuse. On Unix that happens only when ctime is not
+        // representable (below); off-Unix ctime/inode are legitimately absent.
+        let (ctime, inode) = ctime_and_inode(meta)?;
         Some(ViewEpoch {
             mtime,
             size: meta.len(),
@@ -218,20 +223,25 @@ impl ViewEpoch {
 }
 
 #[cfg(unix)]
-fn ctime_and_inode(meta: &std::fs::Metadata) -> (Option<SystemTime>, Option<u64>) {
+fn ctime_and_inode(meta: &std::fs::Metadata) -> Option<(Option<SystemTime>, Option<u64>)> {
     use std::os::unix::fs::MetadataExt;
-    let secs = meta.ctime();
-    let nsecs = meta.ctime_nsec();
-    // ctime is seconds since the epoch; real files are post-1970 (secs >= 0).
-    let ctime = u64::try_from(secs).ok().map(|s| {
-        SystemTime::UNIX_EPOCH + std::time::Duration::new(s, nsecs.clamp(0, 999_999_999) as u32)
-    });
-    (ctime, Some(meta.ino()))
+    // #2193 R4 (codex round 4): a NEGATIVE / unrepresentable ctime must FAIL
+    // CLOSED, not degrade to `None`. If it degraded, two in-place generations
+    // with unrepresentable ctimes would both carry `ctime: None` and compare
+    // equal on (mtime, size, inode) after mtime forgery — the very hole ctime
+    // was added to close. Returning `None` here makes `from_metadata` yield no
+    // epoch, so such a file can never authorize a windowed overwrite.
+    let secs = u64::try_from(meta.ctime()).ok()?;
+    let nsecs = meta.ctime_nsec().clamp(0, 999_999_999) as u32;
+    let ctime = SystemTime::UNIX_EPOCH + std::time::Duration::new(secs, nsecs);
+    Some((Some(ctime), Some(meta.ino())))
 }
 
 #[cfg(not(unix))]
-fn ctime_and_inode(_meta: &std::fs::Metadata) -> (Option<SystemTime>, Option<u64>) {
-    (None, None)
+fn ctime_and_inode(_meta: &std::fs::Metadata) -> Option<(Option<SystemTime>, Option<u64>)> {
+    // Off-Unix: ctime/inode are not available; the documented weaker
+    // (mtime, size) fallback applies (the flag is Unix-primary).
+    Some((None, None))
 }
 
 /// What the ledger knows about one `(session, path)`.
@@ -509,6 +519,23 @@ mod tests {
             ViewStatus::Transformed,
             "full coverage of a transformed view must NOT be Complete",
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn from_metadata_binds_ctime_and_inode_on_unix() {
+        // #2193 R4: the epoch carries ctime + inode on Unix (the fields that
+        // defeat a same-size/same-mtime swap and a rename-over). The
+        // fail-closed negative-ctime path (u64::try_from -> None) is covered by
+        // construction.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"hello").unwrap();
+        let epoch = ViewEpoch::from_metadata(&std::fs::metadata(&path).unwrap())
+            .expect("a normal file has a representable ctime");
+        assert!(epoch.ctime.is_some(), "ctime must be bound on Unix");
+        assert!(epoch.inode.is_some(), "inode must be bound on Unix");
+        assert_eq!(epoch.size, 5);
     }
 
     fn epoch_at(secs_ago: u64, size: u64) -> Option<ViewEpoch> {

--- a/crates/octos-agent/src/tools/read_window.rs
+++ b/crates/octos-agent/src/tools/read_window.rs
@@ -4,8 +4,9 @@
 //! [`WINDOW_MAX_LINES`] lines and at most [`WINDOW_MAX_BYTES`] bytes of
 //! formatted output — whichever limit is hit first — with a footer naming the
 //! limit that fired, the range actually returned, the file's totals, and the
-//! exact next call. Unarmed behaviour is byte-identical to before this module
-//! existed.
+//! exact next call. A `byte_offset`/`byte_limit` raw mode pages content that
+//! line offsets cannot reach (single lines larger than the window). Unarmed
+//! behaviour is byte-identical to before this module existed.
 //!
 //! ## Parameter provenance
 //!
@@ -28,46 +29,80 @@
 //!    does not. 48 KiB (49,152) plus a [`FOOTER_RESERVE`]-byte footer does.
 //!
 //! A tripwire test pins `WINDOW_MAX_BYTES + FOOTER_RESERVE <=
-//! tool_output_limit("read_file")` so lowering the loop budget cannot silently
-//! re-expose windowed reads to the blind backstop.
+//! tool_output_limit("read_file")` so lowering the loop budget cannot
+//! silently re-expose windowed reads to the blind backstop, and every armed
+//! return path carries a `debug_assert` against the same bound (none of them
+//! interpolates unbounded caller input — path spellings can be arbitrarily
+//! long, so model-facing messages clamp them).
 //!
-//! ## The partial-view ledger
+//! ## Why raw byte paging instead of a shell fallback
 //!
-//! The second half of this module tracks, per absolute path, how much of the
-//! file the model has actually been shown — so `write_file` (armed) can refuse
-//! to overwrite a file wholesale from a partial view. The patch tools
-//! (`edit_file`, `diff_edit`, `apply_patch`) are safe — they re-read the whole
-//! file themselves — but `write_file` reconstructs from whatever the model
-//! saw, and the slides workflow mandates exactly read → rebuild → `write_file`.
+//! pi's answer to a line larger than the window is a `sed | head -c` shell
+//! fallback. That is self-defeating under OUR constraints, twice over: the
+//! shell tool's own output cap is 30,000 bytes
+//! (`octos_core::tool_output_limit("shell")`), so the advised `head -c 49152`
+//! can never arrive intact; and the loop sanitizer redacts exactly the
+//! content giant lines are made of (base64 data URIs, long hex —
+//! `sanitize.rs`), so what survives the cap is then redacted. Hence the
+//! in-tool `byte_offset`/`byte_limit` mode: raw slices, no gutter, footer
+//! naming the next `byte_offset`, and the bytes count toward the same
+//! coverage ledger as line reads.
 //!
-//! Coverage is a contiguous-from-line-1 high-water mark, keyed by mtime:
-//! paging 1..2000, 2001..4000, 4001..EOF under one mtime marks the path
-//! COMPLETE (so the refusal's "page through it first" advice is truthful);
-//! any mtime change resets coverage to the new read alone. Reading out of
-//! order (tail before head) under-counts and stays partial — conservative in
-//! the safe direction, and the refusal always offers the patch tools as the
-//! unconditional escape hatch.
+//! ## The view ledger: fail-closed overwrite protection
 //!
-//! The ledger is a process-global map, NOT threaded through `ToolContext`:
-//! the guard is a data-loss check and must hold on every entry path,
+//! The second half of this module tracks, per `(session, path)`, how much of
+//! the file the model has actually been shown — so `write_file` (armed) can
+//! refuse to reconstruct a file wholesale from a view the model does not
+//! have. The slides workflow mandates exactly read → rebuild → `write_file`,
+//! and its prompt forbids the patch tools, so this guard is the only thing
+//! between a windowed read and a truncated script.
+//!
+//! The rule is **fail-closed** (codex review of the first draft, which was
+//! fail-open on four axes): overwriting an EXISTING file larger than
+//! [`WINDOW_MAX_BYTES`] requires a COMPLETE mark from THIS session; no entry
+//! means refuse-and-read-first. Absence being the refusing state makes a
+//! process restart safe by construction (the model must re-read, which is
+//! correct anyway), makes bounded eviction safe (evicting can only cause a
+//! re-read, never an unseen overwrite), and closes the giant-first-line hole
+//! (the advice branch records nothing, and nothing now means NO). Files at
+//! or under the byte window can still be blind-overwritten exactly as today
+//! — a file that size is returned whole by a single unbounded read, so there
+//! is no partial-view illusion to protect against; but once ANY armed read
+//! recorded a view of it, that record is honoured (a partial or tainted or
+//! stale view refuses regardless of size).
+//!
+//! Coverage is tracked in BYTES — one coordinate system for line-mode reads
+//! (converted to their byte spans) and raw byte-mode reads, so paging past a
+//! giant line stitches naturally. The mark is a contiguous-from-byte-0
+//! high-water line keyed by an epoch of `(mtime, size)`: any epoch change
+//! resets coverage to the new read alone, and `write_file` re-validates the
+//! recorded epoch against the CURRENT file at write time, so a file replaced
+//! after reading refuses as stale instead of trusting dead coverage.
+//! Same-mtime-same-size replacement is not detectable by this scheme (no
+//! content hash in the epoch); it is also not detectable by the M8.4
+//! file-state cache today.
+//!
+//! A view only counts if the model actually received the bytes: the recorded
+//! output is checked against `sanitize_tool_output` (the exact function the
+//! execution loop applies afterwards), and a view the sanitizer would alter
+//! is recorded TAINTED — the epoch can then never reach COMPLETE, because a
+//! whole-file rewrite would replace redacted content with redaction
+//! placeholders. Reads that fit no ledger (metadata unavailable) record an
+//! epoch-less entry that likewise never completes.
+//!
+//! The ledger is a process-global map, NOT threaded through `ToolContext`
+//! state: the guard is a data-loss check and must hold on every entry path,
 //! including legacy `Tool::execute` calls that carry a zero context (the
 //! `FileStateCache` on `ToolContext` is optional and absent on those paths,
-//! which is why it was not reused). It records only when armed, so the
-//! unarmed process pays nothing. This is deliberately NOT the #2126 probe's
-//! `LAST_READ` map — that one is observe-only, keyed to the probe's own env
-//! flag and 500/24KiB canary, and its per-path counters are `cfg(test)`.
-//!
-//! ## Known limitation: a single line larger than the window
-//!
-//! `read_file` has no byte-offset parameter, so it cannot page WITHIN a line
-//! (matching pi, which ships the same limitation and points at a shell
-//! fallback instead — `read.ts`'s `firstLineExceedsLimit` branch). A giant
-//! line is delivered via the advice footer's `sed | head -c` command, which
-//! the ledger cannot observe — so a file containing one can never reach
-//! COMPLETE through `read_file` alone, and a whole-file overwrite of it stays
-//! refused. The refusal's `edit_file`/`apply_patch` escape hatch covers that
-//! case; a `byte_offset` continuation parameter is the future fix if the
-//! probe's `unpageable_long_line` counter ever shows it matters.
+//! which is why it was not reused). Entries are keyed by the context's
+//! `parent_session_key` (empty for zero contexts) so one session's COMPLETE
+//! never authorizes another session's overwrite, values are keyed by
+//! canonicalized path so `read_file` and `write_file` cannot miss each other
+//! over path aliases (`/var` vs `/private/var`), and the map is bounded at
+//! [`MAX_LEDGER_ENTRIES`] (oldest-recorded evicted first — safe, because
+//! absence refuses). This is deliberately NOT the #2126 probe's `LAST_READ`
+//! map — that one is observe-only, keyed to the probe's own env flag and
+//! 500/24KiB canary, and its per-path counters are `cfg(test)`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -87,6 +122,20 @@ pub(crate) const WINDOW_MAX_BYTES: usize = 48 * 1024;
 /// Bytes reserved above [`WINDOW_MAX_BYTES`] for the window footer.
 pub(crate) const FOOTER_RESERVE: usize = 400;
 
+/// Ledger capacity. Eviction is oldest-recorded-first and SAFE by the
+/// fail-closed rule: a missing entry refuses an over-window overwrite (one
+/// re-read), it can never authorize one.
+pub(crate) const MAX_LEDGER_ENTRIES: usize = 512;
+
+/// Which window limit clamped an armed read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WindowClamp {
+    /// [`WINDOW_MAX_LINES`] fired first.
+    Lines,
+    /// [`WINDOW_MAX_BYTES`] fired first.
+    Bytes,
+}
+
 /// Typed prefix on the armed `write_file` refusal, so the model (and any
 /// harness) can match it structurally — same convention as
 /// `[FILE_UNCHANGED]`.
@@ -105,37 +154,80 @@ pub(crate) fn armed_from_env() -> bool {
     std::env::var("OCTOS_READ_WINDOW").is_ok_and(|value| value == "1")
 }
 
-/// How much of one path the model has been shown, contiguously from line 1.
+/// The identity of one on-disk generation of a file.
+///
+/// mtime alone is not identity — same-second replacement preserves it on
+/// coarse filesystems — so size is checked too. (A same-mtime same-size
+/// rewrite still passes; closing that needs a content hash, which the M8.4
+/// cache also does not spend on this.)
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct ViewCoverage {
-    /// Lines 1..=`seen_through` have been shown under `mtime`.
-    pub(crate) seen_through: usize,
-    /// Total lines the file had when last read.
-    pub(crate) total_lines: usize,
+pub(crate) struct ViewEpoch {
+    pub(crate) mtime: SystemTime,
+    pub(crate) size: u64,
 }
 
-/// One path's ledger record.
+/// What the ledger knows about one `(session, path)`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ViewStatus {
+    /// Never read in this session (or evicted / restarted): the fail-closed
+    /// default for over-window files.
+    Unknown,
+    /// Some bytes seen, contiguously from 0 up to `seen_through` (exclusive).
+    Partial {
+        seen_through: usize,
+        total_bytes: usize,
+    },
+    /// Bytes were redacted by the sanitizer before reaching the model; no
+    /// amount of further paging makes a faithful whole-file rewrite possible.
+    Tainted,
+    /// Every byte of this epoch reached the model unredacted.
+    Complete { epoch: ViewEpoch },
+}
+
+/// One `(session, path)`'s record.
 #[derive(Clone, Copy, Debug)]
 struct ViewRecord {
-    /// mtime the coverage was accumulated under; `None` = unknown (never
-    /// stitches).
-    mtime: Option<SystemTime>,
+    /// Epoch coverage was accumulated under; `None` = metadata was
+    /// unavailable at read time, which can never validate at write time and
+    /// therefore never completes.
+    epoch: Option<ViewEpoch>,
+    /// Bytes `0..seen_through` have been shown under `epoch`.
     seen_through: usize,
-    total_lines: usize,
+    /// Raw content length when last read.
+    total_bytes: usize,
+    /// Sticky per epoch: some shown bytes were altered by the sanitizer.
+    tainted: bool,
 }
 
-/// Per-path record of what the model has been shown. See the module docs for
-/// why this is process-global rather than `ToolContext`-threaded.
-static LAST_VIEW: Mutex<Option<HashMap<PathBuf, ViewRecord>>> = Mutex::new(None);
-
-/// Which window limit clamped an armed read.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum WindowClamp {
-    /// [`WINDOW_MAX_LINES`] fired first.
-    Lines,
-    /// [`WINDOW_MAX_BYTES`] fired first.
-    Bytes,
+#[derive(Default)]
+struct Ledger {
+    entries: HashMap<(String, PathBuf), ViewRecord>,
+    /// Insertion/update order, oldest first, for bounded eviction.
+    order: Vec<(String, PathBuf)>,
 }
+
+impl Ledger {
+    /// Move `key` to the freshest end of the order and evict the oldest
+    /// entries past [`MAX_LEDGER_ENTRIES`]. Eviction is safe by the
+    /// fail-closed rule: absence refuses.
+    fn touch_and_evict(&mut self, key: (String, PathBuf)) {
+        self.order.retain(|existing| existing != &key);
+        self.order.push(key);
+        while self.entries.len() > MAX_LEDGER_ENTRIES {
+            if self.order.is_empty() {
+                // entries/order desynchronized — clear rather than loop.
+                self.entries.clear();
+                break;
+            }
+            let oldest = self.order.remove(0);
+            self.entries.remove(&oldest);
+        }
+    }
+}
+
+/// See the module docs for why this is process-global rather than
+/// `ToolContext`-threaded.
+static LEDGER: Mutex<Option<Ledger>> = Mutex::new(None);
 
 /// The key both sides of the ledger agree on.
 ///
@@ -144,81 +236,150 @@ pub(crate) enum WindowClamp {
 /// keyed the raw spellings the guard would silently never match. Falls back
 /// to the raw path when canonicalization fails (file deleted between check
 /// and record) — both sides then fail the same way.
-fn ledger_key(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+fn ledger_key(session: &str, path: &Path) -> (String, PathBuf) {
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    (session.to_string(), canonical)
 }
 
-/// Record one armed `read_file` view of `path`: lines `start..=end`
-/// (1-indexed, inclusive) of a `total_lines`-line file at `mtime`.
+/// Record one armed `read_file` view: bytes `byte_start..byte_end`
+/// (half-open) of a `total_bytes` file at `epoch`, `tainted` when the
+/// sanitizer would have altered the returned output.
 ///
-/// Same-mtime views extend the contiguous-from-1 high-water mark; a changed
-/// (or unknown) mtime resets coverage to this view alone, because coverage
-/// stitched across an on-disk edit would claim the model has seen content
-/// that no longer exists. Callers gate on arming — this function itself does
-/// not consult the env, so tests can drive it through per-instance-armed
-/// tools without touching process state.
+/// Same-epoch views extend the contiguous-from-0 high-water mark and OR
+/// their taint; an epoch change (or `None` epoch) resets coverage to this
+/// view alone. Callers gate on arming — this function itself does not
+/// consult the env, so tests can drive it through per-instance-armed tools
+/// without touching process state.
 pub(crate) fn record_view(
+    session: &str,
     path: &Path,
-    mtime: Option<SystemTime>,
-    start: usize,
-    end: usize,
-    total_lines: usize,
+    epoch: Option<ViewEpoch>,
+    byte_start: usize,
+    byte_end: usize,
+    total_bytes: usize,
+    tainted: bool,
 ) {
-    let key = ledger_key(path);
-    let mut guard = LAST_VIEW
+    let key = ledger_key(session, path);
+    let mut guard = LEDGER
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let map = guard.get_or_insert_with(HashMap::new);
-    // Coverage carries over only within one mtime epoch; `None` mtimes never
-    // match (unknown is not evidence).
-    let carried = match map.get(&key) {
-        Some(prev) if prev.mtime.is_some() && prev.mtime == mtime => prev.seen_through,
-        _ => 0,
+    let ledger = guard.get_or_insert_with(Ledger::default);
+    // Coverage and taint carry over only within one known epoch; `None`
+    // epochs never match (unknown is not evidence).
+    let (carried, carried_taint) = match ledger.entries.get(&key) {
+        Some(prev) if prev.epoch.is_some() && prev.epoch == epoch => {
+            (prev.seen_through, prev.tainted)
+        }
+        _ => (0, false),
     };
-    let seen_through = if start <= carried.saturating_add(1) {
-        carried.max(end)
+    // Half-open [byte_start, byte_end): contiguous means starting at or
+    // before the high-water mark; a view past it leaves a gap and the mark
+    // stays.
+    let seen_through = if byte_start <= carried {
+        carried.max(byte_end)
     } else {
-        // A view past the high-water mark leaves a gap; the mark stays.
         carried
     };
-    map.insert(
-        key,
+    ledger.entries.insert(
+        key.clone(),
         ViewRecord {
-            mtime,
+            epoch,
             seen_through,
-            total_lines,
+            total_bytes,
+            tainted: carried_taint || tainted,
         },
     );
+    ledger.touch_and_evict(key);
 }
 
-/// The coverage record for `path` when the model's most recent knowledge of
-/// it is PARTIAL, or `None` when the path is unknown or fully seen.
-pub(crate) fn partial_view_of(path: &Path) -> Option<ViewCoverage> {
-    let key = ledger_key(path);
-    let guard = LAST_VIEW
+/// What this session knows about `path`.
+pub(crate) fn view_status(session: &str, path: &Path) -> ViewStatus {
+    let key = ledger_key(session, path);
+    let guard = LEDGER
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    guard.as_ref()?.get(&key).and_then(|record| {
-        if record.seen_through >= record.total_lines {
-            None
-        } else {
-            Some(ViewCoverage {
-                seen_through: record.seen_through,
-                total_lines: record.total_lines,
-            })
+    let Some(record) = guard.as_ref().and_then(|ledger| ledger.entries.get(&key)) else {
+        return ViewStatus::Unknown;
+    };
+    if record.tainted {
+        return ViewStatus::Tainted;
+    }
+    match record.epoch {
+        // Full contiguous coverage of a validatable generation.
+        Some(epoch) if record.seen_through >= record.total_bytes => ViewStatus::Complete { epoch },
+        // An epoch-less view can never be validated at write time, so full
+        // coverage of it still reports (and refuses as) Partial.
+        _ => ViewStatus::Partial {
+            seen_through: record.seen_through,
+            total_bytes: record.total_bytes,
+        },
+    }
+}
+
+/// Note a successful, unformatted whole-file `write_file`: the on-disk
+/// content is now exactly what the model supplied, so the session's view of
+/// it is COMPLETE at the post-write epoch. (The fail-closed rule would
+/// otherwise refuse the model's own next overwrite of a big file it just
+/// authored.) When the post-write stat fails, the entry is forgotten —
+/// absence refuses, which is the safe direction.
+pub(crate) fn note_full_write(session: &str, path: &Path, written_bytes: usize) {
+    let epoch = std::fs::metadata(path).ok().and_then(|meta| {
+        meta.modified().ok().map(|mtime| ViewEpoch {
+            mtime,
+            size: meta.len(),
+        })
+    });
+    match epoch {
+        Some(epoch) => {
+            let key = ledger_key(session, path);
+            let mut guard = LEDGER
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let ledger = guard.get_or_insert_with(Ledger::default);
+            ledger.entries.insert(
+                key.clone(),
+                ViewRecord {
+                    epoch: Some(epoch),
+                    seen_through: written_bytes,
+                    total_bytes: written_bytes,
+                    tainted: false,
+                },
+            );
+            ledger.touch_and_evict(key);
         }
-    })
+        // Post-write stat failed: nothing validatable to record — forget,
+        // because absence refuses (the safe direction).
+        None => forget(session, path),
+    }
 }
 
-/// Note a successful whole-file `write_file` of `path`: the on-disk content
-/// is now exactly what the model supplied, so any partial mark is obsolete.
-pub(crate) fn note_full_write(path: &Path) {
-    let key = ledger_key(path);
-    let mut guard = LAST_VIEW
+/// Forget one `(session, path)` — used when the on-disk content diverged
+/// from what the model supplied (post-write formatter rewrote the file).
+pub(crate) fn forget(session: &str, path: &Path) {
+    let key = ledger_key(session, path);
+    let mut guard = LEDGER
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(map) = guard.as_mut() {
-        map.remove(&key);
+    if let Some(ledger) = guard.as_mut() {
+        ledger.entries.remove(&key);
+        ledger.order.retain(|existing| existing != &key);
+    }
+}
+
+/// Drop every entry of one session — simulates a process restart for that
+/// session in tests. (The real restart clears all sessions at once, but a
+/// whole-ledger clear from one test would wipe parallel tests' entries
+/// mid-flight — the same cross-test blast radius that rules out global
+/// arming. Restart semantics are per-entry absence, which this preserves
+/// exactly for the session under test.)
+#[cfg(test)]
+pub(crate) fn reset_session_for_test(session: &str) {
+    let mut guard = LEDGER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(ledger) = guard.as_mut() {
+        ledger.entries.retain(|key, _| key.0 != session);
+        ledger.order.retain(|key| key.0 != session);
     }
 }
 
@@ -227,9 +388,17 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    // The ledger is process-global and keyed by path; each test uses paths
-    // under its own tempdir so parallel tests never observe each other
-    // (#2077/#2126: never assert on process-global aggregates).
+    // The ledger is process-global, keyed by (session, path); each test uses
+    // its own tempdir paths and its own session strings, so parallel tests
+    // never observe each other (#2077/#2126: never assert on process-global
+    // aggregates).
+
+    fn epoch_at(secs_ago: u64, size: u64) -> Option<ViewEpoch> {
+        Some(ViewEpoch {
+            mtime: SystemTime::now() - Duration::from_secs(secs_ago),
+            size,
+        })
+    }
 
     #[test]
     fn window_plus_footer_must_fit_under_the_loop_backstop() {
@@ -251,32 +420,34 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("paged.txt");
         std::fs::write(&path, "x").unwrap();
-        let mtime = Some(SystemTime::now());
+        let epoch = epoch_at(0, 5000);
 
-        record_view(&path, mtime, 1, 2000, 5000);
+        record_view("s", &path, epoch, 0, 2000, 5000, false);
         assert_eq!(
-            partial_view_of(&path),
-            Some(ViewCoverage {
+            view_status("s", &path),
+            ViewStatus::Partial {
                 seen_through: 2000,
-                total_lines: 5000
-            }),
+                total_bytes: 5000
+            },
             "a windowed view is partial"
         );
 
-        record_view(&path, mtime, 2001, 4000, 5000);
+        record_view("s", &path, epoch, 2000, 4000, 5000, false);
         assert_eq!(
-            partial_view_of(&path),
-            Some(ViewCoverage {
+            view_status("s", &path),
+            ViewStatus::Partial {
                 seen_through: 4000,
-                total_lines: 5000
-            }),
+                total_bytes: 5000
+            },
             "contiguous pages extend the high-water mark"
         );
 
-        record_view(&path, mtime, 4001, 5000, 5000);
+        record_view("s", &path, epoch, 4000, 5000, 5000, false);
         assert_eq!(
-            partial_view_of(&path),
-            None,
+            view_status("s", &path),
+            ViewStatus::Complete {
+                epoch: epoch.unwrap()
+            },
             "paging through to EOF completes the view — the refusal's advice \
              must be truthful"
         );
@@ -287,56 +458,158 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("gappy.txt");
         std::fs::write(&path, "x").unwrap();
-        let mtime = Some(SystemTime::now());
+        let epoch = epoch_at(0, 5000);
 
-        record_view(&path, mtime, 1, 2000, 5000);
-        record_view(&path, mtime, 2500, 5000, 5000); // lines 2001-2499 never seen
+        record_view("s", &path, epoch, 0, 2000, 5000, false);
+        record_view("s", &path, epoch, 2500, 5000, 5000, false); // bytes 2000..2500 never seen
         assert_eq!(
-            partial_view_of(&path),
-            Some(ViewCoverage {
+            view_status("s", &path),
+            ViewStatus::Partial {
                 seen_through: 2000,
-                total_lines: 5000
-            }),
+                total_bytes: 5000
+            },
             "a gap means the view is still partial at the gap"
         );
     }
 
     #[test]
-    fn should_reset_coverage_when_the_mtime_changes() {
+    fn should_reset_coverage_when_the_epoch_changes() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("edited.txt");
         std::fs::write(&path, "x").unwrap();
-        let old = Some(SystemTime::now() - Duration::from_secs(60));
-        let new = Some(SystemTime::now());
 
-        record_view(&path, old, 1, 2000, 5000);
-        // The file changed on disk; earlier coverage is no longer evidence.
-        record_view(&path, new, 2001, 4000, 5000);
+        record_view("s", &path, epoch_at(60, 5000), 0, 2000, 5000, false);
+        // Same mtime second, DIFFERENT size — still a different epoch.
+        record_view("s", &path, epoch_at(60, 6000), 2000, 4000, 6000, false);
         assert_eq!(
-            partial_view_of(&path),
-            Some(ViewCoverage {
+            view_status("s", &path),
+            ViewStatus::Partial {
                 seen_through: 0,
-                total_lines: 5000
-            }),
-            "coverage accumulated under a different mtime must not survive"
+                total_bytes: 6000
+            },
+            "coverage accumulated under a different (mtime, size) must not \
+             survive — same-second replacement included"
         );
     }
 
     #[test]
-    fn should_forget_a_path_after_a_full_write() {
+    fn should_never_complete_a_tainted_epoch() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("rewritten.txt");
+        let path = dir.path().join("secrets.txt");
+        std::fs::write(&path, "x").unwrap();
+        let epoch = epoch_at(0, 100);
+
+        record_view("s", &path, epoch, 0, 50, 100, true); // sanitizer altered this view
+        record_view("s", &path, epoch, 50, 100, 100, false);
+        assert_eq!(
+            view_status("s", &path),
+            ViewStatus::Tainted,
+            "full coverage with redacted bytes is NOT a faithful view — \
+             taint is sticky for the epoch"
+        );
+
+        // A new epoch starts clean.
+        record_view("s", &path, epoch_at(0, 101), 0, 101, 101, false);
+        assert!(
+            matches!(view_status("s", &path), ViewStatus::Complete { .. }),
+            "an untainted re-read of a new epoch completes"
+        );
+    }
+
+    #[test]
+    fn should_never_complete_without_an_epoch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_meta.txt");
         std::fs::write(&path, "x").unwrap();
 
-        record_view(&path, Some(SystemTime::now()), 1, 10, 5000);
-        assert!(partial_view_of(&path).is_some());
-
-        note_full_write(&path);
+        record_view("s", &path, None, 0, 100, 100, false);
         assert_eq!(
-            partial_view_of(&path),
-            None,
-            "after write_file succeeds the on-disk content is exactly what \
-             the model supplied — no partial mark may linger"
+            view_status("s", &path),
+            ViewStatus::Partial {
+                seen_through: 100,
+                total_bytes: 100
+            },
+            "an epoch-less view can never be validated at write time, so it \
+             must never report Complete"
+        );
+    }
+
+    #[test]
+    fn should_scope_views_to_the_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("scoped.txt");
+        std::fs::write(&path, "x").unwrap();
+
+        record_view("session-a", &path, epoch_at(0, 10), 0, 10, 10, false);
+        assert!(matches!(
+            view_status("session-a", &path),
+            ViewStatus::Complete { .. }
+        ));
+        assert_eq!(
+            view_status("session-b", &path),
+            ViewStatus::Unknown,
+            "one session's COMPLETE must never vouch for another session"
+        );
+    }
+
+    #[test]
+    fn should_forget_and_reset() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("forgotten.txt");
+        std::fs::write(&path, "x").unwrap();
+
+        record_view("s", &path, epoch_at(0, 10), 0, 5, 10, false);
+        assert!(matches!(
+            view_status("s", &path),
+            ViewStatus::Partial { .. }
+        ));
+        forget("s", &path);
+        assert_eq!(view_status("s", &path), ViewStatus::Unknown);
+    }
+
+    #[test]
+    fn should_mark_complete_after_note_full_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("authored.txt");
+        std::fs::write(&path, "0123456789").unwrap();
+
+        note_full_write("s", &path, 10);
+        match view_status("s", &path) {
+            ViewStatus::Complete { epoch } => {
+                assert_eq!(epoch.size, 10, "epoch is the post-write stat");
+            }
+            other => panic!(
+                "the model authored every byte it just wrote — must be \
+                 Complete, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn should_bound_the_ledger_and_evict_oldest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        // Unique session name so parallel tests cannot interleave entries
+        // into this session's eviction accounting.
+        let session = format!("evict-{}", std::process::id());
+        let epoch = epoch_at(0, 1);
+        // Paths need not exist — ledger_key falls back to the raw path.
+        let path_of = |i: usize| dir.path().join(format!("f{i}.txt"));
+
+        for i in 0..MAX_LEDGER_ENTRIES + 1 {
+            record_view(&session, &path_of(i), epoch, 0, 1, 1, false);
+        }
+        assert_eq!(
+            view_status(&session, &path_of(0)),
+            ViewStatus::Unknown,
+            "the oldest entry is evicted once the cap is crossed — safe, \
+             because absence refuses"
+        );
+        assert!(
+            matches!(
+                view_status(&session, &path_of(MAX_LEDGER_ENTRIES)),
+                ViewStatus::Complete { .. }
+            ),
+            "the newest entry survives"
         );
     }
 
@@ -351,9 +624,9 @@ mod tests {
         std::fs::write(&real, "x").unwrap();
         let canonical = real.canonicalize().unwrap();
 
-        record_view(&real, Some(SystemTime::now()), 1, 10, 5000);
+        record_view("s", &real, epoch_at(0, 10), 0, 5, 10, false);
         assert!(
-            partial_view_of(&canonical).is_some(),
+            matches!(view_status("s", &canonical), ViewStatus::Partial { .. }),
             "the canonical form must see coverage recorded via the raw form"
         );
     }

--- a/crates/octos-agent/src/tools/read_window.rs
+++ b/crates/octos-agent/src/tools/read_window.rs
@@ -157,6 +157,12 @@ pub(crate) const PARTIAL_VIEW_OVERWRITE_PREFIX: &str = "[PARTIAL_VIEW_OVERWRITE]
 /// THIS file, rather than the partial-view "page through it" advice.
 pub(crate) const REDACTED_VIEW_OVERWRITE_PREFIX: &str = "[REDACTED_VIEW_OVERWRITE]";
 
+/// Typed prefix for the DISTINCT transformed-view refusal (#2193 R4): the
+/// model was shown TEXT decoded from a binary (PDF extraction), never the
+/// file's own bytes, so — like a redacted view — paging can never deliver the
+/// bytes whole. Its own prefix and a message that says so.
+pub(crate) const TRANSFORMED_VIEW_OVERWRITE_PREFIX: &str = "[TRANSFORMED_VIEW_OVERWRITE]";
+
 /// Whether window enforcement is armed by the environment.
 ///
 /// Mirrors the #2126 probe's gate shape (`OCTOS_READ_PAGING_PROBE=1`). The
@@ -170,16 +176,62 @@ pub(crate) fn armed_from_env() -> bool {
     std::env::var("OCTOS_READ_WINDOW").is_ok_and(|value| value == "1")
 }
 
-/// The identity of one on-disk generation of a file.
+/// The identity of one on-disk generation of a file (#2193 R4).
 ///
-/// mtime alone is not identity — same-second replacement preserves it on
-/// coarse filesystems — so size is checked too. (A same-mtime same-size
-/// rewrite still passes; closing that needs a content hash, which the M8.4
-/// cache also does not spend on this.)
+/// mtime and size alone are NOT identity — a same-size replacement that forges
+/// mtime (`utimensat`) compares equal and would authorize an overwrite of
+/// content the model never saw. So the epoch also binds:
+/// - `ctime`: the inode change time. Userspace has no API to set it backwards;
+///   any in-place rewrite bumps it to "now". This defeats the same-size,
+///   same-mtime replacement outright on every modern filesystem (nanosecond
+///   ctime); only a coarse-granularity FS leaves a sub-tick residual.
+/// - `inode`: the inode number, so a rename-over swap to a different inode with
+///   the same (mtime, size) is a distinct generation and is refused.
+///
+/// Both are `None` off Unix (where the windowed-read flag is secondary and the
+/// sandbox degrades anyway); there the guarantee falls back to (mtime, size).
+/// Build via [`ViewEpoch::from_metadata`], ideally from an ALREADY-OPEN
+/// descriptor's `fstat`, so the epoch describes the exact inode whose bytes
+/// were read rather than a racy re-resolution of the path.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ViewEpoch {
     pub(crate) mtime: SystemTime,
     pub(crate) size: u64,
+    pub(crate) ctime: Option<SystemTime>,
+    pub(crate) inode: Option<u64>,
+}
+
+impl ViewEpoch {
+    /// Build the epoch from a file's metadata — pass the metadata of an
+    /// already-open descriptor (`file.metadata()`) so it binds to that exact
+    /// inode, not a re-resolved path.
+    pub(crate) fn from_metadata(meta: &std::fs::Metadata) -> Option<ViewEpoch> {
+        let mtime = meta.modified().ok()?;
+        let (ctime, inode) = ctime_and_inode(meta);
+        Some(ViewEpoch {
+            mtime,
+            size: meta.len(),
+            ctime,
+            inode,
+        })
+    }
+}
+
+#[cfg(unix)]
+fn ctime_and_inode(meta: &std::fs::Metadata) -> (Option<SystemTime>, Option<u64>) {
+    use std::os::unix::fs::MetadataExt;
+    let secs = meta.ctime();
+    let nsecs = meta.ctime_nsec();
+    // ctime is seconds since the epoch; real files are post-1970 (secs >= 0).
+    let ctime = u64::try_from(secs).ok().map(|s| {
+        SystemTime::UNIX_EPOCH + std::time::Duration::new(s, nsecs.clamp(0, 999_999_999) as u32)
+    });
+    (ctime, Some(meta.ino()))
+}
+
+#[cfg(not(unix))]
+fn ctime_and_inode(_meta: &std::fs::Metadata) -> (Option<SystemTime>, Option<u64>) {
+    (None, None)
 }
 
 /// What the ledger knows about one `(session, path)`.
@@ -196,6 +248,12 @@ pub(crate) enum ViewStatus {
     /// Bytes were redacted by the sanitizer before reaching the model; no
     /// amount of further paging makes a faithful whole-file rewrite possible.
     Tainted,
+    /// The bytes shown were a DECODE of the on-disk file (e.g. PDF text
+    /// extraction), not the file's own bytes. Like `Tainted`, paging can never
+    /// deliver the on-disk bytes whole, so a faithful whole-file rewrite is
+    /// impossible — but for a different reason (transform, not redaction), so
+    /// it gets its own status and write-side message.
+    Transformed,
     /// Every byte of this epoch reached the model unredacted.
     Complete { epoch: ViewEpoch },
 }
@@ -213,6 +271,9 @@ struct ViewRecord {
     total_bytes: usize,
     /// Sticky per epoch: some shown bytes were altered by the sanitizer.
     tainted: bool,
+    /// Sticky per epoch: the shown bytes were a decode of the on-disk file
+    /// (PDF extraction), never the file's own bytes.
+    transformed: bool,
 }
 
 #[derive(Default)]
@@ -266,6 +327,11 @@ fn ledger_key(session: &str, path: &Path) -> (String, PathBuf) {
 /// view alone. Callers gate on arming — this function itself does not
 /// consult the env, so tests can drive it through per-instance-armed tools
 /// without touching process state.
+// Eight cohesive facts about one read (who, which file+generation, the
+// byte span shown, and the two INDEPENDENT non-authorizing flags — a view
+// can be both sanitizer-redacted AND a binary decode). Bundling them would
+// obscure more than it saves.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn record_view(
     session: &str,
     path: &Path,
@@ -274,6 +340,7 @@ pub(crate) fn record_view(
     byte_end: usize,
     total_bytes: usize,
     tainted: bool,
+    transformed: bool,
 ) {
     // R4: a missing/empty session key must never share a bucket with another
     // keyless task, so keyless tasks record NOTHING — they can then never
@@ -289,11 +356,11 @@ pub(crate) fn record_view(
     let ledger = guard.get_or_insert_with(Ledger::default);
     // Coverage and taint carry over only within one known epoch; `None`
     // epochs never match (unknown is not evidence).
-    let (carried, carried_taint) = match ledger.entries.get(&key) {
+    let (carried, carried_taint, carried_transformed) = match ledger.entries.get(&key) {
         Some(prev) if prev.epoch.is_some() && prev.epoch == epoch => {
-            (prev.seen_through, prev.tainted)
+            (prev.seen_through, prev.tainted, prev.transformed)
         }
-        _ => (0, false),
+        _ => (0, false, false),
     };
     // Half-open [byte_start, byte_end): contiguous means starting at or
     // before the high-water mark; a view past it leaves a gap and the mark
@@ -310,6 +377,7 @@ pub(crate) fn record_view(
             seen_through,
             total_bytes,
             tainted: carried_taint || tainted,
+            transformed: carried_transformed || transformed,
         },
     );
     ledger.touch_and_evict(key);
@@ -326,6 +394,9 @@ pub(crate) fn view_status(session: &str, path: &Path) -> ViewStatus {
     };
     if record.tainted {
         return ViewStatus::Tainted;
+    }
+    if record.transformed {
+        return ViewStatus::Transformed;
     }
     match record.epoch {
         // Full contiguous coverage of a validatable generation.
@@ -350,12 +421,9 @@ pub(crate) fn note_full_write(session: &str, path: &Path, written_bytes: usize) 
     if session.is_empty() {
         return;
     }
-    let epoch = std::fs::metadata(path).ok().and_then(|meta| {
-        meta.modified().ok().map(|mtime| ViewEpoch {
-            mtime,
-            size: meta.len(),
-        })
-    });
+    let epoch = std::fs::metadata(path)
+        .ok()
+        .and_then(|meta| ViewEpoch::from_metadata(&meta));
     match epoch {
         // R1 second half: only mark COMPLETE when the bytes on disk are the
         // bytes we wrote. A size disagreement means a replacement landed in
@@ -374,6 +442,7 @@ pub(crate) fn note_full_write(session: &str, path: &Path, written_bytes: usize) 
                     seen_through: written_bytes,
                     total_bytes: written_bytes,
                     tainted: false,
+                    transformed: false,
                 },
             );
             ledger.touch_and_evict(key);
@@ -424,10 +493,30 @@ mod tests {
     // never observe each other (#2077/#2126: never assert on process-global
     // aggregates).
 
+    #[test]
+    fn transformed_view_never_completes_even_at_full_coverage() {
+        // #2193 R4 (codex H6): a PDF read shows extracted TEXT, not the on-disk
+        // bytes. Even paging that text to EOF must report Transformed, never
+        // Complete — else it authorizes overwriting the binary the model never
+        // actually saw.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("doc.pdf");
+        std::fs::write(&path, "x").unwrap();
+        let epoch = epoch_at(0, 500);
+        record_view("s", &path, epoch, 0, 500, 500, false, true);
+        assert_eq!(
+            view_status("s", &path),
+            ViewStatus::Transformed,
+            "full coverage of a transformed view must NOT be Complete",
+        );
+    }
+
     fn epoch_at(secs_ago: u64, size: u64) -> Option<ViewEpoch> {
         Some(ViewEpoch {
             mtime: SystemTime::now() - Duration::from_secs(secs_ago),
             size,
+            ctime: None,
+            inode: None,
         })
     }
 
@@ -453,7 +542,7 @@ mod tests {
         std::fs::write(&path, "x").unwrap();
         let epoch = epoch_at(0, 5000);
 
-        record_view("s", &path, epoch, 0, 2000, 5000, false);
+        record_view("s", &path, epoch, 0, 2000, 5000, false, false);
         assert_eq!(
             view_status("s", &path),
             ViewStatus::Partial {
@@ -463,7 +552,7 @@ mod tests {
             "a windowed view is partial"
         );
 
-        record_view("s", &path, epoch, 2000, 4000, 5000, false);
+        record_view("s", &path, epoch, 2000, 4000, 5000, false, false);
         assert_eq!(
             view_status("s", &path),
             ViewStatus::Partial {
@@ -473,7 +562,7 @@ mod tests {
             "contiguous pages extend the high-water mark"
         );
 
-        record_view("s", &path, epoch, 4000, 5000, 5000, false);
+        record_view("s", &path, epoch, 4000, 5000, 5000, false, false);
         assert_eq!(
             view_status("s", &path),
             ViewStatus::Complete {
@@ -491,8 +580,8 @@ mod tests {
         std::fs::write(&path, "x").unwrap();
         let epoch = epoch_at(0, 5000);
 
-        record_view("s", &path, epoch, 0, 2000, 5000, false);
-        record_view("s", &path, epoch, 2500, 5000, 5000, false); // bytes 2000..2500 never seen
+        record_view("s", &path, epoch, 0, 2000, 5000, false, false);
+        record_view("s", &path, epoch, 2500, 5000, 5000, false, false); // bytes 2000..2500 never seen
         assert_eq!(
             view_status("s", &path),
             ViewStatus::Partial {
@@ -509,9 +598,18 @@ mod tests {
         let path = dir.path().join("edited.txt");
         std::fs::write(&path, "x").unwrap();
 
-        record_view("s", &path, epoch_at(60, 5000), 0, 2000, 5000, false);
+        record_view("s", &path, epoch_at(60, 5000), 0, 2000, 5000, false, false);
         // Same mtime second, DIFFERENT size — still a different epoch.
-        record_view("s", &path, epoch_at(60, 6000), 2000, 4000, 6000, false);
+        record_view(
+            "s",
+            &path,
+            epoch_at(60, 6000),
+            2000,
+            4000,
+            6000,
+            false,
+            false,
+        );
         assert_eq!(
             view_status("s", &path),
             ViewStatus::Partial {
@@ -530,8 +628,8 @@ mod tests {
         std::fs::write(&path, "x").unwrap();
         let epoch = epoch_at(0, 100);
 
-        record_view("s", &path, epoch, 0, 50, 100, true); // sanitizer altered this view
-        record_view("s", &path, epoch, 50, 100, 100, false);
+        record_view("s", &path, epoch, 0, 50, 100, true, false); // sanitizer altered this view
+        record_view("s", &path, epoch, 50, 100, 100, false, false);
         assert_eq!(
             view_status("s", &path),
             ViewStatus::Tainted,
@@ -540,7 +638,7 @@ mod tests {
         );
 
         // A new epoch starts clean.
-        record_view("s", &path, epoch_at(0, 101), 0, 101, 101, false);
+        record_view("s", &path, epoch_at(0, 101), 0, 101, 101, false, false);
         assert!(
             matches!(view_status("s", &path), ViewStatus::Complete { .. }),
             "an untainted re-read of a new epoch completes"
@@ -553,7 +651,7 @@ mod tests {
         let path = dir.path().join("no_meta.txt");
         std::fs::write(&path, "x").unwrap();
 
-        record_view("s", &path, None, 0, 100, 100, false);
+        record_view("s", &path, None, 0, 100, 100, false, false);
         assert_eq!(
             view_status("s", &path),
             ViewStatus::Partial {
@@ -575,7 +673,7 @@ mod tests {
         let path = dir.path().join("keyless.txt");
         std::fs::write(&path, "0123456789").unwrap();
 
-        record_view("", &path, epoch_at(0, 10), 0, 10, 10, false);
+        record_view("", &path, epoch_at(0, 10), 0, 10, 10, false, false);
         assert_eq!(
             view_status("", &path),
             ViewStatus::Unknown,
@@ -597,7 +695,7 @@ mod tests {
         let path = dir.path().join("scoped.txt");
         std::fs::write(&path, "x").unwrap();
 
-        record_view("session-a", &path, epoch_at(0, 10), 0, 10, 10, false);
+        record_view("session-a", &path, epoch_at(0, 10), 0, 10, 10, false, false);
         assert!(matches!(
             view_status("session-a", &path),
             ViewStatus::Complete { .. }
@@ -615,7 +713,7 @@ mod tests {
         let path = dir.path().join("forgotten.txt");
         std::fs::write(&path, "x").unwrap();
 
-        record_view("s", &path, epoch_at(0, 10), 0, 5, 10, false);
+        record_view("s", &path, epoch_at(0, 10), 0, 5, 10, false, false);
         assert!(matches!(
             view_status("s", &path),
             ViewStatus::Partial { .. }
@@ -662,6 +760,8 @@ mod tests {
                 epoch: ViewEpoch {
                     mtime: std::fs::metadata(&path).unwrap().modified().unwrap(),
                     size: 10,
+                    ctime: None,
+                    inode: None,
                 },
             },
             "a size disagreement must not be recorded as COMPLETE"
@@ -683,7 +783,7 @@ mod tests {
         let path_of = |i: usize| dir.path().join(format!("f{i}.txt"));
 
         for i in 0..MAX_LEDGER_ENTRIES + 1 {
-            record_view(&session, &path_of(i), epoch, 0, 1, 1, false);
+            record_view(&session, &path_of(i), epoch, 0, 1, 1, false, false);
         }
         assert_eq!(
             view_status(&session, &path_of(0)),
@@ -711,7 +811,7 @@ mod tests {
         std::fs::write(&real, "x").unwrap();
         let canonical = real.canonicalize().unwrap();
 
-        record_view("s", &real, epoch_at(0, 10), 0, 5, 10, false);
+        record_view("s", &real, epoch_at(0, 10), 0, 5, 10, false, false);
         assert!(
             matches!(view_status("s", &canonical), ViewStatus::Partial { .. }),
             "the canonical form must see coverage recorded via the raw form"

--- a/crates/octos-agent/src/tools/read_window.rs
+++ b/crates/octos-agent/src/tools/read_window.rs
@@ -31,9 +31,10 @@
 //! A tripwire test pins `WINDOW_MAX_BYTES + FOOTER_RESERVE <=
 //! tool_output_limit("read_file")` so lowering the loop budget cannot
 //! silently re-expose windowed reads to the blind backstop, and every armed
-//! return path carries a `debug_assert` against the same bound (none of them
-//! interpolates unbounded caller input — path spellings can be arbitrarily
-//! long, so model-facing messages clamp them).
+//! return path is clamped to `WINDOW_MAX_BYTES + FOOTER_RESERVE` at RUNTIME
+//! (not a `debug_assert`, which release builds drop). None of the armed
+//! returns interpolates unbounded caller input — path spellings can be
+//! arbitrarily long, so model-facing messages clamp them.
 //!
 //! ## Why raw byte paging instead of a shell fallback
 //!
@@ -94,15 +95,23 @@
 //! state: the guard is a data-loss check and must hold on every entry path,
 //! including legacy `Tool::execute` calls that carry a zero context (the
 //! `FileStateCache` on `ToolContext` is optional and absent on those paths,
-//! which is why it was not reused). Entries are keyed by the context's
-//! `parent_session_key` (empty for zero contexts) so one session's COMPLETE
-//! never authorizes another session's overwrite, values are keyed by
-//! canonicalized path so `read_file` and `write_file` cannot miss each other
-//! over path aliases (`/var` vs `/private/var`), and the map is bounded at
-//! [`MAX_LEDGER_ENTRIES`] (oldest-recorded evicted first — safe, because
-//! absence refuses). This is deliberately NOT the #2126 probe's `LAST_READ`
-//! map — that one is observe-only, keyed to the probe's own env flag and
-//! 500/24KiB canary, and its per-path counters are `cfg(test)`.
+//! which is why it was not reused). Entries are keyed by
+//! `(parent_session_key, canonical path)`: one session's COMPLETE never
+//! authorizes another's, and canonicalization keeps `read_file` and
+//! `write_file` agreeing over path aliases (`/var` vs `/private/var`). The map
+//! is bounded at [`MAX_LEDGER_ENTRIES`] (oldest-recorded evicted first — safe,
+//! because absence refuses).
+//!
+//! R4 (codex round 3): a missing/empty session key is reachable in production
+//! (agents default to `None`; FFI and fleet workers; plain CLI chat without
+//! `--goals`), so an empty key must NOT share a bucket with another keyless
+//! task. Empty-session reads and writes therefore record NOTHING — a keyless
+//! task can never establish COMPLETE, so the write guard fails closed for its
+//! over-window overwrites (`record_view`/`note_full_write` are the single
+//! enforcement point; the guard adds only a clearer keyless message). This is
+//! deliberately NOT the #2126 probe's `LAST_READ` map — that one is
+//! observe-only, keyed to the probe's own env flag and 500/24KiB canary, and
+//! its per-path counters are `cfg(test)`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -140,6 +149,13 @@ pub(crate) enum WindowClamp {
 /// harness) can match it structurally — same convention as
 /// `[FILE_UNCHANGED]`.
 pub(crate) const PARTIAL_VIEW_OVERWRITE_PREFIX: &str = "[PARTIAL_VIEW_OVERWRITE]";
+
+/// Typed prefix for the DISTINCT tainted-overwrite refusal. A tainted view is
+/// not a "read more" case — the loop sanitizer redacts every raw byte page
+/// too, so paging can never deliver the bytes whole — so it gets its own
+/// prefix and a message that says the flag is incompatible with rewriting
+/// THIS file, rather than the partial-view "page through it" advice.
+pub(crate) const REDACTED_VIEW_OVERWRITE_PREFIX: &str = "[REDACTED_VIEW_OVERWRITE]";
 
 /// Whether window enforcement is armed by the environment.
 ///
@@ -259,6 +275,13 @@ pub(crate) fn record_view(
     total_bytes: usize,
     tainted: bool,
 ) {
+    // R4: a missing/empty session key must never share a bucket with another
+    // keyless task, so keyless tasks record NOTHING — they can then never
+    // reach COMPLETE, and the write guard fails closed for their big-file
+    // overwrites. This is the single enforcement point for that rule.
+    if session.is_empty() {
+        return;
+    }
     let key = ledger_key(session, path);
     let mut guard = LEDGER
         .lock()
@@ -323,6 +346,10 @@ pub(crate) fn view_status(session: &str, path: &Path) -> ViewStatus {
 /// authored.) When the post-write stat fails, the entry is forgotten —
 /// absence refuses, which is the safe direction.
 pub(crate) fn note_full_write(session: &str, path: &Path, written_bytes: usize) {
+    // R4: keyless tasks never establish coverage (see record_view).
+    if session.is_empty() {
+        return;
+    }
     let epoch = std::fs::metadata(path).ok().and_then(|meta| {
         meta.modified().ok().map(|mtime| ViewEpoch {
             mtime,
@@ -330,7 +357,11 @@ pub(crate) fn note_full_write(session: &str, path: &Path, written_bytes: usize) 
         })
     });
     match epoch {
-        Some(epoch) => {
+        // R1 second half: only mark COMPLETE when the bytes on disk are the
+        // bytes we wrote. A size disagreement means a replacement landed in
+        // the write->stat window; recording COMPLETE then would authorize a
+        // later overwrite of content the model never produced. Forget instead.
+        Some(epoch) if epoch.size == written_bytes as u64 => {
             let key = ledger_key(session, path);
             let mut guard = LEDGER
                 .lock()
@@ -347,9 +378,9 @@ pub(crate) fn note_full_write(session: &str, path: &Path, written_bytes: usize) 
             );
             ledger.touch_and_evict(key);
         }
-        // Post-write stat failed: nothing validatable to record — forget,
-        // because absence refuses (the safe direction).
-        None => forget(session, path),
+        // Stat failed, or on-disk size disagrees with what we wrote: nothing
+        // validatable to record — forget, because absence refuses.
+        _ => forget(session, path),
     }
 }
 
@@ -535,6 +566,32 @@ mod tests {
     }
 
     #[test]
+    fn should_record_nothing_for_an_empty_session() {
+        // R4 single enforcement point for isolation: a keyless task (empty
+        // session key) must record NOTHING, so two keyless tasks can never
+        // cross-authorize via a shared "" bucket. Mutating the empty-session
+        // guard in record_view/note_full_write makes this fail.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("keyless.txt");
+        std::fs::write(&path, "0123456789").unwrap();
+
+        record_view("", &path, epoch_at(0, 10), 0, 10, 10, false);
+        assert_eq!(
+            view_status("", &path),
+            ViewStatus::Unknown,
+            "an empty-session read must leave no trace — else two keyless \
+             tasks share a bucket"
+        );
+
+        note_full_write("", &path, 10);
+        assert_eq!(
+            view_status("", &path),
+            ViewStatus::Unknown,
+            "an empty-session write must leave no COMPLETE mark either"
+        );
+    }
+
+    #[test]
     fn should_scope_views_to_the_session() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("scoped.txt");
@@ -583,6 +640,36 @@ mod tests {
                  Complete, got {other:?}"
             ),
         }
+    }
+
+    #[test]
+    fn should_not_mark_complete_when_written_bytes_disagree_with_disk() {
+        // R1 second half: post-write re-record must verify the bytes on disk
+        // equal what we claim to have written before marking COMPLETE. If the
+        // caller says it wrote N bytes but the file is a different size (a
+        // replacement landed in the write→stat window), the record must NOT
+        // be COMPLETE — otherwise a stale COMPLETE authorizes a later
+        // overwrite of content the model never produced.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mismatch.txt");
+        std::fs::write(&path, "0123456789").unwrap(); // 10 bytes on disk
+
+        // Claim we wrote 25 bytes — disagrees with the 10 on disk.
+        note_full_write("s", &path, 25);
+        assert_ne!(
+            view_status("s", &path),
+            ViewStatus::Complete {
+                epoch: ViewEpoch {
+                    mtime: std::fs::metadata(&path).unwrap().modified().unwrap(),
+                    size: 10,
+                },
+            },
+            "a size disagreement must not be recorded as COMPLETE"
+        );
+        assert!(
+            !matches!(view_status("s", &path), ViewStatus::Complete { .. }),
+            "any COMPLETE here is a lie — the on-disk bytes are not what was written"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/read_window.rs
+++ b/crates/octos-agent/src/tools/read_window.rs
@@ -1,0 +1,367 @@
+//! Flag-gated windowed `read_file` enforcement (#1638). **Off by default.**
+//!
+//! Armed via `OCTOS_READ_WINDOW=1`. When armed, `read_file` returns at most
+//! [`WINDOW_MAX_LINES`] lines and at most [`WINDOW_MAX_BYTES`] bytes of
+//! formatted output — whichever limit is hit first — with a footer naming the
+//! limit that fired, the range actually returned, the file's totals, and the
+//! exact next call. Unarmed behaviour is byte-identical to before this module
+//! existed.
+//!
+//! ## Parameter provenance
+//!
+//! The 2000-line half is the `pi` harness's field-tested default, verbatim
+//! (`truncate.ts: DEFAULT_MAX_LINES = 2000`). An earlier 500-line/24KiB
+//! proposal was rejected as too aggressive — 57.4% of this repo's files are
+//! ≤500 lines, so ~43% of reads would have paged.
+//!
+//! The byte half adapts pi's 50KB (`DEFAULT_MAX_BYTES = 50 * 1024`) to two
+//! local facts pi does not have:
+//!
+//! 1. Our output carries a line-number gutter, so the bytes that actually
+//!    enter the context are the FORMATTED bytes, and that is what this budget
+//!    counts (the execution loop's cap counts `String::len()` of the same
+//!    string).
+//! 2. That loop cap — `octos_core::tool_output_limit("read_file")` = 50,000 —
+//!    is a blind head/tail backstop (#2124). The whole point of an advising
+//!    window is that the tool's own cut is the ONLY cut, so the window plus
+//!    its footer must provably fit under the loop cap. 50 * 1024 = 51,200
+//!    does not. 48 KiB (49,152) plus a [`FOOTER_RESERVE`]-byte footer does.
+//!
+//! A tripwire test pins `WINDOW_MAX_BYTES + FOOTER_RESERVE <=
+//! tool_output_limit("read_file")` so lowering the loop budget cannot silently
+//! re-expose windowed reads to the blind backstop.
+//!
+//! ## The partial-view ledger
+//!
+//! The second half of this module tracks, per absolute path, how much of the
+//! file the model has actually been shown — so `write_file` (armed) can refuse
+//! to overwrite a file wholesale from a partial view. The patch tools
+//! (`edit_file`, `diff_edit`, `apply_patch`) are safe — they re-read the whole
+//! file themselves — but `write_file` reconstructs from whatever the model
+//! saw, and the slides workflow mandates exactly read → rebuild → `write_file`.
+//!
+//! Coverage is a contiguous-from-line-1 high-water mark, keyed by mtime:
+//! paging 1..2000, 2001..4000, 4001..EOF under one mtime marks the path
+//! COMPLETE (so the refusal's "page through it first" advice is truthful);
+//! any mtime change resets coverage to the new read alone. Reading out of
+//! order (tail before head) under-counts and stays partial — conservative in
+//! the safe direction, and the refusal always offers the patch tools as the
+//! unconditional escape hatch.
+//!
+//! The ledger is a process-global map, NOT threaded through `ToolContext`:
+//! the guard is a data-loss check and must hold on every entry path,
+//! including legacy `Tool::execute` calls that carry a zero context (the
+//! `FileStateCache` on `ToolContext` is optional and absent on those paths,
+//! which is why it was not reused). It records only when armed, so the
+//! unarmed process pays nothing. This is deliberately NOT the #2126 probe's
+//! `LAST_READ` map — that one is observe-only, keyed to the probe's own env
+//! flag and 500/24KiB canary, and its per-path counters are `cfg(test)`.
+//!
+//! ## Known limitation: a single line larger than the window
+//!
+//! `read_file` has no byte-offset parameter, so it cannot page WITHIN a line
+//! (matching pi, which ships the same limitation and points at a shell
+//! fallback instead — `read.ts`'s `firstLineExceedsLimit` branch). A giant
+//! line is delivered via the advice footer's `sed | head -c` command, which
+//! the ledger cannot observe — so a file containing one can never reach
+//! COMPLETE through `read_file` alone, and a whole-file overwrite of it stays
+//! refused. The refusal's `edit_file`/`apply_patch` escape hatch covers that
+//! case; a `byte_offset` continuation parameter is the future fix if the
+//! probe's `unpageable_long_line` counter ever shows it matters.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+/// Line half of the armed window: pi's field-tested default, verbatim.
+pub(crate) const WINDOW_MAX_LINES: usize = 2000;
+
+/// Byte half of the armed window, counted on FORMATTED output bytes.
+///
+/// 48 KiB, not pi's 50 KiB — see the module docs: the window plus its footer
+/// must provably fit under the execution loop's 50,000-byte `read_file` cap
+/// so the blind backstop (#2124) can never fire on an armed read.
+pub(crate) const WINDOW_MAX_BYTES: usize = 48 * 1024;
+
+/// Bytes reserved above [`WINDOW_MAX_BYTES`] for the window footer.
+pub(crate) const FOOTER_RESERVE: usize = 400;
+
+/// Typed prefix on the armed `write_file` refusal, so the model (and any
+/// harness) can match it structurally — same convention as
+/// `[FILE_UNCHANGED]`.
+pub(crate) const PARTIAL_VIEW_OVERWRITE_PREFIX: &str = "[PARTIAL_VIEW_OVERWRITE]";
+
+/// Whether window enforcement is armed by the environment.
+///
+/// Mirrors the #2126 probe's gate shape (`OCTOS_READ_PAGING_PROBE=1`). The
+/// test-side arming override is per-tool-instance
+/// (`with_window_enforcement`), NOT a process-global like the probe's
+/// `FORCED_ON`: arming CHANGES `read_file`'s output, so a global test switch
+/// would leak windowed behaviour into every unarmed test running in parallel
+/// (`set_var` is `unsafe` under edition 2024 and this workspace denies
+/// unsafe, so tests cannot scope the env var either).
+pub(crate) fn armed_from_env() -> bool {
+    std::env::var("OCTOS_READ_WINDOW").is_ok_and(|value| value == "1")
+}
+
+/// How much of one path the model has been shown, contiguously from line 1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ViewCoverage {
+    /// Lines 1..=`seen_through` have been shown under `mtime`.
+    pub(crate) seen_through: usize,
+    /// Total lines the file had when last read.
+    pub(crate) total_lines: usize,
+}
+
+/// One path's ledger record.
+#[derive(Clone, Copy, Debug)]
+struct ViewRecord {
+    /// mtime the coverage was accumulated under; `None` = unknown (never
+    /// stitches).
+    mtime: Option<SystemTime>,
+    seen_through: usize,
+    total_lines: usize,
+}
+
+/// Per-path record of what the model has been shown. See the module docs for
+/// why this is process-global rather than `ToolContext`-threaded.
+static LAST_VIEW: Mutex<Option<HashMap<PathBuf, ViewRecord>>> = Mutex::new(None);
+
+/// Which window limit clamped an armed read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WindowClamp {
+    /// [`WINDOW_MAX_LINES`] fired first.
+    Lines,
+    /// [`WINDOW_MAX_BYTES`] fired first.
+    Bytes,
+}
+
+/// The key both sides of the ledger agree on.
+///
+/// `read_file` and `write_file` can resolve the same file to different
+/// spellings (macOS tempdirs alone alias `/var` to `/private/var`); if they
+/// keyed the raw spellings the guard would silently never match. Falls back
+/// to the raw path when canonicalization fails (file deleted between check
+/// and record) — both sides then fail the same way.
+fn ledger_key(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Record one armed `read_file` view of `path`: lines `start..=end`
+/// (1-indexed, inclusive) of a `total_lines`-line file at `mtime`.
+///
+/// Same-mtime views extend the contiguous-from-1 high-water mark; a changed
+/// (or unknown) mtime resets coverage to this view alone, because coverage
+/// stitched across an on-disk edit would claim the model has seen content
+/// that no longer exists. Callers gate on arming — this function itself does
+/// not consult the env, so tests can drive it through per-instance-armed
+/// tools without touching process state.
+pub(crate) fn record_view(
+    path: &Path,
+    mtime: Option<SystemTime>,
+    start: usize,
+    end: usize,
+    total_lines: usize,
+) {
+    let key = ledger_key(path);
+    let mut guard = LAST_VIEW
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let map = guard.get_or_insert_with(HashMap::new);
+    // Coverage carries over only within one mtime epoch; `None` mtimes never
+    // match (unknown is not evidence).
+    let carried = match map.get(&key) {
+        Some(prev) if prev.mtime.is_some() && prev.mtime == mtime => prev.seen_through,
+        _ => 0,
+    };
+    let seen_through = if start <= carried.saturating_add(1) {
+        carried.max(end)
+    } else {
+        // A view past the high-water mark leaves a gap; the mark stays.
+        carried
+    };
+    map.insert(
+        key,
+        ViewRecord {
+            mtime,
+            seen_through,
+            total_lines,
+        },
+    );
+}
+
+/// The coverage record for `path` when the model's most recent knowledge of
+/// it is PARTIAL, or `None` when the path is unknown or fully seen.
+pub(crate) fn partial_view_of(path: &Path) -> Option<ViewCoverage> {
+    let key = ledger_key(path);
+    let guard = LAST_VIEW
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.as_ref()?.get(&key).and_then(|record| {
+        if record.seen_through >= record.total_lines {
+            None
+        } else {
+            Some(ViewCoverage {
+                seen_through: record.seen_through,
+                total_lines: record.total_lines,
+            })
+        }
+    })
+}
+
+/// Note a successful whole-file `write_file` of `path`: the on-disk content
+/// is now exactly what the model supplied, so any partial mark is obsolete.
+pub(crate) fn note_full_write(path: &Path) {
+    let key = ledger_key(path);
+    let mut guard = LAST_VIEW
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(map) = guard.as_mut() {
+        map.remove(&key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    // The ledger is process-global and keyed by path; each test uses paths
+    // under its own tempdir so parallel tests never observe each other
+    // (#2077/#2126: never assert on process-global aggregates).
+
+    #[test]
+    fn window_plus_footer_must_fit_under_the_loop_backstop() {
+        // The whole point of an advising window is that the tool's own cut
+        // is the ONLY cut. If someone lowers the loop's read_file budget
+        // below the window, the blind #2124 backstop starts firing on armed
+        // reads again and mangling footers — this tripwire makes that a
+        // test failure instead of a silent regression.
+        assert!(
+            WINDOW_MAX_BYTES + FOOTER_RESERVE <= octos_core::tool_output_limit("read_file"),
+            "WINDOW_MAX_BYTES ({WINDOW_MAX_BYTES}) + FOOTER_RESERVE ({FOOTER_RESERVE}) must fit \
+             under tool_output_limit(\"read_file\") ({})",
+            octos_core::tool_output_limit("read_file")
+        );
+    }
+
+    #[test]
+    fn should_report_partial_after_a_window_and_complete_after_paging_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("paged.txt");
+        std::fs::write(&path, "x").unwrap();
+        let mtime = Some(SystemTime::now());
+
+        record_view(&path, mtime, 1, 2000, 5000);
+        assert_eq!(
+            partial_view_of(&path),
+            Some(ViewCoverage {
+                seen_through: 2000,
+                total_lines: 5000
+            }),
+            "a windowed view is partial"
+        );
+
+        record_view(&path, mtime, 2001, 4000, 5000);
+        assert_eq!(
+            partial_view_of(&path),
+            Some(ViewCoverage {
+                seen_through: 4000,
+                total_lines: 5000
+            }),
+            "contiguous pages extend the high-water mark"
+        );
+
+        record_view(&path, mtime, 4001, 5000, 5000);
+        assert_eq!(
+            partial_view_of(&path),
+            None,
+            "paging through to EOF completes the view — the refusal's advice \
+             must be truthful"
+        );
+    }
+
+    #[test]
+    fn should_not_stitch_across_a_gap() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gappy.txt");
+        std::fs::write(&path, "x").unwrap();
+        let mtime = Some(SystemTime::now());
+
+        record_view(&path, mtime, 1, 2000, 5000);
+        record_view(&path, mtime, 2500, 5000, 5000); // lines 2001-2499 never seen
+        assert_eq!(
+            partial_view_of(&path),
+            Some(ViewCoverage {
+                seen_through: 2000,
+                total_lines: 5000
+            }),
+            "a gap means the view is still partial at the gap"
+        );
+    }
+
+    #[test]
+    fn should_reset_coverage_when_the_mtime_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("edited.txt");
+        std::fs::write(&path, "x").unwrap();
+        let old = Some(SystemTime::now() - Duration::from_secs(60));
+        let new = Some(SystemTime::now());
+
+        record_view(&path, old, 1, 2000, 5000);
+        // The file changed on disk; earlier coverage is no longer evidence.
+        record_view(&path, new, 2001, 4000, 5000);
+        assert_eq!(
+            partial_view_of(&path),
+            Some(ViewCoverage {
+                seen_through: 0,
+                total_lines: 5000
+            }),
+            "coverage accumulated under a different mtime must not survive"
+        );
+    }
+
+    #[test]
+    fn should_forget_a_path_after_a_full_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rewritten.txt");
+        std::fs::write(&path, "x").unwrap();
+
+        record_view(&path, Some(SystemTime::now()), 1, 10, 5000);
+        assert!(partial_view_of(&path).is_some());
+
+        note_full_write(&path);
+        assert_eq!(
+            partial_view_of(&path),
+            None,
+            "after write_file succeeds the on-disk content is exactly what \
+             the model supplied — no partial mark may linger"
+        );
+    }
+
+    #[test]
+    fn should_match_symlinked_and_canonical_forms_of_the_same_path() {
+        // macOS tempdirs live under /var -> /private/var. If read_file
+        // records the canonical form and write_file looks up the symlinked
+        // form (or vice versa), the guard silently dies — so the ledger
+        // canonicalizes on both sides.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.txt");
+        std::fs::write(&real, "x").unwrap();
+        let canonical = real.canonicalize().unwrap();
+
+        record_view(&real, Some(SystemTime::now()), 1, 10, 5000);
+        assert!(
+            partial_view_of(&canonical).is_some(),
+            "the canonical form must see coverage recorded via the raw form"
+        );
+    }
+
+    #[test]
+    fn armed_from_env_defaults_to_off() {
+        // The suite never sets OCTOS_READ_WINDOW (set_var is unsafe under
+        // edition 2024), so this pins the shipped default: off.
+        assert!(!armed_from_env(), "window enforcement must be opt-in");
+    }
+}

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -22,6 +22,10 @@ pub struct WriteFileTool {
     /// #1976 — optional per-path write fence. `None` (default, every
     /// pre-#1976 construction) = writes governed by scope/access alone.
     write_grant: Option<WritePathGrant>,
+    /// Partial-view overwrite guard (#1638), armed with windowed reads.
+    /// `None` = the `OCTOS_READ_WINDOW` env flag decides (production);
+    /// `Some` = explicit, for tests.
+    window_enforcement: Option<bool>,
 }
 
 impl WriteFileTool {
@@ -32,7 +36,23 @@ impl WriteFileTool {
             filesystem_scope: FilesystemScope::Workspace,
             file_access: FileAccessMode::ReadWrite,
             write_grant: None,
+            window_enforcement: None,
         }
+    }
+
+    /// Test-only arming override for the partial-view overwrite guard — see
+    /// `ReadFileTool::with_window_enforcement` for why this is per-instance
+    /// rather than process-global.
+    #[cfg(test)]
+    pub(crate) fn with_window_enforcement(mut self, armed: bool) -> Self {
+        self.window_enforcement = Some(armed);
+        self
+    }
+
+    /// Whether the partial-view overwrite guard is armed for this instance.
+    fn window_armed(&self) -> bool {
+        self.window_enforcement
+            .unwrap_or_else(super::read_window::armed_from_env)
     }
 
     /// Set the effective filesystem scope.
@@ -75,8 +95,13 @@ impl Tool for WriteFileTool {
         "write_file"
     }
 
+    // #1638 (d): mode-neutral guidance — reconstructing a partially-read file
+    // is destructive in every mode; the armed guard merely enforces what this
+    // sentence advises.
     fn description(&self) -> &str {
-        "Write content to a file. Creates the file if it doesn't exist, or overwrites if it does."
+        "Write content to a file. Creates the file if it doesn't exist, or overwrites if it \
+         does. Overwrites the ENTIRE file: never write back a file you have only partially \
+         read — finish reading it first, or use edit_file/apply_patch for targeted changes."
     }
 
     fn tags(&self) -> &[&str] {
@@ -185,6 +210,44 @@ impl Tool for WriteFileTool {
             }
         }
 
+        // #1638 (c): armed partial-view overwrite guard. When windowed reads
+        // are armed, `read_file` can have shown the model only PART of this
+        // file — and write_file reconstructs from whatever the model saw, so
+        // a whole-file overwrite from a partial view destroys the tail nobody
+        // saw (the slides workflow does exactly read → rebuild → write_file).
+        // The patch tools are safe (they re-read the full file themselves),
+        // which is exactly the escape hatch the refusal names. Sits BEFORE
+        // the write fence and any disk mutation; the #2126 probe block above
+        // stays observe-only and untouched.
+        if self.window_armed() && path.exists() {
+            if let Some(partial) = super::read_window::partial_view_of(&path) {
+                let coverage = if partial.seen_through > 0 {
+                    format!(
+                        "lines 1-{} of {} contiguously",
+                        partial.seen_through, partial.total_lines
+                    )
+                } else {
+                    format!("a fragment of its {} lines", partial.total_lines)
+                };
+                return Ok(ToolResult {
+                    output: format!(
+                        "{} write_file refused: read_file has shown you only part of {} ({}), \
+                         and overwriting the whole file from a partial view would destroy the \
+                         part you have not seen. Either finish reading it first (read_file with \
+                         offset until you have seen line {}) and then retry, or make targeted \
+                         changes with edit_file / diff_edit / apply_patch, which read the full \
+                         file themselves.",
+                        super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
+                        input.path,
+                        coverage,
+                        partial.total_lines,
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        }
+
         // #1976 — per-path write fence. SECURITY ROUND (codex): the allowlist
         // decision and the actual open must target the SAME resolved object,
         // or an attacker who swaps a checked ancestor dir for a symlink
@@ -285,6 +348,14 @@ impl Tool for WriteFileTool {
                     "workspace git snapshot failed after write_file"
                 );
             }
+        }
+
+        // #1638 (c): a successful whole-file write makes the on-disk content
+        // exactly what the model supplied — any partial-view mark for the
+        // path is obsolete, and keeping it would refuse the model's next
+        // legitimate overwrite of its own content.
+        if self.window_armed() {
+            super::read_window::note_full_write(&path);
         }
 
         let line_count = input.content.lines().count();
@@ -960,5 +1031,219 @@ mod tests {
             "write_file must invalidate the cached entry"
         );
         assert_eq!(cache.len(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // #1638 (c): the partial-view overwrite guard, armed with windowed reads.
+    // Both tools are armed per instance (never process-globally); every test
+    // asserts on files it created itself.
+    // -----------------------------------------------------------------------
+
+    use crate::tools::read_file::ReadFileTool;
+
+    /// 1500 x 100-byte lines — windows at 450 lines per page when armed.
+    fn big_rows(dir: &std::path::Path, name: &str) -> String {
+        let content = (1..=1500)
+            .map(|i| format!("row {i:06}{}", "z".repeat(90)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.join(name), &content).unwrap();
+        content
+    }
+
+    #[tokio::test]
+    async fn should_refuse_whole_overwrite_after_partial_read_then_allow_after_paging_through() {
+        // The slides workflow reads a script, reconstructs it whole, and
+        // write_files it back. Under a windowed read that becomes a
+        // destructive partial overwrite of a tail the model never saw — the
+        // guard must refuse it, and its "page through first" advice must be
+        // truthful: after paging to EOF the same write must succeed.
+        let dir = tempfile::tempdir().unwrap();
+        let original = big_rows(dir.path(), "script.js");
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        // Windowed read: the model has seen lines 1-450 of 1500.
+        let page1 = read
+            .execute(&serde_json::json!({"path": "script.js"}))
+            .await
+            .unwrap();
+        assert!(page1.success && page1.output.contains("showing lines 1-450 of 1500"));
+
+        // Whole-file overwrite from that partial view must be refused...
+        let refused = write
+            .execute(&serde_json::json!({"path": "script.js", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            !refused.success,
+            "overwriting from a partial view must be refused: {}",
+            refused.output
+        );
+        assert!(
+            refused.output.contains("[PARTIAL_VIEW_OVERWRITE]"),
+            "the refusal must be typed: {}",
+            refused.output
+        );
+        assert!(
+            refused.output.contains("edit_file") && refused.output.contains("apply_patch"),
+            "the refusal must name the safe alternatives: {}",
+            refused.output
+        );
+        assert!(
+            refused.output.contains("offset"),
+            "the refusal must tell the model how to finish reading: {}",
+            refused.output
+        );
+        // ...and must not have touched the file.
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("script.js")).unwrap(),
+            original,
+            "a refused overwrite must leave the file intact"
+        );
+
+        // Page through to EOF the way the refusal advises.
+        let mut next = 451usize;
+        for _ in 0..10 {
+            let page = read
+                .execute(&serde_json::json!({"path": "script.js", "offset": next}))
+                .await
+                .unwrap();
+            assert!(page.success, "{}", page.output);
+            match page
+                .output
+                .split("offset: ")
+                .nth(1)
+                .and_then(|rest| rest.split('.').next())
+                .and_then(|n| n.parse::<usize>().ok())
+            {
+                Some(n) => next = n,
+                None => break, // no continuation footer — EOF reached
+            }
+        }
+
+        // Now the model has seen the whole file; the same write must pass.
+        let allowed = write
+            .execute(&serde_json::json!({"path": "script.js", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            allowed.success,
+            "after paging through the file, the guard's own advice must \
+             unlock the write: {}",
+            allowed.output
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("script.js")).unwrap(),
+            "rebuilt\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_allow_overwrite_after_a_complete_unbounded_read_when_armed() {
+        // A file that fits the window is returned whole; overwriting it is
+        // exactly as safe as before.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("small.txt"), "one\ntwo\nthree\n").unwrap();
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let r = read
+            .execute(&serde_json::json!({"path": "small.txt"}))
+            .await
+            .unwrap();
+        assert!(r.success && r.output.contains("three"));
+
+        let w = write
+            .execute(&serde_json::json!({"path": "small.txt", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            w.success,
+            "a fully-seen file must remain overwritable: {}",
+            w.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_allow_creating_a_new_file_when_armed() {
+        let dir = tempfile::tempdir().unwrap();
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let w = write
+            .execute(&serde_json::json!({"path": "brand_new.txt", "content": "hello\n"}))
+            .await
+            .unwrap();
+        assert!(
+            w.success,
+            "creating a new file is never a partial overwrite"
+        );
+        assert!(dir.path().join("brand_new.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn should_allow_overwriting_a_never_read_file_when_armed() {
+        // The guard requires partial-READ evidence; a blind overwrite of an
+        // existing file is today's documented write_file semantics.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("blind.txt"), "old\n").unwrap();
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let w = write
+            .execute(&serde_json::json!({"path": "blind.txt", "content": "new\n"}))
+            .await
+            .unwrap();
+        assert!(w.success, "{}", w.output);
+    }
+
+    #[tokio::test]
+    async fn should_not_guard_when_unarmed_even_after_a_partial_read() {
+        // Unarmed behaviour is byte-identical to before: a ranged read
+        // followed by a whole overwrite goes through untouched.
+        let dir = tempfile::tempdir().unwrap();
+        big_rows(dir.path(), "dormant.txt");
+        let read = ReadFileTool::new(dir.path());
+        let write = WriteFileTool::new(dir.path());
+
+        let r = read
+            .execute(&serde_json::json!({"path": "dormant.txt", "start_line": 1, "end_line": 5}))
+            .await
+            .unwrap();
+        assert!(r.success);
+
+        let w = write
+            .execute(&serde_json::json!({"path": "dormant.txt", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(w.success, "the unarmed path must not change: {}", w.output);
+        assert!(w.output.contains("Successfully wrote"));
+    }
+
+    #[tokio::test]
+    async fn should_not_track_views_when_the_read_is_unarmed() {
+        // An UNARMED read must record nothing — otherwise an armed writer
+        // elsewhere in the process would start refusing on evidence gathered
+        // while the feature was off (the probe's "disarmed records nothing"
+        // rule, applied to the ledger).
+        let dir = tempfile::tempdir().unwrap();
+        big_rows(dir.path(), "untracked.txt");
+        let read = ReadFileTool::new(dir.path()); // unarmed
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let r = read
+            .execute(&serde_json::json!({"path": "untracked.txt", "start_line": 1, "end_line": 5}))
+            .await
+            .unwrap();
+        assert!(r.success);
+
+        let w = write
+            .execute(&serde_json::json!({"path": "untracked.txt", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            w.success,
+            "no armed read happened, so there is no partial-view evidence: {}",
+            w.output
+        );
     }
 }

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -151,6 +151,29 @@ impl Tool for WriteFileTool {
         ctx: &ToolContext,
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
+        let mut result = self.execute_capped_inner(ctx, args).await?;
+        // #2193 R4: ONE release-enforced cap over EVERY armed return (success
+        // and early errors). A caller-controlled `input.path` echoed in a
+        // message can otherwise exceed the loop's blind head/tail cut (#2124)
+        // and get mangled; sizing every armed result under the cap makes the
+        // tool's own cut the only cut.
+        if self.window_armed() {
+            octos_core::truncate_utf8(
+                &mut result.output,
+                octos_core::tool_output_limit(self.name()),
+                "",
+            );
+        }
+        Ok(result)
+    }
+}
+
+impl WriteFileTool {
+    async fn execute_capped_inner(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: WriteFileInput =
             super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
@@ -239,7 +262,9 @@ impl Tool for WriteFileTool {
         if self.window_armed() && path.exists() {
             use super::read_window::{
                 PARTIAL_VIEW_OVERWRITE_PREFIX as PREFIX,
-                REDACTED_VIEW_OVERWRITE_PREFIX as REDACTED_PREFIX, ViewStatus, WINDOW_MAX_BYTES,
+                REDACTED_VIEW_OVERWRITE_PREFIX as REDACTED_PREFIX,
+                TRANSFORMED_VIEW_OVERWRITE_PREFIX as TRANSFORMED_PREFIX, ViewStatus,
+                WINDOW_MAX_BYTES,
             };
             // R4: a missing/empty session key is reachable in production
             // (agents default to None; FFI/fleet workers; plain CLI chat
@@ -256,14 +281,10 @@ impl Tool for WriteFileTool {
             let page_advice = "Page through it with read_file (offset/limit, or byte_offset \
                                for single lines too long for the line window) until you reach \
                                the end, then retry the write.";
-            let current = tokio::fs::metadata(&path).await.ok().and_then(|meta| {
-                meta.modified()
-                    .ok()
-                    .map(|mtime| super::read_window::ViewEpoch {
-                        mtime,
-                        size: meta.len(),
-                    })
-            });
+            let current = tokio::fs::metadata(&path)
+                .await
+                .ok()
+                .and_then(|meta| super::read_window::ViewEpoch::from_metadata(&meta));
             let refusal: Option<String> = if session.is_empty() {
                 // Keyless: cannot track reads, so cannot authorize a big
                 // overwrite. Small files keep today's blind semantics.
@@ -311,6 +332,17 @@ impl Tool for WriteFileTool {
                          rewriting THIS file: make a narrower, in-place change rather than a \
                          whole-file rewrite, or tell the user this file cannot be safely \
                          whole-file-rewritten while windowed reads are enabled.",
+                    )),
+                    // #2193 R4: the view was TEXT decoded from a binary (PDF),
+                    // not the on-disk bytes — paging the extracted text to EOF
+                    // must NOT authorize replacing the original binary.
+                    (ViewStatus::Transformed, _) => Some(format!(
+                        "{TRANSFORMED_PREFIX} write_file refused: read_file showed you TEXT \
+                         extracted from {shown_path} (a PDF or other binary), not the file's \
+                         own bytes — so a whole-file overwrite reconstructed from what you saw \
+                         would replace the original with the extracted text and destroy the \
+                         binary. Make a narrower change, write to a different path, or tell the \
+                         user this file cannot be whole-file-rewritten from a windowed read.",
                     )),
                     (
                         ViewStatus::Partial {
@@ -388,19 +420,77 @@ impl Tool for WriteFileTool {
                     });
                 }
             };
-            if let Err(e) = super::write_grant::confined_write(
-                workspace_root.clone(),
-                rel,
-                input.content.as_bytes().to_vec(),
-                grant.create_only(),
-            )
-            .await
-            {
-                return Ok(ToolResult {
-                    output: grant.map_confined_error(&e, &workspace_root, &input.path, self.name()),
-                    success: false,
-                    ..Default::default()
-                });
+            // #2193 R4: an armed, AUTHORIZED over-window overwrite must bind the
+            // truncating write to the epoch it was authorized against — even on
+            // the fenced path, which otherwise re-opens the leaf with O_TRUNC and
+            // clobbers whatever it resolves to. Only existing-file overwrites
+            // (never create_only) take the checked path.
+            match (grant.create_only(), authorized_epoch) {
+                (false, Some(expected)) => {
+                    match super::write_grant::confined_write_checked(
+                        workspace_root.clone(),
+                        rel,
+                        input.content.as_bytes().to_vec(),
+                        expected,
+                    )
+                    .await
+                    {
+                        Ok(super::CheckedWrite::Written) => {}
+                        Ok(super::CheckedWrite::EpochChanged { found }) => {
+                            if let Some(session) =
+                                ctx.parent_session_key.as_deref().filter(|s| !s.is_empty())
+                            {
+                                super::read_window::forget(session, &path);
+                            }
+                            let shown_path = octos_core::truncated_utf8(&input.path, 200, "...");
+                            return Ok(ToolResult {
+                                output: format!(
+                                    "{} write_file refused: {} changed on disk between your read \
+                                     and this write ({} bytes now), so the overwrite was not \
+                                     applied. Re-read it with read_file, then retry.",
+                                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
+                                    shown_path,
+                                    found.size,
+                                ),
+                                success: false,
+                                ..Default::default()
+                            });
+                        }
+                        Err(e) => {
+                            return Ok(ToolResult {
+                                output: grant.map_confined_error(
+                                    &e,
+                                    &workspace_root,
+                                    &input.path,
+                                    self.name(),
+                                ),
+                                success: false,
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
+                _ => {
+                    if let Err(e) = super::write_grant::confined_write(
+                        workspace_root.clone(),
+                        rel,
+                        input.content.as_bytes().to_vec(),
+                        grant.create_only(),
+                    )
+                    .await
+                    {
+                        return Ok(ToolResult {
+                            output: grant.map_confined_error(
+                                &e,
+                                &workspace_root,
+                                &input.path,
+                                self.name(),
+                            ),
+                            success: false,
+                            ..Default::default()
+                        });
+                    }
+                }
             }
             true
         } else {
@@ -527,7 +617,7 @@ impl Tool for WriteFileTool {
             output: format!(
                 "Successfully wrote {} lines to {}{}",
                 line_count,
-                input.path,
+                octos_core::truncated_utf8(&input.path, 200, "..."),
                 format_note.unwrap_or_default()
             ),
             success: true,
@@ -1662,6 +1752,51 @@ mod tests {
             .await
             .unwrap();
         assert!(allowed.success, "{}", allowed.output);
+    }
+
+    #[tokio::test]
+    async fn should_refuse_overwriting_from_a_transformed_view() {
+        // #2193 R4 (codex H6): paging a large PDF's extracted text must not
+        // authorize replacing the original binary. A Transformed view is a
+        // permanent incompatibility with a whole-file rewrite, like Tainted, and
+        // gets its own typed prefix.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("doc.pdf");
+        // Over the window so the guard consults the ledger, not blind-overwrite.
+        std::fs::write(&path, vec![b'%'; 100_000]).unwrap();
+        let session = "transformed-sess";
+        let epoch =
+            crate::tools::read_window::ViewEpoch::from_metadata(&std::fs::metadata(&path).unwrap());
+        crate::tools::read_window::record_view(
+            session, &path, epoch, 0, 100_000, 100_000, false, true,
+        );
+        let ctx = ctx_with_session(session);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let refused = write
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "doc.pdf", "content": "rebuilt\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(!refused.success, "{}", refused.output);
+        assert!(
+            refused
+                .output
+                .contains(crate::tools::read_window::TRANSFORMED_VIEW_OVERWRITE_PREFIX),
+            "transformed overwrite must use the DISTINCT typed prefix: {}",
+            refused.output,
+        );
+        assert!(
+            !refused.output.contains("[PARTIAL_VIEW_OVERWRITE]"),
+            "must not reuse the partial-view prefix: {}",
+            refused.output,
+        );
+        assert_eq!(
+            std::fs::read(&path).unwrap().len(),
+            100_000,
+            "the binary on disk must be untouched",
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -95,13 +95,20 @@ impl Tool for WriteFileTool {
         "write_file"
     }
 
-    // #1638 (d): mode-neutral guidance — reconstructing a partially-read file
-    // is destructive in every mode; the armed guard merely enforces what this
-    // sentence advises.
+    // #1638 R6: conditional so the UNARMED spec is byte-identical to
+    // origin/main (the ToolSpec is serialized into the prompt-cache prefix for
+    // every session). R5: the ARMED description is tool-agnostic — it must NOT
+    // name edit_file/apply_patch, which some armed contexts (the slides
+    // prompt) forbid; naming a forbidden tool would be unfollowable advice.
     fn description(&self) -> &str {
-        "Write content to a file. Creates the file if it doesn't exist, or overwrites if it \
-         does. Overwrites the ENTIRE file: never write back a file you have only partially \
-         read — finish reading it first, or use edit_file/apply_patch for targeted changes."
+        if self.window_armed() {
+            "Write content to a file. Creates the file if it doesn't exist, or overwrites if it \
+             does. Overwrites the ENTIRE file: never write back a file you have only partially \
+             read — finish reading the whole file first, then retry."
+        } else {
+            "Write content to a file. Creates the file if it doesn't exist, or overwrites if it \
+             does."
+        }
     }
 
     fn tags(&self) -> &[&str] {
@@ -224,9 +231,23 @@ impl Tool for WriteFileTool {
         // and any disk mutation; the #2126 probe block above stays
         // observe-only and untouched (an armed refusal still increments its
         // attempt counter — the probe measures intent, not damage).
+        //
+        // A COMPLETE authorization also yields the epoch it was granted
+        // against, which the write below binds to via `write_no_follow_checked`
+        // (R1: closes the authorize→truncate TOCTOU).
+        let mut authorized_epoch: Option<super::read_window::ViewEpoch> = None;
         if self.window_armed() && path.exists() {
-            use super::read_window::{ViewStatus, WINDOW_MAX_BYTES};
-            let session = ctx.parent_session_key.clone().unwrap_or_default();
+            use super::read_window::{
+                PARTIAL_VIEW_OVERWRITE_PREFIX as PREFIX,
+                REDACTED_VIEW_OVERWRITE_PREFIX as REDACTED_PREFIX, ViewStatus, WINDOW_MAX_BYTES,
+            };
+            // R4: a missing/empty session key is reachable in production
+            // (agents default to None; FFI/fleet workers; plain CLI chat
+            // without --goals). Keyless tasks share no bucket and record
+            // nothing, so they can never establish COMPLETE — fail closed for
+            // over-window files rather than let one keyless task authorize
+            // another's overwrite.
+            let session = ctx.parent_session_key.as_deref().unwrap_or("");
             // The path shown to the model is clamped: path SPELLINGS are
             // caller-controlled and can be arbitrarily long, and a refusal
             // that overflows the loop's output cap gets blind-truncated into
@@ -243,64 +264,96 @@ impl Tool for WriteFileTool {
                         size: meta.len(),
                     })
             });
-            let refusal = match (super::read_window::view_status(&session, &path), current) {
-                // The one allowed overwrite: complete, untainted, and the
-                // file on disk is still the generation the model read.
-                (ViewStatus::Complete { epoch }, Some(now)) if epoch == now => None,
-                (ViewStatus::Complete { .. }, _) => Some(format!(
-                    "{} write_file refused: {} has changed on disk since you last read it (or \
-                     its current state could not be validated). Re-read it with read_file, \
-                     then retry the write.",
-                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
-                    shown_path,
-                )),
-                (ViewStatus::Tainted, _) => Some(format!(
-                    "{} write_file refused: parts of {} were redacted from your view (embedded \
-                     data or credentials), so writing the whole file back would replace them \
-                     with redaction placeholders. Make a narrower change instead of a \
-                     whole-file rewrite.",
-                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
-                    shown_path,
-                )),
-                (
-                    ViewStatus::Partial {
-                        seen_through,
-                        total_bytes,
-                    },
-                    _,
-                ) => Some(format!(
-                    "{} write_file refused: read_file has shown you only part of {} (the first \
-                     {seen_through} of its {total_bytes} bytes), and overwriting the whole \
-                     file from a partial view would destroy the part you have not seen. {}",
-                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
-                    shown_path,
-                    page_advice,
-                )),
-                (ViewStatus::Unknown, Some(now)) if now.size as usize > WINDOW_MAX_BYTES => {
-                    Some(format!(
-                        "{} write_file refused: {} is {} bytes — larger than the \
-                         {WINDOW_MAX_BYTES}-byte read window — and you have not read it in \
-                         this session. {}",
-                        super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
-                        shown_path,
+            let refusal: Option<String> = if session.is_empty() {
+                // Keyless: cannot track reads, so cannot authorize a big
+                // overwrite. Small files keep today's blind semantics.
+                match current {
+                    Some(now) if (now.size as usize) <= WINDOW_MAX_BYTES => None,
+                    Some(now) => Some(format!(
+                        "{PREFIX} write_file refused: {shown_path} is {} bytes — larger than \
+                         the {WINDOW_MAX_BYTES}-byte read window — and this session has no \
+                         identity to track what you have read, so a whole-file overwrite \
+                         cannot be authorized. Start the session with a goal/session key, or \
+                         make a narrower change.",
                         now.size,
-                        page_advice,
-                    ))
+                    )),
+                    None => Some(format!(
+                        "{PREFIX} write_file refused: {shown_path} could not be validated on \
+                         disk and this session has no identity to track what you have read. \
+                         Re-read it, or make a narrower change.",
+                    )),
                 }
-                // Existing file whose metadata cannot be read: size cannot
-                // be validated, so fail closed rather than guess.
-                (ViewStatus::Unknown, None) => Some(format!(
-                    "{} write_file refused: {} has changed on disk since you last read it (or \
-                     its current state could not be validated). Re-read it with read_file, \
-                     then retry the write.",
-                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
-                    shown_path,
-                )),
-                // Never-read file at or under the window: blind overwrite is
-                // today's documented write_file semantics.
-                (ViewStatus::Unknown, Some(_)) => None,
+            } else {
+                match (super::read_window::view_status(session, &path), current) {
+                    // The one allowed overwrite: complete, untainted, and the
+                    // file on disk is still the generation the model read.
+                    // Bind the write to this epoch (R1).
+                    (ViewStatus::Complete { epoch }, Some(now)) if epoch == now => {
+                        authorized_epoch = Some(now);
+                        None
+                    }
+                    (ViewStatus::Complete { .. }, _) => Some(format!(
+                        "{PREFIX} write_file refused: {shown_path} has changed on disk since \
+                         you last read it (or its current state could not be validated). \
+                         Re-read it with read_file, then retry the write.",
+                    )),
+                    // R2: TAINTED is a DISTINCT failure — the loop sanitizer
+                    // redacts every raw byte page too, so paging can NEVER
+                    // deliver these bytes whole. Its own prefix, and advice
+                    // that does NOT say "page through" (which would loop
+                    // forever): the flag is incompatible with rewriting this
+                    // file.
+                    (ViewStatus::Tainted, _) => Some(format!(
+                        "{REDACTED_PREFIX} write_file refused: {shown_path} contains content \
+                         the harness redacts from tool output (embedded data or credentials), \
+                         so read_file cannot deliver it to you whole — no amount of paging \
+                         will. The windowed-read flag is incompatible with reconstructing and \
+                         rewriting THIS file: make a narrower, in-place change rather than a \
+                         whole-file rewrite, or tell the user this file cannot be safely \
+                         whole-file-rewritten while windowed reads are enabled.",
+                    )),
+                    (
+                        ViewStatus::Partial {
+                            seen_through,
+                            total_bytes,
+                        },
+                        _,
+                    ) => Some(format!(
+                        "{PREFIX} write_file refused: read_file has shown you only part of \
+                         {shown_path} (the first {seen_through} of its {total_bytes} bytes), \
+                         and overwriting the whole file from a partial view would destroy the \
+                         part you have not seen. {page_advice}",
+                    )),
+                    (ViewStatus::Unknown, Some(now)) if now.size as usize > WINDOW_MAX_BYTES => {
+                        Some(format!(
+                            "{PREFIX} write_file refused: {shown_path} is {} bytes — larger \
+                             than the {WINDOW_MAX_BYTES}-byte read window — and you have not \
+                             read it in this session. {page_advice}",
+                            now.size,
+                        ))
+                    }
+                    // Existing file whose metadata cannot be read: size cannot
+                    // be validated, so fail closed rather than guess.
+                    (ViewStatus::Unknown, None) => Some(format!(
+                        "{PREFIX} write_file refused: {shown_path} has changed on disk since \
+                         you last read it (or its current state could not be validated). \
+                         Re-read it with read_file, then retry the write.",
+                    )),
+                    // Never-read file at or under the window: blind overwrite
+                    // is today's documented write_file semantics.
+                    (ViewStatus::Unknown, Some(_)) => None,
+                }
             };
             if let Some(output) = refusal {
+                // R5: real runtime clamp on the armed refusal (release builds
+                // drop debug_assert). shown_path is already bounded to ~200
+                // bytes, so this never actually cuts; it is the enforced
+                // backstop keeping the loop's blind cut off the advice.
+                let output = octos_core::truncated_utf8(
+                    &output,
+                    octos_core::tool_output_limit("write_file"),
+                    "",
+                );
                 return Ok(ToolResult {
                     output,
                     success: false,
@@ -361,9 +414,49 @@ impl Tool for WriteFileTool {
                     format!("failed to create directories: {}", parent.display())
                 })?;
             }
-            // Write file (O_NOFOLLOW atomically rejects symlinks, no TOCTOU race).
-            if let Err(e) = super::write_no_follow(&path, input.content.as_bytes()).await {
-                return Ok(super::file_io_error(e, &input.path));
+            // #1638 R1: when the armed guard authorized this overwrite against
+            // a specific epoch, bind the truncating write to the exact opened
+            // inode — a replacement in the authorize→truncate window is
+            // refused, not clobbered. Non-authorized writes (new files, small
+            // never-read files under today's blind semantics) take the plain
+            // O_NOFOLLOW path.
+            match authorized_epoch {
+                Some(expected) => {
+                    match super::write_no_follow_checked(&path, input.content.as_bytes(), expected)
+                        .await
+                    {
+                        Ok(super::CheckedWrite::Written) => {}
+                        Ok(super::CheckedWrite::EpochChanged { found }) => {
+                            // The inode we were authorized against is gone;
+                            // forget the now-invalid coverage and refuse.
+                            if let Some(session) =
+                                ctx.parent_session_key.as_deref().filter(|s| !s.is_empty())
+                            {
+                                super::read_window::forget(session, &path);
+                            }
+                            let shown_path = octos_core::truncated_utf8(&input.path, 200, "...");
+                            return Ok(ToolResult {
+                                output: format!(
+                                    "{} write_file refused: {} changed on disk between your read \
+                                     and this write ({} bytes now), so the overwrite was not \
+                                     applied. Re-read it with read_file, then retry.",
+                                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
+                                    shown_path,
+                                    found.size,
+                                ),
+                                success: false,
+                                ..Default::default()
+                            });
+                        }
+                        Err(e) => return Ok(super::file_io_error(e, &input.path)),
+                    }
+                }
+                None => {
+                    // Write file (O_NOFOLLOW atomically rejects symlinks, no TOCTOU race).
+                    if let Err(e) = super::write_no_follow(&path, input.content.as_bytes()).await {
+                        return Ok(super::file_io_error(e, &input.path));
+                    }
+                }
             }
         }
 
@@ -1139,6 +1232,58 @@ mod tests {
         ctx
     }
 
+    // R6: unarmed write_file must be byte-for-byte origin/main at the wire.
+    #[test]
+    fn unarmed_write_file_toolspec_is_byte_identical_to_origin_main() {
+        let origin = serde_json::json!({
+            "name": "write_file",
+            "description": "Write content to a file. Creates the file if it doesn't exist, or overwrites if it does.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the file to write (alias: filePath)"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "The content to write to the file"
+                    }
+                },
+                "required": ["path", "content"]
+            }
+        });
+        let tool = WriteFileTool::new("/tmp").with_window_enforcement(false);
+        let spec = serde_json::json!({
+            "name": tool.name(),
+            "description": tool.description(),
+            "input_schema": tool.input_schema(),
+        });
+        assert_eq!(
+            spec, origin,
+            "the UNARMED write_file ToolSpec must equal origin/main exactly — in \
+             particular the description must NOT name edit_file/apply_patch (which \
+             some armed contexts forbid) and must not carry a windowing sentence"
+        );
+        assert_eq!(
+            serde_json::to_string(&spec).unwrap(),
+            serde_json::to_string(&origin).unwrap()
+        );
+    }
+
+    #[test]
+    fn armed_write_file_description_names_no_forbidden_tools() {
+        // R5: the armed description is sent to the model in sessions where
+        // edit_file/apply_patch may be forbidden (slides), so it must be
+        // tool-agnostic — never naming a specific patch tool.
+        let tool = WriteFileTool::new("/tmp").with_window_enforcement(true);
+        let desc = tool.description();
+        assert!(
+            !desc.contains("edit_file") && !desc.contains("apply_patch"),
+            "armed description must name no forbidden tools: {desc}"
+        );
+    }
+
     /// Follow the window footers from `offset` until the file has no
     /// continuation left — exactly what the refusal tells the model to do.
     async fn page_through(read: &ReadFileTool, ctx: &ToolContext, path: &str, mut next: usize) {
@@ -1173,18 +1318,21 @@ mod tests {
         let original = big_rows(dir.path(), "script.js");
         let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
-        let ctx = ToolContext::zero();
+        let ctx = ctx_with_session("partial-flow");
 
         // Windowed read: the model has seen page one only.
         let page1 = read
-            .execute(&serde_json::json!({"path": "script.js"}))
+            .execute_with_context(&ctx, &serde_json::json!({"path": "script.js"}))
             .await
             .unwrap();
         assert!(page1.success && page1.output.contains("showing lines 1-450 of 1500"));
 
         // Whole-file overwrite from that partial view must be refused...
         let refused = write
-            .execute(&serde_json::json!({"path": "script.js", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "script.js", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1225,7 +1373,10 @@ mod tests {
         // must then pass.
         page_through(&read, &ctx, "script.js", 451).await;
         let allowed = write
-            .execute(&serde_json::json!({"path": "script.js", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "script.js", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1250,9 +1401,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let original = big_rows(dir.path(), "unread.js");
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ctx_with_session("unread-big");
 
         let refused = write
-            .execute(&serde_json::json!({"path": "unread.js", "content": "blind rebuild\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "unread.js", "content": "blind rebuild\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1297,6 +1452,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         big_rows(dir.path(), "untracked.js");
         let read = ReadFileTool::new(dir.path()); // unarmed
+        let ctx = ctx_with_session("unarmed-read");
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
 
         let full = read
@@ -1308,7 +1464,10 @@ mod tests {
         assert!(full.success);
 
         let refused = write
-            .execute(&serde_json::json!({"path": "untracked.js", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "untracked.js", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1326,10 +1485,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("moving.txt"), "v1\n").unwrap();
         let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ctx_with_session("epoch-change");
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
 
         let r = read
-            .execute(&serde_json::json!({"path": "moving.txt"}))
+            .execute_with_context(&ctx, &serde_json::json!({"path": "moving.txt"}))
             .await
             .unwrap();
         assert!(r.success && r.output.contains("v1"));
@@ -1339,7 +1499,10 @@ mod tests {
         std::fs::write(dir.path().join("moving.txt"), "version-two-longer\n").unwrap();
 
         let refused = write
-            .execute(&serde_json::json!({"path": "moving.txt", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "moving.txt", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1357,10 +1520,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         big_rows(dir.path(), "shrinky.txt");
         let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ctx_with_session("shrink");
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
 
         let page1 = read
-            .execute(&serde_json::json!({"path": "shrinky.txt"}))
+            .execute_with_context(&ctx, &serde_json::json!({"path": "shrinky.txt"}))
             .await
             .unwrap();
         assert!(page1.success && page1.output.contains("showing lines 1-450 of 1500"));
@@ -1369,7 +1533,10 @@ mod tests {
         std::fs::write(dir.path().join("shrinky.txt"), "tiny now\n").unwrap();
 
         let refused = write
-            .execute(&serde_json::json!({"path": "shrinky.txt", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "shrinky.txt", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1380,14 +1547,17 @@ mod tests {
 
         // A fresh read of the (now small) file completes in one call...
         let fresh = read
-            .execute(&serde_json::json!({"path": "shrinky.txt"}))
+            .execute_with_context(&ctx, &serde_json::json!({"path": "shrinky.txt"}))
             .await
             .unwrap();
         assert!(fresh.success && fresh.output.contains("tiny now"));
 
         // ...and the write goes through.
         let allowed = write
-            .execute(&serde_json::json!({"path": "shrinky.txt", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "shrinky.txt", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1505,23 +1675,52 @@ mod tests {
         let secret = format!("before\n{}\nafter\n", "a".repeat(64)); // 64+ hex chars => redacted
         std::fs::write(dir.path().join("secrets.env"), &secret).unwrap();
         let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ctx_with_session("redacted");
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
 
         // The whole file fits one window — coverage is FULL, and that must
         // still not count as a faithful view.
         let r = read
-            .execute(&serde_json::json!({"path": "secrets.env"}))
+            .execute_with_context(&ctx, &serde_json::json!({"path": "secrets.env"}))
             .await
             .unwrap();
         assert!(r.success, "{}", r.output);
 
         let refused = write
-            .execute(&serde_json::json!({"path": "secrets.env", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "secrets.env", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
+        // R2: TAINTED is a permanent incompatibility, not a "read more" case —
+        // the loop redacts every raw byte page too, so paging can NEVER unlock
+        // it. It must therefore be a DISTINCT typed refusal, and its text must
+        // NOT tell the model to keep paging (which would be an infinite loop),
+        // but say the flag is incompatible with rewriting this file and to
+        // tell the user.
+        assert!(!refused.success, "{}", refused.output);
         assert!(
-            !refused.success && refused.output.contains("redacted from your view"),
-            "full coverage of redacted bytes is not knowledge: {}",
+            refused
+                .output
+                .contains(crate::tools::read_window::REDACTED_VIEW_OVERWRITE_PREFIX),
+            "tainted overwrite must use the DISTINCT typed prefix, not the \
+             generic partial-view one: {}",
+            refused.output
+        );
+        assert!(
+            !refused.output.contains("[PARTIAL_VIEW_OVERWRITE]"),
+            "must not reuse the partial-view prefix — a different failure mode: {}",
+            refused.output
+        );
+        assert!(
+            !refused.output.to_lowercase().contains("page through"),
+            "must NOT advise paging (futile — every page is re-redacted): {}",
+            refused.output
+        );
+        assert!(
+            refused.output.contains("tell the user") || refused.output.contains("cannot"),
+            "must signal the flag is incompatible with rewriting this file: {}",
             refused.output
         );
         assert_eq!(
@@ -1540,11 +1739,12 @@ mod tests {
         let giant = "G".repeat(60_000);
         std::fs::write(dir.path().join("one_line.min.js"), &giant).unwrap();
         let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ctx_with_session("byte-complete");
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
 
         // Line mode: advice only (and no ledger entry).
         let advice = read
-            .execute(&serde_json::json!({"path": "one_line.min.js"}))
+            .execute_with_context(&ctx, &serde_json::json!({"path": "one_line.min.js"}))
             .await
             .unwrap();
         assert!(advice.success, "{}", advice.output);
@@ -1556,7 +1756,10 @@ mod tests {
 
         // Fail-closed: advice is not a view; the write refuses.
         let refused = write
-            .execute(&serde_json::json!({"path": "one_line.min.js", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "one_line.min.js", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1570,7 +1773,10 @@ mod tests {
         let mut next = 0usize;
         for _ in 0..4 {
             let slab = read
-                .execute(&serde_json::json!({"path": "one_line.min.js", "byte_offset": next}))
+                .execute_with_context(
+                    &ctx,
+                    &serde_json::json!({"path": "one_line.min.js", "byte_offset": next}),
+                )
                 .await
                 .unwrap();
             assert!(slab.success, "{}", slab.output);
@@ -1587,7 +1793,10 @@ mod tests {
         }
 
         let allowed = write
-            .execute(&serde_json::json!({"path": "one_line.min.js", "content": "rebuilt\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "one_line.min.js", "content": "rebuilt\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1609,18 +1818,25 @@ mod tests {
         // it authored one call ago.
         let dir = tempfile::tempdir().unwrap();
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ctx_with_session("author");
         let big_content = format!("created big\n{}\n", "x".repeat(60_000));
 
         // Creating a new file is always allowed...
         let first = write
-            .execute(&serde_json::json!({"path": "authored.txt", "content": big_content}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "authored.txt", "content": big_content}),
+            )
             .await
             .unwrap();
         assert!(first.success, "{}", first.output);
 
         // ...and overwriting one's own just-written over-window content too.
         let second = write
-            .execute(&serde_json::json!({"path": "authored.txt", "content": "second version\n"}))
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "authored.txt", "content": "second version\n"}),
+            )
             .await
             .unwrap();
         assert!(
@@ -1722,5 +1938,115 @@ mod tests {
             .unwrap();
         assert!(w.success, "the unarmed path must not change: {}", w.output);
         assert!(w.output.contains("Successfully wrote"));
+    }
+
+    // R4: empty session keys must NOT share a bucket. A missing/empty key is
+    // reachable in production (agents default to None, FFI/fleet workers,
+    // plain CLI chat without --goals), so one keyless task's COMPLETE must
+    // never authorize a DIFFERENT keyless task's overwrite. Fail-closed: no
+    // key ⇒ cannot establish COMPLETE ⇒ over-window overwrite refused.
+    #[tokio::test]
+    async fn should_not_let_one_keyless_task_authorize_another_keyless_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        big_rows(dir.path(), "keyless.js");
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        // Two DISTINCT keyless agents: both carry no session key (the common
+        // production default), so both map to the "" bucket if we are not
+        // careful. Task A reads the file to completion.
+        let ctx_a = ToolContext::zero(); // parent_session_key = None
+        let page1 = read
+            .execute_with_context(&ctx_a, &serde_json::json!({"path": "keyless.js"}))
+            .await
+            .unwrap();
+        assert!(page1.success, "{}", page1.output);
+        // Page A through to EOF.
+        let mut next = 451usize;
+        for _ in 0..12 {
+            let page = read
+                .execute_with_context(
+                    &ctx_a,
+                    &serde_json::json!({"path": "keyless.js", "offset": next}),
+                )
+                .await
+                .unwrap();
+            assert!(page.success, "{}", page.output);
+            match page
+                .output
+                .split("offset: ")
+                .nth(1)
+                .and_then(|rest| rest.split('.').next())
+                .and_then(|n| n.parse::<usize>().ok())
+            {
+                Some(n) => next = n,
+                None => break,
+            }
+        }
+
+        // Task B — a DIFFERENT keyless agent — must NOT be authorized by A's
+        // reading. (And A's own keyless read must not authorize A either:
+        // keyless cannot establish COMPLETE at all.)
+        let ctx_b = ToolContext::zero();
+        let refused = write
+            .execute_with_context(
+                &ctx_b,
+                &serde_json::json!({"path": "keyless.js", "content": "rebuilt by b\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !refused.success,
+            "a keyless task must never be authorized to overwrite a big file — \
+             not by another keyless task, not by itself: {}",
+            refused.output
+        );
+        assert!(
+            refused.output.contains("[PARTIAL_VIEW_OVERWRITE]"),
+            "the refusal must be typed: {}",
+            refused.output
+        );
+        // The keyless refusal must be DISTINCT from the "you have not read it"
+        // refusal: paging won't help a keyless task (it records nothing), so
+        // the message must name the real remedy — a session identity — not
+        // send the model into a futile page-then-retry loop.
+        assert!(
+            refused.output.contains("no identity")
+                && refused.output.contains("cannot be authorized"),
+            "the keyless refusal must explain the missing session identity, not \
+             advise futile paging: {}",
+            refused.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_still_allow_a_keyed_session_to_complete_and_overwrite() {
+        // Positive control for R4: a real session key still works end to end,
+        // proving the keyless refusal is about identity, not a blanket block.
+        let dir = tempfile::tempdir().unwrap();
+        medium_rows(dir.path(), "keyed.js");
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ctx_with_session("real-session-r4");
+
+        let page1 = read
+            .execute_with_context(&ctx, &serde_json::json!({"path": "keyed.js"}))
+            .await
+            .unwrap();
+        assert!(page1.success, "{}", page1.output);
+        page_through(&read, &ctx, "keyed.js", 451).await;
+
+        let allowed = write
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "keyed.js", "content": "rebuilt\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(
+            allowed.success,
+            "a keyed session that read the whole file must be allowed: {}",
+            allowed.output
+        );
     }
 }

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -501,7 +501,12 @@ impl WriteFileTool {
             // Create parent directories if needed (generic, unfenced path).
             if let Some(parent) = path.parent() {
                 tokio::fs::create_dir_all(parent).await.wrap_err_with(|| {
-                    format!("failed to create directories: {}", parent.display())
+                    // Bound the caller-derived path so an armed Err stays under
+                    // the tool-output cap (#2193 R4).
+                    format!(
+                        "failed to create directories: {}",
+                        octos_core::truncated_utf8(&parent.display().to_string(), 200, "…")
+                    )
                 })?;
             }
             // #1638 R1: when the armed guard authorized this overwrite against
@@ -630,6 +635,34 @@ impl WriteFileTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn armed_write_caps_an_oversized_malformed_argument_error() {
+        // #2193 R4 (codex round 4): mirror of the read_file cap on write_file's
+        // armed Err path — the caller-controlled unknown key must not blow past
+        // the tool-output cap. Error stays a ToolInputError.
+        let tool = WriteFileTool::new("/tmp").with_window_enforcement(true);
+        let big_key = "k".repeat(60_000);
+        let mut map = serde_json::Map::new();
+        map.insert(big_key, serde_json::json!(1));
+        map.insert("path".to_string(), serde_json::json!("f.txt"));
+        map.insert("content".to_string(), serde_json::json!("x"));
+        let err = match tool.execute(&serde_json::Value::Object(map)).await {
+            Ok(_) => panic!("an unknown parameter must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.chain()
+                .any(|src| src.is::<crate::tools::ToolInputError>()),
+            "the error identity must stay ToolInputError: {err:#}",
+        );
+        let rendered = format!("{err}");
+        assert!(
+            rendered.len() <= crate::tools::TOOL_INPUT_ERROR_MAX_BYTES + 64,
+            "armed malformed-arg error must be capped (got {} bytes)",
+            rendered.len(),
+        );
+    }
 
     #[test]
     fn write_file_tool_is_exclusive() {

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -210,38 +210,99 @@ impl Tool for WriteFileTool {
             }
         }
 
-        // #1638 (c): armed partial-view overwrite guard. When windowed reads
-        // are armed, `read_file` can have shown the model only PART of this
-        // file — and write_file reconstructs from whatever the model saw, so
-        // a whole-file overwrite from a partial view destroys the tail nobody
-        // saw (the slides workflow does exactly read → rebuild → write_file).
-        // The patch tools are safe (they re-read the full file themselves),
-        // which is exactly the escape hatch the refusal names. Sits BEFORE
-        // the write fence and any disk mutation; the #2126 probe block above
-        // stays observe-only and untouched.
+        // #1638 (c): armed FAIL-CLOSED overwrite guard. write_file
+        // reconstructs a file from whatever the model saw, so overwriting an
+        // existing over-window file requires a COMPLETE, current-epoch,
+        // untainted view from THIS session — no ledger entry means refuse
+        // and read first (which makes restart and eviction safe by
+        // construction: absence can only cost a re-read, never an unseen
+        // overwrite). Files at or under the byte window can still be
+        // blind-overwritten exactly as today, but any recorded view of them
+        // is honoured. The advice names only read_file — the calling context
+        // may forbid every other tool (the slides prompt allows nothing but
+        // read_file/write_file for authoring). Sits BEFORE the write fence
+        // and any disk mutation; the #2126 probe block above stays
+        // observe-only and untouched (an armed refusal still increments its
+        // attempt counter — the probe measures intent, not damage).
         if self.window_armed() && path.exists() {
-            if let Some(partial) = super::read_window::partial_view_of(&path) {
-                let coverage = if partial.seen_through > 0 {
-                    format!(
-                        "lines 1-{} of {} contiguously",
-                        partial.seen_through, partial.total_lines
-                    )
-                } else {
-                    format!("a fragment of its {} lines", partial.total_lines)
-                };
-                return Ok(ToolResult {
-                    output: format!(
-                        "{} write_file refused: read_file has shown you only part of {} ({}), \
-                         and overwriting the whole file from a partial view would destroy the \
-                         part you have not seen. Either finish reading it first (read_file with \
-                         offset until you have seen line {}) and then retry, or make targeted \
-                         changes with edit_file / diff_edit / apply_patch, which read the full \
-                         file themselves.",
+            use super::read_window::{ViewStatus, WINDOW_MAX_BYTES};
+            let session = ctx.parent_session_key.clone().unwrap_or_default();
+            // The path shown to the model is clamped: path SPELLINGS are
+            // caller-controlled and can be arbitrarily long, and a refusal
+            // that overflows the loop's output cap gets blind-truncated into
+            // useless advice.
+            let shown_path = octos_core::truncated_utf8(&input.path, 200, "...");
+            let page_advice = "Page through it with read_file (offset/limit, or byte_offset \
+                               for single lines too long for the line window) until you reach \
+                               the end, then retry the write.";
+            let current = tokio::fs::metadata(&path).await.ok().and_then(|meta| {
+                meta.modified()
+                    .ok()
+                    .map(|mtime| super::read_window::ViewEpoch {
+                        mtime,
+                        size: meta.len(),
+                    })
+            });
+            let refusal = match (super::read_window::view_status(&session, &path), current) {
+                // The one allowed overwrite: complete, untainted, and the
+                // file on disk is still the generation the model read.
+                (ViewStatus::Complete { epoch }, Some(now)) if epoch == now => None,
+                (ViewStatus::Complete { .. }, _) => Some(format!(
+                    "{} write_file refused: {} has changed on disk since you last read it (or \
+                     its current state could not be validated). Re-read it with read_file, \
+                     then retry the write.",
+                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
+                    shown_path,
+                )),
+                (ViewStatus::Tainted, _) => Some(format!(
+                    "{} write_file refused: parts of {} were redacted from your view (embedded \
+                     data or credentials), so writing the whole file back would replace them \
+                     with redaction placeholders. Make a narrower change instead of a \
+                     whole-file rewrite.",
+                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
+                    shown_path,
+                )),
+                (
+                    ViewStatus::Partial {
+                        seen_through,
+                        total_bytes,
+                    },
+                    _,
+                ) => Some(format!(
+                    "{} write_file refused: read_file has shown you only part of {} (the first \
+                     {seen_through} of its {total_bytes} bytes), and overwriting the whole \
+                     file from a partial view would destroy the part you have not seen. {}",
+                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
+                    shown_path,
+                    page_advice,
+                )),
+                (ViewStatus::Unknown, Some(now)) if now.size as usize > WINDOW_MAX_BYTES => {
+                    Some(format!(
+                        "{} write_file refused: {} is {} bytes — larger than the \
+                         {WINDOW_MAX_BYTES}-byte read window — and you have not read it in \
+                         this session. {}",
                         super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
-                        input.path,
-                        coverage,
-                        partial.total_lines,
-                    ),
+                        shown_path,
+                        now.size,
+                        page_advice,
+                    ))
+                }
+                // Existing file whose metadata cannot be read: size cannot
+                // be validated, so fail closed rather than guess.
+                (ViewStatus::Unknown, None) => Some(format!(
+                    "{} write_file refused: {} has changed on disk since you last read it (or \
+                     its current state could not be validated). Re-read it with read_file, \
+                     then retry the write.",
+                    super::read_window::PARTIAL_VIEW_OVERWRITE_PREFIX,
+                    shown_path,
+                )),
+                // Never-read file at or under the window: blind overwrite is
+                // today's documented write_file semantics.
+                (ViewStatus::Unknown, Some(_)) => None,
+            };
+            if let Some(output) = refusal {
+                return Ok(ToolResult {
+                    output,
                     success: false,
                     ..Default::default()
                 });
@@ -351,11 +412,21 @@ impl Tool for WriteFileTool {
         }
 
         // #1638 (c): a successful whole-file write makes the on-disk content
-        // exactly what the model supplied — any partial-view mark for the
-        // path is obsolete, and keeping it would refuse the model's next
-        // legitimate overwrite of its own content.
+        // exactly what the model supplied, so record the view COMPLETE at
+        // the post-write epoch — under the fail-closed rule, merely
+        // forgetting the path would refuse the model's next overwrite of a
+        // big file it authored one call ago. Exception: when the post-edit
+        // formatter rewrote the file, the on-disk bytes are no longer what
+        // the model supplied (the note echoes at most a truncated preview),
+        // so the path is forgotten instead — absence refuses, and the model
+        // re-reads the formatted result, which is correct.
         if self.window_armed() {
-            super::read_window::note_full_write(&path);
+            let session = ctx.parent_session_key.clone().unwrap_or_default();
+            if format_note.is_none() {
+                super::read_window::note_full_write(&session, &path, input.content.len());
+            } else {
+                super::read_window::forget(&session, &path);
+            }
         }
 
         let line_count = input.content.lines().count();
@@ -1034,14 +1105,15 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // #1638 (c): the partial-view overwrite guard, armed with windowed reads.
+    // #1638 (c): the fail-closed overwrite guard, armed with windowed reads.
     // Both tools are armed per instance (never process-globally); every test
-    // asserts on files it created itself.
+    // asserts on files it created itself, under its own session keys.
     // -----------------------------------------------------------------------
 
     use crate::tools::read_file::ReadFileTool;
 
-    /// 1500 x 100-byte lines — windows at 450 lines per page when armed.
+    /// 1500 x 100-byte lines, 151,500 content bytes — well over the 48KiB
+    /// window; line mode pages it at ~450 lines per page when armed.
     fn big_rows(dir: &std::path::Path, name: &str) -> String {
         let content = (1..=1500)
             .map(|i| format!("row {i:06}{}", "z".repeat(90)))
@@ -1051,19 +1123,59 @@ mod tests {
         content
     }
 
+    /// 700 x 100-byte lines, ~70,700 content bytes — over-window, but only
+    /// two pages, for tests that page through repeatedly.
+    fn medium_rows(dir: &std::path::Path, name: &str) {
+        let content = (1..=700)
+            .map(|i| format!("row {i:06}{}", "z".repeat(90)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.join(name), &content).unwrap();
+    }
+
+    fn ctx_with_session(session: &str) -> ToolContext {
+        let mut ctx = ToolContext::zero();
+        ctx.parent_session_key = Some(session.to_string());
+        ctx
+    }
+
+    /// Follow the window footers from `offset` until the file has no
+    /// continuation left — exactly what the refusal tells the model to do.
+    async fn page_through(read: &ReadFileTool, ctx: &ToolContext, path: &str, mut next: usize) {
+        for _ in 0..12 {
+            let page = read
+                .execute_with_context(ctx, &serde_json::json!({"path": path, "offset": next}))
+                .await
+                .unwrap();
+            assert!(page.success, "{}", page.output);
+            match page
+                .output
+                .split("offset: ")
+                .nth(1)
+                .and_then(|rest| rest.split('.').next())
+                .and_then(|n| n.parse::<usize>().ok())
+            {
+                Some(n) => next = n,
+                None => return, // no continuation footer — EOF reached
+            }
+        }
+        panic!("paging did not converge");
+    }
+
     #[tokio::test]
     async fn should_refuse_whole_overwrite_after_partial_read_then_allow_after_paging_through() {
         // The slides workflow reads a script, reconstructs it whole, and
-        // write_files it back. Under a windowed read that becomes a
-        // destructive partial overwrite of a tail the model never saw — the
-        // guard must refuse it, and its "page through first" advice must be
-        // truthful: after paging to EOF the same write must succeed.
+        // write_files it back — and its prompt permits ONLY
+        // read_file/write_file for authoring, so the refusal advice must be
+        // followable with read_file alone, and following it must unlock the
+        // write.
         let dir = tempfile::tempdir().unwrap();
         let original = big_rows(dir.path(), "script.js");
         let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ToolContext::zero();
 
-        // Windowed read: the model has seen lines 1-450 of 1500.
+        // Windowed read: the model has seen page one only.
         let page1 = read
             .execute(&serde_json::json!({"path": "script.js"}))
             .await
@@ -1086,13 +1198,20 @@ mod tests {
             refused.output
         );
         assert!(
-            refused.output.contains("edit_file") && refused.output.contains("apply_patch"),
-            "the refusal must name the safe alternatives: {}",
+            refused.output.contains("only part of"),
+            "the refusal must say what the model has actually seen: {}",
             refused.output
         );
         assert!(
-            refused.output.contains("offset"),
-            "the refusal must tell the model how to finish reading: {}",
+            refused.output.contains("read_file") && refused.output.contains("offset"),
+            "the advice must be followable in a context that allows ONLY \
+             read_file/write_file (the slides prompt forbids the patch \
+             tools): {}",
+            refused.output
+        );
+        assert!(
+            !refused.output.contains("edit_file") && !refused.output.contains("apply_patch"),
+            "naming forbidden tools deadlocks the slides flow: {}",
             refused.output
         );
         // ...and must not have touched the file.
@@ -1102,27 +1221,9 @@ mod tests {
             "a refused overwrite must leave the file intact"
         );
 
-        // Page through to EOF the way the refusal advises.
-        let mut next = 451usize;
-        for _ in 0..10 {
-            let page = read
-                .execute(&serde_json::json!({"path": "script.js", "offset": next}))
-                .await
-                .unwrap();
-            assert!(page.success, "{}", page.output);
-            match page
-                .output
-                .split("offset: ")
-                .nth(1)
-                .and_then(|rest| rest.split('.').next())
-                .and_then(|n| n.parse::<usize>().ok())
-            {
-                Some(n) => next = n,
-                None => break, // no continuation footer — EOF reached
-            }
-        }
-
-        // Now the model has seen the whole file; the same write must pass.
+        // Page through to EOF the way the refusal advises; the same write
+        // must then pass.
+        page_through(&read, &ctx, "script.js", 451).await;
         let allowed = write
             .execute(&serde_json::json!({"path": "script.js", "content": "rebuilt\n"}))
             .await
@@ -1136,6 +1237,396 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(dir.path().join("script.js")).unwrap(),
             "rebuilt\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_refuse_overwriting_a_big_never_read_file_when_armed() {
+        // THE fail-closed default: no ledger entry for an over-window file
+        // means REFUSE — closing the giant-first-line hole (where the
+        // advice branch records nothing), the restart hole (empty ledger),
+        // and the eviction hole, all of which were fail-open when "no entry"
+        // meant "allow".
+        let dir = tempfile::tempdir().unwrap();
+        let original = big_rows(dir.path(), "unread.js");
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let refused = write
+            .execute(&serde_json::json!({"path": "unread.js", "content": "blind rebuild\n"}))
+            .await
+            .unwrap();
+        assert!(
+            !refused.success,
+            "an over-window file never read this session must not be \
+             overwritten: {}",
+            refused.output
+        );
+        assert!(
+            refused.output.contains("[PARTIAL_VIEW_OVERWRITE]")
+                && refused.output.contains("have not read it in this session"),
+            "the refusal must say WHY and what to do: {}",
+            refused.output
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("unread.js")).unwrap(),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn should_allow_overwriting_a_never_read_small_file_when_armed() {
+        // A file at or under the byte window is returned whole by a single
+        // unbounded read — there is no partial-view illusion to protect
+        // against, so blind overwrite stays exactly today's semantics.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("blind.txt"), "old\n").unwrap();
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let w = write
+            .execute(&serde_json::json!({"path": "blind.txt", "content": "new\n"}))
+            .await
+            .unwrap();
+        assert!(w.success, "{}", w.output);
+    }
+
+    #[tokio::test]
+    async fn should_not_earn_completeness_from_an_unarmed_read() {
+        // An UNARMED read records nothing — so even a full-range unarmed
+        // read must not vouch for an armed write later (evidence gathered
+        // while the feature was off is not evidence).
+        let dir = tempfile::tempdir().unwrap();
+        big_rows(dir.path(), "untracked.js");
+        let read = ReadFileTool::new(dir.path()); // unarmed
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let full = read
+            .execute(
+                &serde_json::json!({"path": "untracked.js", "start_line": 1, "end_line": 1500}),
+            )
+            .await
+            .unwrap();
+        assert!(full.success);
+
+        let refused = write
+            .execute(&serde_json::json!({"path": "untracked.js", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            !refused.success && refused.output.contains("have not read it in this session"),
+            "unarmed reads must leave no trace the armed guard would trust: {}",
+            refused.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_refuse_when_the_file_changed_on_disk_after_a_complete_read() {
+        // Epoch validation at WRITE time: coverage is only as good as the
+        // generation it was read from. A different (mtime, size) on disk
+        // means the model's COMPLETE view is of a dead generation.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("moving.txt"), "v1\n").unwrap();
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let r = read
+            .execute(&serde_json::json!({"path": "moving.txt"}))
+            .await
+            .unwrap();
+        assert!(r.success && r.output.contains("v1"));
+
+        // Replace the file with different-sized content — even an equal
+        // mtime second cannot mask a size change.
+        std::fs::write(dir.path().join("moving.txt"), "version-two-longer\n").unwrap();
+
+        let refused = write
+            .execute(&serde_json::json!({"path": "moving.txt", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            !refused.success && refused.output.contains("changed on disk"),
+            "stale coverage must refuse with re-read advice: {}",
+            refused.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_recover_after_a_shrink_between_pages() {
+        // H6: a file that shrinks between pages must not leave a stale
+        // refusal forever — a fresh read of the new generation resets
+        // coverage and unlocks the write.
+        let dir = tempfile::tempdir().unwrap();
+        big_rows(dir.path(), "shrinky.txt");
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        let page1 = read
+            .execute(&serde_json::json!({"path": "shrinky.txt"}))
+            .await
+            .unwrap();
+        assert!(page1.success && page1.output.contains("showing lines 1-450 of 1500"));
+
+        // The file shrinks to a single small line.
+        std::fs::write(dir.path().join("shrinky.txt"), "tiny now\n").unwrap();
+
+        let refused = write
+            .execute(&serde_json::json!({"path": "shrinky.txt", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            !refused.success,
+            "coverage of the old generation must not authorize a write: {}",
+            refused.output
+        );
+
+        // A fresh read of the (now small) file completes in one call...
+        let fresh = read
+            .execute(&serde_json::json!({"path": "shrinky.txt"}))
+            .await
+            .unwrap();
+        assert!(fresh.success && fresh.output.contains("tiny now"));
+
+        // ...and the write goes through.
+        let allowed = write
+            .execute(&serde_json::json!({"path": "shrinky.txt", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            allowed.success,
+            "a fresh read of the current generation must recover: {}",
+            allowed.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_refuse_across_sessions_even_after_a_complete_read() {
+        // The ledger is keyed by (session, path): session A's COMPLETE must
+        // never authorize session B's overwrite of content B has not seen.
+        let dir = tempfile::tempdir().unwrap();
+        medium_rows(dir.path(), "shared.js");
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx_a = ctx_with_session("xsession-a");
+        let ctx_b = ctx_with_session("xsession-b");
+
+        // Session A pages the file through to completion.
+        let page1 = read
+            .execute_with_context(&ctx_a, &serde_json::json!({"path": "shared.js"}))
+            .await
+            .unwrap();
+        assert!(page1.success, "{}", page1.output);
+        page_through(&read, &ctx_a, "shared.js", 451).await;
+
+        // Session B has seen nothing and must be refused.
+        let refused = write
+            .execute_with_context(
+                &ctx_b,
+                &serde_json::json!({"path": "shared.js", "content": "rebuilt by b\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !refused.success && refused.output.contains("have not read it in this session"),
+            "another session's coverage is not this session's: {}",
+            refused.output
+        );
+
+        // Session A's own write is allowed (positive control).
+        let allowed = write
+            .execute_with_context(
+                &ctx_a,
+                &serde_json::json!({"path": "shared.js", "content": "rebuilt by a\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(allowed.success, "{}", allowed.output);
+    }
+
+    #[tokio::test]
+    async fn should_refuse_after_a_restart_until_reread() {
+        // Restart safety by construction: the in-memory ledger is empty
+        // after a restart, and absence REFUSES over-window overwrites, so a
+        // fresh process can never silently trust pre-restart coverage.
+        // (Simulated per session rather than clearing the whole ledger — a
+        // global clear would wipe parallel tests' entries mid-flight.)
+        let dir = tempfile::tempdir().unwrap();
+        medium_rows(dir.path(), "reboot.js");
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let ctx = ctx_with_session("restart-sim");
+
+        let page1 = read
+            .execute_with_context(&ctx, &serde_json::json!({"path": "reboot.js"}))
+            .await
+            .unwrap();
+        assert!(page1.success, "{}", page1.output);
+        page_through(&read, &ctx, "reboot.js", 451).await;
+
+        // "Restart": this session's ledger entries are gone.
+        crate::tools::read_window::reset_session_for_test("restart-sim");
+
+        let refused = write
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "reboot.js", "content": "rebuilt\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !refused.success && refused.output.contains("have not read it in this session"),
+            "post-restart, the model must re-read before overwriting: {}",
+            refused.output
+        );
+
+        // Re-reading re-earns the write.
+        let again = read
+            .execute_with_context(&ctx, &serde_json::json!({"path": "reboot.js"}))
+            .await
+            .unwrap();
+        assert!(again.success, "{}", again.output);
+        page_through(&read, &ctx, "reboot.js", 451).await;
+        let allowed = write
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "reboot.js", "content": "rebuilt\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(allowed.success, "{}", allowed.output);
+    }
+
+    #[tokio::test]
+    async fn should_refuse_when_redacted_content_never_reached_the_model() {
+        // H1b: the ledger records what the TOOL returned, but the loop
+        // sanitizer rewrites afterwards — a view it would alter never
+        // reaches the model as-is, so it must record TAINTED and a
+        // whole-file rewrite must refuse (the model would write redaction
+        // placeholders over real content).
+        let dir = tempfile::tempdir().unwrap();
+        let secret = format!("before\n{}\nafter\n", "a".repeat(64)); // 64+ hex chars => redacted
+        std::fs::write(dir.path().join("secrets.env"), &secret).unwrap();
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        // The whole file fits one window — coverage is FULL, and that must
+        // still not count as a faithful view.
+        let r = read
+            .execute(&serde_json::json!({"path": "secrets.env"}))
+            .await
+            .unwrap();
+        assert!(r.success, "{}", r.output);
+
+        let refused = write
+            .execute(&serde_json::json!({"path": "secrets.env", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            !refused.success && refused.output.contains("redacted from your view"),
+            "full coverage of redacted bytes is not knowledge: {}",
+            refused.output
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("secrets.env")).unwrap(),
+            secret,
+            "the refusal must leave the secret-bearing file intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_complete_via_byte_paging_and_allow_the_write() {
+        // The giant-FIRST-line family end to end: line mode can only advise,
+        // the fail-closed default refuses the blind write, raw byte paging
+        // earns completeness, and the write then passes.
+        let dir = tempfile::tempdir().unwrap();
+        let giant = "G".repeat(60_000);
+        std::fs::write(dir.path().join("one_line.min.js"), &giant).unwrap();
+        let read = ReadFileTool::new(dir.path()).with_window_enforcement(true);
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+
+        // Line mode: advice only (and no ledger entry).
+        let advice = read
+            .execute(&serde_json::json!({"path": "one_line.min.js"}))
+            .await
+            .unwrap();
+        assert!(advice.success, "{}", advice.output);
+        assert!(
+            advice.output.contains("byte_offset: 0"),
+            "the advice names the byte-mode continuation: {}",
+            advice.output
+        );
+
+        // Fail-closed: advice is not a view; the write refuses.
+        let refused = write
+            .execute(&serde_json::json!({"path": "one_line.min.js", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            !refused.success && refused.output.contains("have not read it in this session"),
+            "a giant-first-line file with no real view must refuse — this \
+             was the fail-open hole in the first draft: {}",
+            refused.output
+        );
+
+        // Byte-page the whole line: two slabs.
+        let mut next = 0usize;
+        for _ in 0..4 {
+            let slab = read
+                .execute(&serde_json::json!({"path": "one_line.min.js", "byte_offset": next}))
+                .await
+                .unwrap();
+            assert!(slab.success, "{}", slab.output);
+            match slab
+                .output
+                .split("byte_offset: ")
+                .nth(1)
+                .and_then(|rest| rest.split('.').next())
+                .and_then(|n| n.parse::<usize>().ok())
+            {
+                Some(n) => next = n,
+                None => break, // no footer — EOF
+            }
+        }
+
+        let allowed = write
+            .execute(&serde_json::json!({"path": "one_line.min.js", "content": "rebuilt\n"}))
+            .await
+            .unwrap();
+        assert!(
+            allowed.success,
+            "byte paging to EOF must earn the write: {}",
+            allowed.output
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("one_line.min.js")).unwrap(),
+            "rebuilt\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_allow_a_second_overwrite_of_a_file_the_model_just_wrote() {
+        // A successful write records the view COMPLETE at the post-write
+        // epoch — merely forgetting the path (the redesign as first
+        // proposed) would refuse the model's next overwrite of a big file
+        // it authored one call ago.
+        let dir = tempfile::tempdir().unwrap();
+        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let big_content = format!("created big\n{}\n", "x".repeat(60_000));
+
+        // Creating a new file is always allowed...
+        let first = write
+            .execute(&serde_json::json!({"path": "authored.txt", "content": big_content}))
+            .await
+            .unwrap();
+        assert!(first.success, "{}", first.output);
+
+        // ...and overwriting one's own just-written over-window content too.
+        let second = write
+            .execute(&serde_json::json!({"path": "authored.txt", "content": "second version\n"}))
+            .await
+            .unwrap();
+        assert!(
+            second.success,
+            "the author of the current content must not be locked out: {}",
+            second.output
         );
     }
 
@@ -1182,18 +1673,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_allow_overwriting_a_never_read_file_when_armed() {
-        // The guard requires partial-READ evidence; a blind overwrite of an
-        // existing file is today's documented write_file semantics.
+    async fn should_clamp_pathological_paths_in_the_refusal() {
+        // H4: refusal messages interpolate the caller's path SPELLING, which
+        // is unbounded — a 50KB spelling must not push the refusal past the
+        // loop's output cap (a blind head/tail cut there would mangle the
+        // advice).
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("blind.txt"), "old\n").unwrap();
+        big_rows(dir.path(), "deep.js");
         let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
+        let pathological = format!("{}deep.js", "./".repeat(25_000));
 
-        let w = write
-            .execute(&serde_json::json!({"path": "blind.txt", "content": "new\n"}))
+        let refused = write
+            .execute(&serde_json::json!({"path": pathological, "content": "rebuilt\n"}))
             .await
             .unwrap();
-        assert!(w.success, "{}", w.output);
+        assert!(!refused.success, "{}", refused.output);
+        assert!(
+            refused.output.contains("[PARTIAL_VIEW_OVERWRITE]"),
+            "still the typed refusal: {}",
+            octos_core::truncated_utf8(&refused.output, 200, "...")
+        );
+        assert!(
+            refused.output.len() <= octos_core::tool_output_limit("write_file"),
+            "the refusal must clamp the path so the loop backstop cannot \
+             mangle the advice: {} bytes",
+            refused.output.len()
+        );
     }
 
     #[tokio::test]
@@ -1217,33 +1722,5 @@ mod tests {
             .unwrap();
         assert!(w.success, "the unarmed path must not change: {}", w.output);
         assert!(w.output.contains("Successfully wrote"));
-    }
-
-    #[tokio::test]
-    async fn should_not_track_views_when_the_read_is_unarmed() {
-        // An UNARMED read must record nothing — otherwise an armed writer
-        // elsewhere in the process would start refusing on evidence gathered
-        // while the feature was off (the probe's "disarmed records nothing"
-        // rule, applied to the ledger).
-        let dir = tempfile::tempdir().unwrap();
-        big_rows(dir.path(), "untracked.txt");
-        let read = ReadFileTool::new(dir.path()); // unarmed
-        let write = WriteFileTool::new(dir.path()).with_window_enforcement(true);
-
-        let r = read
-            .execute(&serde_json::json!({"path": "untracked.txt", "start_line": 1, "end_line": 5}))
-            .await
-            .unwrap();
-        assert!(r.success);
-
-        let w = write
-            .execute(&serde_json::json!({"path": "untracked.txt", "content": "rebuilt\n"}))
-            .await
-            .unwrap();
-        assert!(
-            w.success,
-            "no armed read happened, so there is no partial-view evidence: {}",
-            w.output
-        );
     }
 }

--- a/crates/octos-agent/src/tools/write_grant.rs
+++ b/crates/octos-agent/src/tools/write_grant.rs
@@ -511,6 +511,41 @@ pub async fn confined_write(
     .unwrap_or_else(|e| Err(std::io::Error::other(e)))
 }
 
+/// Confined overwrite of an EXISTING leaf, bound to `expected` (#2193 R4).
+///
+/// The fenced write path otherwise re-opens the leaf with `O_TRUNC` and
+/// destroys whatever it resolves to — so an armed, *authorized* over-window
+/// overwrite must instead open the confined leaf WITHOUT truncating, `fstat`
+/// the descriptor, and truncate + rewrite only when its epoch still equals the
+/// one the read ledger authorized. Same binding as
+/// [`crate::tools::write_no_follow_checked`], but via the ancestor-safe
+/// `openat` walk so the write fence still holds. Only for existing files
+/// (`OpenExistingRw`), so it is never used under a `create_only` grant.
+pub(crate) async fn confined_write_checked(
+    workspace_root: PathBuf,
+    rel: PathBuf,
+    content: Vec<u8>,
+    expected: crate::tools::read_window::ViewEpoch,
+) -> std::io::Result<crate::tools::CheckedWrite> {
+    tokio::task::spawn_blocking(move || {
+        use std::io::Write;
+        let mut file = open_confined(&workspace_root, &rel, ConfinedLeaf::OpenExistingRw)?;
+        // fstat the walked descriptor and bind to the authorizing epoch before
+        // destroying any content.
+        let meta = file.metadata()?;
+        let found = crate::tools::read_window::ViewEpoch::from_metadata(&meta)
+            .ok_or_else(|| std::io::Error::other("descriptor metadata unavailable"))?;
+        if found != expected {
+            return Ok(crate::tools::CheckedWrite::EpochChanged { found });
+        }
+        file.set_len(0)?;
+        file.write_all(&content)?;
+        Ok(crate::tools::CheckedWrite::Written)
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+}
+
 /// Confined edit — phase 1: open the existing leaf `O_RDWR` via
 /// [`open_confined`] and read its contents, returning BOTH the open handle and
 /// the bytes. The SAME handle is handed to [`confined_rewrite`] for the
@@ -586,6 +621,61 @@ fn validate_pattern(pattern: &str) -> eyre::Result<()> {
 mod tests {
     use super::*;
     use std::sync::Mutex;
+
+    #[tokio::test]
+    async fn confined_write_checked_refuses_a_changed_leaf() {
+        // #2193 R4 (codex H2c): the fenced write path used to O_TRUNC the leaf
+        // blind. It must now bind to the authorizing epoch, catching a same-size,
+        // same-mtime content swap exactly like the non-fenced checked writer.
+        let ws = tempfile::tempdir().unwrap();
+        let path = ws.path().join("card.txt");
+        std::fs::write(&path, b"AAAAAAAAAA").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let mtime = meta.modified().unwrap();
+        let authorized = crate::tools::read_window::ViewEpoch::from_metadata(&meta).unwrap();
+
+        std::fs::write(&path, b"BBBBBBBBBB").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+
+        let result = confined_write_checked(
+            ws.path().to_path_buf(),
+            std::path::PathBuf::from("card.txt"),
+            b"CCCCCCCCCC".to_vec(),
+            authorized,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(result, crate::tools::CheckedWrite::EpochChanged { .. }),
+            "fenced checked write must refuse a changed leaf",
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), b"BBBBBBBBBB");
+    }
+
+    #[tokio::test]
+    async fn confined_write_checked_writes_an_unchanged_leaf() {
+        let ws = tempfile::tempdir().unwrap();
+        let path = ws.path().join("card.txt");
+        std::fs::write(&path, b"hello").unwrap();
+        let authorized =
+            crate::tools::read_window::ViewEpoch::from_metadata(&std::fs::metadata(&path).unwrap())
+                .unwrap();
+        let result = confined_write_checked(
+            ws.path().to_path_buf(),
+            std::path::PathBuf::from("card.txt"),
+            b"world!!".to_vec(),
+            authorized,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(result, crate::tools::CheckedWrite::Written));
+        assert_eq!(std::fs::read(&path).unwrap(), b"world!!");
+    }
 
     fn grant(patterns: &[&str], create_only: bool) -> WritePathGrant {
         let owned: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();

--- a/crates/octos-agent/src/tools/write_grant.rs
+++ b/crates/octos-agent/src/tools/write_grant.rs
@@ -622,6 +622,9 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
+    // Unix-only: relies on ctime advancing to detect a same-size/same-mtime
+    // swap; off-Unix the weaker (mtime,size) fallback cannot.
+    #[cfg(unix)]
     #[tokio::test]
     async fn confined_write_checked_refuses_a_changed_leaf() {
         // #2193 R4 (codex H2c): the fenced write path used to O_TRUNC the leaf


### PR DESCRIPTION
Third step of the #1638 sequence: #2124 gave truncated reads a named next call, #2126 measured whether forcing pages is even a good idea without changing behaviour. This PR builds the enforcement itself — **off by default, armed via `OCTOS_READ_WINDOW=1`** — together with the safety mechanisms an adversarial review (two rounds) showed must land in the same change. The second commit is a redesign of the first after that review found it fail-open on four axes; the findings and their dispositions are in the review-response comment below.

## Design

**Window (armed only).** `read_file` returns at most **2000 lines** and at most **48 KiB of formatted output** — whichever limit is hit first — as whole lines only, with a footer naming which limit fired, the range actually returned, the totals, and the exact next call:

```
[read_file window: showing lines 1-450 of 1500 — 49152-byte limit hit; file is 151500 bytes. Continue with offset: 451.]
[read_file window: showing lines 1-2000 of 3000 — 2000-line limit hit. Continue with offset: 2001.]
```

The #2131 refusal for oversized unbounded reads is subsumed on the armed path, and the internal blind 100KB cut is skipped there: the window IS the advising cut, sized so the execution loop's 50,000-byte backstop (#2124) can **never** fire on an armed read. A tripwire test pins `WINDOW_MAX_BYTES + FOOTER_RESERVE <= tool_output_limit("read_file")`, every armed return path carries a `debug_assert` against the loop cap, **no armed return interpolates caller-controlled text** (path spellings are unbounded — a `./`-chain spelling of 50KB is pinned under the cap by test), and refusal messages clamp the path they echo.

**Raw byte mode (new `byte_offset`/`byte_limit` parameters).** A single line larger than the window cannot be paged by line offset. The first draft followed pi's shell fallback (`sed | head -c`) — the review proved that self-defeating under OUR constraints: shell output is capped at 30,000 bytes (`tool_output_limit("shell")`), and the loop sanitizer redacts exactly what giant lines are made of (base64 data URIs, 64+ hex). So paging within a line is now in-tool: raw slices without a gutter, UTF-8-boundary-snapped (never splitting a character, never leaving a gap), footer naming the exact next `byte_offset`, no footer at EOF. The giant-line advice names the line, its size, and the byte offset where it starts:

```
[read_file window: line 2 is 60000 bytes — larger than the 49152-byte window, and lines cannot be
split across line-mode pages. Read it in raw byte mode with byte_offset: 12 (returns bytes without
line numbers; follow the byte_offset each footer names). Lines after it resume at offset: 3.]
```

Byte mode works unarmed too (the schema is static; an advertised parameter must always work) and bypasses the M8.4 cache in both directions — its view ranges are line ranges, so a byte request is never answered with a `[FILE_UNCHANGED]` stub and never stored as one.

**Parameter provenance.** 2000 lines is pi's field-tested default verbatim (`truncate.ts: DEFAULT_MAX_LINES`); the earlier 500-line/24KiB proposal was rejected as too aggressive (57.4% of repo files ≤500 lines). The byte half adapts pi's 50KB to two local facts pi does not have: our output carries a line-number gutter (the budget counts the FORMATTED bytes that enter context — what the loop cap counts), and 50×1024 = 51,200 does not fit under our 50,000-byte loop cap; 48 KiB plus the footer reserve provably does. The byte-paging mode and the write guard are the two places this deliberately does NOT follow pi: pi's giant-line shell fallback dies against our shell cap and sanitizer, and pi ships no write guard (verified: its `write.ts` has no read-first check) but also no prompt that mandates read→rebuild→overwrite — our slides prompt does, and it permits ONLY `read_file`/`write_file` for authoring.

## The overwrite guard: fail-closed, session-scoped, epoch-validated, taint-aware

`write_file` reconstructs a file from whatever the model saw; the slides flow does read → rebuild → `write_file` with the patch tools forbidden. The guard's rule, armed only:

> Overwriting an EXISTING file larger than the 48 KiB window requires a **COMPLETE** mark from **THIS session** at the **current (mtime, size) epoch**, **untainted**. No ledger entry ⇒ refuse and read first.

Absence being the refusing state makes restart safe by construction (post-restart the model must re-read — correct anyway), makes bounded eviction safe (512 entries, oldest first — eviction can only cost a re-read, never an unseen overwrite), and closes the giant-first-line hole (the advice branch records nothing, and nothing means NO). Files at or under the window keep today's blind-overwrite semantics — a file that size is returned whole by one unbounded read, so there is no partial-view illusion — but any recorded view of them is honoured (partial/tainted/stale refuses regardless of size).

The ledger (`tools/read_window.rs`, process-global — it must hold on every entry path including zero-context `Tool::execute`, where the optional `FileStateCache` is absent):

- **Keyed by `(parent_session_key, canonical path)`** — one session's COMPLETE never authorizes another session's overwrite; canonicalization keeps `read_file` and `write_file` agreeing across path aliases (`/var` vs `/private/var`).
- **Coverage in bytes** — line-mode reads convert to their raw byte spans, so line pages and byte pages stitch in one coordinate system as a contiguous-from-0 high-water mark; paging 1→EOF (by lines, bytes, or both) earns COMPLETE, so the refusal's own advice truthfully unlocks the write.
- **Epoch = (mtime, size), validated twice** — at read time for stitching (same-second replacement with a different size still resets) and again at WRITE time against a fresh stat (a file replaced after a complete read refuses as stale; a shrink between pages recovers via one fresh read). Same-mtime same-size replacement is not detectable without a content hash — neither is it by the M8.4 cache today.
- **Taint** — the recorded output is checked against `sanitize_tool_output` (the exact function the loop applies afterwards); a view the sanitizer would alter records TAINTED and the epoch never completes, because the model would write redaction placeholders over real content it never received.
- **A successful unformatted write re-records COMPLETE at the post-write epoch** (improvement over the redesign as proposed, which forgot the entry — locking the model out of a big file it authored one call ago). A post-write formatter rewrite forgets instead: the on-disk bytes are no longer what the model supplied.

Refusals are typed (`[PARTIAL_VIEW_OVERWRITE]`) with four variants — unread / partial / stale / tainted — and the advice is **tool-agnostic and read_file-only** ("page through it with read_file (offset/limit, or byte_offset…) until you reach the end, then retry"): the first draft named `edit_file`/`apply_patch`, which the slides prompt forbids — advice the calling context cannot follow is a deadlock, not an escape hatch.

**File-state cache (hazard b, unchanged from round 1):** the cache records the view RETURNED, not requested — a clamped read stores its actual window, so an unbounded request can never hit a windowed entry and claim `[FILE_UNCHANGED] (full file cached)` against content the model was never shown.

**Test arming is per-instance** (`with_window_enforcement`, `cfg(test)`), not the probe's process-global pattern: arming *changes* output, so a global switch would leak into parallel unarmed tests; likewise the restart simulation clears one session's entries, never the whole ledger. `set_var` is `unsafe` under edition 2024 and this workspace denies unsafe. Every test asserts on its own files and sessions — never process-global aggregates (#2077/#2126).

## What stays unarmed-identical

Pinned by `should_keep_unarmed_outputs_byte_identical_to_pre_change_goldens` — exact `(success, length, fnv1a)` triples captured on the pre-change tree for: a small unbounded read, an in-budget explicit range, the #2131 refusal, the internal 100KB cut, and a >2000-line unbounded FULL read. Armed reads of anything that fits the window are byte-identical too; the unarmed write path is pinned dormant; an unarmed read records nothing, so arming later never trusts evidence gathered while off. The new `byte_offset` mode is new surface, not a change to any existing call shape.

## Verification

```
cargo test -p octos-agent --lib                          => ok. 2735 passed; 0 failed; 3 ignored
cargo clippy -p octos-agent --all-targets -- -D warnings => no warnings
cargo fmt --all -- --check                               => clean
```

37 tests across the three modules drive the real `execute`/`execute_with_context` paths, RED-first (22 watched failing before the redesign's implementation). Regression families from the review: giant-first-line refuses then completes via byte paging; long-path invariant (read advice and write refusal both ≤ the loop cap); redaction ⇒ TAINTED ⇒ refuse with the file left intact; cross-session refuses with same-session positive control; post-restart refuses until re-read; (mtime, size) replacement refuses; shrink-between-pages recovers via a fresh read; write-then-write stays unlocked. **Mutation-proofed:** disabling the fail-closed Unknown⇒refuse arm fails 6 tests (the whole family); disabling the sanitize-taint check fails the redaction test with the secret-bearing file overwritten; the round-1 mutations (write-guard removal, cache-keying reversion) were also verified killed.

## Tracking (not fixed here)

- **#2126 probe double-count when both flags are armed:** the probe's overwrite hook runs before this guard, so a REFUSED attempt still increments `partial_read_then_overwrite`. Left as is deliberately — the probe measures the dangerous *intent* rate (what would have been destroyed without a guard), and reordering would under-report exactly that; noted here so nobody reads armed-probe numbers as damage.
- **#2197 (filed):** pre-existing unarmed 100KB-cut cache lie — the blind cut can truncate output while the cache records the read as a complete view.
- Pre-existing oddity, untouched: reading an empty file errors with `Start line 1 is beyond file length (0 lines)`.

Refs #1638

---

## Round 3 (codex DO-NOT-MERGE): flag-gating made real, plus TOCTOU / keyless / taint

Round 2's "zero blast radius when off" was false at the wire, and three more holes were found. All fixed; the review-response comment maps each finding to its disposition.

**R6 — the flag was not default-off at the wire (the reframe).** read_file's description and schema, and write_file's description, changed unconditionally, and byte mode executed unarmed — so the ToolSpec serialized into the prompt-cache prefix changed for **every** session, armed or not. Decision, justified: **byte-paging is part of the armed feature** (it exists only to serve the windowed giant-line case — no consumer when the window is off). So description **and** schema **and** byte-mode execution are now all conditional on the arm; unarmed byte params are rejected, never silently ignored. New golden tests pin the unarmed ToolSpec JSON of both tools byte-for-byte against origin/main. Not split into a separate PR because an always-on byte mode would ship a permanent capability whose only user (the window) is still flag-gated.

**R1 — authorize-on-stat, truncate-on-independent-open TOCTOU.** The authorized overwrite now binds to the exact opened inode: `write_no_follow_checked` opens without `O_TRUNC`, `fstat`s the descriptor, and truncates + writes only when its `(mtime, size)` still equals the epoch that authorized the write; a replacement in the authorize→truncate window is refused, not clobbered. `note_full_write` records COMPLETE only when the on-disk size equals the bytes written.

**R4 — empty session keys collapsed together, reachable in production.** A missing key (agents default to `None`; FFI and fleet workers; plain CLI chat without `--goals`) mapped to `""` in both tools, so one keyless task's COMPLETE could authorize another's overwrite. Now keyless tasks record **nothing** (single enforcement point in the ledger) and fail closed for over-window overwrites, with a **distinct** "no session identity" refusal — paging can't help a keyless task, so it must not be advised to page.

**R5 — the invariant was `debug_assert` only.** All three loop-cap checks are now real runtime clamps (release builds drop `debug_assert`); armed returns interpolate no unbounded caller input and clamp the echoed path. The armed write description names no patch tools.

**R2 — TAINTED was a silent permanent deadlock.** A redaction-bearing file gets sticky-TAINTED and the loop re-redacts every raw byte page, so paging can never unlock it. It now has a **distinct** `[REDACTED_VIEW_OVERWRITE]` refusal that says the flag is incompatible with rewriting that file and to tell the user — it never advises paging.

### Known limitation operators must know before arming

**Armed mode is incompatible with whole-file rewrites of redaction-bearing files.** When windowed reads are armed, a file containing content the harness redacts from tool output (base64 data URIs, 64+‑char hex, credential patterns — see `sanitize.rs`) can never be delivered to the model whole, so `write_file` will refuse to reconstruct-and-overwrite it (typed `[REDACTED_VIEW_OVERWRITE]`). This directly affects the **slides** flow if a `script.js` embeds a data-URI image and the model tries to rewrite the whole file: it must make a narrower change, or the operator must not arm the flag for that workload. This is inherent to combining "never overwrite from a view the model didn't fully receive" with "the harness redacts some content" — not a bug, but a real operational constraint.

**Keyless armed sessions cannot whole-file-overwrite existing >48KiB files.** A session with no identity (CLI chat without `--goals`, FFI, fleet) can create files and overwrite small ones, but not reconstruct-and-overwrite a large existing file — it has no way to establish that it read the whole thing. Give the session an identity (e.g. `--goals`) for such flows.

### Round-3 tracking (not fixed, per scope)

- #2126 probe records overwrite **intent** before the guard decides, so an armed refusal still increments its counter — deliberate (the probe measures intent, not damage); left one-line-reorderable but out of scope.
- #2197 (filed round 2): pre-existing unarmed 100KB-cut cache lie.
- Empty-file `Start line 1 is beyond file length (0 lines)` oddity — pre-existing.
