### PR TITLE
Cache economics: one-shot cache-write opt-out, cache-write-aware pricing, get_goal probe latch

### DIFF
--- a/crates/octos-agent/src/agent/llm_call.rs
+++ b/crates/octos-agent/src/agent/llm_call.rs
@@ -142,6 +142,8 @@ impl Agent {
                         let final_cost = self.response_usage_cost(
                             response.usage.input_tokens,
                             response.usage.output_tokens,
+                            response.usage.cache_read_tokens,
+                            response.usage.cache_write_tokens,
                             response.provider_index,
                         );
                         let attributed_cost = match (retry_spend, final_cost) {
@@ -158,10 +160,21 @@ impl Agent {
                             let latency_ms = call_start.elapsed().as_millis() as u64;
                             let cum_in = total_usage.input_tokens + response.usage.input_tokens;
                             let cum_out = total_usage.output_tokens + response.usage.output_tokens;
+                            let cum_cache_read =
+                                total_usage.cache_read_tokens + response.usage.cache_read_tokens;
+                            let cum_cache_write =
+                                total_usage.cache_write_tokens + response.usage.cache_write_tokens;
                             let pricing = octos_llm::pricing::model_pricing(self.llm.model_id());
-                            let session_cost = pricing.map(|p| p.cost(cum_in, cum_out));
+                            let session_cost = pricing.map(|p| {
+                                p.cost_with_cache(cum_in, cum_out, cum_cache_read, cum_cache_write)
+                            });
                             let response_cost = pricing.map(|p| {
-                                p.cost(response.usage.input_tokens, response.usage.output_tokens)
+                                p.cost_with_cache(
+                                    response.usage.input_tokens,
+                                    response.usage.output_tokens,
+                                    response.usage.cache_read_tokens,
+                                    response.usage.cache_write_tokens,
+                                )
                             });
                             let payload = HookPayload::after_llm(
                                 self.llm.model_id(),
@@ -219,6 +232,8 @@ impl Agent {
                                 let final_cost = self.response_usage_cost(
                                     fallback_resp.usage.input_tokens,
                                     fallback_resp.usage.output_tokens,
+                                    fallback_resp.usage.cache_read_tokens,
+                                    fallback_resp.usage.cache_write_tokens,
                                     fallback_resp.provider_index,
                                 );
                                 let attributed_cost = match (retry_spend, final_cost) {
@@ -256,6 +271,8 @@ impl Agent {
                     if let Some(cost) = self.response_usage_cost(
                         response.usage.input_tokens,
                         response.usage.output_tokens,
+                        response.usage.cache_read_tokens,
+                        response.usage.cache_write_tokens,
                         response.provider_index,
                     ) {
                         retry_spend = Some(retry_spend.unwrap_or(0.0) + cost);
@@ -378,6 +395,8 @@ impl Agent {
                                 let final_cost = self.response_usage_cost(
                                     resp.usage.input_tokens,
                                     resp.usage.output_tokens,
+                                    resp.usage.cache_read_tokens,
+                                    resp.usage.cache_write_tokens,
                                     resp.provider_index,
                                 );
                                 let attributed_cost = match (retry_spend, final_cost) {

--- a/crates/octos-agent/src/agent/llm_call.rs
+++ b/crates/octos-agent/src/agent/llm_call.rs
@@ -160,22 +160,20 @@ impl Agent {
                             let latency_ms = call_start.elapsed().as_millis() as u64;
                             let cum_in = total_usage.input_tokens + response.usage.input_tokens;
                             let cum_out = total_usage.output_tokens + response.usage.output_tokens;
-                            let cum_cache_read =
-                                total_usage.cache_read_tokens + response.usage.cache_read_tokens;
-                            let cum_cache_write =
-                                total_usage.cache_write_tokens + response.usage.cache_write_tokens;
-                            let pricing = octos_llm::pricing::model_pricing(self.llm.model_id());
-                            let session_cost = pricing.map(|p| {
-                                p.cost_with_cache(cum_in, cum_out, cum_cache_read, cum_cache_write)
-                            });
-                            let response_cost = pricing.map(|p| {
-                                p.cost_with_cache(
-                                    response.usage.input_tokens,
-                                    response.usage.output_tokens,
-                                    response.usage.cache_read_tokens,
-                                    response.usage.cache_write_tokens,
-                                )
-                            });
+                            // #2194 review: the payload carries the ATTRIBUTED
+                            // spend — each attempt priced at the slot that
+                            // produced it — never a reprice of the merged
+                            // usage at `self.llm.model_id()`, which misprices
+                            // cross-provider retries. `turn` has not recorded
+                            // THIS response yet, so its spend is exactly the
+                            // turn's prior responses; without a figure for
+                            // this call the turn's prior attributed spend is
+                            // still the honest cumulative.
+                            let response_cost = attributed_cost;
+                            let session_cost = match attributed_cost {
+                                Some(cost) => Some(turn.spend_usd() + cost),
+                                None => turn.priced_spend(),
+                            };
                             let payload = HookPayload::after_llm(
                                 self.llm.model_id(),
                                 iteration,
@@ -666,6 +664,124 @@ mod tests {
 
     fn turn() -> LoopTurnState {
         LoopTurnState::new(Instant::now())
+    }
+
+    /// One clean streamed tool-call response with cache-bearing usage, on a
+    /// priced model under an anthropic label — for hook payload cost tests.
+    struct PricedGoodStreamProvider;
+
+    #[async_trait]
+    impl LlmProvider for PricedGoodStreamProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            eyre::bail!("non-streaming fallback should not be reached in this test")
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatStream> {
+            let events = vec![
+                StreamEvent::ToolCallDelta {
+                    index: 0,
+                    id: Some("read_file_1".to_string()),
+                    name: Some("read_file".to_string()),
+                    arguments_delta: "{\"path\":\"a.md\"}".to_string(),
+                },
+                StreamEvent::Usage(LlmTokenUsage {
+                    input_tokens: 100_000,
+                    output_tokens: 10_000,
+                    cache_read_tokens: 10_000,
+                    cache_write_tokens: 2_000,
+                    ..Default::default()
+                }),
+                StreamEvent::Done(StopReason::ToolUse),
+            ];
+            Ok(Box::pin(stream::iter(events)))
+        }
+
+        fn model_id(&self) -> &str {
+            "claude-opus-4"
+        }
+
+        fn provider_name(&self) -> &str {
+            "anthropic"
+        }
+    }
+
+    /// #2194 review: `attributed_cost` prices each attempt at its actual
+    /// provider slot, but the after-LLM hook payload used to REPRICE the
+    /// merged usage at `self.llm.model_id()` — wrong for anything the
+    /// attribution already priced differently. The payload must carry the
+    /// attributed figures: response_cost = this call's attributed spend,
+    /// session_cost = the turn's previously attributed spend + this call's.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn should_report_attributed_spend_in_after_llm_hook_payload() {
+        use crate::hooks::{HookConfig, HookExecutor};
+
+        let capture_dir = tempfile::tempdir().unwrap();
+        let capture = capture_dir.path().join("after_llm_payload.json");
+        let hook = HookConfig {
+            event: crate::hooks::HookEvent::AfterLlmCall,
+            command: vec![
+                "sh".into(),
+                "-c".into(),
+                format!("cat > {}", capture.display()),
+            ],
+            timeout_ms: 5_000,
+            tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
+        };
+
+        let (agent, _dir) = build_agent(Arc::new(PricedGoodStreamProvider)).await;
+        let agent = agent.with_hooks(Arc::new(HookExecutor::new(vec![hook])));
+
+        // Prior turn spend recorded with a DELIBERATELY off-catalog figure:
+        // the hook's cumulative cost must be built from this attribution,
+        // never from repricing the cumulative tokens at the current model.
+        let mut turn = turn();
+        turn.record_usage(5_000, 1_000, 0, 0, None, Some(0.005));
+        let total_usage = turn.total_usage().clone();
+
+        let (_response, _streamed, attributed) = agent
+            .call_llm_with_hooks(
+                &msgs(),
+                &[],
+                &ChatConfig::default(),
+                1,
+                &total_usage,
+                &mut turn,
+            )
+            .await
+            .expect("clean streamed response");
+        let attributed = attributed.expect("claude-opus-4 has catalog pricing");
+
+        let raw = std::fs::read_to_string(&capture).expect("hook captured the payload");
+        let payload: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let response_cost = payload["response_cost"]
+            .as_f64()
+            .expect("response_cost present");
+        let session_cost = payload["session_cost"]
+            .as_f64()
+            .expect("session_cost present");
+        assert!(
+            (response_cost - attributed).abs() < 1e-12,
+            "hook response_cost must be the attributed spend, got {response_cost} vs {attributed}"
+        );
+        assert!(
+            (session_cost - (0.005 + attributed)).abs() < 1e-12,
+            "hook session_cost must be prior attributed turn spend + this call's, \
+             got {session_cost} vs {}",
+            0.005 + attributed
+        );
     }
 
     // ── Tests ─────────────────────────────────────────────────────────────────

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -3145,7 +3145,13 @@ impl Agent {
             tracker,
             // Tool-reported usage has no per-response provider attribution;
             // price it at the active slot as the closest estimate.
-            self.response_usage_cost(tool_tokens.input_tokens, tool_tokens.output_tokens, None),
+            self.response_usage_cost(
+                tool_tokens.input_tokens,
+                tool_tokens.output_tokens,
+                tool_tokens.cache_read_tokens,
+                tool_tokens.cache_write_tokens,
+                None,
+            ),
         );
         // Codex round-3: return the sanitized response so the caller's
         // synth-ack gate sees the SAME tool_call_ids that the success-bit

--- a/crates/octos-agent/src/agent/rich_output.rs
+++ b/crates/octos-agent/src/agent/rich_output.rs
@@ -104,6 +104,11 @@ pub async fn author_html(llm: &dyn LlmProvider, ctx: &RichHtmlContext) -> eyre::
         temperature: Some(0.2),
         tool_choice: ToolChoice::None,
         reasoning_effort: Some(ReasoningEffort::Low),
+        // #2194 review: a single-shot authoring call per voice turn — the
+        // request is dominated by the per-turn dynamic user block (transcript
+        // + spoken reply + brief), and the breakpoint lands on that block, so
+        // a cache write is never read back.
+        cache_retention: octos_llm::CacheRetention::None,
         ..Default::default()
     };
     let resp = llm.chat(&messages, &[], &config).await?;
@@ -168,6 +173,72 @@ mod tests {
         fn provider_name(&self) -> &str {
             "stub"
         }
+    }
+
+    struct RetentionProbeProvider {
+        seen: Arc<std::sync::Mutex<Option<octos_llm::CacheRetention>>>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for RetentionProbeProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            config: &ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            *self.seen.lock().unwrap() = Some(config.cache_retention);
+            Ok(ChatResponse {
+                content: Some("<!doctype html><html><body>ok</body></html>".into()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatStream> {
+            unimplemented!("probe does not stream")
+        }
+
+        fn model_id(&self) -> &str {
+            "retention-probe"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn should_opt_out_of_cache_writes_when_authoring_rich_output() {
+        // #2194 review: author_html is a single-shot authoring call — one
+        // request per voice turn, dominated by a per-turn dynamic user block
+        // (transcript + spoken reply + brief) that is never replayed. The
+        // request must not pay for cache writes.
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let ctx = RichHtmlContext {
+            transcript: "看看天气".into(),
+            spoken_reply: "今天晴".into(),
+            brief: "天气卡片".into(),
+            illustration: false,
+        };
+        let probe = RetentionProbeProvider {
+            seen: Arc::clone(&seen),
+        };
+        let html = author_html(&probe, &ctx).await.expect("probe returns html");
+        assert!(html.contains("<body>ok</body>"));
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some(octos_llm::CacheRetention::None),
+            "one-shot rich-output authoring must not request cache writes"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -544,10 +544,11 @@ impl Agent {
     /// `provider_index: None` to price at the active slot — used for
     /// tool-reported usage that has no per-response attribution.
     ///
-    /// Cache-aware (#1640 follow-up, provider-aware per #2194 review): the
-    /// resolved slot's PROVIDER picks the cache rate card
-    /// (`cache_rates_for_provider` — Anthropic 0.1x/1.25x, Gemini 0.25x/0,
-    /// unknown 1.0x/0), and `TokenUsage`'s crate-wide contract is DISJOINT
+    /// Cache-aware (#1640 follow-up, protocol-aware per #2194 review): the
+    /// resolved slot's PROVIDER + MODEL pick the cache rate card
+    /// (`pricing::cache_rates` — Anthropic protocol 0.1x/1.25x incl. relabeled
+    /// proxies, Gemini 0.25x/0, unknown 1.0x/1.25x so a reported write never
+    /// vanishes), and `TokenUsage`'s crate-wide contract is DISJOINT
     /// accounting (inclusive wire formats are normalized at each provider's
     /// parse boundary), so the three counts price independently without
     /// double-billing.
@@ -563,6 +564,7 @@ impl Agent {
         octos_llm::pricing::model_pricing(&metadata.model).map(|p| {
             p.cost_with_cache_for_provider(
                 &metadata.provider,
+                &metadata.model,
                 input_tokens,
                 output_tokens,
                 cache_read_tokens,
@@ -599,6 +601,7 @@ impl Agent {
             pricing.map(|p| {
                 p.cost_with_cache_for_provider(
                     &metadata.provider,
+                    &metadata.model,
                     response_usage.input_tokens,
                     response_usage.output_tokens,
                     response_usage.cache_read_tokens,
@@ -853,29 +856,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_price_cache_at_provider_rate_card_when_slot_is_not_anthropic() {
-        // #2194 review: the multipliers are a PROVIDER property. The same
-        // usage on an openai-labeled slot must bill reads at the full input
-        // rate with no write premium — NOT at Anthropic's 0.1x/1.25x.
+    async fn should_price_unknown_slot_cache_reads_full_and_writes_never_free() {
+        // #2194 review round 2: an unknown-labeled slot bills cache READS at
+        // the full input rate (no invented discount), but cache WRITES are
+        // NEVER free — cache_write_tokens is only ever emitted by the
+        // Anthropic parser, so a write reaching the residual bucket is an
+        // Anthropic-protocol write from an unrecognized proxy and bills at
+        // 1.25x rather than vanishing.
         let (agent, _dir) = priced_agent("openai").await;
         let priced = agent
             .response_usage_cost(100_000, 10_000, 10_000, 2_000, None)
             .expect("claude-opus-4 has catalog pricing");
 
         let pricing = octos_llm::pricing::model_pricing("claude-opus-4").unwrap();
-        let expected = pricing.cost(100_000 + 10_000, 10_000);
+        // reads folded in at full input rate + 2k writes at 1.25x.
+        let expected = pricing.cost(100_000 + 10_000, 10_000)
+            + (2_000.0 / 1_000_000.0) * pricing.input_per_million * 1.25;
         assert!(
             (priced - expected).abs() < 1e-12,
-            "unknown-rate providers bill reads at the full input rate, writes free (got {priced})"
+            "unknown slot: reads at full input rate, writes at 1.25x (got {priced})"
+        );
+        // The write must not vanish: dropping it lowers the price.
+        let read_only = agent
+            .response_usage_cost(100_000, 10_000, 10_000, 0, None)
+            .unwrap();
+        assert!(
+            priced - read_only > 1e-9,
+            "a reported cache write must add cost on an unknown slot"
         );
 
+        // And the Anthropic card is still cheaper (0.1x reads), so the
+        // protocol branch genuinely changes the price.
         let (anthropic_agent, _dir2) = priced_agent("anthropic").await;
         let anthropic_priced = anthropic_agent
             .response_usage_cost(100_000, 10_000, 10_000, 2_000, None)
             .unwrap();
         assert!(
-            (priced - anthropic_priced).abs() > 1e-9,
-            "the provider label must change the cache pricing"
+            priced - anthropic_priced > 1e-9,
+            "unknown full-rate reads must cost more than Anthropic 0.1x reads"
         );
     }
 

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -543,15 +543,29 @@ impl Agent {
     /// `None` when that model has no catalog pricing. Pass
     /// `provider_index: None` to price at the active slot — used for
     /// tool-reported usage that has no per-response attribution.
+    ///
+    /// Cache-aware (#1640 follow-up): reads bill at 0.1x and writes at
+    /// 1.25x the input rate, and `TokenUsage`'s crate-wide contract is
+    /// DISJOINT accounting (inclusive wire formats are normalized at each
+    /// provider's parse boundary), so the three counts can be priced
+    /// independently without double-billing.
     pub(super) fn response_usage_cost(
         &self,
         input_tokens: u32,
         output_tokens: u32,
+        cache_read_tokens: u32,
+        cache_write_tokens: u32,
         provider_index: Option<usize>,
     ) -> Option<f64> {
         let metadata = self.llm.provider_metadata_for_index(provider_index);
-        octos_llm::pricing::model_pricing(&metadata.model)
-            .map(|p| p.cost(input_tokens, output_tokens))
+        octos_llm::pricing::model_pricing(&metadata.model).map(|p| {
+            p.cost_with_cache(
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_write_tokens,
+            )
+        })
     }
 
     /// `attributed_cost` is the caller's per-attempt-priced cost for
@@ -579,7 +593,14 @@ impl Agent {
             .provider_metadata_for_index(response.provider_index);
         let pricing = octos_llm::pricing::model_pricing(&metadata.model);
         let response_cost = attributed_cost.or_else(|| {
-            pricing.map(|p| p.cost(response_usage.input_tokens, response_usage.output_tokens))
+            pricing.map(|p| {
+                p.cost_with_cache(
+                    response_usage.input_tokens,
+                    response_usage.output_tokens,
+                    response_usage.cache_read_tokens,
+                    response_usage.cache_write_tokens,
+                )
+            })
         });
         // Session figures = completed-runs base + this turn so far.
         //
@@ -749,6 +770,71 @@ mod tests {
         fn provider_name(&self) -> &str {
             "mock"
         }
+    }
+
+    /// Provider that never answers but reports a model with catalog pricing,
+    /// so cost plumbing can be exercised without a network call.
+    struct PricedNoopProvider;
+
+    #[async_trait]
+    impl LlmProvider for PricedNoopProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            eyre::bail!("chat() unused in pricing tests")
+        }
+
+        fn model_id(&self) -> &str {
+            "claude-opus-4"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn should_price_cache_reads_and_writes_at_multiplier_rates_when_usage_reports_them() {
+        // #1640 follow-up: runtime pricing must charge cache reads at 0.1x
+        // and cache writes at 1.25x the input rate instead of ignoring both
+        // — otherwise caching experiments are unpriceable after the fact.
+        let dir = tempfile::tempdir().unwrap();
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedNoopProvider);
+        let agent = Agent::new(
+            AgentId::new("pricing-test"),
+            provider,
+            ToolRegistry::new(),
+            memory,
+        );
+
+        let priced = agent
+            .response_usage_cost(100_000, 10_000, 10_000, 2_000, None)
+            .expect("claude-opus-4 has catalog pricing");
+
+        let pricing = octos_llm::pricing::model_pricing("claude-opus-4").unwrap();
+        let naive = pricing.cost(100_000, 10_000);
+        let expected = pricing.cost_with_cache(100_000, 10_000, 10_000, 2_000);
+        assert!(
+            (priced - expected).abs() < 1e-12,
+            "cache-aware figure expected {expected}, got {priced}"
+        );
+        assert!(
+            (priced - naive).abs() > 1e-9,
+            "cache tokens must move the price off the naive input/output figure ({naive})"
+        );
+        // The exact premium: 10_000 reads at 0.1x + 2_000 writes at 1.25x of
+        // the input rate.
+        let input_rate = pricing.input_per_million;
+        let premium = (10_000.0 / 1_000_000.0) * input_rate * 0.1
+            + (2_000.0 / 1_000_000.0) * input_rate * 1.25;
+        assert!(
+            (priced - (naive + premium)).abs() < 1e-12,
+            "premium must be 0.1x reads + 1.25x writes on the input rate"
+        );
     }
 
     /// Build a bare `Agent` whose backing provider is unused — the streaming

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -562,9 +562,8 @@ impl Agent {
     ) -> Option<f64> {
         let metadata = self.llm.provider_metadata_for_index(provider_index);
         octos_llm::pricing::model_pricing(&metadata.model).map(|p| {
-            p.cost_with_cache_for_provider(
-                &metadata.provider,
-                &metadata.model,
+            p.cost_with_cache_for_metadata(
+                &metadata,
                 input_tokens,
                 output_tokens,
                 cache_read_tokens,
@@ -599,9 +598,8 @@ impl Agent {
         let pricing = octos_llm::pricing::model_pricing(&metadata.model);
         let response_cost = attributed_cost.or_else(|| {
             pricing.map(|p| {
-                p.cost_with_cache_for_provider(
-                    &metadata.provider,
-                    &metadata.model,
+                p.cost_with_cache_for_metadata(
+                    &metadata,
                     response_usage.input_tokens,
                     response_usage.output_tokens,
                     response_usage.cache_read_tokens,
@@ -803,6 +801,20 @@ mod tests {
 
         fn provider_name(&self) -> &str {
             self.provider
+        }
+
+        fn provider_metadata(&self) -> octos_llm::ProviderMetadata {
+            // #2194 R4: real providers source their cache lane from their TYPE.
+            // Mirror that so these pricing tests exercise the metadata lane the
+            // production path now uses: an Anthropic-protocol slot reports the
+            // Anthropic lane, everything else the residual lane.
+            let lane = if self.provider == "anthropic" {
+                octos_llm::CacheLane::Anthropic
+            } else {
+                octos_llm::CacheLane::Residual
+            };
+            octos_llm::ProviderMetadata::new(self.provider, self.model_id(), None)
+                .with_cache_lane(lane)
         }
     }
 

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -544,11 +544,13 @@ impl Agent {
     /// `provider_index: None` to price at the active slot — used for
     /// tool-reported usage that has no per-response attribution.
     ///
-    /// Cache-aware (#1640 follow-up): reads bill at 0.1x and writes at
-    /// 1.25x the input rate, and `TokenUsage`'s crate-wide contract is
-    /// DISJOINT accounting (inclusive wire formats are normalized at each
-    /// provider's parse boundary), so the three counts can be priced
-    /// independently without double-billing.
+    /// Cache-aware (#1640 follow-up, provider-aware per #2194 review): the
+    /// resolved slot's PROVIDER picks the cache rate card
+    /// (`cache_rates_for_provider` — Anthropic 0.1x/1.25x, Gemini 0.25x/0,
+    /// unknown 1.0x/0), and `TokenUsage`'s crate-wide contract is DISJOINT
+    /// accounting (inclusive wire formats are normalized at each provider's
+    /// parse boundary), so the three counts price independently without
+    /// double-billing.
     pub(super) fn response_usage_cost(
         &self,
         input_tokens: u32,
@@ -559,7 +561,8 @@ impl Agent {
     ) -> Option<f64> {
         let metadata = self.llm.provider_metadata_for_index(provider_index);
         octos_llm::pricing::model_pricing(&metadata.model).map(|p| {
-            p.cost_with_cache(
+            p.cost_with_cache_for_provider(
+                &metadata.provider,
                 input_tokens,
                 output_tokens,
                 cache_read_tokens,
@@ -594,7 +597,8 @@ impl Agent {
         let pricing = octos_llm::pricing::model_pricing(&metadata.model);
         let response_cost = attributed_cost.or_else(|| {
             pricing.map(|p| {
-                p.cost_with_cache(
+                p.cost_with_cache_for_provider(
+                    &metadata.provider,
                     response_usage.input_tokens,
                     response_usage.output_tokens,
                     response_usage.cache_read_tokens,
@@ -772,9 +776,12 @@ mod tests {
         }
     }
 
-    /// Provider that never answers but reports a model with catalog pricing,
-    /// so cost plumbing can be exercised without a network call.
-    struct PricedNoopProvider;
+    /// Provider that never answers but reports a model with catalog pricing
+    /// under a configurable provider label, so cost plumbing (including the
+    /// per-provider cache rate card) can be exercised without a network call.
+    struct PricedNoopProvider {
+        provider: &'static str,
+    }
 
     #[async_trait]
     impl LlmProvider for PricedNoopProvider {
@@ -792,24 +799,32 @@ mod tests {
         }
 
         fn provider_name(&self) -> &str {
-            "mock"
+            self.provider
         }
     }
 
-    #[tokio::test]
-    async fn should_price_cache_reads_and_writes_at_multiplier_rates_when_usage_reports_them() {
-        // #1640 follow-up: runtime pricing must charge cache reads at 0.1x
-        // and cache writes at 1.25x the input rate instead of ignoring both
-        // — otherwise caching experiments are unpriceable after the fact.
+    async fn priced_agent(provider_label: &'static str) -> (Agent, TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
-        let provider: Arc<dyn LlmProvider> = Arc::new(PricedNoopProvider);
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedNoopProvider {
+            provider: provider_label,
+        });
         let agent = Agent::new(
             AgentId::new("pricing-test"),
             provider,
             ToolRegistry::new(),
             memory,
         );
+        (agent, dir)
+    }
+
+    #[tokio::test]
+    async fn should_price_cache_reads_and_writes_at_multiplier_rates_when_usage_reports_them() {
+        // #1640 follow-up: on an ANTHROPIC-labeled slot, runtime pricing
+        // must charge cache reads at 0.1x and cache writes at 1.25x the
+        // input rate instead of ignoring both — otherwise caching
+        // experiments are unpriceable after the fact.
+        let (agent, _dir) = priced_agent("anthropic").await;
 
         let priced = agent
             .response_usage_cost(100_000, 10_000, 10_000, 2_000, None)
@@ -834,6 +849,33 @@ mod tests {
         assert!(
             (priced - (naive + premium)).abs() < 1e-12,
             "premium must be 0.1x reads + 1.25x writes on the input rate"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_price_cache_at_provider_rate_card_when_slot_is_not_anthropic() {
+        // #2194 review: the multipliers are a PROVIDER property. The same
+        // usage on an openai-labeled slot must bill reads at the full input
+        // rate with no write premium — NOT at Anthropic's 0.1x/1.25x.
+        let (agent, _dir) = priced_agent("openai").await;
+        let priced = agent
+            .response_usage_cost(100_000, 10_000, 10_000, 2_000, None)
+            .expect("claude-opus-4 has catalog pricing");
+
+        let pricing = octos_llm::pricing::model_pricing("claude-opus-4").unwrap();
+        let expected = pricing.cost(100_000 + 10_000, 10_000);
+        assert!(
+            (priced - expected).abs() < 1e-12,
+            "unknown-rate providers bill reads at the full input rate, writes free (got {priced})"
+        );
+
+        let (anthropic_agent, _dir2) = priced_agent("anthropic").await;
+        let anthropic_priced = anthropic_agent
+            .response_usage_cost(100_000, 10_000, 10_000, 2_000, None)
+            .unwrap();
+        assert!(
+            (priced - anthropic_priced).abs() > 1e-9,
+            "the provider label must change the cache pricing"
         );
     }
 

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -556,6 +556,7 @@ impl Agent {
             octos_llm::pricing::model_pricing(&verifier_metadata.model).map(|p| {
                 p.cost_with_cache_for_provider(
                     &verifier_metadata.provider,
+                    &verifier_metadata.model,
                     response.usage.input_tokens,
                     response.usage.output_tokens,
                     response.usage.cache_read_tokens,

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -554,9 +554,8 @@ impl Agent {
             response.usage.cache_write_tokens,
             tracker,
             octos_llm::pricing::model_pricing(&verifier_metadata.model).map(|p| {
-                p.cost_with_cache_for_provider(
-                    &verifier_metadata.provider,
-                    &verifier_metadata.model,
+                p.cost_with_cache_for_metadata(
+                    &verifier_metadata,
                     response.usage.input_tokens,
                     response.usage.output_tokens,
                     response.usage.cache_read_tokens,

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -533,17 +533,7 @@ impl Agent {
                 timestamp: chrono::Utc::now(),
             },
         ];
-        let verifier_config = ChatConfig {
-            max_tokens: Some(VERIFIER_MAX_TOKENS),
-            temperature: Some(0.0),
-            tool_choice: ToolChoice::None,
-            response_format: Some(ResponseFormat::JsonSchema {
-                name: "octos_verifier_verdict".to_string(),
-                schema: verifier_schema(),
-                strict: true,
-            }),
-            ..Default::default()
-        };
+        let verifier_config = verifier_chat_config();
         let response = octos_llm::with_lane_context(
             config.lane_context.clone(),
             config.provider.chat(&messages, &[], &verifier_config),
@@ -586,6 +576,27 @@ impl Agent {
         });
         ledger.record_verdict(iteration, verdict.clone(), &config.model_label);
         Ok(verdict)
+    }
+}
+
+/// The `ChatConfig` for one verifier verdict call, split out so its cache
+/// economics are pinnable in isolation.
+fn verifier_chat_config() -> ChatConfig {
+    ChatConfig {
+        max_tokens: Some(VERIFIER_MAX_TOKENS),
+        temperature: Some(0.0),
+        tool_choice: ToolChoice::None,
+        response_format: Some(ResponseFormat::JsonSchema {
+            name: "octos_verifier_verdict".to_string(),
+            schema: verifier_schema(),
+            strict: true,
+        }),
+        // #2194 review: the only stable prefix is a one-sentence system block
+        // (below any cacheable minimum); the breakpoint-marked last user
+        // block carries the rolling TurnLedger, which differs every round —
+        // a cache write here is never read back.
+        cache_retention: octos_llm::CacheRetention::None,
+        ..Default::default()
     }
 }
 
@@ -733,6 +744,31 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn should_opt_out_of_cache_writes_when_building_verifier_config() {
+        // #2194 review: the verifier's stable prefix is a single system
+        // sentence (below any cacheable minimum); the breakpoint-marked last
+        // user block carries the rolling TurnLedger, which differs every
+        // round — so a cache write is never read back. The verdict call must
+        // opt out, while keeping its strict-JSON response contract intact.
+        let config = verifier_chat_config();
+        assert_eq!(
+            config.cache_retention,
+            octos_llm::CacheRetention::None,
+            "verifier verdict calls must not request cache writes"
+        );
+        match config.response_format {
+            Some(ResponseFormat::JsonSchema {
+                ref name, strict, ..
+            }) => {
+                assert_eq!(name, "octos_verifier_verdict");
+                assert!(strict);
+            }
+            other => panic!("verifier must keep its JSON-schema contract, got {other:?}"),
+        }
+        assert!(matches!(config.tool_choice, ToolChoice::None));
+    }
 
     #[test]
     fn ledger_marks_repeating_only_when_caller_reports_repeating() {

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -544,18 +544,18 @@ impl Agent {
         // also handles verifier-side failover). `config.model_label` is a
         // DISPLAY label ("session-cheap-verifier" when no explicit
         // OCTOS_AGENT_VERIFIER_MODEL is set) and misses the catalog.
-        let verifier_model = config
+        let verifier_metadata = config
             .provider
-            .provider_metadata_for_index(response.provider_index)
-            .model;
+            .provider_metadata_for_index(response.provider_index);
         turn.record_usage(
             response.usage.input_tokens,
             response.usage.output_tokens,
             response.usage.cache_read_tokens,
             response.usage.cache_write_tokens,
             tracker,
-            octos_llm::pricing::model_pricing(&verifier_model).map(|p| {
-                p.cost_with_cache(
+            octos_llm::pricing::model_pricing(&verifier_metadata.model).map(|p| {
+                p.cost_with_cache_for_provider(
+                    &verifier_metadata.provider,
                     response.usage.input_tokens,
                     response.usage.output_tokens,
                     response.usage.cache_read_tokens,

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -564,8 +564,14 @@ impl Agent {
             response.usage.cache_read_tokens,
             response.usage.cache_write_tokens,
             tracker,
-            octos_llm::pricing::model_pricing(&verifier_model)
-                .map(|p| p.cost(response.usage.input_tokens, response.usage.output_tokens)),
+            octos_llm::pricing::model_pricing(&verifier_model).map(|p| {
+                p.cost_with_cache(
+                    response.usage.input_tokens,
+                    response.usage.output_tokens,
+                    response.usage.cache_read_tokens,
+                    response.usage.cache_write_tokens,
+                )
+            }),
         );
         let content = response.content.unwrap_or_default();
         let verdict = parse_verifier_verdict(&content).unwrap_or_else(|| {

--- a/crates/octos-agent/src/compaction.rs
+++ b/crates/octos-agent/src/compaction.rs
@@ -1193,6 +1193,9 @@ pub fn llm_compaction_summary(
             max_tokens: Some(provider.max_output_tokens()),
             // Low but non-zero: a factual handoff summary, lightly deterministic.
             temperature: Some(0.2),
+            // One-shot: the transcript is summarized exactly once and its
+            // prefix never replayed, so cache writes would be pure premium.
+            cache_retention: octos_llm::CacheRetention::None,
             ..Default::default()
         };
         let request = vec![
@@ -1314,6 +1317,68 @@ mod tests {
             result: Ok("unused".into()),
         });
         assert!(llm_compaction_summary(&provider, &[], Duration::from_secs(5)).is_none());
+    }
+
+    /// Captures the `ChatConfig` the summary call sends so the cache-economics
+    /// contract is pinned at the call site, not just in the provider.
+    struct RetentionProbeProvider {
+        seen: Arc<std::sync::Mutex<Option<octos_llm::CacheRetention>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for RetentionProbeProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            config: &ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            *self.seen.lock().unwrap() = Some(config.cache_retention);
+            Ok(octos_llm::ChatResponse {
+                content: Some("one-shot summary".into()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatStream> {
+            unimplemented!("probe does not stream")
+        }
+
+        fn model_id(&self) -> &str {
+            "retention-probe"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn should_opt_out_of_cache_writes_when_summarizing_one_shot() {
+        // The compaction summary sends its transcript exactly once — the
+        // prefix is never replayed, so marking cache breakpoints would pay
+        // the 1.25x write premium for nothing. The request must opt out.
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let provider: Arc<dyn LlmProvider> = Arc::new(RetentionProbeProvider {
+            seen: Arc::clone(&seen),
+        });
+        let messages = vec![Message::user("do X"), Message::assistant("did Y")];
+        let out = llm_compaction_summary(&provider, &messages, Duration::from_secs(5));
+        assert!(out.is_some(), "probe provider returns a summary");
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some(octos_llm::CacheRetention::None),
+            "one-shot compaction summaries must not request cache writes"
+        );
     }
 
     #[tokio::test] // current_thread runtime (the default, no `flavor`)

--- a/crates/octos-agent/src/subagent_summary.rs
+++ b/crates/octos-agent/src/subagent_summary.rs
@@ -477,6 +477,9 @@ async fn fetch_summary(
         response_format: None,
         context_management: None,
         sampling_params: None,
+        // One-shot: each digest prompt is fresh activity, sent exactly once
+        // — opt out of the 1.25x cache-write premium.
+        cache_retention: octos_llm::CacheRetention::None,
     };
     let messages = vec![Message::user(prompt)];
     let fut = async move { provider.chat(&messages, &[], &config).await };
@@ -501,6 +504,9 @@ mod tests {
     struct MockProvider {
         output: String,
         calls: Arc<AtomicU32>,
+        /// Cache-retention preference of the last request, so tests can pin
+        /// the one-shot digest's opt-out at the call site.
+        seen_retention: Arc<std::sync::Mutex<Option<octos_llm::CacheRetention>>>,
     }
 
     impl MockProvider {
@@ -510,6 +516,7 @@ mod tests {
                 Self {
                     output: output.into(),
                     calls: Arc::clone(&calls),
+                    seen_retention: Arc::new(std::sync::Mutex::new(None)),
                 },
                 calls,
             )
@@ -522,9 +529,10 @@ mod tests {
             &self,
             _messages: &[Message],
             _tools: &[ToolSpec],
-            _config: &ChatConfig,
+            config: &ChatConfig,
         ) -> eyre::Result<ChatResponse> {
             self.calls.fetch_add(1, Ordering::SeqCst);
+            *self.seen_retention.lock().unwrap() = Some(config.cache_retention);
             Ok(ChatResponse {
                 content: Some(self.output.clone()),
                 reasoning_content: None,
@@ -643,6 +651,30 @@ mod tests {
         assert_eq!(detail["summary"], "parsing response");
         assert_eq!(detail["tick"], 7);
         assert!(detail["at"].is_string());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn should_opt_out_of_cache_writes_when_fetching_subagent_digest() {
+        // Each 64-token digest call sends a fresh activity prompt exactly
+        // once — a cache write on it is pure 1.25x premium, never read back.
+        let (mock, _) = MockProvider::new("parsing response");
+        let seen = Arc::clone(&mock.seen_retention);
+        let supervisor = TaskSupervisor::new();
+        let id = register_running_task(&supervisor);
+        let generator = AgentSummaryGenerator::with_activity_source(
+            Arc::new(mock),
+            fixed_activity(&["fetch", "parse"]),
+            supervisor.clone(),
+        )
+        .with_llm_timeout(Duration::from_secs(1));
+
+        let _ = generator.summarize_once("api:session", &id, 1).await;
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some(octos_llm::CacheRetention::None),
+            "one-shot sub-agent digests must not request cache writes"
+        );
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/octos-agent/src/subagent_summary.rs
+++ b/crates/octos-agent/src/subagent_summary.rs
@@ -303,6 +303,8 @@ impl AgentSummaryGenerator {
             task_id,
             tick_seq,
             self.summary_window,
+            // One-off invocation: no cross-tick state, so it always calls.
+            &mut None,
         )
         .await
     }
@@ -343,6 +345,8 @@ async fn run_watcher_loop(
     }
 
     let mut tick_seq: u32 = 0;
+    // #2194 review: per-watcher dedupe state — see [`LastTickSummary`].
+    let mut last_emitted: Option<LastTickSummary> = None;
     loop {
         tick_seq = tick_seq.saturating_add(1);
         let _ = summarize_tick(
@@ -354,6 +358,7 @@ async fn run_watcher_loop(
             &task_id,
             tick_seq,
             window,
+            &mut last_emitted,
         )
         .await;
 
@@ -375,6 +380,20 @@ fn is_terminal(supervisor: &TaskSupervisor, task_id: &str) -> bool {
     }
 }
 
+/// #2194 review — the snapshot + summary a watcher last EMITTED, kept per
+/// watcher loop so an idle tick can be answered without an LLM call.
+///
+/// An idle sub-agent rebuilds the byte-identical prompt every 30s tick
+/// (deterministic [`build_prompt`] over an unchanged activity tail). Dedupe
+/// beats caching here: a prompt-cache hit would still bill ~0.1x of the
+/// prompt, a reused summary bills nothing — and it leaves every prompt that
+/// DOES reach the provider genuinely fresh, which is what justifies
+/// [`fetch_summary`]'s cache-write opt-out.
+struct LastTickSummary {
+    lines: Vec<String>,
+    summary: String,
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn summarize_tick(
     provider: Arc<dyn LlmProvider>,
@@ -385,8 +404,22 @@ async fn summarize_tick(
     task_id: &str,
     tick_seq: u32,
     window: usize,
+    last: &mut Option<LastTickSummary>,
 ) -> Option<String> {
     let lines = activity.snapshot(task_id, window);
+
+    // Unchanged snapshot => identical prompt => identical answer. Re-emit the
+    // previous summary (so runtime_detail's tick/at stay live) and skip the
+    // LLM round trip entirely. A changed snapshot, an LLM failure, or an
+    // empty summary all fall through to a real call — failures never latch.
+    if let Some(prev) = last.as_ref()
+        && prev.lines == lines
+    {
+        let summary = prev.summary.clone();
+        emit_progress(supervisor, session_id, task_id, &summary, tick_seq);
+        return Some(summary);
+    }
+
     let prompt = build_prompt(&lines);
 
     let summary = match fetch_summary(Arc::clone(&provider), prompt, llm_timeout).await {
@@ -407,10 +440,25 @@ async fn summarize_tick(
         return None;
     }
 
+    *last = Some(LastTickSummary {
+        lines,
+        summary: trimmed.clone(),
+    });
+    emit_progress(supervisor, session_id, task_id, &trimmed, tick_seq);
+    Some(trimmed)
+}
+
+fn emit_progress(
+    supervisor: &TaskSupervisor,
+    session_id: &str,
+    task_id: &str,
+    summary: &str,
+    tick_seq: u32,
+) {
     let event = HarnessEvent::subagent_progress(
         session_id.to_string(),
         task_id.to_string(),
-        trimmed.clone(),
+        summary.to_string(),
         tick_seq,
         Utc::now(),
     );
@@ -421,7 +469,6 @@ async fn summarize_tick(
             "subagent summary event could not be applied to supervisor"
         );
     }
-    Some(trimmed)
 }
 
 fn build_prompt(lines: &[String]) -> String {
@@ -477,8 +524,10 @@ async fn fetch_summary(
         response_format: None,
         context_management: None,
         sampling_params: None,
-        // One-shot: each digest prompt is fresh activity, sent exactly once
-        // — opt out of the 1.25x cache-write premium.
+        // Every prompt that reaches the provider is genuinely fresh: the
+        // watcher dedupes unchanged-snapshot ticks BEFORE calling (see
+        // [`LastTickSummary`]), so an identical prompt is never re-sent and
+        // a cache write would be pure 1.25x premium.
         cache_retention: octos_llm::CacheRetention::None,
     };
     let messages = vec![Message::user(prompt)];
@@ -682,9 +731,13 @@ mod tests {
         let (mock, calls) = MockProvider::new("working hard");
         let supervisor = TaskSupervisor::new();
         let id = register_running_task(&supervisor);
+        // The activity CHANGES between ticks — an active sub-agent — so every
+        // tick carries a fresh snapshot and must reach the LLM (the unchanged-
+        // snapshot dedupe is pinned separately below).
+        let buf = Arc::new(Mutex::new(vec!["doing something".to_string()]));
         let generator = AgentSummaryGenerator::with_activity_source(
             Arc::new(mock),
-            fixed_activity(&["doing something"]),
+            Arc::new(ActivitySource::Fixed(Arc::clone(&buf))),
             supervisor.clone(),
         )
         .with_tick(Duration::from_millis(100))
@@ -695,10 +748,12 @@ mod tests {
         assert!(spawned);
 
         // Drive the watcher a few times so multiple ticks fire. We alternate
-        // time advance + yield so the spawned task actually runs.
-        for _ in 0..10 {
+        // time advance + yield so the spawned task actually runs, and push a
+        // new activity line per round so each snapshot differs.
+        for i in 0..10 {
             tokio::task::yield_now().await;
             tokio::time::advance(Duration::from_millis(110)).await;
+            buf.lock().unwrap().push(format!("step {i}"));
         }
         supervisor.mark_completed(&id, vec![]);
         for _ in 0..4 {
@@ -708,6 +763,54 @@ mod tests {
 
         let observed = calls.load(Ordering::SeqCst);
         assert!(observed >= 2, "expected multiple ticks, got {observed}");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn should_skip_llm_call_when_activity_snapshot_unchanged() {
+        // #2194 review: an IDLE sub-agent rebuilds the byte-identical prompt
+        // every 30s tick. Re-asking the model (cached or not) buys nothing —
+        // the watcher must reuse the previous summary without an LLM call,
+        // while still re-stamping runtime_detail so tick/at stay live.
+        let (mock, calls) = MockProvider::new("compiling code");
+        let supervisor = TaskSupervisor::new();
+        let id = register_running_task(&supervisor);
+        let generator = AgentSummaryGenerator::with_activity_source(
+            Arc::new(mock),
+            fixed_activity(&["doing something"]),
+            supervisor.clone(),
+        )
+        .with_tick(Duration::from_millis(100))
+        .with_min_runtime(Duration::from_millis(0))
+        .with_llm_timeout(Duration::from_secs(1));
+
+        assert!(generator.spawn_watcher("api:session", &id));
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+            tokio::time::advance(Duration::from_millis(110)).await;
+        }
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "an unchanged activity snapshot must not trigger another LLM call"
+        );
+        let task = supervisor.get_task(&id).unwrap();
+        let detail: serde_json::Value =
+            serde_json::from_str(task.runtime_detail.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            detail["summary"], "compiling code",
+            "deduped ticks re-emit the previous summary"
+        );
+        assert!(
+            detail["tick"].as_u64().unwrap() > 1,
+            "the watcher must keep ticking (re-stamping) while deduping: {detail}"
+        );
+
+        supervisor.mark_completed(&id, vec![]);
+        for _ in 0..2 {
+            tokio::task::yield_now().await;
+            tokio::time::advance(Duration::from_millis(110)).await;
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/octos-agent/src/subagent_summary.rs
+++ b/crates/octos-agent/src/subagent_summary.rs
@@ -380,8 +380,8 @@ fn is_terminal(supervisor: &TaskSupervisor, task_id: &str) -> bool {
     }
 }
 
-/// #2194 review — the snapshot + summary a watcher last EMITTED, kept per
-/// watcher loop so an idle tick can be answered without an LLM call.
+/// #2194 review — the rendered prompt + summary a watcher last EMITTED,
+/// kept per watcher loop so an idle tick can be answered without an LLM call.
 ///
 /// An idle sub-agent rebuilds the byte-identical prompt every 30s tick
 /// (deterministic [`build_prompt`] over an unchanged activity tail). Dedupe
@@ -389,9 +389,18 @@ fn is_terminal(supervisor: &TaskSupervisor, task_id: &str) -> bool {
 /// prompt, a reused summary bills nothing — and it leaves every prompt that
 /// DOES reach the provider genuinely fresh, which is what justifies
 /// [`fetch_summary`]'s cache-write opt-out.
+///
+/// Round 2: the dedupe key is the CANONICAL RENDERED PROMPT, not the raw
+/// activity lines. `build_prompt` truncates each line to 400 chars, so two
+/// snapshots that differ only past char 400 produce the same prompt — the
+/// only correct key is the exact string that would hit the provider.
 struct LastTickSummary {
-    lines: Vec<String>,
+    prompt: String,
     summary: String,
+    /// When the summary was actually PRODUCED (the model call that emitted
+    /// it). Reused on deduped ticks so the event's `at` never lies about
+    /// production time; tick_seq alone conveys that the watcher is live.
+    produced_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -407,22 +416,32 @@ async fn summarize_tick(
     last: &mut Option<LastTickSummary>,
 ) -> Option<String> {
     let lines = activity.snapshot(task_id, window);
+    // Render the prompt FIRST: it is both the dedupe key and the exact bytes
+    // the provider would receive, so post-truncation-identical snapshots
+    // dedupe correctly.
+    let prompt = build_prompt(&lines);
 
-    // Unchanged snapshot => identical prompt => identical answer. Re-emit the
-    // previous summary (so runtime_detail's tick/at stay live) and skip the
-    // LLM round trip entirely. A changed snapshot, an LLM failure, or an
-    // empty summary all fall through to a real call — failures never latch.
+    // Unchanged rendered prompt => identical answer. Re-emit the previous
+    // summary with its ORIGINAL production timestamp (tick_seq still advances
+    // to show the watcher is live) and skip the LLM round trip entirely. A
+    // changed prompt, an LLM failure, or an empty summary all fall through to
+    // a real call — failures never latch.
     if let Some(prev) = last.as_ref()
-        && prev.lines == lines
+        && prev.prompt == prompt
     {
         let summary = prev.summary.clone();
-        emit_progress(supervisor, session_id, task_id, &summary, tick_seq);
+        emit_progress(
+            supervisor,
+            session_id,
+            task_id,
+            &summary,
+            tick_seq,
+            prev.produced_at,
+        );
         return Some(summary);
     }
 
-    let prompt = build_prompt(&lines);
-
-    let summary = match fetch_summary(Arc::clone(&provider), prompt, llm_timeout).await {
+    let summary = match fetch_summary(Arc::clone(&provider), prompt.clone(), llm_timeout).await {
         Ok(s) => s,
         Err(error) => {
             tracing::warn!(
@@ -440,11 +459,20 @@ async fn summarize_tick(
         return None;
     }
 
+    let produced_at = Utc::now();
     *last = Some(LastTickSummary {
-        lines,
+        prompt,
         summary: trimmed.clone(),
+        produced_at,
     });
-    emit_progress(supervisor, session_id, task_id, &trimmed, tick_seq);
+    emit_progress(
+        supervisor,
+        session_id,
+        task_id,
+        &trimmed,
+        tick_seq,
+        produced_at,
+    );
     Some(trimmed)
 }
 
@@ -454,13 +482,14 @@ fn emit_progress(
     task_id: &str,
     summary: &str,
     tick_seq: u32,
+    produced_at: chrono::DateTime<chrono::Utc>,
 ) {
     let event = HarnessEvent::subagent_progress(
         session_id.to_string(),
         task_id.to_string(),
         summary.to_string(),
         tick_seq,
-        Utc::now(),
+        produced_at,
     );
     if let Err(error) = supervisor.apply_harness_event(task_id, &event) {
         tracing::debug!(
@@ -804,6 +833,113 @@ mod tests {
         assert!(
             detail["tick"].as_u64().unwrap() > 1,
             "the watcher must keep ticking (re-stamping) while deduping: {detail}"
+        );
+
+        supervisor.mark_completed(&id, vec![]);
+        for _ in 0..2 {
+            tokio::task::yield_now().await;
+            tokio::time::advance(Duration::from_millis(110)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn should_keep_original_production_timestamp_on_a_deduped_tick() {
+        // #2194 review round 2: the public `at` field means "when the summary
+        // was PRODUCED". A deduped tick re-emits an EARLIER summary, so it
+        // must carry that summary's original production time — NOT Utc::now()
+        // — or a consumer reads "produced just now" for a 10-tick-old summary.
+        // tick_seq (a separate field) alone conveys that the watcher is live.
+        //
+        // Timing-free by construction: we seed the dedupe state with a fixed
+        // 2020 production timestamp and a prompt that the next snapshot
+        // re-renders exactly, then assert the emitted `at` is that 2020
+        // value. A reused Utc::now() would land in 2026 and fail.
+        let (mock, calls) = MockProvider::new("unused on the dedupe path");
+        let supervisor = TaskSupervisor::new();
+        let id = register_running_task(&supervisor);
+        let activity = fixed_activity(&["installing deps"]);
+
+        let produced_at = chrono::DateTime::parse_from_rfc3339("2020-01-02T03:04:05Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut last = Some(LastTickSummary {
+            // Exactly what the next snapshot will render, so the tick dedupes.
+            prompt: build_prompt(&["installing deps".to_string()]),
+            summary: "installing dependencies".to_string(),
+            produced_at,
+        });
+
+        let out = summarize_tick(
+            Arc::new(mock),
+            Duration::from_secs(1),
+            activity,
+            &supervisor,
+            "api:session",
+            &id,
+            9,
+            DEFAULT_SUBAGENT_SUMMARY_WINDOW,
+            &mut last,
+        )
+        .await;
+
+        assert_eq!(out.as_deref(), Some("installing dependencies"));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "a deduped tick must not call the LLM"
+        );
+        let task = supervisor.get_task(&id).unwrap();
+        let detail: serde_json::Value =
+            serde_json::from_str(task.runtime_detail.as_deref().unwrap()).unwrap();
+        assert_eq!(detail["tick"], 9, "tick_seq advances to show liveness");
+        let emitted_at = chrono::DateTime::parse_from_rfc3339(detail["at"].as_str().unwrap())
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            emitted_at, produced_at,
+            "a reused summary keeps its ORIGINAL production time, not now()"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn should_dedupe_on_the_rendered_prompt_not_the_pre_truncation_lines() {
+        // #2194 review round 2: build_prompt truncates each activity line to
+        // 400 chars, so two snapshots that differ ONLY after char 400 render
+        // the SAME prompt. Deduping on the raw lines would re-send that
+        // byte-identical prompt with caching disabled — the exact
+        // "identical prompt never re-sent" invariant the opt-out relies on.
+        // The dedupe key must be the canonical rendered prompt.
+        let (mock, calls) = MockProvider::new("linking objects");
+        let supervisor = TaskSupervisor::new();
+        let id = register_running_task(&supervisor);
+        // One activity line: 400 identical chars + a per-tick tail that the
+        // 400-char truncation drops. Raw lines differ every tick; the
+        // rendered prompt does not.
+        let head = "a".repeat(400);
+        let buf = Arc::new(Mutex::new(vec![format!("{head}0")]));
+        let generator = AgentSummaryGenerator::with_activity_source(
+            Arc::new(mock),
+            Arc::new(ActivitySource::Fixed(Arc::clone(&buf))),
+            supervisor.clone(),
+        )
+        .with_tick(Duration::from_millis(100))
+        .with_min_runtime(Duration::from_millis(0))
+        .with_llm_timeout(Duration::from_secs(1));
+
+        assert!(generator.spawn_watcher("api:session", &id));
+        for i in 1..8 {
+            tokio::task::yield_now().await;
+            tokio::time::advance(Duration::from_millis(110)).await;
+            // Replace (not append) so the snapshot stays a single line whose
+            // first 400 chars are constant and whose tail alone changes.
+            *buf.lock().unwrap() = vec![format!("{head}{i}")];
+        }
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "snapshots differing only past the 400-char prompt truncation render \
+             an identical prompt and must NOT trigger another LLM call"
         );
 
         supervisor.mark_completed(&id, vec![]);

--- a/crates/octos-agent/src/summarizer.rs
+++ b/crates/octos-agent/src/summarizer.rs
@@ -300,6 +300,10 @@ rather than appending duplicates.\n\n",
             }),
             context_management: None,
             sampling_params: None,
+            // One-shot: every iterative-summarizer prompt differs (prior
+            // summary + new turns) and is sent exactly once — opt out of the
+            // 1.25x cache-write premium.
+            cache_retention: octos_llm::CacheRetention::None,
         };
         let messages = vec![Message::user(prompt)];
         // Bridge the async LLM call to the synchronous Summarizer contract.
@@ -616,6 +620,66 @@ mod tests {
             .expect("summarize should succeed");
         assert!(summary.contains("Conversation Summary"));
         assert!(summary.contains("> User: hello"));
+    }
+
+    struct RetentionProbeProvider {
+        seen: Arc<std::sync::Mutex<Option<octos_llm::CacheRetention>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for RetentionProbeProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            config: &ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            *self.seen.lock().unwrap() = Some(config.cache_retention);
+            Ok(octos_llm::ChatResponse {
+                content: Some(r#"{"goal":"ship the feature"}"#.into()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatStream> {
+            unimplemented!("probe does not stream")
+        }
+
+        fn model_id(&self) -> &str {
+            "retention-probe"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn should_opt_out_of_cache_writes_when_folding_iterative_summary() {
+        // Every iterative-summarizer call sends a different prompt (prior
+        // summary + the new turns) exactly once — no prefix is ever replayed,
+        // so the request must not pay for cache writes.
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let summarizer = LlmIterativeSummarizer::new(Arc::new(RetentionProbeProvider {
+            seen: Arc::clone(&seen),
+        }));
+        summarizer
+            .summarize(&[user("turn one")], 2_000)
+            .expect("probe provider yields a valid SessionSummary");
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some(octos_llm::CacheRetention::None),
+            "one-shot iterative summaries must not request cache writes"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/research_utils.rs
+++ b/crates/octos-agent/src/tools/research_utils.rs
@@ -160,6 +160,9 @@ pub async fn extract_findings(
     let config = ChatConfig {
         max_tokens: Some(8192),
         temperature: Some(0.0),
+        // One-shot: each map-reduce prompt is unique and sent exactly once —
+        // opt out of the 1.25x cache-write premium.
+        cache_retention: octos_llm::CacheRetention::None,
         ..Default::default()
     };
 
@@ -228,6 +231,9 @@ pub async fn merge_findings(
     let config = ChatConfig {
         max_tokens: Some(8192),
         temperature: Some(0.0),
+        // One-shot: each map-reduce prompt is unique and sent exactly once —
+        // opt out of the 1.25x cache-write premium.
+        cache_retention: octos_llm::CacheRetention::None,
         ..Default::default()
     };
 
@@ -359,6 +365,80 @@ pub fn truncate_to_limit(files: Vec<(String, String)>) -> Vec<(String, String)> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct RetentionProbeProvider {
+        seen: std::sync::Mutex<Option<octos_llm::CacheRetention>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for RetentionProbeProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            config: &ChatConfig,
+        ) -> Result<octos_llm::ChatResponse> {
+            *self.seen.lock().unwrap() = Some(config.cache_retention);
+            Ok(octos_llm::ChatResponse {
+                content: Some("findings".into()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<octos_llm::ChatStream> {
+            unimplemented!("probe does not stream")
+        }
+
+        fn model_id(&self) -> &str {
+            "retention-probe"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn should_opt_out_of_cache_writes_when_extracting_findings() {
+        // Each map-reduce batch prompt is unique (its own slice of sources)
+        // and sent exactly once — cache writes on it are never read back.
+        let probe = RetentionProbeProvider {
+            seen: std::sync::Mutex::new(None),
+        };
+        let files = vec![("a.md".to_string(), "content".to_string())];
+        extract_findings(&probe, "q", None, &files, &[0], 1, 1)
+            .await
+            .expect("probe provider yields findings");
+        assert_eq!(
+            *probe.seen.lock().unwrap(),
+            Some(octos_llm::CacheRetention::None),
+            "one-shot research batch analysis must not request cache writes"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_opt_out_of_cache_writes_when_merging_findings() {
+        let probe = RetentionProbeProvider {
+            seen: std::sync::Mutex::new(None),
+        };
+        merge_findings(&probe, "q", None, &["partial one".to_string()], 1)
+            .await
+            .expect("probe provider yields a merged report");
+        assert_eq!(
+            *probe.seen.lock().unwrap(),
+            Some(octos_llm::CacheRetention::None),
+            "one-shot research synthesis must not request cache writes"
+        );
+    }
 
     #[test]
     fn test_partition_batches_single() {

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -36951,6 +36951,37 @@ async fn connection_close_settles_steers_before_connection_closed_terminal() {
 /// `cached_input_tokens`, without which an operator cannot tell whether prompt
 /// caching is working.
 #[test]
+fn should_opt_out_of_cache_writes_when_building_btw_config() {
+    // #2194 review: `session/btw` is ONE restricted LLM call per aside — its
+    // prompt (transcript tail + activity tail + question) is never replayed,
+    // so the request must not pay for cache writes. The aside's other
+    // restrictions (no tools, small answer cap) must survive.
+    let config = btw_chat_config();
+    assert_eq!(
+        config.cache_retention,
+        octos_llm::CacheRetention::None,
+        "btw asides must not request cache writes"
+    );
+    assert_eq!(config.max_tokens, Some(BTW_ANSWER_MAX_TOKENS));
+    assert!(matches!(config.tool_choice, octos_llm::ToolChoice::None));
+}
+
+#[test]
+fn should_opt_out_of_cache_writes_when_building_review_join_config() {
+    // #2194 review: the final code-review join runs once per review with a
+    // prompt unique to that join (objective + target + specialist outputs) —
+    // never replayed, so it must not pay for cache writes.
+    let config = review_join_chat_config();
+    assert_eq!(
+        config.cache_retention,
+        octos_llm::CacheRetention::None,
+        "the review join must not request cache writes"
+    );
+    assert_eq!(config.max_tokens, Some(1800));
+    assert!(matches!(config.tool_choice, octos_llm::ToolChoice::None));
+}
+
+#[test]
 fn should_report_cache_read_tokens_in_session_usage_status() {
     let totals = UsageTotals {
         run_count: 2,

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -36957,6 +36957,7 @@ fn should_report_cache_read_tokens_in_session_usage_status() {
         input_tokens: 105,
         output_tokens: 20,
         cache_read_tokens: 95,
+        cache_write_tokens: 0,
         estimated_cost_usd: 0.25,
     };
     let usage = usage_status_json(&totals);
@@ -36981,6 +36982,7 @@ fn should_omit_cost_when_no_run_was_priced() {
         input_tokens: 100,
         output_tokens: 10,
         cache_read_tokens: 0,
+        cache_write_tokens: 0,
         estimated_cost_usd: 0.0,
     };
     let usage = usage_status_json(&totals);
@@ -36999,6 +37001,7 @@ fn should_report_zero_cache_reads_explicitly_on_a_cold_session() {
         input_tokens: 13_302,
         output_tokens: 76,
         cache_read_tokens: 0,
+        cache_write_tokens: 0,
         estimated_cost_usd: 0.0,
     };
     let usage = usage_status_json(&totals);

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -24512,9 +24512,8 @@ async fn handle_session_btw(
                     let model = (!metadata.model.is_empty()).then(|| metadata.model.clone());
                     let estimated_cost_usd =
                         model.as_deref().and_then(model_pricing).map(|pricing| {
-                            pricing.cost_with_cache_for_provider(
-                                &metadata.provider,
-                                &metadata.model,
+                            pricing.cost_with_cache_for_metadata(
+                                &metadata,
                                 response.usage.input_tokens,
                                 response.usage.output_tokens,
                                 response.usage.cache_read_tokens,

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -24512,7 +24512,8 @@ async fn handle_session_btw(
                     let model = (!metadata.model.is_empty()).then(|| metadata.model.clone());
                     let estimated_cost_usd =
                         model.as_deref().and_then(model_pricing).map(|pricing| {
-                            pricing.cost_with_cache(
+                            pricing.cost_with_cache_for_provider(
+                                &metadata.provider,
                                 response.usage.input_tokens,
                                 response.usage.output_tokens,
                                 response.usage.cache_read_tokens,
@@ -33577,7 +33578,8 @@ async fn run_standalone_turn(
                     // #1632 P1); the reprice fallback covers legacy paths.
                     let estimated_cost_usd = response.estimated_spend_usd.or_else(|| {
                         model.as_deref().and_then(model_pricing).map(|pricing| {
-                            pricing.cost_with_cache(
+                            pricing.cost_with_cache_for_provider(
+                                provider.as_deref().unwrap_or(""),
                                 response.token_usage.input_tokens,
                                 response.token_usage.output_tokens,
                                 response.token_usage.cache_read_tokens,

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -24502,7 +24502,12 @@ async fn handle_session_btw(
                     let model = (!metadata.model.is_empty()).then(|| metadata.model.clone());
                     let estimated_cost_usd =
                         model.as_deref().and_then(model_pricing).map(|pricing| {
-                            pricing.cost(response.usage.input_tokens, response.usage.output_tokens)
+                            pricing.cost_with_cache(
+                                response.usage.input_tokens,
+                                response.usage.output_tokens,
+                                response.usage.cache_read_tokens,
+                                response.usage.cache_write_tokens,
+                            )
                         });
                     let cost_source = if estimated_cost_usd.is_some() {
                         UsageCostSource::CatalogEstimate
@@ -24525,7 +24530,8 @@ async fn handle_session_btw(
                         "appui_btw",
                         None,
                     )
-                    .with_cache_read_tokens(u64::from(response.usage.cache_read_tokens));
+                    .with_cache_read_tokens(u64::from(response.usage.cache_read_tokens))
+                    .with_cache_write_tokens(u64::from(response.usage.cache_write_tokens));
                     if let Err(error) = usage_ledger.record(event).await {
                         warn!(
                             session = %session_id.0,
@@ -33551,9 +33557,11 @@ async fn run_standalone_turn(
                     // #1632 P1); the reprice fallback covers legacy paths.
                     let estimated_cost_usd = response.estimated_spend_usd.or_else(|| {
                         model.as_deref().and_then(model_pricing).map(|pricing| {
-                            pricing.cost(
+                            pricing.cost_with_cache(
                                 response.token_usage.input_tokens,
                                 response.token_usage.output_tokens,
+                                response.token_usage.cache_read_tokens,
+                                response.token_usage.cache_write_tokens,
                             )
                         })
                     });
@@ -33578,7 +33586,8 @@ async fn run_standalone_turn(
                         "appui",
                         None,
                     )
-                    .with_cache_read_tokens(u64::from(response.token_usage.cache_read_tokens));
+                    .with_cache_read_tokens(u64::from(response.token_usage.cache_read_tokens))
+                    .with_cache_write_tokens(u64::from(response.token_usage.cache_write_tokens));
                     if let Err(error) = usage_ledger.record(event).await {
                         warn!(
                             session = %usage_session_id_for_result,

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -24514,6 +24514,7 @@ async fn handle_session_btw(
                         model.as_deref().and_then(model_pricing).map(|pricing| {
                             pricing.cost_with_cache_for_provider(
                                 &metadata.provider,
+                                &metadata.model,
                                 response.usage.input_tokens,
                                 response.usage.output_tokens,
                                 response.usage.cache_read_tokens,
@@ -33580,6 +33581,7 @@ async fn run_standalone_turn(
                         model.as_deref().and_then(model_pricing).map(|pricing| {
                             pricing.cost_with_cache_for_provider(
                                 provider.as_deref().unwrap_or(""),
+                                model.as_deref().unwrap_or(""),
                                 response.token_usage.input_tokens,
                                 response.token_usage.output_tokens,
                                 response.token_usage.cache_read_tokens,

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -24123,6 +24123,21 @@ const BTW_TIMEOUT_SECS: u64 = 30;
 /// context shape is unit-testable: transcript tail (already limited by the
 /// caller) + a short live-activity digest + the question. The system prompt
 /// carries the restrictions: no tools, brief answer, ephemeral exchange.
+/// The `ChatConfig` for a `session/btw` aside — split out so its cache
+/// economics are pinnable in isolation.
+fn btw_chat_config() -> octos_llm::ChatConfig {
+    octos_llm::ChatConfig {
+        max_tokens: Some(BTW_ANSWER_MAX_TOKENS),
+        temperature: Some(0.2),
+        tool_choice: octos_llm::ToolChoice::None,
+        // #2194 review: ONE restricted LLM call per aside — the prompt
+        // (transcript tail + activity tail + question) is never replayed, so
+        // a cache write is pure premium.
+        cache_retention: octos_llm::CacheRetention::None,
+        ..Default::default()
+    }
+}
+
 fn build_btw_messages(
     transcript_tail: &[Message],
     activity_lines: &[String],
@@ -24454,12 +24469,7 @@ async fn handle_session_btw(
             &live_draft_tail,
             &question,
         );
-        let config = octos_llm::ChatConfig {
-            max_tokens: Some(BTW_ANSWER_MAX_TOKENS),
-            temperature: Some(0.2),
-            tool_choice: octos_llm::ToolChoice::None,
-            ..Default::default()
-        };
+        let config = btw_chat_config();
         // `&[]` tool specs IS the "no tools" restriction — the model cannot
         // call what it is never offered.
         let response = match tokio::time::timeout(
@@ -29275,12 +29285,7 @@ async fn model_join_review_summary(
             timestamp: Utc::now(),
         },
     ];
-    let config = octos_llm::ChatConfig {
-        max_tokens: Some(1800),
-        temperature: Some(0.0),
-        tool_choice: octos_llm::ToolChoice::None,
-        ..Default::default()
-    };
+    let config = review_join_chat_config();
     match llm.chat(&messages, &[], &config).await {
         Ok(response) => response
             .content
@@ -29312,6 +29317,21 @@ fn requested_final_marker(objective: &str) -> Option<String> {
         .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
         .find(|token| token.ends_with("_FINAL_LINE"))?;
     (!marker.is_empty()).then(|| marker.to_owned())
+}
+
+/// The `ChatConfig` for the final code-review join — split out so its cache
+/// economics are pinnable in isolation.
+fn review_join_chat_config() -> octos_llm::ChatConfig {
+    octos_llm::ChatConfig {
+        max_tokens: Some(1800),
+        temperature: Some(0.0),
+        tool_choice: octos_llm::ToolChoice::None,
+        // #2194 review: the join runs once per review with a prompt unique
+        // to that join (objective + target + specialist outputs) — never
+        // replayed, so a cache write is pure premium.
+        cache_retention: octos_llm::CacheRetention::None,
+        ..Default::default()
+    }
 }
 
 fn fallback_join_review_summary(target: &str, results: &[NativeCodeReviewResult]) -> String {

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -13266,6 +13266,9 @@ objective is fully met, or `NOT_DONE: <short reason>` otherwise."
         response_format: None,
         context_management: None,
         sampling_params: None,
+        // One-shot: each verdict prompt embeds its own objective + evidence
+        // and is never replayed, so skip prompt-cache writes.
+        cache_retention: octos_llm::CacheRetention::None,
     };
     let messages = vec![octos_core::Message::user(prompt)];
     let (verdict_text, usage) = match provider.chat(&messages, &[], &config).await {

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -3735,12 +3735,11 @@ fn create_custom_provider(
         "anthropic" => {
             let mut provider = octos_llm::anthropic::AnthropicProvider::new(key, model)
                 .with_base_url(&base_url)
-                // #2194: encode the protocol in the label so the cache-pricing
-                // classifier (which keys off the metadata label) recognizes this
-                // as Anthropic-protocol (0.1x read / 1.25x write), not the 1.0x
-                // residual bucket. `contains("anthropic")` is the classifier's
-                // documented catch for custom Anthropic-compatible endpoints.
-                .with_provider_label("custom-anthropic");
+                // #2194: label stays "custom" (its logical identity for
+                // adaptive-lane / QoS matching); the Anthropic cache rate is
+                // carried by ProviderMetadata::cache_lane, set from the provider
+                // TYPE in AnthropicProvider::provider_metadata().
+                .with_provider_label("custom");
             if let Some(t) = llm_timeout_secs {
                 let c =
                     llm_connect_timeout_secs.unwrap_or(octos_llm::DEFAULT_LLM_CONNECT_TIMEOUT_SECS);
@@ -4081,13 +4080,14 @@ mod custom_provider_tests {
 
         assert_eq!(provider.provider_name(), "custom");
         assert_eq!(provider.model_id(), "llama-3.1-70b-instruct");
-        // #2194 R3: a custom OpenAI-protocol endpoint stays in the residual
-        // cache bucket (full-rate reads), NOT the Anthropic 0.1x bucket.
+        // #2194 R4: a custom OpenAI endpoint keeps the "custom" identity AND the
+        // residual cache lane (full-rate reads) — NOT the Anthropic 0.1x bucket.
+        let meta = provider.provider_metadata();
+        assert_eq!(meta.cache_lane, octos_llm::CacheLane::Residual);
         assert_eq!(
-            octos_llm::pricing::cache_rates(provider.provider_name(), provider.model_id())
-                .read_multiplier,
+            octos_llm::pricing::cache_rates_for_lane(meta.cache_lane).read_multiplier,
             1.0,
-            "custom + api_type=openai must not be priced as Anthropic-protocol cache",
+            "custom + api_type=openai must price cache reads at the residual rate",
         );
     }
 
@@ -4102,17 +4102,23 @@ mod custom_provider_tests {
         )
         .unwrap();
 
-        // #2194 R3: the label must ENCODE the Anthropic protocol so the
-        // cache-pricing classifier (which keys off the metadata label) hands
-        // it the 0.1x read / 1.25x write bucket instead of the 1.0x residual
-        // — a 10x cache-read overcharge before this fix.
-        assert_eq!(provider.provider_name(), "custom-anthropic");
+        // #2194 R4: the label STAYS "custom" (its logical identity for
+        // adaptive-lane / QoS matching — relabeling it silently disabled a
+        // configured lane restriction). The Anthropic cache rate is instead
+        // carried by the metadata cache_lane, sourced from the provider TYPE,
+        // so pricing is correct WITHOUT overloading the identity label.
+        assert_eq!(provider.provider_name(), "custom");
         assert_eq!(provider.model_id(), "claude-compatible");
+        let meta = provider.provider_metadata();
         assert_eq!(
-            octos_llm::pricing::cache_rates(provider.provider_name(), provider.model_id())
-                .read_multiplier,
+            meta.cache_lane,
+            octos_llm::CacheLane::Anthropic,
+            "custom + api_type=anthropic must carry the Anthropic cache lane",
+        );
+        assert_eq!(
+            octos_llm::pricing::cache_rates_for_lane(meta.cache_lane).read_multiplier,
             0.1,
-            "custom + api_type=anthropic must be priced as Anthropic-protocol cache",
+            "and therefore price cache reads at 0.1x, not the 1.0x residual",
         );
     }
 

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -3735,7 +3735,12 @@ fn create_custom_provider(
         "anthropic" => {
             let mut provider = octos_llm::anthropic::AnthropicProvider::new(key, model)
                 .with_base_url(&base_url)
-                .with_provider_label("custom");
+                // #2194: encode the protocol in the label so the cache-pricing
+                // classifier (which keys off the metadata label) recognizes this
+                // as Anthropic-protocol (0.1x read / 1.25x write), not the 1.0x
+                // residual bucket. `contains("anthropic")` is the classifier's
+                // documented catch for custom Anthropic-compatible endpoints.
+                .with_provider_label("custom-anthropic");
             if let Some(t) = llm_timeout_secs {
                 let c =
                     llm_connect_timeout_secs.unwrap_or(octos_llm::DEFAULT_LLM_CONNECT_TIMEOUT_SECS);
@@ -4076,6 +4081,14 @@ mod custom_provider_tests {
 
         assert_eq!(provider.provider_name(), "custom");
         assert_eq!(provider.model_id(), "llama-3.1-70b-instruct");
+        // #2194 R3: a custom OpenAI-protocol endpoint stays in the residual
+        // cache bucket (full-rate reads), NOT the Anthropic 0.1x bucket.
+        assert_eq!(
+            octos_llm::pricing::cache_rates(provider.provider_name(), provider.model_id())
+                .read_multiplier,
+            1.0,
+            "custom + api_type=openai must not be priced as Anthropic-protocol cache",
+        );
     }
 
     #[test]
@@ -4089,8 +4102,18 @@ mod custom_provider_tests {
         )
         .unwrap();
 
-        assert_eq!(provider.provider_name(), "custom");
+        // #2194 R3: the label must ENCODE the Anthropic protocol so the
+        // cache-pricing classifier (which keys off the metadata label) hands
+        // it the 0.1x read / 1.25x write bucket instead of the 1.0x residual
+        // — a 10x cache-read overcharge before this fix.
+        assert_eq!(provider.provider_name(), "custom-anthropic");
         assert_eq!(provider.model_id(), "claude-compatible");
+        assert_eq!(
+            octos_llm::pricing::cache_rates(provider.provider_name(), provider.model_id())
+                .read_multiplier,
+            0.1,
+            "custom + api_type=anthropic must be priced as Anthropic-protocol cache",
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/memory_refresh/service.rs
+++ b/crates/octos-cli/src/memory_refresh/service.rs
@@ -824,6 +824,12 @@ async fn extract_one_session(
     ];
     let config = ChatConfig {
         max_tokens: Some(2_000),
+        // #2194 review: one extraction call per session transcript — the
+        // prompt embeds that session's rendered transcript and is never
+        // replayed, so a cache write is pure premium. (The consolidation
+        // pass is different: its corrective re-ask APPENDS to the original
+        // messages, genuinely reusing the prefix, so it keeps caching.)
+        cache_retention: octos_llm::CacheRetention::None,
         ..Default::default()
     };
     let response = provider.chat(&messages, &[], &config).await?;
@@ -959,6 +965,73 @@ mod tests {
         msg.role = MessageRole::Assistant;
         msg.content = "ok".to_string();
         mgr.add_message(&key, msg).await.unwrap();
+    }
+
+    struct RetentionProbeProvider {
+        response: String,
+        seen: std::sync::Mutex<Option<octos_llm::CacheRetention>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for RetentionProbeProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            config: &ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            *self.seen.lock().unwrap() = Some(config.cache_retention);
+            Ok(ChatResponse {
+                content: Some(self.response.clone()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatStream> {
+            unimplemented!("probe does not stream")
+        }
+
+        fn model_id(&self) -> &str {
+            "retention-probe"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn should_opt_out_of_cache_writes_when_extracting_session_memory() {
+        // #2194 review: extraction sends one per-session transcript prompt,
+        // never replayed — it must not pay for cache writes.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        seed_session(dir.path(), "tg:200", "I prefer tabs over spaces").await;
+
+        let provider = RetentionProbeProvider {
+            response: r#"{"items":[{"kind":"fact","content":"prefers tabs","evidence":[0]}]}"#
+                .to_string(),
+            seen: std::sync::Mutex::new(None),
+        };
+        let knobs = knobs_for_test();
+        let report = run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        assert_eq!(report.extracted, 1, "probe extraction must go through");
+        assert_eq!(
+            *provider.seen.lock().unwrap(),
+            Some(octos_llm::CacheRetention::None),
+            "one-shot memory extraction must not request cache writes"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -8860,23 +8860,29 @@ impl SessionActor {
                     .as_ref()
                     .map(|meta| meta.model.clone());
                 let overflow_cost = conv_response.estimated_spend_usd.or_else(|| {
-                    let overflow_provider = conv_response
-                        .provider_metadata
-                        .as_ref()
-                        .map(|meta| meta.provider.as_str())
-                        .unwrap_or("");
                     overflow_model
                         .as_deref()
                         .and_then(model_pricing)
                         .map(|pricing| {
-                            pricing.cost_with_cache_for_provider(
-                                overflow_provider,
-                                overflow_model.as_deref().unwrap_or(""),
-                                conv_response.token_usage.input_tokens,
-                                conv_response.token_usage.output_tokens,
-                                conv_response.token_usage.cache_read_tokens,
-                                conv_response.token_usage.cache_write_tokens,
-                            )
+                            // Prefer the authoritative per-slot cache lane; fall back
+                            // to the label guess only if no metadata was carried.
+                            match conv_response.provider_metadata.as_ref() {
+                                Some(meta) => pricing.cost_with_cache_for_metadata(
+                                    meta,
+                                    conv_response.token_usage.input_tokens,
+                                    conv_response.token_usage.output_tokens,
+                                    conv_response.token_usage.cache_read_tokens,
+                                    conv_response.token_usage.cache_write_tokens,
+                                ),
+                                None => pricing.cost_with_cache_for_provider(
+                                    "",
+                                    overflow_model.as_deref().unwrap_or(""),
+                                    conv_response.token_usage.input_tokens,
+                                    conv_response.token_usage.output_tokens,
+                                    conv_response.token_usage.cache_read_tokens,
+                                    conv_response.token_usage.cache_write_tokens,
+                                ),
+                            }
                         })
                 });
                 overflow_session_usage.fold_run(

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4628,6 +4628,7 @@ impl SessionActor {
             model.as_deref().and_then(model_pricing).map(|pricing| {
                 pricing.cost_with_cache_for_provider(
                     provider.as_deref().unwrap_or(""),
+                    model.as_deref().unwrap_or(""),
                     response.token_usage.input_tokens,
                     response.token_usage.output_tokens,
                     response.token_usage.cache_read_tokens,
@@ -8870,6 +8871,7 @@ impl SessionActor {
                         .map(|pricing| {
                             pricing.cost_with_cache_for_provider(
                                 overflow_provider,
+                                overflow_model.as_deref().unwrap_or(""),
                                 conv_response.token_usage.input_tokens,
                                 conv_response.token_usage.output_tokens,
                                 conv_response.token_usage.cache_read_tokens,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4626,9 +4626,11 @@ impl SessionActor {
         // fallback reprice covers legacy paths that predate the field.
         let estimated_cost_usd = response.estimated_spend_usd.or_else(|| {
             model.as_deref().and_then(model_pricing).map(|pricing| {
-                pricing.cost(
+                pricing.cost_with_cache(
                     response.token_usage.input_tokens,
                     response.token_usage.output_tokens,
+                    response.token_usage.cache_read_tokens,
+                    response.token_usage.cache_write_tokens,
                 )
             })
         });
@@ -4671,7 +4673,8 @@ impl SessionActor {
             self.channel.clone(),
             attribution.map(ToOwned::to_owned),
         )
-        .with_cache_read_tokens(u64::from(response.token_usage.cache_read_tokens));
+        .with_cache_read_tokens(u64::from(response.token_usage.cache_read_tokens))
+        .with_cache_write_tokens(u64::from(response.token_usage.cache_write_tokens));
         if let Err(error) = usage_ledger.record(event).await {
             warn!(
                 session = %self.session_key,
@@ -8859,9 +8862,11 @@ impl SessionActor {
                         .as_deref()
                         .and_then(model_pricing)
                         .map(|pricing| {
-                            pricing.cost(
+                            pricing.cost_with_cache(
                                 conv_response.token_usage.input_tokens,
                                 conv_response.token_usage.output_tokens,
+                                conv_response.token_usage.cache_read_tokens,
+                                conv_response.token_usage.cache_write_tokens,
                             )
                         })
                 });
@@ -8895,7 +8900,10 @@ impl SessionActor {
                         channel.clone(),
                         Some("speculative_overflow".to_string()),
                     )
-                    .with_cache_read_tokens(u64::from(conv_response.token_usage.cache_read_tokens));
+                    .with_cache_read_tokens(u64::from(conv_response.token_usage.cache_read_tokens))
+                    .with_cache_write_tokens(u64::from(
+                        conv_response.token_usage.cache_write_tokens,
+                    ));
                     if let Err(error) = ledger.record(event).await {
                         warn!(
                             session = %session_key,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4626,7 +4626,8 @@ impl SessionActor {
         // fallback reprice covers legacy paths that predate the field.
         let estimated_cost_usd = response.estimated_spend_usd.or_else(|| {
             model.as_deref().and_then(model_pricing).map(|pricing| {
-                pricing.cost_with_cache(
+                pricing.cost_with_cache_for_provider(
+                    provider.as_deref().unwrap_or(""),
                     response.token_usage.input_tokens,
                     response.token_usage.output_tokens,
                     response.token_usage.cache_read_tokens,
@@ -8858,11 +8859,17 @@ impl SessionActor {
                     .as_ref()
                     .map(|meta| meta.model.clone());
                 let overflow_cost = conv_response.estimated_spend_usd.or_else(|| {
+                    let overflow_provider = conv_response
+                        .provider_metadata
+                        .as_ref()
+                        .map(|meta| meta.provider.as_str())
+                        .unwrap_or("");
                     overflow_model
                         .as_deref()
                         .and_then(model_pricing)
                         .map(|pricing| {
-                            pricing.cost_with_cache(
+                            pricing.cost_with_cache_for_provider(
+                                overflow_provider,
                                 conv_response.token_usage.input_tokens,
                                 conv_response.token_usage.output_tokens,
                                 conv_response.token_usage.cache_read_tokens,

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -12,6 +12,21 @@ use std::sync::{Arc, Mutex};
 
 pub struct GoalLedger {
     conn: Arc<Mutex<Connection>>,
+    /// #2085 — latched POSITIVE result of [`Self::goals_has_time_column`]
+    /// for this connection, so `get_goal` stops paying a
+    /// `pragma_table_info` round trip before every point lookup once the
+    /// column has been observed. The capability is MONOTONE per connection:
+    /// `ALTER TABLE … ADD COLUMN` is the only schema transition and nothing
+    /// ever drops the column, so a committed "yes" can never become "no" in
+    /// a later snapshot. A NEGATIVE result is deliberately never latched —
+    /// an unmigrated file can migrate mid-connection through a writer's
+    /// in-transaction [`Self::ensure_goals_time_column`], and a reader that
+    /// latched "no" would synthesize `time_used_seconds: 0` forever.
+    goals_time_column_seen: std::sync::atomic::AtomicBool,
+    /// #2085 — number of `pragma_table_info` probes `get_goal` actually
+    /// executed. Lets tests pin "the probe is skipped once latched"
+    /// structurally instead of by timing.
+    goals_time_probe_count: std::sync::atomic::AtomicU64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -286,6 +301,8 @@ impl GoalLedger {
 
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
+            goals_time_column_seen: std::sync::atomic::AtomicBool::new(false),
+            goals_time_probe_count: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -945,10 +962,31 @@ impl GoalLedger {
     /// acquires only a shared read lock, and only on first access, so this
     /// still runs no DDL and takes no write lock. It is rolled back on drop,
     /// which for a read is a no-op.
+    ///
+    /// #2085 — once one probe has answered "yes", later calls skip the
+    /// `pragma_table_info` round trip via `goals_time_column_seen` (see the
+    /// field doc). That does NOT reopen the torn-read window above: the
+    /// window was probe-says-NO in one state + SELECT in a later state; a
+    /// latched YES means the column existed in a COMMITTED state this
+    /// connection already observed, and column existence is monotone, so it
+    /// exists in this transaction's snapshot too and the SELECT reads the
+    /// real value. While the answer is still "no", the probe continues to
+    /// run — inside the same DEFERRED transaction as the SELECT, exactly as
+    /// before.
     pub fn get_goal(&self, goal_id: &str) -> Result<Option<Goal>> {
+        use std::sync::atomic::Ordering;
         let conn = self.conn.lock().unwrap();
         let tx = conn.unchecked_transaction()?;
-        let has_time = Self::goals_has_time_column(&tx)?;
+        let has_time = if self.goals_time_column_seen.load(Ordering::Acquire) {
+            true
+        } else {
+            self.goals_time_probe_count.fetch_add(1, Ordering::Relaxed);
+            let probed = Self::goals_has_time_column(&tx)?;
+            if probed {
+                self.goals_time_column_seen.store(true, Ordering::Release);
+            }
+            probed
+        };
         let sql = if has_time {
             "SELECT goal_id, objective, status, tokens_used, token_budget, continuations_used, \
              revision, created_at_ms, updated_at_ms, time_used_seconds
@@ -977,6 +1015,15 @@ impl GoalLedger {
             rows.next().transpose()?
         };
         Ok(goal)
+    }
+
+    /// #2085 test seam — how many `pragma_table_info` probes [`Self::get_goal`]
+    /// has actually run on this ledger. Structural pin for "the probe is
+    /// skipped once a positive has been latched" without timing assertions.
+    #[cfg(test)]
+    pub(crate) fn time_column_probe_count(&self) -> u64 {
+        self.goals_time_probe_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// #2055 review round 5 — the authority rank a freshly CREATED row
@@ -5354,6 +5401,109 @@ mod digest_integration_tests {
                 torn.map(|g| g.tokens_used).unwrap_or_default(),
             );
         }
+    }
+
+    /// #2085 — a NEGATIVE probe result must never be cached: an unmigrated
+    /// file can migrate mid-connection through a writer's in-transaction
+    /// `ensure_goals_time_column`, so a reader that latched "no column" would
+    /// synthesize `time_used_seconds: 0` forever. Every read of an
+    /// unmigrated file re-probes, and the read AFTER the migration commits
+    /// sees the real column value through a fresh probe.
+    #[test]
+    fn should_reprobe_time_column_when_file_still_unmigrated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reprobe.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            create_legacy_schema(&conn, "");
+        }
+        let reader = GoalLedger::open(&path).unwrap();
+
+        // Unmigrated: the probe answers "no" on every read and is never
+        // latched — one probe per get_goal.
+        for expected_probes in 1..=2u64 {
+            let goal = reader.get_goal("g1").unwrap().unwrap();
+            assert_eq!(goal.time_used_seconds, 0, "legacy shape reports zero");
+            assert_eq!(
+                reader.time_column_probe_count(),
+                expected_probes,
+                "a negative probe result must not be cached"
+            );
+        }
+
+        // A DIFFERENT connection migrates the file mid-(reader-)connection
+        // and writes both cost dimensions non-zero.
+        let writer = GoalLedger::open_with_busy_retry(&path).unwrap();
+        writer
+            .upsert_goal(&Goal {
+                goal_id: "g1".into(),
+                objective: "ship".into(),
+                status: "active".into(),
+                tokens_used: 4_242,
+                token_budget: 1_000,
+                time_used_seconds: 77,
+                continuations_used: 0,
+                revision: 1,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            })
+            .unwrap();
+
+        // The reader's next probe is FRESH, so it observes the migration and
+        // reads the real value instead of synthesizing 0.
+        let goal = reader.get_goal("g1").unwrap().unwrap();
+        assert_eq!(
+            goal.time_used_seconds, 77,
+            "a fresh probe must observe the mid-connection migration"
+        );
+        assert_eq!(goal.tokens_used, 4_242);
+        assert_eq!(reader.time_column_probe_count(), 3);
+    }
+
+    /// #2085 — the capability is MONOTONE per connection (a committed column
+    /// never disappears), so once one probe has answered "yes" every later
+    /// `get_goal` on the same ledger skips the `pragma_table_info` round
+    /// trip entirely. Pinned via a probe counter, not timing.
+    #[test]
+    fn should_skip_time_column_probe_when_positive_already_observed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skip.db");
+        // Current-schema file: the very first read probes positively.
+        let ledger = GoalLedger::open_with_busy_retry(&path).unwrap();
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".into(),
+                objective: "ship".into(),
+                status: "active".into(),
+                tokens_used: 10,
+                token_budget: 1_000,
+                time_used_seconds: 5,
+                continuations_used: 0,
+                revision: 1,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            })
+            .unwrap();
+
+        let goal = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(goal.time_used_seconds, 5);
+        assert_eq!(
+            ledger.time_column_probe_count(),
+            1,
+            "the first read pays exactly one schema probe"
+        );
+
+        // Every later read skips the probe and still returns full rows.
+        for _ in 0..3 {
+            let goal = ledger.get_goal("g1").unwrap().unwrap();
+            assert_eq!(goal.time_used_seconds, 5);
+            assert_eq!(goal.tokens_used, 10);
+        }
+        assert_eq!(
+            ledger.time_column_probe_count(),
+            1,
+            "a positive probe result is latched for the connection's lifetime"
+        );
     }
 
     /// #2068 — a ledger FILE created before the time column existed migrates

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -145,7 +145,13 @@ impl AnthropicProvider {
         config: &'a ChatConfig,
     ) -> AnthropicRequest<'a> {
         let max_tokens = config.max_tokens.unwrap_or(4096);
-        let cache = self.prompt_caching.then_some(EPHEMERAL_CACHE_CONTROL);
+        // Provider default AND the request did not opt out: a one-shot call
+        // (`ChatConfig.cache_retention: None`) pays the 1.25x cache-write
+        // premium on a prefix it never sends again, so it gets the exact
+        // pre-caching wire shape instead (mirrors pi's `cacheRetention:
+        // "none"` on summarization requests).
+        let cache = (self.prompt_caching && config.cache_retention != crate::CacheRetention::None)
+            .then_some(EPHEMERAL_CACHE_CONTROL);
         let mut api_messages = build_anthropic_messages(messages);
         if cache.is_some() {
             apply_message_cache_breakpoint(&mut api_messages);
@@ -1805,6 +1811,80 @@ mod tests {
         assert!(
             !body.to_string().contains("cache_control"),
             "no cache_control key may appear anywhere when caching is off: {body}"
+        );
+    }
+
+    #[test]
+    fn should_not_emit_cache_control_anywhere_when_request_opts_out_of_cache_writes() {
+        // A one-shot request (`ChatConfig.cache_retention: None`) must not
+        // pay the 1.25x cache-write premium: with caching enabled on the
+        // PROVIDER, the opted-out REQUEST still serializes to the exact
+        // pre-caching wire shape — plain-string system, verbatim tools, no
+        // cache_control key anywhere.
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(true);
+        let tools = vec![
+            tool_spec("alpha", "first tool"),
+            tool_spec("omega", "last tool"),
+        ];
+        let messages = vec![
+            msg(MessageRole::System, "system prompt"),
+            msg(MessageRole::User, "hello"),
+        ];
+        let opted_out = ChatConfig {
+            cache_retention: crate::CacheRetention::None,
+            ..Default::default()
+        };
+        let body =
+            serde_json::to_string(&provider.build_request(&messages, &tools, &opted_out)).unwrap();
+        assert!(
+            !body.contains("cache_control"),
+            "an opted-out request must carry zero cache_control blocks: {body}"
+        );
+
+        // Byte-identical to the shape a caching-disabled provider emits —
+        // the opt-out and the provider-level kill switch are the same wire
+        // contract.
+        let disabled = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(false);
+        let disabled_body = serde_json::to_string(&disabled.build_request(
+            &messages,
+            &tools,
+            &ChatConfig::default(),
+        ))
+        .unwrap();
+        assert_eq!(
+            body, disabled_body,
+            "opted-out request must match the caching-disabled wire shape byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn should_keep_default_request_byte_identical_when_cache_retention_unset() {
+        // The opt-out is strictly per-request: a config that never touches
+        // `cache_retention` (and one that sets it to `Default` explicitly)
+        // must keep the exact cached wire shape, breakpoints included.
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(true);
+        let tools = vec![tool_spec("alpha", "first tool")];
+        let messages = vec![
+            msg(MessageRole::System, "system prompt"),
+            msg(MessageRole::User, "hello"),
+        ];
+        let unset = serde_json::to_string(&provider.build_request(
+            &messages,
+            &tools,
+            &ChatConfig::default(),
+        ))
+        .unwrap();
+        let explicit_default = ChatConfig {
+            cache_retention: crate::CacheRetention::Default,
+            ..Default::default()
+        };
+        let explicit =
+            serde_json::to_string(&provider.build_request(&messages, &tools, &explicit_default))
+                .unwrap();
+        assert_eq!(unset, explicit);
+        assert!(
+            unset.contains("cache_control"),
+            "the default request must keep its cache breakpoints: {unset}"
         );
     }
 

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -343,6 +343,7 @@ impl LlmProvider for AnthropicProvider {
             None
         };
         ProviderMetadata::new(self.provider_label.clone(), self.model.clone(), endpoint)
+            .with_cache_lane(crate::types::CacheLane::Anthropic)
     }
 }
 

--- a/crates/octos-llm/src/config.rs
+++ b/crates/octos-llm/src/config.rs
@@ -41,6 +41,41 @@ pub struct ChatConfig {
     /// `max_tokens` here — use their dedicated fields. See issue #2172.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sampling_params: Option<serde_json::Map<String, serde_json::Value>>,
+    /// Per-request prompt-cache retention preference.
+    ///
+    /// [`CacheRetention::None`] asks the provider to skip prompt-cache
+    /// WRITES for this one request — on Anthropic that means emitting NO
+    /// `cache_control` breakpoints, since every breakpoint both reads and
+    /// writes and an unread write still bills the 1.25x premium. Set it on
+    /// one-shot calls (compaction summaries, sub-agent digests) whose
+    /// prefix is never sent again; the agent loop, whose prefix IS replayed
+    /// every iteration, must stay on [`CacheRetention::Default`]. Mirrors
+    /// pi's `cacheRetention: "none"` on its summarization requests.
+    /// Providers without explicit cache breakpoints ignore this field.
+    #[serde(default, skip_serializing_if = "CacheRetention::is_default")]
+    pub cache_retention: CacheRetention,
+}
+
+/// Prompt-cache retention for a single request. See
+/// [`ChatConfig::cache_retention`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheRetention {
+    /// The provider's configured caching behavior (on Anthropic: the three
+    /// ephemeral `cache_control` breakpoints, unless the provider was built
+    /// with caching disabled).
+    #[default]
+    Default,
+    /// Do not write this request's prefix to the provider's prompt cache.
+    None,
+}
+
+impl CacheRetention {
+    /// `skip_serializing_if` hook: an unset preference stays off the wire so
+    /// persisted `ChatConfig` JSON keeps its pre-field shape.
+    pub fn is_default(&self) -> bool {
+        matches!(self, CacheRetention::Default)
+    }
 }
 
 /// Structured output format for chat responses.
@@ -94,6 +129,7 @@ impl Default for ChatConfig {
             response_format: None,
             context_management: None,
             sampling_params: None,
+            cache_retention: CacheRetention::Default,
         }
     }
 }
@@ -146,6 +182,34 @@ mod tests {
     }
 
     #[test]
+    fn should_default_cache_retention_to_provider_default_when_unset() {
+        assert_eq!(
+            ChatConfig::default().cache_retention,
+            CacheRetention::Default
+        );
+    }
+
+    #[test]
+    fn should_keep_cache_retention_off_the_wire_when_default() {
+        // Persisted ChatConfig JSON must keep its pre-field byte shape for a
+        // config that never touches the preference.
+        let json = serde_json::to_value(ChatConfig::default()).unwrap();
+        assert!(json.get("cache_retention").is_none());
+    }
+
+    #[test]
+    fn should_round_trip_cache_retention_none_as_snake_case() {
+        let config = ChatConfig {
+            cache_retention: CacheRetention::None,
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["cache_retention"], "none");
+        let decoded: ChatConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.cache_retention, CacheRetention::None);
+    }
+
+    #[test]
     fn test_chat_config_serde_roundtrip() {
         let config = ChatConfig {
             max_tokens: Some(2048),
@@ -156,6 +220,7 @@ mod tests {
             response_format: None,
             context_management: None,
             sampling_params: None,
+            cache_retention: CacheRetention::Default,
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: ChatConfig = serde_json::from_str(&json).unwrap();
@@ -176,6 +241,7 @@ mod tests {
             response_format: None,
             context_management: None,
             sampling_params: None,
+            cache_retention: CacheRetention::Default,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert!(json.get("max_tokens").is_none());

--- a/crates/octos-llm/src/context_override.rs
+++ b/crates/octos-llm/src/context_override.rs
@@ -70,6 +70,19 @@ impl LlmProvider for ContextWindowOverride {
         self.inner.provider_name()
     }
 
+    fn provider_metadata(&self) -> crate::ProviderMetadata {
+        // #2194 R4: transparent wrapper — carry the inner slot's cache lane
+        // (and identity) through, or pricing sees the default Residual lane.
+        self.inner.provider_metadata()
+    }
+
+    fn provider_metadata_for_index(
+        &self,
+        provider_index: Option<usize>,
+    ) -> crate::ProviderMetadata {
+        self.inner.provider_metadata_for_index(provider_index)
+    }
+
     fn report_late_failure(&self) {
         self.inner.report_late_failure();
     }

--- a/crates/octos-llm/src/fallback.rs
+++ b/crates/octos-llm/src/fallback.rs
@@ -83,6 +83,12 @@ impl FallbackProvider {
     }
 }
 
+/// Fallback wins are attributed with `FALLBACK_INDEX_BASE + j`, a range
+/// disjoint from any realistic primary slot index, so metadata resolution can
+/// tell a fallback win from the primary's OWN (possibly nested-container)
+/// winner index WITHOUT clobbering the latter. No provider has a million slots.
+pub(crate) const FALLBACK_INDEX_BASE: usize = 1_000_000;
+
 #[async_trait]
 impl LlmProvider for FallbackProvider {
     async fn chat(
@@ -92,13 +98,11 @@ impl LlmProvider for FallbackProvider {
         config: &ChatConfig,
     ) -> Result<ChatResponse> {
         match self.primary.chat(messages, tools, config).await {
-            Ok(mut resp) => {
-                // #2194 R5: attribute the winner so pricing resolves the exact
-                // answering provider's cache lane (slots are [primary=0,
-                // fallbacks[i]=i+1]).
-                resp.provider_index = Some(0);
-                Ok(resp)
-            }
+            // #2194 R6: PRESERVE the primary's own attribution. A nested
+            // container primary already stamped its real winner; clobbering it
+            // with a flat slot index would mis-resolve a mixed-lane primary.
+            // Resolution treats any primary-range index as the primary's own.
+            Ok(resp) => Ok(resp),
             Err(primary_err) => {
                 if crate::current_llm_call_policy() == crate::LlmCallPolicy::FailFast {
                     return Err(primary_err);
@@ -133,7 +137,10 @@ impl LlmProvider for FallbackProvider {
                                 fallback_idx = i,
                                 "fallback provider succeeded"
                             );
-                            resp.provider_index = Some(i + 1);
+                            // Tag in a range disjoint from any primary index
+                            // so resolution can tell a fallback win from the
+                            // primary's own index.
+                            resp.provider_index = Some(FALLBACK_INDEX_BASE + i);
                             return Ok(resp);
                         }
                         Err(e) => {
@@ -158,7 +165,9 @@ impl LlmProvider for FallbackProvider {
         config: &ChatConfig,
     ) -> Result<ChatStream> {
         match self.primary.chat_stream(messages, tools, config).await {
-            Ok(stream) => Ok(self.stream_with_provider_index(0, stream)),
+            // Pass the primary's stream through unchanged so its own
+            // ProviderIndex (a nested container's real winner) survives.
+            Ok(stream) => Ok(stream),
             Err(primary_err) => {
                 if crate::current_llm_call_policy() == crate::LlmCallPolicy::FailFast {
                     return Err(primary_err);
@@ -183,7 +192,11 @@ impl LlmProvider for FallbackProvider {
                         continue;
                     }
                     match fb.chat_stream(messages, tools, config).await {
-                        Ok(stream) => return Ok(self.stream_with_provider_index(i + 1, stream)),
+                        Ok(stream) => {
+                            return Ok(
+                                self.stream_with_provider_index(FALLBACK_INDEX_BASE + i, stream)
+                            );
+                        }
                         Err(e) => {
                             self.record_failure(fb.model_id());
                             warn!(fallback = fb.model_id(), error = %e, "fallback stream also failed");
@@ -209,16 +222,21 @@ impl LlmProvider for FallbackProvider {
     }
 
     fn provider_metadata_for_index(&self, provider_index: Option<usize>) -> ProviderMetadata {
-        // Slots are [primary=0, fallbacks[i]=i+1]; delegate to the EXACT
-        // answering provider so its cache lane (and identity) reaches pricing,
-        // not the default Residual — matching the ProviderChain winner stamp.
         match provider_index {
-            Some(0) | None => self.primary.provider_metadata(),
-            Some(i) => self
+            // A fallback answered (tagged FALLBACK_INDEX_BASE + j): resolve to
+            // that fallback. KNOWN LIMITATION (tracked): if the fallback is
+            // itself a mixed-lane container, its exact answering slot is not
+            // resolved here — its default metadata is used.
+            Some(i) if i >= FALLBACK_INDEX_BASE => self
                 .fallbacks
-                .get(i - 1)
+                .get(i - FALLBACK_INDEX_BASE)
                 .map(|fb| fb.provider_metadata())
                 .unwrap_or_else(|| self.primary.provider_metadata()),
+            // The primary answered: the index is the primary's OWN (preserved),
+            // so DELEGATE — a mixed-lane container primary then resolves the
+            // exact answering slot's cache lane rather than its default.
+            Some(i) => self.primary.provider_metadata_for_index(Some(i)),
+            None => self.primary.provider_metadata(),
         }
     }
 
@@ -443,36 +461,48 @@ mod tests {
             crate::CacheLane::Anthropic,
             "primary's Anthropic lane, not the default Residual",
         );
+        // Primary-range indices (incl. a nested container primary's own
+        // winner) and None resolve THROUGH the primary.
         assert_eq!(
             fp.provider_metadata_for_index(Some(0)).cache_lane,
             crate::CacheLane::Anthropic,
         );
         assert_eq!(
             fp.provider_metadata_for_index(Some(1)).cache_lane,
-            crate::CacheLane::Residual,
-            "slot 1 is the OpenAI fallback (residual lane)",
-        );
-        // Out-of-range and None both resolve to the primary, never a panic.
-        assert_eq!(
-            fp.provider_metadata_for_index(Some(99)).cache_lane,
             crate::CacheLane::Anthropic,
+            "index 1 is a primary-range index, delegated to the primary",
         );
         assert_eq!(
             fp.provider_metadata_for_index(None).cache_lane,
             crate::CacheLane::Anthropic,
         );
+        // A fallback win is tagged FALLBACK_INDEX_BASE + j.
+        assert_eq!(
+            fp.provider_metadata_for_index(Some(super::FALLBACK_INDEX_BASE))
+                .cache_lane,
+            crate::CacheLane::Residual,
+            "fallback slot 0 (OpenAI) -> residual lane",
+        );
+        // Out-of-range fallback tag falls back to the primary, never a panic.
+        assert_eq!(
+            fp.provider_metadata_for_index(Some(super::FALLBACK_INDEX_BASE + 99))
+                .cache_lane,
+            crate::CacheLane::Anthropic,
+        );
     }
 
     #[tokio::test]
-    async fn primary_winner_is_attributed_slot_zero() {
+    async fn primary_winner_preserves_child_attribution() {
+        // #2194 R6: a leaf primary reports no index; FallbackProvider must NOT
+        // clobber it, so a nested container primary's real winner survives and
+        // pricing resolves through the primary.
         let primary = CountingProvider::ok();
         let fallback = CountingProvider::always_err_500();
         let fp = FallbackProvider::new(Arc::new(primary), vec![Arc::new(fallback)]);
         let result = fp.chat(&[], &[], &ChatConfig::default()).await.unwrap();
         assert_eq!(
-            result.provider_index,
-            Some(0),
-            "the primary (slot 0) answered"
+            result.provider_index, None,
+            "leaf primary's own attribution (None) is preserved, not clobbered",
         );
     }
 
@@ -491,8 +521,8 @@ mod tests {
         .expect("fallback answers under Normal policy");
         assert_eq!(
             result.provider_index,
-            Some(1),
-            "the fallback (slot 1) answered, so it is the attributed winner",
+            Some(super::FALLBACK_INDEX_BASE),
+            "fallback slot 0 answered -> tagged FALLBACK_INDEX_BASE + 0",
         );
     }
 

--- a/crates/octos-llm/src/fallback.rs
+++ b/crates/octos-llm/src/fallback.rs
@@ -87,6 +87,13 @@ impl FallbackProvider {
 /// disjoint from any realistic primary slot index, so metadata resolution can
 /// tell a fallback win from the primary's OWN (possibly nested-container)
 /// winner index WITHOUT clobbering the latter. No provider has a million slots.
+///
+/// KNOWN LIMITATION (#2199): this flat tag does NOT compose when the PRIMARY is
+/// itself a `FallbackProvider` — the inner's `FALLBACK_INDEX_BASE + j` tag is
+/// indistinguishable from the outer's own, so a preserved inner-fallback index
+/// resolves to the OUTER's fallback. Same root cause as #2199 (a flat
+/// `provider_index` cannot carry `(which-child, child-index)` through nesting);
+/// the durable fix carries the answering leaf's metadata on the response.
 pub(crate) const FALLBACK_INDEX_BASE: usize = 1_000_000;
 
 #[async_trait]
@@ -488,6 +495,40 @@ mod tests {
             fp.provider_metadata_for_index(Some(super::FALLBACK_INDEX_BASE + 99))
                 .cache_lane,
             crate::CacheLane::Anthropic,
+        );
+    }
+
+    // KNOWN LIMITATION (#2199): a flat provider_index does not compose when a
+    // FallbackProvider is the PRIMARY of another FallbackProvider. The inner's
+    // fallback tag (FALLBACK_INDEX_BASE + j) is misread by the outer as its own
+    // fallback index, so resolution routes to outer.fallbacks[j] instead of the
+    // inner's answering fallback. Ignored until the durable answering-metadata
+    // fix (carry the resolved leaf metadata on the response) lands.
+    #[ignore = "flat-index nesting non-compositionality; tracked in #2199"]
+    #[test]
+    fn nested_fallback_as_primary_resolves_inner_fallback_lane() {
+        let inner_primary: Arc<dyn LlmProvider> = Arc::new(
+            crate::anthropic::AnthropicProvider::new("k", "claude-3-5-sonnet")
+                .with_provider_label("custom"),
+        );
+        let inner_fallback: Arc<dyn LlmProvider> = Arc::new(
+            crate::openai::OpenAIProvider::new("k", "gpt-4o").with_provider_label("openai"),
+        );
+        let inner: Arc<dyn LlmProvider> =
+            Arc::new(FallbackProvider::new(inner_primary, vec![inner_fallback]));
+        let outer_fallback: Arc<dyn LlmProvider> = Arc::new(
+            crate::anthropic::AnthropicProvider::new("k", "claude-3-opus")
+                .with_provider_label("other-anthropic"),
+        );
+        let outer = FallbackProvider::new(inner, vec![outer_fallback]);
+        // The inner's fallback answered -> its tag is Some(FALLBACK_INDEX_BASE).
+        // DESIRED: resolve to the inner's OpenAI fallback (residual lane).
+        // ACTUAL (bug): resolves to outer.fallbacks[0] (Anthropic).
+        assert_eq!(
+            outer
+                .provider_metadata_for_index(Some(super::FALLBACK_INDEX_BASE))
+                .cache_lane,
+            crate::CacheLane::Residual,
         );
     }
 

--- a/crates/octos-llm/src/fallback.rs
+++ b/crates/octos-llm/src/fallback.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use eyre::Result;
+use futures::StreamExt;
 use octos_core::Message;
 use tracing::warn;
 
@@ -12,7 +13,7 @@ use crate::config::ChatConfig;
 use crate::provider::LlmProvider;
 use crate::retry::RetryProvider;
 use crate::router::ProviderRouter;
-use crate::types::{ChatResponse, ChatStream, ToolSpec};
+use crate::types::{ChatResponse, ChatStream, ProviderMetadata, StreamEvent, ToolSpec};
 
 /// A provider that falls back to compatible alternatives on failure.
 /// When a provider fails, it's put in cooldown via the router so future
@@ -71,6 +72,15 @@ impl FallbackProvider {
             router.record_failure(model_id);
         }
     }
+
+    /// Prepend the winning slot index to a stream so a downstream consumer can
+    /// attribute the response to the exact answering provider (mirrors
+    /// `ProviderChain::stream_with_provider_index`).
+    fn stream_with_provider_index(&self, idx: usize, stream: ChatStream) -> ChatStream {
+        Box::pin(
+            futures::stream::once(async move { StreamEvent::ProviderIndex(idx) }).chain(stream),
+        )
+    }
 }
 
 #[async_trait]
@@ -82,7 +92,13 @@ impl LlmProvider for FallbackProvider {
         config: &ChatConfig,
     ) -> Result<ChatResponse> {
         match self.primary.chat(messages, tools, config).await {
-            Ok(resp) => Ok(resp),
+            Ok(mut resp) => {
+                // #2194 R5: attribute the winner so pricing resolves the exact
+                // answering provider's cache lane (slots are [primary=0,
+                // fallbacks[i]=i+1]).
+                resp.provider_index = Some(0);
+                Ok(resp)
+            }
             Err(primary_err) => {
                 if crate::current_llm_call_policy() == crate::LlmCallPolicy::FailFast {
                     return Err(primary_err);
@@ -110,13 +126,14 @@ impl LlmProvider for FallbackProvider {
                         continue;
                     }
                     match fb.chat(messages, tools, config).await {
-                        Ok(resp) => {
+                        Ok(mut resp) => {
                             warn!(
                                 primary = self.primary.model_id(),
                                 fallback = fb.model_id(),
                                 fallback_idx = i,
                                 "fallback provider succeeded"
                             );
+                            resp.provider_index = Some(i + 1);
                             return Ok(resp);
                         }
                         Err(e) => {
@@ -141,7 +158,7 @@ impl LlmProvider for FallbackProvider {
         config: &ChatConfig,
     ) -> Result<ChatStream> {
         match self.primary.chat_stream(messages, tools, config).await {
-            Ok(stream) => Ok(stream),
+            Ok(stream) => Ok(self.stream_with_provider_index(0, stream)),
             Err(primary_err) => {
                 if crate::current_llm_call_policy() == crate::LlmCallPolicy::FailFast {
                     return Err(primary_err);
@@ -155,7 +172,7 @@ impl LlmProvider for FallbackProvider {
                     error = %primary_err,
                     "primary stream failed, trying fallbacks"
                 );
-                for fb in &self.fallbacks {
+                for (i, fb) in self.fallbacks.iter().enumerate() {
                     // #2135 round-7 P1: same fit guard as the chat path.
                     if !crate::context::route_fits_request(fb, messages, tools).await {
                         warn!(
@@ -166,7 +183,7 @@ impl LlmProvider for FallbackProvider {
                         continue;
                     }
                     match fb.chat_stream(messages, tools, config).await {
-                        Ok(stream) => return Ok(stream),
+                        Ok(stream) => return Ok(self.stream_with_provider_index(i + 1, stream)),
                         Err(e) => {
                             self.record_failure(fb.model_id());
                             warn!(fallback = fb.model_id(), error = %e, "fallback stream also failed");
@@ -184,6 +201,25 @@ impl LlmProvider for FallbackProvider {
 
     fn provider_name(&self) -> &str {
         self.primary.provider_name()
+    }
+
+    fn provider_metadata(&self) -> ProviderMetadata {
+        // #2194 R5: slot 0 (primary) is the identity/default.
+        self.primary.provider_metadata()
+    }
+
+    fn provider_metadata_for_index(&self, provider_index: Option<usize>) -> ProviderMetadata {
+        // Slots are [primary=0, fallbacks[i]=i+1]; delegate to the EXACT
+        // answering provider so its cache lane (and identity) reaches pricing,
+        // not the default Residual — matching the ProviderChain winner stamp.
+        match provider_index {
+            Some(0) | None => self.primary.provider_metadata(),
+            Some(i) => self
+                .fallbacks
+                .get(i - 1)
+                .map(|fb| fb.provider_metadata())
+                .unwrap_or_else(|| self.primary.provider_metadata()),
+        }
     }
 
     // #2135 round-6 P1: the MINIMUM across primary and every fallback —
@@ -383,6 +419,80 @@ mod tests {
             fb_calls.load(Ordering::SeqCst),
             1,
             "fallback must be called once"
+        );
+    }
+
+    #[test]
+    fn fallback_propagates_lane_and_identity_by_index() {
+        // #2194 R5: FallbackProvider wraps [primary, fallbacks...]; pricing must
+        // see the ANSWERING provider's cache lane, not the default Residual, and
+        // the primary's identity must survive for adaptive-lane matching.
+        let primary: Arc<dyn LlmProvider> = Arc::new(
+            crate::anthropic::AnthropicProvider::new("k", "claude-3-5-sonnet")
+                .with_provider_label("custom"),
+        );
+        let fallback: Arc<dyn LlmProvider> = Arc::new(
+            crate::openai::OpenAIProvider::new("k", "gpt-4o").with_provider_label("openai"),
+        );
+        let fp = FallbackProvider::new(primary, vec![fallback]);
+
+        let meta = fp.provider_metadata();
+        assert_eq!(meta.provider, "custom", "identity is the primary's label");
+        assert_eq!(
+            meta.cache_lane,
+            crate::CacheLane::Anthropic,
+            "primary's Anthropic lane, not the default Residual",
+        );
+        assert_eq!(
+            fp.provider_metadata_for_index(Some(0)).cache_lane,
+            crate::CacheLane::Anthropic,
+        );
+        assert_eq!(
+            fp.provider_metadata_for_index(Some(1)).cache_lane,
+            crate::CacheLane::Residual,
+            "slot 1 is the OpenAI fallback (residual lane)",
+        );
+        // Out-of-range and None both resolve to the primary, never a panic.
+        assert_eq!(
+            fp.provider_metadata_for_index(Some(99)).cache_lane,
+            crate::CacheLane::Anthropic,
+        );
+        assert_eq!(
+            fp.provider_metadata_for_index(None).cache_lane,
+            crate::CacheLane::Anthropic,
+        );
+    }
+
+    #[tokio::test]
+    async fn primary_winner_is_attributed_slot_zero() {
+        let primary = CountingProvider::ok();
+        let fallback = CountingProvider::always_err_500();
+        let fp = FallbackProvider::new(Arc::new(primary), vec![Arc::new(fallback)]);
+        let result = fp.chat(&[], &[], &ChatConfig::default()).await.unwrap();
+        assert_eq!(
+            result.provider_index,
+            Some(0),
+            "the primary (slot 0) answered"
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_winner_is_attributed_with_its_slot_index() {
+        use crate::{LlmCallPolicy, with_llm_call_policy};
+        // #2194 R5: primary fails, fallback answers -> the response must carry
+        // the fallback's slot index (1) so pricing resolves the fallback's lane.
+        let primary = CountingProvider::always_err_500();
+        let fallback = CountingProvider::ok();
+        let fp = FallbackProvider::new(Arc::new(primary), vec![Arc::new(fallback)]);
+        let result = with_llm_call_policy(LlmCallPolicy::Normal, async {
+            fp.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .expect("fallback answers under Normal policy");
+        assert_eq!(
+            result.provider_index,
+            Some(1),
+            "the fallback (slot 1) answered, so it is the attributed winner",
         );
     }
 

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -373,6 +373,7 @@ impl LlmProvider for GeminiProvider {
         // Derive the metadata name from the auth mode (same as `provider_name`)
         // so Vertex calls aren't mislabelled as AI Studio gemini in provenance.
         ProviderMetadata::new(self.provider_name(), self.model.clone(), endpoint)
+            .with_cache_lane(crate::types::CacheLane::Gemini)
     }
 }
 

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -55,7 +55,7 @@ pub use adaptive::{
 };
 pub use call_policy::{LlmCallPolicy, current_llm_call_policy, with_llm_call_policy};
 pub use catalog::{ModelCapabilities, ModelCatalog, ModelCost, ModelInfo};
-pub use config::{ChatConfig, ReasoningEffort, ResponseFormat, ToolChoice};
+pub use config::{CacheRetention, ChatConfig, ReasoningEffort, ResponseFormat, ToolChoice};
 pub use content_classifier::{
     ClassificationDecision, ContentClassifier, HarnessRoutingDecisionPayload, ModelTier,
     RoutingConfig,

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -91,6 +91,6 @@ pub use stream_accumulator::StreamAccumulator;
 pub use swappable::SwappableProvider;
 pub use throttle::SemaphoreThrottledProvider;
 pub use types::{
-    ChatResponse, ChatStream, ProviderMetadata, StopReason, StreamEvent, ThinkTagStreamSplitter,
-    TokenUsage, ToolSpec, strip_think_tags,
+    CacheLane, ChatResponse, ChatStream, ProviderMetadata, StopReason, StreamEvent,
+    ThinkTagStreamSplitter, TokenUsage, ToolSpec, strip_think_tags,
 };

--- a/crates/octos-llm/src/middleware.rs
+++ b/crates/octos-llm/src/middleware.rs
@@ -126,6 +126,19 @@ impl LlmProvider for MiddlewareStack {
         self.inner.provider_name()
     }
 
+    fn provider_metadata(&self) -> crate::ProviderMetadata {
+        // #2194 R4: transparent wrapper — carry the inner slot's cache lane
+        // (and identity) through, or pricing sees the default Residual lane.
+        self.inner.provider_metadata()
+    }
+
+    fn provider_metadata_for_index(
+        &self,
+        provider_index: Option<usize>,
+    ) -> crate::ProviderMetadata {
+        self.inner.provider_metadata_for_index(provider_index)
+    }
+
     fn context_window(&self) -> u32 {
         self.inner.context_window()
     }

--- a/crates/octos-llm/src/pricing.rs
+++ b/crates/octos-llm/src/pricing.rs
@@ -127,6 +127,65 @@ const CACHE_READ_INPUT_MULTIPLIER: f64 = 0.1;
 /// ephemeral cache writes at 1.25x the base input price).
 const CACHE_WRITE_INPUT_MULTIPLIER: f64 = 1.25;
 
+/// Provider-specific prompt-cache billing multipliers on the base input rate.
+///
+/// #2194 review: cache economics are a PROVIDER property, not a universal
+/// constant — pricing OpenAI or Gemini cache traffic at Anthropic's
+/// 0.1x/1.25x misprices both. See [`cache_rates_for_provider`] for the rate
+/// cards and their sources.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CacheRates {
+    /// Cache-read (cache-hit) tokens bill at this multiple of the input rate.
+    pub read_multiplier: f64,
+    /// Cache-write tokens bill at this multiple of the input rate on TOP of
+    /// nothing (they are disjoint from `input_tokens`); 0.0 means the
+    /// provider does not bill cache writes per token.
+    pub write_multiplier: f64,
+}
+
+/// The prompt-cache rate card for a provider label ([`ProviderMetadata::provider`]
+/// / `LlmProvider::provider_name()`, matched case-insensitively).
+///
+/// Sources, and why each bucket is what it is:
+/// - `anthropic`: cache reads 0.1x the input rate, 5-minute ephemeral cache
+///   writes 1.25x — uniform across Claude models per Anthropic's prompt
+///   caching pricing docs, and consistent with every catalog row that
+///   carries a cached rate (`catalog.rs`: sonnet-4 0.3/3.0, haiku-4.5
+///   0.08/0.80 — both exactly 0.1x).
+/// - `gemini` / `vertex` / `google`: implicit caching bills cached tokens at
+///   25% of the input rate (catalog row gemini-2.5-flash: 0.0375/0.15 =
+///   0.25x). No per-token write charge — explicit-cache STORAGE is
+///   time-billed, and octos never creates explicit caches.
+/// - everything else (openai, openrouter, deepseek, local, relabeled
+///   proxies, unknown/empty): no cached rate is knowable here — the
+///   catalog's only OpenAI row carries `cache_read_per_mtok: None`, and the
+///   public discount varies per model FAMILY (0.5x for gpt-4o-era, deeper
+///   for newer families), so any provider-wide discount would be invented
+///   for some models. Reads therefore bill at the FULL input rate (the
+///   never-understate bound; deliberately overstates where a real discount
+///   exists) and writes carry no premium (automatic caching has no write
+///   charge). Tightening this to real per-model rates needs cached-rate
+///   fields in the runtime model catalog first.
+pub fn cache_rates_for_provider(provider: &str) -> CacheRates {
+    let p = provider.to_ascii_lowercase();
+    if p.contains("anthropic") {
+        CacheRates {
+            read_multiplier: CACHE_READ_INPUT_MULTIPLIER,
+            write_multiplier: CACHE_WRITE_INPUT_MULTIPLIER,
+        }
+    } else if p.contains("gemini") || p.contains("vertex") || p.contains("google") {
+        CacheRates {
+            read_multiplier: 0.25,
+            write_multiplier: 0.0,
+        }
+    } else {
+        CacheRates {
+            read_multiplier: 1.0,
+            write_multiplier: 0.0,
+        }
+    }
+}
+
 impl ModelPricing {
     /// Calculate cost for given token counts.
     pub fn cost(&self, input_tokens: u32, output_tokens: u32) -> f64 {
@@ -134,16 +193,15 @@ impl ModelPricing {
             + (output_tokens as f64 / 1_000_000.0) * self.output_per_million
     }
 
-    /// Cache-aware cost using Anthropic's DISJOINT accounting: `input_tokens`
-    /// excludes cached tokens, `cache_read_tokens` bills at 0.1x the input
-    /// rate and `cache_write_tokens` at 1.25x. Degenerates to [`Self::cost`]
-    /// when both cache counts are zero.
+    /// Cache-aware cost at ANTHROPIC's multipliers (0.1x read / 1.25x write)
+    /// under the crate-wide DISJOINT accounting contract: `input_tokens`
+    /// excludes cached tokens. Degenerates to [`Self::cost`] when both cache
+    /// counts are zero.
     ///
-    /// Do NOT feed this OpenAI/Gemini usage as-is: those providers report
-    /// cached tokens INSIDE `input_tokens` (overlapping accounting), so the
-    /// cached portion would be double-billed. Call sites that price mixed
-    /// providers need per-provider normalization first — until then they
-    /// keep using [`Self::cost`].
+    /// Token-count normalization is handled at every provider's parse
+    /// boundary (see `TokenUsage`), but the MULTIPLIERS here are Anthropic's
+    /// alone — call sites pricing arbitrary providers must use
+    /// [`Self::cost_with_cache_for_provider`] instead (#2194 review).
     pub fn cost_with_cache(
         &self,
         input_tokens: u32,
@@ -151,13 +209,55 @@ impl ModelPricing {
         cache_read_tokens: u32,
         cache_write_tokens: u32,
     ) -> f64 {
+        self.cost_with_cache_rates(
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+            CacheRates {
+                read_multiplier: CACHE_READ_INPUT_MULTIPLIER,
+                write_multiplier: CACHE_WRITE_INPUT_MULTIPLIER,
+            },
+        )
+    }
+
+    /// Cache-aware cost at the rate card of the provider that actually
+    /// served the response ([`cache_rates_for_provider`]). This is the entry
+    /// point runtime pricing should use: `TokenUsage` counts are already
+    /// disjoint-normalized for every provider, so the only provider-specific
+    /// part left is the multipliers.
+    pub fn cost_with_cache_for_provider(
+        &self,
+        provider: &str,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_read_tokens: u32,
+        cache_write_tokens: u32,
+    ) -> f64 {
+        self.cost_with_cache_rates(
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+            cache_rates_for_provider(provider),
+        )
+    }
+
+    fn cost_with_cache_rates(
+        &self,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_read_tokens: u32,
+        cache_write_tokens: u32,
+        rates: CacheRates,
+    ) -> f64 {
         self.cost(input_tokens, output_tokens)
             + (cache_read_tokens as f64 / 1_000_000.0)
                 * self.input_per_million
-                * CACHE_READ_INPUT_MULTIPLIER
+                * rates.read_multiplier
             + (cache_write_tokens as f64 / 1_000_000.0)
                 * self.input_per_million
-                * CACHE_WRITE_INPUT_MULTIPLIER
+                * rates.write_multiplier
     }
 }
 
@@ -399,6 +499,77 @@ mod tests {
         // Zero cache counts degenerate to the plain cost().
         let plain = p.cost_with_cache(100_000, 10_000, 0, 0);
         assert!((plain - p.cost(100_000, 10_000)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn should_price_anthropic_cache_at_tenth_read_and_five_fourths_write() {
+        let p = ModelPricing {
+            input_per_million: 3.0,
+            output_per_million: 15.0,
+        };
+        let cost = p.cost_with_cache_for_provider("anthropic", 100_000, 10_000, 10_000, 2_000);
+        let naive = p.cost(100_000, 10_000);
+        // 10k reads at 0.1x ($0.003) + 2k writes at 1.25x ($0.0075).
+        assert!(
+            (cost - (naive + 0.003 + 0.0075)).abs() < 1e-12,
+            "got {cost}"
+        );
+        // The label match must also catch relabeled Anthropic slots that keep
+        // the family in the label, and the direct primitive stays aligned.
+        assert!((cost - p.cost_with_cache(100_000, 10_000, 10_000, 2_000)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn should_price_gemini_cache_reads_at_quarter_rate_with_no_write_premium() {
+        let p = ModelPricing {
+            input_per_million: 0.15,
+            output_per_million: 0.60,
+        };
+        let cost = p.cost_with_cache_for_provider("gemini", 100_000, 10_000, 100_000, 5_000);
+        let naive = p.cost(100_000, 10_000);
+        // 100k cached reads at 0.25x of $0.15/M = $0.00375; writes free.
+        assert!((cost - (naive + 0.00375)).abs() < 1e-12, "got {cost}");
+        let vertex = p.cost_with_cache_for_provider("vertex", 100_000, 10_000, 100_000, 5_000);
+        assert!(
+            (vertex - cost).abs() < 1e-12,
+            "vertex bills at Google rates"
+        );
+    }
+
+    #[test]
+    fn should_price_unknown_provider_cache_reads_at_full_input_rate_with_no_write_premium() {
+        // No cached rate is knowable for these providers (the catalog's only
+        // OpenAI row carries cache_read_per_mtok: None, and the public
+        // discount varies per model family), so reads bill at the FULL input
+        // rate — never an invented discount — and writes carry no premium.
+        let p = ModelPricing {
+            input_per_million: 2.5,
+            output_per_million: 10.0,
+        };
+        for provider in ["openai", "openrouter", "deepseek", "local", ""] {
+            let cost = p.cost_with_cache_for_provider(provider, 100_000, 10_000, 40_000, 8_000);
+            let expected = p.cost(100_000 + 40_000, 10_000);
+            assert!(
+                (cost - expected).abs() < 1e-12,
+                "{provider}: cached reads bill at the full input rate, writes free (got {cost})"
+            );
+        }
+    }
+
+    #[test]
+    fn should_change_cache_cost_when_provider_changes() {
+        // Mutation guard for the provider lookup itself: identical usage must
+        // price differently across the three rate cards.
+        let p = ModelPricing {
+            input_per_million: 3.0,
+            output_per_million: 15.0,
+        };
+        let anthropic = p.cost_with_cache_for_provider("anthropic", 100_000, 10_000, 50_000, 5_000);
+        let gemini = p.cost_with_cache_for_provider("gemini", 100_000, 10_000, 50_000, 5_000);
+        let unknown = p.cost_with_cache_for_provider("openai", 100_000, 10_000, 50_000, 5_000);
+        assert!((anthropic - gemini).abs() > 1e-9);
+        assert!((anthropic - unknown).abs() > 1e-9);
+        assert!((gemini - unknown).abs() > 1e-9);
     }
 
     #[test]

--- a/crates/octos-llm/src/pricing.rs
+++ b/crates/octos-llm/src/pricing.rs
@@ -159,11 +159,13 @@ pub struct CacheRates {
 /// deliberately excluded.
 fn speaks_anthropic_protocol(provider: &str, model: &str) -> bool {
     let p = provider.to_ascii_lowercase();
-    let m = model.to_ascii_lowercase();
     p.contains("anthropic")
         || p == "zai"
         || p == "zai-coding"
-        || (p == "r9s" && m.starts_with("claude"))
+        // Mirror r9s construction EXACTLY (case-sensitive `starts_with("claude-")`
+        // on the RAW model): r9s speaks the Anthropic protocol only for the models
+        // it actually builds an `AnthropicProvider` for — see `registry::r9s`.
+        || (p == "r9s" && crate::registry::r9s::prefers_anthropic(model))
 }
 
 /// The prompt-cache rate card for the answering slot, keyed on its
@@ -501,6 +503,33 @@ pub fn model_pricing(model_id: &str) -> Option<ModelPricing> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_mirror_r9s_construction_predicate_when_pricing_cache() {
+        // #2194 R3: r9s auto-selects the Anthropic protocol ONLY for
+        // `model.starts_with("claude-")` (case-sensitive; see registry/r9s.rs).
+        // Cache pricing must classify by the SAME predicate, or a model r9s
+        // actually serves over the OpenAI protocol (mixed-case "Claude-...", or
+        // a "claude"-prefixed-but-not-"claude-" name) is handed Anthropic cache
+        // rates it never earns. Before this fix pricing used a LOWERCASED
+        // `starts_with("claude")` and diverged from construction.
+        assert_eq!(
+            cache_rates("r9s", "claude-3-5-sonnet").read_multiplier,
+            CACHE_READ_INPUT_MULTIPLIER,
+            "r9s + claude-* is Anthropic protocol -> 0.1x cache reads",
+        );
+        assert_eq!(
+            cache_rates("r9s", "Claude-3-5-sonnet").read_multiplier,
+            1.0,
+            "r9s builds an OpenAIProvider for a non-'claude-' (mixed-case) model, \
+             so pricing must NOT hand it Anthropic cache rates",
+        );
+        assert_eq!(
+            cache_rates("r9s", "claude2-experimental").read_multiplier,
+            1.0,
+            "a 'claude'-prefixed-but-not-'claude-' model is OpenAI protocol at r9s",
+        );
+    }
 
     #[test]
     fn test_known_model_pricing() {

--- a/crates/octos-llm/src/pricing.rs
+++ b/crates/octos-llm/src/pricing.rs
@@ -129,60 +129,92 @@ const CACHE_WRITE_INPUT_MULTIPLIER: f64 = 1.25;
 
 /// Provider-specific prompt-cache billing multipliers on the base input rate.
 ///
-/// #2194 review: cache economics are a PROVIDER property, not a universal
-/// constant — pricing OpenAI or Gemini cache traffic at Anthropic's
-/// 0.1x/1.25x misprices both. See [`cache_rates_for_provider`] for the rate
-/// cards and their sources.
+/// #2194 review: cache economics are a PROTOCOL/provider property, not a
+/// universal constant — pricing OpenAI or Gemini cache traffic at Anthropic's
+/// 0.1x/1.25x misprices both. See [`cache_rates`] for the rate cards, their
+/// sources, and the protocol keying.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CacheRates {
     /// Cache-read (cache-hit) tokens bill at this multiple of the input rate.
     pub read_multiplier: f64,
-    /// Cache-write tokens bill at this multiple of the input rate on TOP of
-    /// nothing (they are disjoint from `input_tokens`); 0.0 means the
-    /// provider does not bill cache writes per token.
+    /// Cache-write tokens bill at this multiple of the input rate. They are
+    /// DISJOINT from `input_tokens`, so a 0.0 here makes a reported write
+    /// VANISH from cost — only correct for a protocol that never reports
+    /// writes (Google), never for one that does.
     pub write_multiplier: f64,
 }
 
-/// The prompt-cache rate card for a provider label ([`ProviderMetadata::provider`]
-/// / `LlmProvider::provider_name()`, matched case-insensitively).
+/// Whether the answering slot speaks the ANTHROPIC Messages API, keyed on the
+/// resolved provider label + model. This is the protocol that reports
+/// `cache_creation_input_tokens` (writes, 1.25x) and `cache_read_input_tokens`
+/// (reads, 0.1x).
+///
+/// Native `anthropic` plus the relabeled proxies that construct an
+/// `AnthropicProvider` under a custom label: `zai` / `zai-coding` (GLM over
+/// the Anthropic API) and `r9s` when it is serving a `claude-*` model (r9s
+/// auto-selects the Anthropic protocol for claude models and OpenAI for the
+/// rest — see `registry/r9s.rs`). A label CONTAINING "anthropic" also counts,
+/// covering custom Anthropic-compatible endpoints. zhipu / dashscope /
+/// minimax / moonshot-coding are OpenAI-protocol re-hosts and are
+/// deliberately excluded.
+fn speaks_anthropic_protocol(provider: &str, model: &str) -> bool {
+    let p = provider.to_ascii_lowercase();
+    let m = model.to_ascii_lowercase();
+    p.contains("anthropic")
+        || p == "zai"
+        || p == "zai-coding"
+        || (p == "r9s" && m.starts_with("claude"))
+}
+
+/// The prompt-cache rate card for the answering slot, keyed on its
+/// [`ProviderMetadata`] provider label + model (matched case-insensitively).
 ///
 /// Sources, and why each bucket is what it is:
-/// - `anthropic`: cache reads 0.1x the input rate, 5-minute ephemeral cache
-///   writes 1.25x — uniform across Claude models per Anthropic's prompt
-///   caching pricing docs, and consistent with every catalog row that
-///   carries a cached rate (`catalog.rs`: sonnet-4 0.3/3.0, haiku-4.5
-///   0.08/0.80 — both exactly 0.1x).
+/// - ANTHROPIC protocol (native `anthropic`, plus relabeled Anthropic-API
+///   proxies — see [`speaks_anthropic_protocol`]): cache reads 0.1x the input
+///   rate, 5-minute ephemeral cache writes 1.25x — uniform across Claude
+///   models per Anthropic's prompt-caching pricing docs, and consistent with
+///   every catalog row that carries a cached rate (`catalog.rs`: sonnet-4
+///   0.3/3.0, haiku-4.5 0.08/0.80 — both exactly 0.1x). This branch is keyed
+///   on PROTOCOL, not on the family label, because a relabeled proxy (zai
+///   serving GLM, r9s serving claude) still emits Anthropic cache accounting.
 /// - `gemini` / `vertex` / `google`: implicit caching bills cached tokens at
 ///   25% of the input rate (catalog row gemini-2.5-flash: 0.0375/0.15 =
 ///   0.25x). No per-token write charge — explicit-cache STORAGE is
-///   time-billed, and octos never creates explicit caches.
-/// - everything else (openai, openrouter, deepseek, local, relabeled
-///   proxies, unknown/empty): no cached rate is knowable here — the
-///   catalog's only OpenAI row carries `cache_read_per_mtok: None`, and the
-///   public discount varies per model FAMILY (0.5x for gpt-4o-era, deeper
-///   for newer families), so any provider-wide discount would be invented
-///   for some models. Reads therefore bill at the FULL input rate (the
-///   never-understate bound; deliberately overstates where a real discount
-///   exists) and writes carry no premium (automatic caching has no write
-///   charge). Tightening this to real per-model rates needs cached-rate
-///   fields in the runtime model catalog first.
-pub fn cache_rates_for_provider(provider: &str) -> CacheRates {
-    let p = provider.to_ascii_lowercase();
-    if p.contains("anthropic") {
-        CacheRates {
+///   time-billed, octos never creates explicit caches, and the Gemini parser
+///   never reports write tokens, so 0.0 writes can never make a real token
+///   vanish.
+/// - everything else (openai, openrouter, deepseek, local, unknown/empty):
+///   no cached READ rate is knowable — the catalog's only OpenAI row carries
+///   `cache_read_per_mtok: None`, and the public discount varies per model
+///   FAMILY (0.5x for gpt-4o-era, deeper for newer), so a provider-wide
+///   discount would be invented for some models. Reads bill at the FULL input
+///   rate (1.0x — the never-understate bound; overstates where a real
+///   discount exists). WRITES bill at 1.25x, NOT 0: `cache_write_tokens` is
+///   populated ONLY by the Anthropic parser (`anthropic.rs`;
+///   `TokenUsage`'s contract — no OpenAI/Gemini path sets it), so any write
+///   token that reaches this residual bucket is an Anthropic-protocol write
+///   from a proxy whose label we failed to recognize. Pricing it at 0 would
+///   make a billed token vanish (an understatement); 1.25x is the honest
+///   value. Tightening the read side needs cached-rate fields in the runtime
+///   model catalog first.
+pub fn cache_rates(provider: &str, model: &str) -> CacheRates {
+    if speaks_anthropic_protocol(provider, model) {
+        return CacheRates {
             read_multiplier: CACHE_READ_INPUT_MULTIPLIER,
             write_multiplier: CACHE_WRITE_INPUT_MULTIPLIER,
-        }
-    } else if p.contains("gemini") || p.contains("vertex") || p.contains("google") {
-        CacheRates {
+        };
+    }
+    let p = provider.to_ascii_lowercase();
+    if p.contains("gemini") || p.contains("vertex") || p.contains("google") {
+        return CacheRates {
             read_multiplier: 0.25,
             write_multiplier: 0.0,
-        }
-    } else {
-        CacheRates {
-            read_multiplier: 1.0,
-            write_multiplier: 0.0,
-        }
+        };
+    }
+    CacheRates {
+        read_multiplier: 1.0,
+        write_multiplier: CACHE_WRITE_INPUT_MULTIPLIER,
     }
 }
 
@@ -221,14 +253,17 @@ impl ModelPricing {
         )
     }
 
-    /// Cache-aware cost at the rate card of the provider that actually
-    /// served the response ([`cache_rates_for_provider`]). This is the entry
-    /// point runtime pricing should use: `TokenUsage` counts are already
-    /// disjoint-normalized for every provider, so the only provider-specific
-    /// part left is the multipliers.
+    /// Cache-aware cost at the rate card of the slot that actually served the
+    /// response ([`cache_rates`], keyed on its provider label + model). This
+    /// is the entry point runtime pricing should use: `TokenUsage` counts are
+    /// already disjoint-normalized for every provider, so the only
+    /// provider-specific part left is the multipliers, and the model is
+    /// needed to tell a relabeled Anthropic proxy (r9s serving claude) from
+    /// the same label serving an OpenAI-protocol model.
     pub fn cost_with_cache_for_provider(
         &self,
         provider: &str,
+        model: &str,
         input_tokens: u32,
         output_tokens: u32,
         cache_read_tokens: u32,
@@ -239,7 +274,7 @@ impl ModelPricing {
             output_tokens,
             cache_read_tokens,
             cache_write_tokens,
-            cache_rates_for_provider(provider),
+            cache_rates(provider, model),
         )
     }
 
@@ -507,7 +542,14 @@ mod tests {
             input_per_million: 3.0,
             output_per_million: 15.0,
         };
-        let cost = p.cost_with_cache_for_provider("anthropic", 100_000, 10_000, 10_000, 2_000);
+        let cost = p.cost_with_cache_for_provider(
+            "anthropic",
+            "claude-opus-4",
+            100_000,
+            10_000,
+            10_000,
+            2_000,
+        );
         let naive = p.cost(100_000, 10_000);
         // 10k reads at 0.1x ($0.003) + 2k writes at 1.25x ($0.0075).
         assert!(
@@ -525,11 +567,25 @@ mod tests {
             input_per_million: 0.15,
             output_per_million: 0.60,
         };
-        let cost = p.cost_with_cache_for_provider("gemini", 100_000, 10_000, 100_000, 5_000);
+        let cost = p.cost_with_cache_for_provider(
+            "gemini",
+            "gemini-2.5-flash",
+            100_000,
+            10_000,
+            100_000,
+            5_000,
+        );
         let naive = p.cost(100_000, 10_000);
         // 100k cached reads at 0.25x of $0.15/M = $0.00375; writes free.
         assert!((cost - (naive + 0.00375)).abs() < 1e-12, "got {cost}");
-        let vertex = p.cost_with_cache_for_provider("vertex", 100_000, 10_000, 100_000, 5_000);
+        let vertex = p.cost_with_cache_for_provider(
+            "vertex",
+            "gemini-2.5-pro",
+            100_000,
+            10_000,
+            100_000,
+            5_000,
+        );
         assert!(
             (vertex - cost).abs() < 1e-12,
             "vertex bills at Google rates"
@@ -537,21 +593,41 @@ mod tests {
     }
 
     #[test]
-    fn should_price_unknown_provider_cache_reads_at_full_input_rate_with_no_write_premium() {
-        // No cached rate is knowable for these providers (the catalog's only
-        // OpenAI row carries cache_read_per_mtok: None, and the public
+    fn should_price_unknown_provider_cache_reads_at_full_input_rate_and_writes_never_free() {
+        // No cached READ rate is knowable for these providers (the catalog's
+        // only OpenAI row carries cache_read_per_mtok: None, and the public
         // discount varies per model family), so reads bill at the FULL input
-        // rate — never an invented discount — and writes carry no premium.
+        // rate — never an invented discount. WRITES, however, are never 0:
+        // cache_write_tokens is only ever populated by the Anthropic parser,
+        // so any write reaching this bucket is an Anthropic-protocol write
+        // from an unrecognized proxy label and bills at 1.25x rather than
+        // vanishing.
         let p = ModelPricing {
             input_per_million: 2.5,
             output_per_million: 10.0,
         };
-        for provider in ["openai", "openrouter", "deepseek", "local", ""] {
-            let cost = p.cost_with_cache_for_provider(provider, 100_000, 10_000, 40_000, 8_000);
-            let expected = p.cost(100_000 + 40_000, 10_000);
+        for (provider, model) in [
+            ("openai", "gpt-4o"),
+            ("openrouter", "anthropic/claude-3.5-sonnet"),
+            ("deepseek", "deepseek-chat"),
+            ("local", "qwen2.5"),
+            ("", ""),
+        ] {
+            let cost =
+                p.cost_with_cache_for_provider(provider, model, 100_000, 10_000, 40_000, 8_000);
+            // reads at full input rate (folded into input) + writes at 1.25x.
+            let expected = p.cost(100_000 + 40_000, 10_000)
+                + (8_000.0 / 1_000_000.0) * p.input_per_million * 1.25;
             assert!(
                 (cost - expected).abs() < 1e-12,
-                "{provider}: cached reads bill at the full input rate, writes free (got {cost})"
+                "{provider}/{model}: reads at full input rate, writes at 1.25x, not free (got {cost})"
+            );
+            // A reported write must never vanish.
+            let read_only =
+                p.cost_with_cache_for_provider(provider, model, 100_000, 10_000, 40_000, 0);
+            assert!(
+                cost - read_only > 1e-9,
+                "{provider}/{model}: cache-write tokens must add cost"
             );
         }
     }
@@ -564,12 +640,70 @@ mod tests {
             input_per_million: 3.0,
             output_per_million: 15.0,
         };
-        let anthropic = p.cost_with_cache_for_provider("anthropic", 100_000, 10_000, 50_000, 5_000);
-        let gemini = p.cost_with_cache_for_provider("gemini", 100_000, 10_000, 50_000, 5_000);
-        let unknown = p.cost_with_cache_for_provider("openai", 100_000, 10_000, 50_000, 5_000);
+        let anthropic = p.cost_with_cache_for_provider(
+            "anthropic",
+            "claude-opus-4",
+            100_000,
+            10_000,
+            50_000,
+            5_000,
+        );
+        let gemini = p.cost_with_cache_for_provider(
+            "gemini",
+            "gemini-2.5-flash",
+            100_000,
+            10_000,
+            50_000,
+            5_000,
+        );
+        let unknown =
+            p.cost_with_cache_for_provider("openai", "gpt-4o", 100_000, 10_000, 50_000, 5_000);
         assert!((anthropic - gemini).abs() > 1e-9);
         assert!((anthropic - unknown).abs() > 1e-9);
         assert!((gemini - unknown).abs() > 1e-9);
+    }
+
+    #[test]
+    fn should_price_relabeled_anthropic_protocol_cache_writes_and_reads_at_anthropic_rates() {
+        // #2194 review round 2: relabeled Anthropic-protocol providers
+        // (zai / zai-coding serving GLM, r9s serving claude, custom
+        // anthropic) emit cache_creation_input_tokens as WRITES. Their label
+        // is not "anthropic", but they speak the Anthropic Messages API, so
+        // writes bill at 1.25x and reads at 0.1x — NOT free, and not the
+        // full-rate residual bucket.
+        let p = ModelPricing {
+            input_per_million: 3.0,
+            output_per_million: 15.0,
+        };
+        let anthropic_ref = p.cost_with_cache_for_provider(
+            "anthropic",
+            "claude-opus-4",
+            100_000,
+            10_000,
+            40_000,
+            8_000,
+        );
+        for (provider, model) in [
+            ("zai", "glm-4.6"),
+            ("zai-coding", "glm-4.6"),
+            ("r9s", "claude-3-5-sonnet"),
+            ("custom-anthropic", "claude-3-7-sonnet"),
+        ] {
+            let cost =
+                p.cost_with_cache_for_provider(provider, model, 100_000, 10_000, 40_000, 8_000);
+            assert!(
+                (cost - anthropic_ref).abs() < 1e-12,
+                "{provider}/{model}: Anthropic-protocol cache must price at 0.1x read / 1.25x write \
+                 (got {cost}, anthropic {anthropic_ref})"
+            );
+            // And explicitly: the write is NOT free.
+            let read_only =
+                p.cost_with_cache_for_provider(provider, model, 100_000, 10_000, 40_000, 0);
+            assert!(
+                cost - read_only > 1e-9,
+                "{provider}/{model}: 8k cache-write tokens must add cost, not vanish"
+            );
+        }
     }
 
     #[test]

--- a/crates/octos-llm/src/pricing.rs
+++ b/crates/octos-llm/src/pricing.rs
@@ -220,6 +220,30 @@ pub fn cache_rates(provider: &str, model: &str) -> CacheRates {
     }
 }
 
+/// Rate card for a [`CacheLane`] taken from the answering slot's
+/// [`ProviderMetadata`]. This is the AUTHORITATIVE path — the lane is set from
+/// the provider TYPE at construction, so it needs no label guessing and prices
+/// a relabeled Anthropic proxy (zai/r9s/custom+anthropic) correctly. The
+/// label-guessing [`cache_rates`] remains only for the legacy string-only
+/// reprice fallbacks that carry no metadata.
+pub fn cache_rates_for_lane(lane: crate::types::CacheLane) -> CacheRates {
+    use crate::types::CacheLane;
+    match lane {
+        CacheLane::Anthropic => CacheRates {
+            read_multiplier: CACHE_READ_INPUT_MULTIPLIER,
+            write_multiplier: CACHE_WRITE_INPUT_MULTIPLIER,
+        },
+        CacheLane::Gemini => CacheRates {
+            read_multiplier: 0.25,
+            write_multiplier: 0.0,
+        },
+        CacheLane::Residual => CacheRates {
+            read_multiplier: 1.0,
+            write_multiplier: CACHE_WRITE_INPUT_MULTIPLIER,
+        },
+    }
+}
+
 impl ModelPricing {
     /// Calculate cost for given token counts.
     pub fn cost(&self, input_tokens: u32, output_tokens: u32) -> f64 {
@@ -277,6 +301,29 @@ impl ModelPricing {
             cache_read_tokens,
             cache_write_tokens,
             cache_rates(provider, model),
+        )
+    }
+
+    /// Cache-aware cost keyed on the answering slot's [`ProviderMetadata`]
+    /// cache lane (the AUTHORITATIVE, provider-type-sourced rate). Use this
+    /// wherever the metadata is in hand; it prices relabeled Anthropic proxies
+    /// (and `custom` + `api_type=anthropic`) correctly without guessing from
+    /// the label, whose value must stay the slot's logical identity for
+    /// adaptive-lane / QoS matching.
+    pub fn cost_with_cache_for_metadata(
+        &self,
+        metadata: &crate::types::ProviderMetadata,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_read_tokens: u32,
+        cache_write_tokens: u32,
+    ) -> f64 {
+        self.cost_with_cache_rates(
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+            cache_rates_for_lane(metadata.cache_lane),
         )
     }
 
@@ -716,7 +763,6 @@ mod tests {
             ("zai", "glm-4.6"),
             ("zai-coding", "glm-4.6"),
             ("r9s", "claude-3-5-sonnet"),
-            ("custom-anthropic", "claude-3-7-sonnet"),
         ] {
             let cost =
                 p.cost_with_cache_for_provider(provider, model, 100_000, 10_000, 40_000, 8_000);

--- a/crates/octos-llm/src/registry/mod.rs
+++ b/crates/octos-llm/src/registry/mod.rs
@@ -80,7 +80,7 @@ mod nvidia;
 mod ollama;
 mod openai;
 mod openrouter;
-mod r9s;
+pub(crate) mod r9s;
 mod vertex;
 mod vllm;
 mod zai;

--- a/crates/octos-llm/src/registry/r9s.rs
+++ b/crates/octos-llm/src/registry/r9s.rs
@@ -8,6 +8,19 @@ use crate::provider::LlmProvider;
 
 use super::{CreateParams, ProviderEntry};
 
+/// Whether r9s serves `model` over the Anthropic Messages API.
+///
+/// r9s auto-selects the Anthropic protocol for `claude-*` models and the
+/// OpenAI Chat Completions protocol for everything else. This is the SINGLE
+/// source of truth for that split so provider construction (below) and the
+/// cache-pricing classifier (`crate::pricing`) can never diverge — a
+/// divergence would price an OpenAI-protocol model at Anthropic cache rates
+/// (or vice versa). Case-sensitive by construction: a mixed-case
+/// "Claude-..." is NOT `claude-*` and is served over OpenAI.
+pub(crate) fn prefers_anthropic(model: &str) -> bool {
+    model.starts_with("claude-")
+}
+
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "r9s",
     aliases: &["r9s.ai"],
@@ -41,7 +54,7 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
 
     // Auto-detect protocol: Anthropic Messages API for claude-* models,
     // OpenAI Chat Completions for everything else.
-    if model.starts_with("claude-") {
+    if prefers_anthropic(&model) {
         let anthropic_url = url
             .strip_suffix("/v1")
             .map(|base| format!("{base}/anthropic"))

--- a/crates/octos-llm/src/retry.rs
+++ b/crates/octos-llm/src/retry.rs
@@ -434,6 +434,19 @@ impl LlmProvider for RetryProvider {
         self.inner.provider_name()
     }
 
+    fn provider_metadata(&self) -> crate::ProviderMetadata {
+        // #2194 R4: transparent wrapper — carry the inner slot's cache lane
+        // (and identity) through, or pricing sees the default Residual lane.
+        self.inner.provider_metadata()
+    }
+
+    fn provider_metadata_for_index(
+        &self,
+        provider_index: Option<usize>,
+    ) -> crate::ProviderMetadata {
+        self.inner.provider_metadata_for_index(provider_index)
+    }
+
     fn report_late_failure(&self) {
         self.inner.report_late_failure();
     }
@@ -442,6 +455,35 @@ impl LlmProvider for RetryProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retry_provider_propagates_the_inner_cache_lane() {
+        use std::sync::Arc;
+        // #2194 R4: providers are wrapped RetryProvider -> Chain -> Router; a
+        // wrapper that drops the inner cache lane prices a custom-anthropic slot
+        // at the Residual default. RetryProvider must carry it through.
+        let inner: Arc<dyn LlmProvider> = Arc::new(
+            crate::anthropic::AnthropicProvider::new("k", "claude-3-5-sonnet")
+                .with_provider_label("custom"),
+        );
+        assert_eq!(
+            inner.provider_metadata().cache_lane,
+            crate::CacheLane::Anthropic,
+            "sanity: the raw AnthropicProvider reports the Anthropic lane",
+        );
+        let retry = RetryProvider::new(inner);
+        assert_eq!(
+            retry.provider_metadata().cache_lane,
+            crate::CacheLane::Anthropic,
+            "RetryProvider must propagate the inner Anthropic cache lane",
+        );
+        assert_eq!(
+            retry.provider_metadata_for_index(None).cache_lane,
+            crate::CacheLane::Anthropic,
+        );
+        // Identity (label) is preserved — adaptive-lane matching keys on it.
+        assert_eq!(retry.provider_metadata().provider, "custom");
+    }
 
     #[test]
     fn test_is_retryable_429() {

--- a/crates/octos-llm/src/router.rs
+++ b/crates/octos-llm/src/router.rs
@@ -378,6 +378,25 @@ impl LlmProvider for ProviderRouter {
         "router"
     }
 
+    fn provider_metadata(&self) -> crate::ProviderMetadata {
+        // #2194 R4: delegate to the active sub-provider so its cache lane (and
+        // real model/provider) reaches pricing, not the "router"/Residual stub.
+        self.active_provider()
+            .map(|p| p.provider_metadata())
+            .unwrap_or_else(|_| {
+                crate::ProviderMetadata::new(self.provider_name(), self.model_id(), None)
+            })
+    }
+
+    fn provider_metadata_for_index(
+        &self,
+        provider_index: Option<usize>,
+    ) -> crate::ProviderMetadata {
+        self.active_provider()
+            .map(|p| p.provider_metadata_for_index(provider_index))
+            .unwrap_or_else(|_| self.provider_metadata())
+    }
+
     fn report_late_failure(&self) {
         if let Ok(p) = self.active_provider() {
             p.report_late_failure();

--- a/crates/octos-llm/src/swappable.rs
+++ b/crates/octos-llm/src/swappable.rs
@@ -112,6 +112,22 @@ impl LlmProvider for SwappableProvider {
         *self.cached_provider_name.read().unwrap()
     }
 
+    fn provider_metadata(&self) -> crate::ProviderMetadata {
+        // #2194 R4: delegate to the currently-swapped provider so its cache
+        // lane reaches pricing (not the default Residual).
+        self.inner.read().unwrap().provider_metadata()
+    }
+
+    fn provider_metadata_for_index(
+        &self,
+        provider_index: Option<usize>,
+    ) -> crate::ProviderMetadata {
+        self.inner
+            .read()
+            .unwrap()
+            .provider_metadata_for_index(provider_index)
+    }
+
     fn export_metrics(&self) -> Option<serde_json::Value> {
         self.inner.read().unwrap().export_metrics()
     }

--- a/crates/octos-llm/src/types.rs
+++ b/crates/octos-llm/src/types.rs
@@ -3,6 +3,26 @@
 use octos_core::ToolCall;
 use serde::{Deserialize, Serialize};
 
+/// Which prompt-cache rate card the answering slot bills at.
+///
+/// Sourced from the provider TYPE (which API it speaks), NOT from a guessed
+/// label — so a relabeled Anthropic-API proxy (`zai` / `r9s` serving claude /
+/// `custom` + `api_type=anthropic`) is priced correctly while its label stays
+/// its logical identity for adaptive-lane and persisted-QoS matching. Anthropic
+/// = 0.1x read / 1.25x write; Gemini = 0.25x read / 0 write; Residual = full
+/// read rate, writes never free (the fail-safe default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheLane {
+    /// Anthropic Messages API prompt-cache accounting.
+    Anthropic,
+    /// Gemini implicit caching.
+    Gemini,
+    /// OpenAI-protocol / unknown: no known read discount; writes at 1.25x.
+    #[default]
+    Residual,
+}
+
 /// Structured provenance for the provider instance that produced a response.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProviderMetadata {
@@ -10,6 +30,10 @@ pub struct ProviderMetadata {
     pub model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
+    /// The cache rate card this slot bills at (see [`CacheLane`]). `#[serde(default)]`
+    /// so older persisted metadata deserializes to `Residual`.
+    #[serde(default)]
+    pub cache_lane: CacheLane,
 }
 
 impl ProviderMetadata {
@@ -22,7 +46,16 @@ impl ProviderMetadata {
             provider: provider.into(),
             model: model.into(),
             endpoint,
+            cache_lane: CacheLane::Residual,
         }
+    }
+
+    /// Set the cache rate card (providers that speak Anthropic/Gemini call this
+    /// from their `provider_metadata()`).
+    #[must_use]
+    pub fn with_cache_lane(mut self, lane: CacheLane) -> Self {
+        self.cache_lane = lane;
+        self
     }
 
     pub fn display_label(&self) -> String {

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -1199,6 +1199,10 @@ async fn plan_dynamic_tasks(
 
     let config = ChatConfig {
         max_tokens: Some(4096),
+        // #2194 review: ONE planning call per dynamic node, its prompt built
+        // from that node's planning_prompt + the user query — never replayed,
+        // so a cache write is pure premium.
+        cache_retention: octos_llm::CacheRetention::None,
         ..Default::default()
     };
 

--- a/crates/octos-pipeline/src/executor_tests.rs
+++ b/crates/octos-pipeline/src/executor_tests.rs
@@ -5,6 +5,66 @@ use crate::handler::Handler;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
+struct RetentionProbeProvider {
+    seen: Mutex<Option<octos_llm::CacheRetention>>,
+}
+
+#[async_trait::async_trait]
+impl octos_llm::LlmProvider for RetentionProbeProvider {
+    async fn chat(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        *self.seen.lock().unwrap() = Some(config.cache_retention);
+        Ok(octos_llm::ChatResponse {
+            content: Some(r#"[{"task": "search for X", "label": "X"}]"#.into()),
+            reasoning_content: None,
+            tool_calls: Vec::new(),
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    async fn chat_stream(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatStream> {
+        unimplemented!("probe does not stream")
+    }
+
+    fn model_id(&self) -> &str {
+        "retention-probe"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+#[tokio::test]
+async fn should_opt_out_of_cache_writes_when_planning_dynamic_tasks() {
+    // #2194 review: dynamic-node planning is ONE call per dynamic node with a
+    // prompt built from that node's planning_prompt + the user query — never
+    // replayed, so it must not pay for cache writes.
+    let probe = RetentionProbeProvider {
+        seen: Mutex::new(None),
+    };
+    let (tasks, _usage) = plan_dynamic_tasks(&probe, "plan the research", "rust caching", 3)
+        .await
+        .expect("probe returns a valid task array");
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(
+        *probe.seen.lock().unwrap(),
+        Some(octos_llm::CacheRetention::None),
+        "one-shot dynamic planning must not request cache writes"
+    );
+}
+
 #[test]
 fn sanitize_label_for_filename_yields_a_deterministic_fs_safe_token() {
     // deep_research workers write `findings-{label}.md`; the substituted token

--- a/crates/octos-services/src/compaction.rs
+++ b/crates/octos-services/src/compaction.rs
@@ -137,6 +137,9 @@ pub async fn maybe_compact_with_config(
     let chat_config = ChatConfig {
         max_tokens: Some(768),
         temperature: Some(0.0),
+        // One-shot: the transcript is summarized exactly once (then replaced
+        // by the summary), so cache writes would be pure 1.25x premium.
+        cache_retention: octos_llm::CacheRetention::None,
         ..Default::default()
     };
 
@@ -271,6 +274,9 @@ pub async fn maybe_compact_handle(
     let chat_config = ChatConfig {
         max_tokens: Some(768),
         temperature: Some(0.0),
+        // One-shot: the transcript is summarized exactly once (then replaced
+        // by the summary), so cache writes would be pure 1.25x premium.
+        cache_retention: octos_llm::CacheRetention::None,
         ..Default::default()
     };
 

--- a/crates/octos-services/src/persona_service.rs
+++ b/crates/octos-services/src/persona_service.rs
@@ -225,6 +225,9 @@ impl PersonaService {
             response_format: None,
             context_management: None,
             sampling_params: None,
+            // One-shot persona generation; the prompt is never replayed
+            // within a cache TTL, so skip cache writes.
+            cache_retention: octos_llm::CacheRetention::None,
         };
 
         match self.llm.chat(&messages, &[], &config).await {
@@ -388,6 +391,9 @@ impl PersonaService {
             response_format: None,
             context_management: None,
             sampling_params: None,
+            // One-shot status-words generation; never replayed within a
+            // cache TTL, so skip cache writes.
+            cache_retention: octos_llm::CacheRetention::None,
         };
 
         match self.llm.chat(&messages, &[], &config).await {

--- a/crates/octos-store/src/usage_ledger.rs
+++ b/crates/octos-store/src/usage_ledger.rs
@@ -72,6 +72,19 @@ pub struct UsageEvent {
     /// uncached run and needs no migration.
     #[serde(default)]
     pub cache_read_tokens: u64,
+    /// Prompt tokens WRITTEN to the provider's cache (Anthropic
+    /// `cache_creation_input_tokens`). Disjoint from `input_tokens` and
+    /// `cache_read_tokens` under the same `TokenUsage` contract — the full
+    /// prompt is `input + cache_read + cache_write`. Cache writes bill at a
+    /// 1.25x premium on the input rate, so without this field the ledger
+    /// could answer the cache-READ half of a caching experiment but never
+    /// the write-side cost it paid for it.
+    ///
+    /// `#[serde(default)]`: rows written before this field existed decode
+    /// as 0 — indistinguishable from a run with no cache writes, so no
+    /// migration is needed.
+    #[serde(default)]
+    pub cache_write_tokens: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub estimated_cost_usd: Option<f64>,
     #[serde(default)]
@@ -111,6 +124,7 @@ impl UsageEvent {
             input_tokens,
             output_tokens,
             cache_read_tokens: 0,
+            cache_write_tokens: 0,
             estimated_cost_usd,
             cost_source,
             channel: channel.into(),
@@ -126,6 +140,14 @@ impl UsageEvent {
     #[must_use]
     pub fn with_cache_read_tokens(mut self, cache_read_tokens: u64) -> Self {
         self.cache_read_tokens = cache_read_tokens;
+        self
+    }
+
+    /// Record the cache-write portion of this run's prompt. Same builder
+    /// shape (and rationale) as [`Self::with_cache_read_tokens`].
+    #[must_use]
+    pub fn with_cache_write_tokens(mut self, cache_write_tokens: u64) -> Self {
+        self.cache_write_tokens = cache_write_tokens;
         self
     }
 }
@@ -148,6 +170,10 @@ pub struct UsageTotals {
     /// means every round paid full price for its prefix.
     #[serde(default)]
     pub cache_read_tokens: u64,
+    /// Cache-WRITTEN prompt tokens (see [`UsageEvent::cache_write_tokens`]),
+    /// the 1.25x-premium side of the same ledger dimension.
+    #[serde(default)]
+    pub cache_write_tokens: u64,
     pub estimated_cost_usd: f64,
 }
 
@@ -159,6 +185,9 @@ impl UsageTotals {
         self.cache_read_tokens = self
             .cache_read_tokens
             .saturating_add(event.cache_read_tokens);
+        self.cache_write_tokens = self
+            .cache_write_tokens
+            .saturating_add(event.cache_write_tokens);
         if let Some(cost) = event.estimated_cost_usd {
             self.estimated_cost_usd += cost;
         }
@@ -171,6 +200,9 @@ impl UsageTotals {
         self.cache_read_tokens = self
             .cache_read_tokens
             .saturating_add(other.cache_read_tokens);
+        self.cache_write_tokens = self
+            .cache_write_tokens
+            .saturating_add(other.cache_write_tokens);
         self.estimated_cost_usd += other.estimated_cost_usd;
     }
 }
@@ -600,6 +632,71 @@ mod tests {
         let decoded: UsageEvent = serde_json::from_value(legacy).expect("legacy record decodes");
         assert_eq!(decoded.cache_read_tokens, 0);
         assert_eq!(decoded.input_tokens, 100);
+    }
+
+    /// Rows written before `cache_write_tokens` existed (including rows that
+    /// DO carry `cache_read_tokens` — the shape every deployment wrote
+    /// between the two fields landing) must keep decoding, with the write
+    /// side defaulting to 0.
+    #[test]
+    fn should_decode_rows_predating_cache_write_field_as_zero_writes() {
+        let pre_cache_write = serde_json::json!({
+            "schema_version": USAGE_EVENT_SCHEMA_VERSION,
+            "event_id": "e2",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "profile_id": "p",
+            "session_id": "s",
+            "run_id": "r",
+            "input_tokens": 100,
+            "output_tokens": 10,
+            "cache_read_tokens": 640,
+            "cost_source": "unavailable",
+            "channel": "test"
+        });
+        let decoded: UsageEvent =
+            serde_json::from_value(pre_cache_write).expect("pre-cache-write record decodes");
+        assert_eq!(decoded.cache_write_tokens, 0);
+        assert_eq!(decoded.cache_read_tokens, 640);
+        assert_eq!(decoded.input_tokens, 100);
+    }
+
+    #[test]
+    fn should_round_trip_cache_write_tokens_when_recorded() {
+        let event = UsageEvent::completed_run(
+            "p",
+            "s",
+            "r",
+            None,
+            None,
+            None,
+            100,
+            10,
+            None,
+            UsageCostSource::Unavailable,
+            "test",
+            None,
+        )
+        .with_cache_read_tokens(10_000)
+        .with_cache_write_tokens(2_000);
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["cache_write_tokens"], 2_000);
+        let decoded: UsageEvent = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded, event);
+        assert_eq!(decoded.cache_write_tokens, 2_000);
+    }
+
+    #[test]
+    fn should_accumulate_cache_write_tokens_across_events_and_merges() {
+        let mut totals = UsageTotals::default();
+        totals.add_event(&cache_event(10, 40).with_cache_write_tokens(15));
+        totals.add_event(&cache_event(20, 55).with_cache_write_tokens(25));
+        assert_eq!(totals.cache_write_tokens, 40);
+
+        let mut other = UsageTotals::default();
+        other.add_event(&cache_event(5, 5).with_cache_write_tokens(60));
+        totals.merge(&other);
+        assert_eq!(totals.cache_write_tokens, 100);
+        assert_eq!(totals.cache_read_tokens, 100);
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Three related cache-economics fixes, one per commit — plus a three-commit round addressing the round-1 adversarial review (see "Review round 1" below).

## 1. One-shot summary calls no longer pay cache writes (`feat(llm)`)

Prompt caching (#1640, default ON in `AnthropicProvider`) marked three ephemeral `cache_control` breakpoints on EVERY request — including one-shot summarization calls whose prefixes are never sent again. Each such call paid the 1.25x cache-write premium for nothing.

The pi harness already avoids this: `completeSummarization` sets `cacheRetention: "none"` with the comment "Avoid cache writes for one-off summaries" (`packages/coding-agent/src/core/compaction/compaction.ts:587-591`). This PR adds the equivalent: `ChatConfig.cache_retention: CacheRetention::{Default,None}`; `AnthropicProvider::build_request` honors `None` by emitting zero `cache_control` blocks — byte-identical to the caching-disabled wire shape — while an unset config keeps the exact cached shape.

Opted-out one-shot sites (each sends its prompt exactly once, prefix never replayed):
- `octos-agent` `compaction::llm_compaction_summary`
- `octos-agent` `summarizer::LlmIterativeSummarizer` (each prompt embeds the prior summary + new turns)
- `octos-agent` `subagent_summary::fetch_summary` (kept opted out after round 1 — see the dedupe below, which is what makes it correct)
- `octos-agent` `research_utils::{extract_findings, merge_findings}` (unique per-batch prompts)
- `octos-services` `compaction` (both transcript summaries — the transcript is replaced by its summary)
- `octos-services` `persona_service` (persona + status-words generation, regeneration interval >> cache TTL)
- `octos-cli` `agent_orchestrator::run_goal_completion_verifier_with_usage` (unique objective+evidence prompt per verdict)

Round 1 added six more one-shot sites (see below) and the sub-agent watcher dedupe.

Deliberately left cached (prefix IS replayed): the agent loop (`llm_call.rs` — system+tools+history replayed every iteration) and `memory_consolidate` (its corrective re-ask appends to the original messages, genuinely reusing the prefix).

Tests: golden serialization (opt-out => zero `cache_control` and byte-equal to the disabled provider's shape; default => breakpoints intact and byte-identical with the field unset vs explicit `Default`), plus per-call-site capture probes pinning `cache_retention: None`. Removing the honor in `build_request` or any call-site opt-out fails a test.

## 2. Cache-write-aware cost accounting (the #1640 follow-up)

Adversarial review flagged twice that octos cannot price caching experiments: runtime pricing called plain `cost(input, output)` (`crates/octos-agent/src/agent/streaming.rs`, `response_usage_cost` / `emit_cost_update`) while `cost_with_cache` (the 0.1x read / 1.25x write primitive from #1640) sat unwired, and the persistent usage event (`crates/octos-store/src/usage_ledger.rs`) recorded cache reads but had NO cache-write field.

- `UsageEvent.cache_write_tokens` + `UsageTotals.cache_write_tokens`: additive, `#[serde(default)]`. Old-row compat pinned by a raw old-shape JSON fixture (carries `cache_read_tokens`, lacks `cache_write_tokens` — the exact shape every deployment wrote until now) plus a round-trip test. All four ledger writers (session actor, speculative overflow, AppUI, btw aside) now record it.
- Pricing wired through the cache-aware path wherever the provider reports cache tokens: `response_usage_cost` (all five callers pass the cache counts), `emit_cost_update`'s reprice fallback, the turn verifier's price, and the four octos-cli reprice fallbacks. Safe cross-provider because `TokenUsage`'s crate-wide contract is DISJOINT accounting (OpenAI/Gemini inclusive counts are normalized at their parse boundaries). `cost_ledger::project_cost_usd` stays on `cost()` — it prices token estimates for dispatch projections where no provider-reported cache figures exist.
- Budget-gate semantics unchanged: admission still counts cached traffic (`budget_tokens_used` = input + cache_read + cache_write, pinned by the existing `budget_counts_cache_tokens_as_used`); this fixes PRICE, not admission.

Pin: usage of 100k in / 10k out with `cache_read=10_000`, `cache_write=2_000` prices at exactly naive + the provider rate card's premiums, and moves off the naive figure.

## 3. `get_goal` schema-probe latch (`perf(fleet)`)

Every `get_goal` ran `pragma_table_info('goals')` before its point lookup. The capability is monotone per connection (a committed column never disappears), so the POSITIVE result is now latched in an `AtomicBool` on `GoalLedger`; once observed, reads skip the probe. A NEGATIVE result is never latched — an unmigrated file can migrate mid-connection via a writer's in-transaction `ensure_goals_time_column`, and a latched "no" would synthesize `time_used_seconds: 0` forever.

The #2092 torn-read fix is preserved: while the answer is still "no", the probe keeps running inside the same DEFERRED transaction as the SELECT (single database state, exactly as before). The latched fast path only asserts a fact observed in a committed state that monotonicity carries into every later snapshot, so the `has_time` SELECT always reads the real column value — the probe/SELECT state split cannot reappear. Pinned via a probe counter (no timing/sleep): unmigrated files re-probe every read and observe a mid-connection migration through a fresh probe; a migrated ledger pays exactly one probe then skips it; the #2092 concurrent-migration torn-read test passes unchanged.

Closes #2085

## Review round 1 (three commits)

**Retention flips, both directions** (`fix(llm)` `094355329`):
- `subagent_summary::fetch_summary` was NOT one-shot as claimed: the watcher ticks every 30s and an idle tick deterministically rebuilds the byte-identical prompt. Rather than reverting to `Default` (a cache hit still bills ~0.1x), the watcher now DEDUPES: an unchanged activity snapshot reuses the previous summary with no LLM call at all (`runtime_detail` still re-stamped so tick/at stay live). Dedupe strictly dominates caching — idle ticks cost zero — and every prompt that still reaches the provider is genuinely fresh, which is what makes the retained opt-out correct. Failures/empty summaries never latch.
- Six sites that should have been `None` and were not, now flipped with per-site RED-first probes: the turn verifier (`agent/verifier.rs` — the stable system block is one sentence; the breakpoint-marked last user block carries the rolling TurnLedger), `rich_output::author_html` (single-shot authoring per voice turn), pipeline `plan_dynamic_tasks` (one planning call per dynamic node), `session/btw` (one restricted call per aside), the final code-review join (once per review), and memory-refresh extraction (one per-session transcript).

**Provider-aware cache pricing** (`fix(llm)` `5ddff0f12`): `cost_with_cache` hardcoded Anthropic's 0.1x/1.25x and `response_usage_cost` discarded the provider it had just resolved — OpenAI/Gemini cache traffic was billed at Anthropic multipliers. New `pricing::cache_rates_for_provider` rate cards, sources documented in code: anthropic 0.1x/1.25x (uniform per Anthropic pricing docs; catalog rows agree); gemini/vertex/google 0.25x/0 (catalog row gemini-2.5-flash 0.0375/0.15); everything else 1.0x/0 — verified against the codebase first as instructed: the catalog's only OpenAI row carries `cache_read_per_mtok: None` and the public OpenAI discount varies per model family (0.5x gpt-4o-era, deeper for newer), so a provider-wide constant would invent a discount for some models; reads bill at the full input rate (never-understate bound) until the runtime catalog carries per-model cached rates. All runtime call sites now price via `cost_with_cache_for_provider` with the answering slot's provider label. Mutation-proofed: same usage across three provider labels yields three different figures, and an openai-labeled agent slot prices differently from an anthropic-labeled one.

**Hook costs are attributed spend** (`fix(agent)` `b9c688d67`): the after-LLM hook payload repriced the MERGED usage at `self.llm.model_id()`, mispricing cross-provider retries. It now carries the attributed figures — `response_cost` = this call's `attributed_cost` verbatim; `session_cost` = the turn's previously attributed spend + this call's. Pinned by a hook-capture test with a deliberately off-catalog prior spend that any repricing implementation fails.

### Tracking notes (no code change)
- The two anthropic golden tests compare new-code against new-code (opt-out vs `with_prompt_caching(false)`, unset vs explicit `Default`), not against a checked-in pre-change fixture. That the default wire shape is byte-identical to pre-PR output is established by inspection: the only change on the default path is `self.prompt_caching && config.cache_retention != None`, where the second operand is `true` for every config that predates the field, and `ChatConfig`'s serde keeps `cache_retention` off the wire when default.
- `CacheRetention` is a closed enum with no serde fallback variant: a FUTURE retention value (e.g. a "long"/1h tier) arriving in persisted JSON would fail deserialization in today's binary rather than degrade to `Default`. Fine today (only "default"/"none" exist and the field is skip-serialized when default); revisit if the enum grows.

## Review round 2 (two commits)

Round-2 verdict closed item 3 (hook attribution — no double-count, refuted V4) and accepted the six retention flips. Two MUST-FIX gaps remained:

**V1 — dedupe key + timestamp** (`fix(agent)` `be2b2d863`): the round-1 sub-agent dedupe compared the raw activity lines, but `build_prompt` truncates each line to 400 chars — two snapshots differing only past char 400 render a BYTE-IDENTICAL prompt, so the raw-line compare would re-send that identical prompt with caching disabled, violating the exact invariant the opt-out relies on. The dedupe key is now the canonical rendered prompt (`build_prompt`'s output — the bytes that actually hit the provider). Separately, a deduped tick re-stamped the reused summary with `Utc::now()` while the event's `at` means "when the summary was PRODUCED"; `LastTickSummary` now carries the original `produced_at` and reuses it, with `tick_seq` (a separate field) conveying liveness. Tests (timing-free): a >400-char-tail-differing pair asserts exactly ONE LLM call (fails the old line-compare), and a directly-driven `summarize_tick` seeded with a fixed 2020 production time asserts the deduped event carries that 2020 `at` (mutation-verified against a `Utc::now()` reuse path).

**V3 — protocol-aware cache-write pricing** (`fix(llm)` `f13b8bfc8`): the round-1 unknown-provider card `(1.0 read, 0.0 write)` was wrong on the WRITE side. `cache_write_tokens` are disjoint from `input_tokens`, so a `0.0` write multiplier makes a reported write VANISH — an understatement — and it is reachable: relabeled Anthropic-protocol providers (r9s serving claude, zai/zai-coding serving GLM over the Anthropic Messages API) land in the unknown bucket and DO emit `cache_creation_input_tokens`. The rate card is now keyed on PROTOCOL, from the resolved slot's provider label + model (both threaded through `cache_rates` / `cost_with_cache_for_provider`): Anthropic protocol (native + `anthropic`-containing labels + `zai`/`zai-coding` + `r9s`&claude-\*) → 0.1x/1.25x; gemini/vertex/google → 0.25x/0 (Gemini never reports writes); residual unknown → 1.0x read (no invented discount) / **1.25x write** — because `cache_write_tokens` is populated ONLY by the Anthropic parser (`anthropic.rs`; verified no OpenAI/Gemini path sets it), any write reaching the residual bucket is an Anthropic-protocol write from an unrecognized label and 1.25x is the honest value, not a vanish. zhipu/dashscope/minimax/moonshot-coding are OpenAI-protocol re-hosts and correctly stay in the residual read bucket (they never emit writes). Tests: zai/zai-coding/r9s-claude/custom-anthropic regressions asserting reads at 0.1x and writes NOT free; the unknown-bucket + agent-level tests rewritten to expect the write priced at 1.25x (the old "writes free" expectation is gone); mutation-verified by forcing the write multiplier to 0.

### Tracking notes — round 2 (no code change)
- "Never replayed" was slightly too absolute: two dynamic pipeline nodes with identical `planning_prompt`+input+`max_tasks`, or two identical higher-level BTW requests, produce the same request bytes. These are externally-duplicated INVOCATIONS, not internal retry/replay, so the one-shot flips remain correct (the prefix is not re-sent within one logical call). 
- Pre-existing, out of scope: the final failed streaming attempt's usage is not accumulated before the non-streaming fallback (`llm_call.rs`); the hook-capture test is unix-only.

## Verification (all green, sequential, after round 2)

- `cargo test -p octos-llm --lib` — 588 passed
- `cargo test -p octos-agent --lib` — 2709 passed
- `cargo test -p octos-fleet` — 192 passed
- `cargo test -p octos-store` — 36 passed
- `cargo test -p octos-pipeline` — 355 passed; `cargo test -p octos-services` — 52 passed (lib)
- `cargo test -p octos-cli --lib` — 1625 passed; api-gated probes + usage tests via `--features api`
- `cargo clippy -p {octos-llm,octos-agent,octos-fleet,octos-store,octos-pipeline,octos-services,octos-cli} --all-targets -- -D warnings` — clean (octos-cli also with `--features api`)
- `cargo fmt --all -- --check` — clean
