### PR TITLE
chore(release): v2.0.3-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "async-trait",
  "base64",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "aes",
  "async-imap",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "chrono",
  "eyre",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4743,14 +4743,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4813,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "async-trait",
  "base64",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "bincode",
  "chrono",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "eyre",
  "metrics",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "async-trait",
  "axum",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "chrono",
  "dirs",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "base64",
  "chrono",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "chrono",
  "eyre",
@@ -8475,7 +8475,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
     "crates/octos-pyo3",
 ]
 [workspace.package]
-version = "2.0.3-rc.9"
+version = "2.0.3-rc.10"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
Version bump 2.0.3-rc.9 → 2.0.3-rc.10.

Releases everything on main since rc.9 (rc.9 was ~100 commits behind), including:
- the qwen3.8 long-run fixes (5-min stream cap, greedy temp=0 collapse, sampler passthrough, empty-MaxTokens silent exit, knobs threaded to serve/octoscode) — all merged but previously unreleased,
- #2196 sandbox fail-closed, #2190 Anthropic sampling params (default-deny GLM gate),
- #2193 flag-gated windowed read_file + partial-view write guard,
- #2194 cache-lane pricing (custom/zai/r9s Anthropic-protocol proxies priced correctly).

Tag `v2.0.3-rc.10` on the merge commit triggers the 8-asset release build.