### PR TITLE
chore(dev): add local workflow make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.DEFAULT_GOAL := help
+
+CARGO ?= cargo
+FEATURES ?= api
+OCTOS_DIR ?= $(CURDIR)/.octos
+HOST ?= 127.0.0.1
+PORT ?= 50080
+SERVE_FLAGS ?= --solo
+
+.PHONY: help init serve dashboard-build web-build app-build dev test
+
+help: ## Show available local-development commands.
+	@awk 'BEGIN {FS = ":.*##"}; /^[a-zA-Z][a-zA-Z0-9_-]*:.*##/ {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+init: ## Interactively create project-local .octos/config.json.
+	$(CARGO) run -p octos-cli -- init --cwd "$(CURDIR)"
+
+serve: ## Start the local API server (default: password-free local login).
+	$(CARGO) run -p octos-cli --features "$(FEATURES)" -- serve --cwd "$(CURDIR)" --data-dir "$(OCTOS_DIR)" --host "$(HOST)" --port "$(PORT)" $(SERVE_FLAGS)
+
+dashboard-build: ## Build the embedded /admin/ dashboard.
+	./scripts/build-dashboard.sh
+
+web-build: ## Initialize octos-web and build the embedded /app/ client.
+	git submodule update --init octos-web
+	./scripts/build-web-app.sh
+
+app-build: dashboard-build web-build ## Build all embedded browser assets.
+
+dev: app-build serve ## Build browser assets, then start the local web app.
+
+test: ## Run the Rust workspace test suite.
+	$(CARGO) test --workspace

--- a/README-zh.md
+++ b/README-zh.md
@@ -50,6 +50,22 @@ export ANTHROPIC_API_KEY=your-key-here
 octos chat
 ```
 
+## 本地源码开发
+
+仓库顶层的 `Makefile` 封装了常见的本地开发流程；可用 `make help` 查看全部目标：
+
+```bash
+make init                         # 交互式创建 ./.octos/config.json
+# 设置 init 中所选提供者对应的 API Key 环境变量，例如：
+export OPENAI_API_KEY=你的密钥
+make serve                        # 启动 API，并启用免密码本地登录
+make dev                          # 构建 /admin/、/app/ 后启动服务
+```
+
+`make serve` 默认仅构建 `api` feature，并监听 `127.0.0.1:50080`。需要时可覆盖，例如
+`make serve PORT=50081 FEATURES=api,telegram`。`make dev` 需要 Node.js；它会初始化
+`octos-web` 子模块并调用现有的前端构建脚本。
+
 ## 在 Zed 中使用 octos（ACP）
 
 `octos acp` 让 octos 成为一个 **ACP（[Agent Client Protocol](https://agentclientprotocol.com)）服务器**，可被 [Zed](https://zed.dev) 等 ACP 编辑器作为一等的编码 Agent 驱动——具备与 `octos chat` 相同的能力：你的工具 + 沙箱、长期记忆 + `MEMORY.md` 注入、技能/插件、MCP、hooks、上下文压缩、提供者故障转移。

--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ guide covers the managed-signup, background-service, and public-VPS options.
 
 For development against an unreleased checkout:
 
+### Local development shortcuts
+
+The repository's `Makefile` wraps the common local workflow while retaining
+the existing build scripts. Run `make help` to see every target.
+
+```bash
+make init                         # creates ./.octos/config.json interactively
+# set the API key variable for the provider selected during init, for example:
+export OPENAI_API_KEY=your-key-here
+make serve                        # API + local password-free sign-in
+make dev                          # build /admin/ and /app/, then start the server
+```
+
+`make serve` builds only the `api` feature and serves on `127.0.0.1:50080` by
+default. Override values when needed, for example
+`make serve PORT=50081 FEATURES=api,telegram`. `make dev` requires Node.js;
+it initializes the `octos-web` submodule and invokes the existing frontend
+build scripts.
+
 ```bash
 # Build and install. The features below are the canonical default
 # (matches scripts/milestone-ci.sh) — `octos serve` requires `api`,


### PR DESCRIPTION
## Summary
- add Makefile targets for local initialization, serving, frontend asset builds, and tests
- document the Makefile workflow in English and Chinese READMEs
- keep provider credentials configurable through the provider selected during init

## Validation
- make help
- make -n init serve dev
- git diff --check