### PR TITLE
fix(api): re-apply profile tool_policy after per-turn session-tool registration on the UI Protocol path (#2202)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -10432,6 +10432,63 @@ fn ws_turn_handler_registers_supervisor_with_task_query_store() {
     assert_eq!(tasks[0]["status"], "running");
 }
 
+/// Regression: `run_standalone_turn` registers per-session channel/dispatcher
+/// tools (send_file, peer_*, spawn) onto the per-turn snapshot, then MUST
+/// re-apply the profile `tool_policy` so an allow/deny list actually
+/// constrains the roster the model sees. Before the fix the re-apply was
+/// missing on the UI-Protocol path, so octoscode ran turns at `tools=31`
+/// despite an 8-tool allow-list, drowning small local models. Mirrors the
+/// gateway re-apply at `session_actor.rs:3748`.
+#[test]
+fn ws_turn_snapshot_is_constrained_by_reapplied_tool_policy() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let parent = octos_agent::ToolRegistry::with_builtins(temp.path());
+    // The per-turn snapshot, exactly as run_standalone_turn builds it.
+    let mut tool_registry = parent.snapshot_excluding(&[]);
+
+    let full_before = tool_registry.tool_names();
+    assert!(
+        full_before.len() > 1,
+        "snapshot should carry the full builtin roster, got {}",
+        full_before.len()
+    );
+    let keep = full_before
+        .iter()
+        .find(|n| n.as_str() == "read_file")
+        .cloned()
+        .unwrap_or_else(|| full_before[0].clone());
+
+    // Register a real per-session tool AFTER the snapshot — the exact class of
+    // tool `run_standalone_turn` adds (send_file / peer_* / spawn) and that used
+    // to bypass the profile policy.
+    let (out_tx, _out_rx) = mpsc::channel::<octos_core::OutboundMessage>(1);
+    tool_registry.register(octos_agent::SendFileTool::new(out_tx));
+    assert!(
+        tool_registry.tool_names().iter().any(|n| n == "send_file"),
+        "send_file must be present after being registered onto the per-turn snapshot",
+    );
+
+    // Re-apply an allow-list that OMITS send_file — what the fix now does with
+    // `session_runtime.profile.tool_policy` after registering session tools.
+    let policy = octos_agent::ToolPolicy {
+        allow: vec![keep.clone()],
+        ..Default::default()
+    };
+    tool_registry.apply_policy(&policy);
+
+    let after = tool_registry.tool_names();
+    assert_eq!(
+        after,
+        vec![keep.clone()],
+        "after re-applying the allow-list, only the allowed tool must remain \
+         — got {after:?}"
+    );
+    assert!(
+        !after.iter().any(|n| n == "send_file"),
+        "the re-applied allow-list must strip the post-snapshot session tool that used to leak",
+    );
+}
+
 /// PR #1324 follow-up — pin that wiring `set_on_failure_signal` on a
 /// per-turn `TaskSupervisor` (the way `run_standalone_turn` does
 /// after this fix) routes a `SpawnOnlyFailureSignal` through to the

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -32424,6 +32424,20 @@ async fn run_standalone_turn(
     // RFC-0 (#1289): LRU tool deferral + the `activate_tools` recovery
     // meta-tool were removed. Voice turns now carry the full enabled tool set
     // like every other turn.
+    // Re-apply the profile tool_policy AFTER this turn's per-session
+    // channel/dispatcher tools were registered (send_file, peer_*, spawn,
+    // run_pipeline, …). The snapshot at the top of the turn (31061) inherited
+    // the profile-BOOTSTRAP policy, but these tools are added here at
+    // turn-build time and would otherwise bypass an allow/deny list — so a
+    // profile `tool_policy` only constrained the bootstrap roster, not the
+    // per-turn roster the model actually sees. Symptom: octoscode ran a turn
+    // with `tools=31` despite an 8-tool allow-list, drowning small local
+    // models. Mirrors `session_actor.rs:3748` (the gateway path already does
+    // this). No-op when no policy is set, so cloud/default behavior is
+    // unchanged.
+    if let Some(ref policy) = session_runtime.profile.tool_policy {
+        tool_registry.apply_policy(policy);
+    }
     // Wrap the per-turn `ToolRegistry` in an `Arc` here so we retain a
     // handle after `Agent::new_shared` consumes its own clone. The
     // post-terminal drain task (issue #961) inspects


### PR DESCRIPTION
## What & why

Closes #2202. `run_standalone_turn` (the WS/UI-Protocol turn path **octoscode** uses) builds the per-turn `ToolRegistry` as a snapshot of the profile's policy-filtered registry, then registers per-session channel/dispatcher tools onto it (`send_file`, `peer_*`, `spawn`, the pipeline factory's `run_pipeline`) — and **never re-applies the profile `tool_policy`**. So an allow/deny list only constrained the profile-**bootstrap** roster, not the **per-turn** roster the model sees.

**Symptom (live):** an octoscode session with an 8-tool allow-list bootstrapped at `tools=8` but ran turns at **`tools=31`** (the ~23 session tools bolted back on), with octos's own `high tool count may cause empty responses` warning — drowning a small local model (Qwen 3.8 on llama.cpp) into empty responses. This is why octos couldn't match Pi's minimal coding roster on the octoscode path.

## Change

Re-apply `session_runtime.profile.tool_policy` once, right after the last per-session `register(...)` and before the registry is finalized (`Arc::new`). It's a 3-line mirror of the gateway path's existing guard at **`session_actor.rs:3748`** (which re-applies after registering `run_pipeline`).

## Cloud safety

`None` policy → block skipped → **byte-for-byte unchanged**. `retain`-based `apply_policy` preserves the `spawn_only` marker for retained tools (`registry.rs:799-806`), so an allow-list that keeps `run_pipeline` keeps it correctly; one that omits it drops it — intended, and identical semantics to the gateway path.

## Test

`ws_turn_snapshot_is_constrained_by_reapplied_tool_policy`: builds the per-turn snapshot the way `run_standalone_turn` does, **registers `send_file` onto it** (the exact class of tool that leaked), then re-applies an allow-list omitting it and asserts only the allowed tool remains and `send_file` is gone.

An adversarial review confirmed the fix is correct, cloud-safe, consistent with the gateway guard, and the only leaking path (the other snapshot at 28971 is `Arc::new`'d with no added tools). fmt + clippy clean.

## Note

This is the 7th and deepest fix from the pi-harness comparison — the one that lets an octoscode session honor a Pi-sized tool roster for a local model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
