### PR TITLE
fix(resume): fail an interrupted thinking-only turn on cold reload instead of resuming it

### DIFF
--- a/crates/octos-bus/src/resume_policy.rs
+++ b/crates/octos-bus/src/resume_policy.rs
@@ -19,9 +19,13 @@
 //!    tool-call messages whose ids have no matching tool result (unless the
 //!    call is referenced by pending retry state).
 //! 2. [`filter_orphaned_thinking_only_messages`] — drops assistant messages
-//!    that have `reasoning_content` but empty `content` and no tool calls,
-//!    unless the message is the tail of the transcript (allow in-flight
-//!    reasoning).
+//!    that have `reasoning_content` but empty `content` and no tool calls.
+//!    A thinking-only message at the tail of the transcript is preserved
+//!    ONLY when `preserve_in_flight_tail` is set — i.e. a live in-process
+//!    retry is under way ([`ResumePolicy::sanitize`] derives this from a
+//!    non-`None` `retry_state`). On a cold reload from disk there is no
+//!    in-flight turn by construction, so the interrupted thinking-only tail
+//!    is failed (dropped) rather than resurrected and resumed.
 //! 3. [`filter_whitespace_only_assistant_messages`] — drops assistant
 //!    messages whose `content.trim().is_empty()` and no tool calls and no
 //!    reasoning content.
@@ -205,7 +209,15 @@ impl ResumePolicy {
         report.unresolved_tool_uses_dropped = dropped_tool_use;
 
         // Pass 2: drop orphan thinking-only assistant messages.
-        let (messages, dropped_thinking) = filter_orphaned_thinking_only_messages(messages);
+        //
+        // A thinking-only tail is preserved only during a live in-process
+        // retry. `retry_state` is `Some` only in that case; on every cold
+        // reload from disk it is `None`, and the process that produced the
+        // tail is gone — so the interrupted turn is failed (dropped) here
+        // rather than resurrected and resumed by the session actor.
+        let preserve_in_flight_tail = retry_state.is_some();
+        let (messages, dropped_thinking) =
+            filter_orphaned_thinking_only_messages(messages, preserve_in_flight_tail);
         report.orphan_thinking_dropped = dropped_thinking;
 
         // Pass 3: drop whitespace-only assistant messages.
@@ -384,17 +396,28 @@ fn result_has_matching_call(kept: &[Message], id: &str) -> bool {
 ///   - `content.trim().is_empty()`.
 ///   - `tool_calls` is None or empty.
 ///
-/// Such messages are dropped EXCEPT when they are the last message in the
-/// transcript — that case represents an in-flight reasoning turn the harness
-/// will continue on resume.
-pub fn filter_orphaned_thinking_only_messages(messages: Vec<Message>) -> (Vec<Message>, usize) {
+/// Such messages are dropped. The one exception is the tail of the transcript
+/// when `preserve_in_flight_tail` is `true`: that represents a live in-process
+/// reasoning turn the harness is about to continue, so it is kept. When
+/// `preserve_in_flight_tail` is `false` (a cold reload from disk, where no turn
+/// is in flight by construction) the tail is treated like any other orphan and
+/// dropped — failing the interrupted turn instead of resurrecting it on resume.
+pub fn filter_orphaned_thinking_only_messages(
+    messages: Vec<Message>,
+    preserve_in_flight_tail: bool,
+) -> (Vec<Message>, usize) {
     let total = messages.len();
     let mut dropped = 0_usize;
     let mut kept = Vec::with_capacity(total);
 
     for (idx, msg) in messages.into_iter().enumerate() {
+        // The tail thinking-only message is kept only when a live in-process
+        // retry is under way (`preserve_in_flight_tail`). On a cold reload it
+        // is an interrupted turn with no live task behind it, so it is dropped
+        // like any other orphan rather than resumed.
         let is_tail = idx + 1 == total;
-        if !is_tail && is_thinking_only(&msg) {
+        let is_live_tail = is_tail && preserve_in_flight_tail;
+        if !is_live_tail && is_thinking_only(&msg) {
             dropped += 1;
         } else {
             kept.push(msg);
@@ -975,7 +998,8 @@ mod tests {
             assistant_text("here is the answer"),
         ];
 
-        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages);
+        // A mid-transcript orphan is dropped even with tail-preservation on.
+        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages, true);
 
         assert_eq!(dropped, 1);
         assert_eq!(filtered.len(), 2);
@@ -983,20 +1007,37 @@ mod tests {
     }
 
     #[test]
-    fn should_keep_trailing_thinking_only_message() {
-        // In-flight reasoning: session crashed mid-think. The tail
-        // thinking-only message represents state the harness will
-        // continue — keep it.
+    fn should_keep_trailing_thinking_only_message_during_in_flight_retry() {
+        // Live in-process retry (`preserve_in_flight_tail = true`): the tail
+        // thinking-only message represents state the harness will continue —
+        // keep it.
         let messages = vec![
             user("long one"),
             assistant_thinking_only("still working on it ..."),
         ];
 
-        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages);
+        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages, true);
 
         assert_eq!(dropped, 0);
         assert_eq!(filtered.len(), 2);
         assert!(filtered[1].reasoning_content.is_some());
+    }
+
+    #[test]
+    fn should_drop_trailing_thinking_only_message_on_cold_reload() {
+        // Cold reload (`preserve_in_flight_tail = false`): the process that
+        // produced the tail is gone, so the interrupted thinking-only turn is
+        // failed (dropped) rather than resurrected and resumed.
+        let messages = vec![
+            user("hi"),
+            assistant_thinking_only("... spiralling reasoning, never answered ..."),
+        ];
+
+        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages, false);
+
+        assert_eq!(dropped, 1);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].content, "hi");
     }
 
     #[test]
@@ -1101,6 +1142,34 @@ mod tests {
         assert_eq!(outcome.report.output_len, 4);
         assert!(!outcome.report.worktree_missing);
         assert!(outcome.report.warnings.is_empty());
+    }
+
+    #[test]
+    fn sanitize_fails_interrupted_thinking_tail_on_cold_reload() {
+        // Cold reload: `retry_state = None`. A transcript ending in a
+        // thinking-only assistant turn (interrupted mid-reasoning) must have
+        // that turn dropped so the session opens clean instead of resuming it.
+        let messages = vec![user("hi"), assistant_thinking_only("... never finished")];
+
+        let outcome = ResumePolicy::sanitize(messages, None, None).unwrap();
+
+        assert_eq!(outcome.report.orphan_thinking_dropped, 1);
+        assert_eq!(outcome.messages.len(), 1);
+        assert_eq!(outcome.messages[0].content, "hi");
+    }
+
+    #[test]
+    fn sanitize_preserves_thinking_tail_during_in_flight_retry() {
+        // Live in-process retry: a non-empty `retry_state` marks the turn as
+        // in-flight, so the trailing thinking-only message is preserved.
+        let messages = vec![user("hi"), assistant_thinking_only("... still going")];
+        let retry_state: HashSet<String> = ["pending-call".to_string()].into_iter().collect();
+
+        let outcome = ResumePolicy::sanitize(messages, Some(&retry_state), None).unwrap();
+
+        assert_eq!(outcome.report.orphan_thinking_dropped, 0);
+        assert_eq!(outcome.messages.len(), 2);
+        assert!(outcome.messages[1].reasoning_content.is_some());
     }
 
     #[test]

--- a/crates/octos-bus/src/resume_policy.rs
+++ b/crates/octos-bus/src/resume_policy.rs
@@ -162,6 +162,13 @@ impl std::error::Error for SanitizeError {}
 /// retry-state types in `octos-agent` (e.g. a future `LoopRetryState` with
 /// pending id tracking) implement this to bridge into the policy without
 /// introducing a reverse crate dependency.
+///
+/// WARNING (#2204): a value handed to [`ResumePolicy::sanitize`] must reflect
+/// state that is LIVE in the current process. `sanitize` treats a non-`None`
+/// `retry_state` as "a turn is in flight" and, on that basis, preserves a
+/// trailing thinking-only turn. A persisted retry-state sidecar reloaded from
+/// disk is NOT live — passing it in on a cold reload would resurrect an
+/// interrupted turn. Pass `None` on every cold reload.
 pub trait RetryStateView {
     /// Returns `true` when the given tool_call_id is pinned by an in-flight
     /// retry (e.g. the harness is about to replay the call after a provider
@@ -215,6 +222,14 @@ impl ResumePolicy {
         // reload from disk it is `None`, and the process that produced the
         // tail is gone — so the interrupted turn is failed (dropped) here
         // rather than resurrected and resumed by the session actor.
+        //
+        // INVARIANT (#2204): `retry_state` here means "a turn is live in this
+        // process", NOT merely "retry state exists on disk". `LoopRetryState`
+        // is persisted to a sidecar and survives a cold reload — it must NEVER
+        // be loaded from disk and threaded into `sanitize`, because `is_some()`
+        // would then be `true` on a cold reload and resurrect exactly the dead
+        // thinking-only tail this pass exists to fail. Cold-reload callers pass
+        // `None`; a live-retry caller passes the in-memory pending-id set.
         let preserve_in_flight_tail = retry_state.is_some();
         let (messages, dropped_thinking) =
             filter_orphaned_thinking_only_messages(messages, preserve_in_flight_tail);

--- a/crates/octos-bus/src/session_tests.rs
+++ b/crates/octos-bus/src/session_tests.rs
@@ -2087,6 +2087,73 @@ fn should_sanitize_loaded_messages_in_place() {
     assert_eq!(handle.session.messages[0].content, "hi");
 }
 
+/// #2204 regression (real disk round-trip): a session whose persisted
+/// transcript ends in an interrupted thinking-only assistant turn must, on a
+/// COLD reload from disk, have that turn FAILED (dropped) — not resurrected
+/// and resumed. Exercises the exact production path the session actor uses at
+/// bootstrap: persist → `SessionHandle::open` (loads from disk) →
+/// `sanitize_loaded_messages(None, ..)`.
+#[tokio::test]
+async fn cold_reload_fails_interrupted_thinking_only_tail() {
+    let tmp = TempDir::new().unwrap();
+    let key = SessionKey::new("cli", "coding");
+
+    // Persist a completed user turn, then an interrupted thinking-only
+    // assistant turn (empty content, non-empty reasoning, no tool calls) — the
+    // killed reasoning spiral that used to be resurrected on the next launch.
+    {
+        let mut writer = SessionHandle::open(tmp.path(), &key);
+        writer
+            .add_message(make_message(MessageRole::User, "hi"))
+            .await
+            .unwrap();
+        let spiral = Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: Some(
+                "... geometry topology manifold spacetime quantum mechanics ...".into(),
+            ),
+            client_message_id: None,
+            thread_id: Some("01a05fda-turn".into()),
+            timestamp: chrono::Utc::now(),
+        };
+        writer.add_message(spiral).await.unwrap();
+    }
+
+    // Cold reload: a fresh handle loads the transcript from disk, exactly as
+    // the session actor does at bootstrap (retry_state = None).
+    let mut handle = SessionHandle::open(tmp.path(), &key);
+    assert_eq!(
+        handle.session.messages.len(),
+        2,
+        "both persisted turns must load from disk"
+    );
+
+    let (report, _refs) = handle
+        .sanitize_loaded_messages(None, None)
+        .expect("clean outcome — no workspace root");
+
+    assert_eq!(
+        report.orphan_thinking_dropped, 1,
+        "the interrupted thinking-only tail must be failed on cold reload"
+    );
+    assert_eq!(handle.session.messages.len(), 1);
+    assert_eq!(handle.session.messages[0].content, "hi");
+    assert!(
+        handle
+            .session
+            .messages
+            .last()
+            .unwrap()
+            .reasoning_content
+            .is_none(),
+        "no thinking-only turn survives to be resumed"
+    );
+}
+
 /// M8.6: a missing worktree surfaces as `Err` and DOES NOT mutate the
 /// session's in-memory transcript — callers can still log what was
 /// loaded before deciding to refuse resume.


### PR DESCRIPTION
## What & why

Closes #2204. After a session is interrupted mid-turn (process killed, or a reasoning model that spiraled and was force-stopped), the next **cold reload resurrected the dead turn instead of failing it**. Observed with a local reasoning model (Qwen3 on llama.cpp) via octoscode: every "fresh" launch re-activated the previous session's killed turn — the model resumed generating against the old prompt with no new user input, looking like the client auto-sent the last message.

## Root cause

`ResumePolicy::sanitize` (`crates/octos-bus/src/resume_policy.rs`) runs **only on reload from disk** (module doc: "at startup or after a crash"). Pass 2, `filter_orphaned_thinking_only_messages`, dropped thinking-only assistant messages (non-empty `reasoning_content`, empty `content`, no `tool_calls`) **except the tail**:

```rust
let is_tail = idx + 1 == total;
if !is_tail && is_thinking_only(&msg) { dropped += 1; } else { kept.push(msg); }
```

The tail exception ("allow in-flight reasoning") was unconditional. But on a **cold reload there is no in-flight turn by construction** — the process that was generating is dead, the in-memory active-turns registry is empty — so a thinking-only tail is always an *interrupted* turn. Preserving it handed the session actor a dangling in-flight assistant turn, which the next turn's context build (`session.get_history()` → the sanitized transcript) then resumed.

This is the same contradiction the **client** already guards against (`octoscode` `client_event.rs`, `BackendRelaunched`): *"A freshly spawned child has no in-flight turns by construction … the store must fail those latched turns … or every subsequent prompt wedges behind the phantom turn forever."* The backend's `ResumePolicy` didn't apply the same rule.

## Change

Gate the tail exception on `preserve_in_flight_tail`, derived in `sanitize` from `retry_state.is_some()`:

- **Cold reload (`retry_state == None`)** → the interrupted thinking-only tail is dropped (turn failed); the session opens clean.
- **Live in-process retry (`retry_state == Some`)** → the tail is kept, unchanged.

`retry_state` is `Some` only during a live, same-process retry; all production callers (`session_actor.rs:3168`, `commands/acp.rs:1627`) pass `None`. No caller signatures change. Mid-transcript orphan-thinking dropping is unchanged.

## Cloud safety

A healthy turn from any provider (cloud or local) ends with content or tool calls, never thinking-only — so a cloud session is affected only in the same interrupted-turn case, where failing the dead turn on cold reload is the correct behavior. Warm-retry behavior is byte-for-byte unchanged.

## Tests

- `sanitize_fails_interrupted_thinking_tail_on_cold_reload` — `sanitize(.., None, ..)` drops a trailing thinking-only turn; `orphan_thinking_dropped == 1`.
- `sanitize_preserves_thinking_tail_during_in_flight_retry` — `sanitize(.., Some(&retry_state), ..)` keeps it.
- `should_drop_trailing_thinking_only_message_on_cold_reload` / `should_keep_trailing_thinking_only_message_during_in_flight_retry` — filter-level cold vs warm.
- `should_drop_orphan_thinking_only_message` — mid-transcript orphan still dropped with tail-preservation on (regression).

`cargo test -p octos-bus` green (resume_policy 28 passed; session 91 passed); `octos-agent` m8 end-to-end gate green; fmt + clippy clean; `octos-cli` / `octos-agent` build clean.

## Scope note (potential follow-up)

This fixes the **agent transcript** resume path — the messages the LLM actually sees on the next turn. The UI-Protocol per-session **event log** (`ui-protocol/<key>/snapshot.json`) is a separate client-facing *display* projection replayed on hydrate; it does not feed the LLM context (turns read `session.get_history()` from the sanitized `SessionHandle`). If a stale display replay is ever observed independently of the transcript, that projection's cold-hydrate handling is a separate, narrower follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
