### PR TITLE
fix(llm): warn when sampling_params keys collide with reserved request fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4832,6 +4832,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "tracing-subscriber",
  "wiremock",
 ]
 

--- a/crates/octos-llm/Cargo.toml
+++ b/crates/octos-llm/Cargo.toml
@@ -38,3 +38,4 @@ workspace = true
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
 wiremock = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -640,8 +640,22 @@ impl OpenAIProvider {
                 // dedicated fields, so a misconfigured sampler param can't emit
                 // duplicate/divergent keys across the streaming (to_value,
                 // last-wins) and non-streaming (to_vec, duplicate) send paths.
+                // The strip must not be silent (#2177): an operator who puts
+                // e.g. `temperature` in sampling_params would otherwise see a
+                // configured-but-unchanged request with no signal at any level.
+                let mut dropped = Vec::new();
                 for reserved in RESERVED_SAMPLING_KEYS {
-                    extra.remove(*reserved);
+                    if extra.remove(*reserved).is_some() {
+                        dropped.push(*reserved);
+                    }
+                }
+                if !dropped.is_empty() {
+                    tracing::warn!(
+                        provider = %self.provider_label,
+                        model = %self.model,
+                        dropped = ?dropped,
+                        "sampling_params keys collide with dedicated request fields and are dropped; use the dedicated config knobs instead"
+                    );
                 }
                 extra
             },
@@ -1647,6 +1661,79 @@ mod tests {
         let v = serde_json::to_value(p.build_request(&msgs, &[], &cfg, false)).unwrap();
         assert_eq!(v["temperature"], serde_json::json!(0.5));
         assert_eq!(v["repeat_penalty"], serde_json::json!(1.1));
+    }
+
+    /// In-memory log capture so a test can assert a `tracing::warn!` fired
+    /// (same shape as octos-cli's turn_trace tests).
+    #[derive(Clone, Default)]
+    struct CapturedLogs(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CapturedLogs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture_logs(run: impl FnOnce()) -> String {
+        let captured = CapturedLogs::default();
+        let writer = captured.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_target(false)
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(move || writer.clone())
+            .finish();
+        tracing::subscriber::with_default(subscriber, run);
+        String::from_utf8(captured.0.lock().unwrap().clone()).unwrap()
+    }
+
+    #[test]
+    fn should_warn_when_sampling_params_contain_reserved_keys() {
+        // #2177: stripping reserved keys from sampling_params must not be
+        // silent — an operator who puts `temperature` there otherwise gets a
+        // configured-but-unchanged request with zero signal.
+        let p = OpenAIProvider::new("key", "gpt-4o");
+        let mut sp = serde_json::Map::new();
+        sp.insert("temperature".to_string(), serde_json::json!(1.9));
+        sp.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+        let cfg = ChatConfig {
+            sampling_params: Some(sp),
+            ..Default::default()
+        };
+        let msgs = [msg("hi")];
+        let logs = capture_logs(|| {
+            p.build_request(&msgs, &[], &cfg, false);
+        });
+        assert!(logs.contains("WARN"), "{logs}");
+        assert!(logs.contains("temperature"), "{logs}");
+        assert!(
+            !logs.contains("repeat_penalty"),
+            "non-reserved keys pass through and are not named in the warning: {logs}"
+        );
+    }
+
+    #[test]
+    fn should_not_warn_when_sampling_params_have_no_reserved_keys() {
+        let p = OpenAIProvider::new("key", "gpt-4o");
+        let mut sp = serde_json::Map::new();
+        sp.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+        let cfg = ChatConfig {
+            sampling_params: Some(sp),
+            ..Default::default()
+        };
+        let msgs = [msg("hi")];
+        let logs = capture_logs(|| {
+            p.build_request(&msgs, &[], &cfg, false);
+        });
+        assert!(
+            !logs.contains("WARN"),
+            "no reserved keys → no warning, got: {logs}"
+        );
     }
 
     #[test]

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -654,7 +654,7 @@ impl OpenAIProvider {
                         provider = %self.provider_label,
                         model = %self.model,
                         dropped = ?dropped,
-                        "sampling_params keys collide with dedicated request fields and are dropped; use the dedicated config knobs instead"
+                        "sampling_params keys collide with reserved request fields and are dropped; set them via the dedicated ChatConfig field where one exists (e.g. temperature, max_tokens) — keys without one must not be sent"
                     );
                 }
                 extra


### PR DESCRIPTION
## Problem

`OpenAIProvider::build_request` strips `RESERVED_SAMPLING_KEYS` from operator-supplied `ChatConfig.sampling_params`. The stripping itself is correct defense-in-depth (#2172), but it was **silent**: an operator who puts `temperature`/`top_p`-style keys in `gateway.llm_sampling_params` (instead of the dedicated knobs) got a request that was configured-but-unchanged, with zero log output at any level. Follow-up from the #2176 review (nit ①).

## Root cause

The strip loop in `build_request` called `extra.remove(*reserved)` and discarded the result — no signal was emitted about which keys (if any) were dropped.

## Fix

Collect the keys actually removed and emit one `tracing::warn!` per request build naming the provider, model, and the dropped keys, pointing at the dedicated `ChatConfig` fields where one exists (`temperature`, `max_tokens`) and stating that keys without a dedicated field must not be sent. Non-reserved keys (`repeat_penalty` etc.) still pass through untouched and are not named in the warning. No signature or wire-behavior change: with no colliding keys the request build is byte-identical and logs nothing.

Per-request-build warning (rather than once per process) is deliberate: it matches the existing `anthropic.rs` per-build warn precedent, and a persistent misconfiguration should stay visible until fixed.

## Test evidence

- `should_warn_when_sampling_params_contain_reserved_keys`: RED before the fix (no warning emitted), GREEN after — asserts the WARN names `temperature` and does not name the passthrough `repeat_penalty`.
- `should_not_warn_when_sampling_params_have_no_reserved_keys`: no colliding keys → no warning.
- Log capture uses an in-memory `tracing_subscriber` writer, same shape as octos-cli's turn_trace tests (`tracing-subscriber` added as a dev-dependency of octos-llm; Cargo.lock +1 line).
- Mutation check: disabling the warn (`if false && ...`) turns the positive test red, as expected.
- Full `cargo test -p octos-llm --lib`: 607 passed, 0 failed. `cargo fmt` clean; `cargo clippy -p octos-llm --all-targets` no warnings.

Closes #2177