### PR TITLE
fix(bus): quarantine a corrupt active_sessions.json instead of silently wiping every topic

### DIFF
--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -3306,7 +3306,28 @@ impl ActiveSessionStore {
         let path = data_dir.join("active_sessions.json");
         let (active, previous) = if path.exists() {
             let data = std::fs::read_to_string(&path)?;
-            let stored: StoredActiveSessions = serde_json::from_str(&data).unwrap_or_default();
+            // #2013: a corrupt store must never silently become an empty one
+            // — the store is not read-only, so the next `save` would persist
+            // the empty-plus-one store OVER the file and destroy every chat's
+            // active topic and `/back` target permanently. Quarantine the
+            // bytes aside (loudly) and start empty instead; the operator can
+            // recover the mappings from the preserved file. Twin of #2005
+            // (cron store).
+            let stored: StoredActiveSessions = match serde_json::from_str(&data) {
+                Ok(stored) => stored,
+                Err(error) => {
+                    tracing::error!(
+                        path = %path.display(),
+                        %error,
+                        bytes = data.len(),
+                        "active session store is corrupt; quarantining it and starting \
+                         with no active topics. Existing topic mappings will not apply \
+                         until this is resolved.",
+                    );
+                    quarantine_active_session_store(&path);
+                    StoredActiveSessions::default()
+                }
+            };
             (stored.active, stored.previous)
         } else {
             (Default::default(), Default::default())
@@ -3372,10 +3393,32 @@ impl ActiveSessionStore {
         };
         let json = serde_json::to_string_pretty(&stored)?;
 
-        // Atomic write-then-rename
-        let tmp = self.path.with_extension("json.tmp");
-        std::fs::write(&tmp, &json)?;
-        std::fs::rename(&tmp, &self.path)?;
+        // Atomic write-then-rename. #2013: the temp name must be UNIQUE —
+        // two processes sharing a data dir racing one fixed `.tmp` path would
+        // both write it and race the rename, one clobbering the other's
+        // store (the same hazard `rewrite_tmp_path` documents for session
+        // JSONL). fsync the temp file BEFORE the rename and the directory
+        // AFTER: the rename was already atomic, but not DURABLE — a hard
+        // power loss could leave a zero-length/truncated
+        // `active_sessions.json`, exactly the input the corrupt-store branch
+        // in `open` then has to quarantine. Mirrors `write_cron_json_atomic`
+        // (#2005).
+        let tmp = self.path.with_extension(format!(
+            "json.{}-{}.tmp",
+            std::process::id(),
+            ACTIVE_SESSIONS_TMP_SEQ.fetch_add(1, Ordering::Relaxed),
+        ));
+        if let Err(error) = write_and_sync(&tmp, &json) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(error.wrap_err("failed to write active session store temp"));
+        }
+        if let Err(error) = std::fs::rename(&tmp, &self.path) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(eyre::Report::new(error).wrap_err("failed to rename active session store"));
+        }
+        if let Some(dir) = self.path.parent() {
+            fsync_dir(dir);
+        }
         Ok(())
     }
 }
@@ -3386,6 +3429,61 @@ struct StoredActiveSessions {
     active: std::collections::HashMap<String, String>,
     #[serde(default)]
     previous: std::collections::HashMap<String, String>,
+}
+
+/// Per-process counter for unique active-session-store temp-file names
+/// (same collision argument as `REWRITE_TMP_COUNTER` above, for the
+/// `active_sessions.json` rewrite in `ActiveSessionStore::save`).
+static ACTIVE_SESSIONS_TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Move a corrupt active-session store aside so the next save cannot
+/// overwrite it. Best-effort: if the rename fails we have still logged the
+/// corruption, and leaving the file in place is no worse than the pre-#2013
+/// behaviour.
+fn quarantine_active_session_store(path: &Path) {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or_default();
+    let quarantined = path.with_extension(format!("corrupt-{stamp}"));
+    match std::fs::rename(path, &quarantined) {
+        Ok(()) => tracing::error!(
+            quarantined = %quarantined.display(),
+            "corrupt active session store preserved here — recover topic mappings from it",
+        ),
+        Err(error) => tracing::error!(
+            path = %path.display(),
+            %error,
+            "could not quarantine the corrupt active session store",
+        ),
+    }
+}
+
+/// Write `json` to `path` and fsync the FILE before it is renamed into place.
+fn write_and_sync(path: &Path, json: &str) -> Result<()> {
+    use std::io::Write as _;
+    let mut file = std::fs::File::create(path)?;
+    file.write_all(json.as_bytes())?;
+    // `flush()` on a std File is a no-op (no userspace buffer) — `sync_all` is
+    // what actually gets the bytes to stable storage.
+    file.sync_all()?;
+    Ok(())
+}
+
+/// fsync a directory so a rename into it is durable. Best-effort: on non-Unix
+/// std cannot open a directory for syncing, so the rename there is only as
+/// durable as the filesystem makes it (it stays atomic either way).
+fn fsync_dir(dir: &Path) {
+    #[cfg(unix)]
+    {
+        if let Ok(handle) = std::fs::File::open(dir) {
+            let _ = handle.sync_all();
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = dir;
+    }
 }
 
 /// Validate a topic name. Returns Err with a message if invalid.

--- a/crates/octos-bus/src/session_tests.rs
+++ b/crates/octos-bus/src/session_tests.rs
@@ -1651,6 +1651,108 @@ fn test_active_session_store_persistence() {
     assert_eq!(store.get_active_topic("telegram:12345"), "research");
 }
 
+/// #2013 — a corrupt `active_sessions.json` must NEVER be silently swallowed
+/// into an empty store that the next `switch_to` then overwrites.
+///
+/// Old behaviour: `serde_json::from_str(..).unwrap_or_default()` turned a
+/// truncated file into an empty store with no error and no log line; the next
+/// topic switch persisted over `active_sessions.json` and every chat's active
+/// topic and `/back` target was gone for good. The load-side property that
+/// prevents that is: the original bytes must still exist on disk afterwards.
+#[test]
+fn corrupt_active_session_store_is_quarantined_not_silently_discarded() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("active_sessions.json");
+    // Truncated mid-token, as an unfsynced write + power loss leaves it. The
+    // cut-off word is deliberately NOT a prefix of a real English word: the
+    // `typos` CI gate reads a truncated word as a misspelling and fails the
+    // build, which is ironic for a fixture whose whole job is to BE
+    // truncated — but not a battle worth having with a spell-checker.
+    let corrupt = r#"{"active":{"telegram:12345":"topic-zzq"#;
+    std::fs::write(&path, corrupt).unwrap();
+
+    let mut store = ActiveSessionStore::open(tmp.path()).unwrap();
+    assert_eq!(
+        store.get_active_topic("telegram:12345"),
+        "",
+        "the store still opens (topics reset is recoverable; losing the mappings is not)",
+    );
+
+    // THE load-bearing assertion: the operator can still get the mappings back.
+    let preserved: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains("corrupt-"))
+        })
+        .collect();
+    assert_eq!(
+        preserved.len(),
+        1,
+        "the corrupt store must be quarantined aside, not discarded (got {preserved:?})",
+    );
+    assert_eq!(
+        std::fs::read_to_string(&preserved[0]).unwrap(),
+        corrupt,
+        "the quarantined copy must be byte-identical so mappings can be recovered",
+    );
+    assert!(
+        !path.exists(),
+        "the corrupt file is moved aside, so a later save cannot overwrite it in place",
+    );
+
+    // The next topic switch persists the near-empty store — and must leave
+    // the quarantined evidence untouched.
+    store.switch_to("telegram:12345", "fresh").unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&preserved[0]).unwrap(),
+        corrupt,
+        "a post-quarantine save must not clobber the preserved store",
+    );
+}
+
+/// A MISSING store is the normal first run — it must stay silent and must
+/// NOT create a quarantine file.
+#[test]
+fn missing_active_session_store_is_not_treated_as_corruption() {
+    let tmp = TempDir::new().unwrap();
+    let store = ActiveSessionStore::open(tmp.path()).unwrap();
+    assert_eq!(store.get_active_topic("telegram:12345"), "");
+    assert_eq!(
+        std::fs::read_dir(tmp.path()).unwrap().count(),
+        0,
+        "first run must not leave a quarantine artifact behind",
+    );
+}
+
+/// #2013 — the save path's temp files must be unique and must never linger:
+/// two stores on one data dir saving alternately (the two-processes shape)
+/// leave exactly the store file behind, no `*.tmp` orphans.
+#[test]
+fn active_session_store_saves_leave_no_tmp_orphans() {
+    let tmp = TempDir::new().unwrap();
+    let mut a = ActiveSessionStore::open(tmp.path()).unwrap();
+    let mut b = ActiveSessionStore::open(tmp.path()).unwrap();
+
+    a.switch_to("telegram:1", "from-a").unwrap();
+    b.switch_to("telegram:2", "from-b").unwrap();
+    a.switch_to("telegram:1", "from-a-again").unwrap();
+
+    let leftovers: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n != "active_sessions.json")
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "saves must clean up their unique temp files, got {leftovers:?}",
+    );
+}
+
 #[test]
 fn test_validate_topic_name() {
     assert!(validate_topic_name("research").is_ok());


### PR DESCRIPTION
## Problem

`ActiveSessionStore::open` parsed `active_sessions.json` with `serde_json::from_str(&data).unwrap_or_default()`, collapsing "file present but unparseable" into "no sessions yet" — no error, no log line. The store is not read-only, so the next topic switch persisted the empty-plus-one store over the file, permanently destroying every chat's active topic and `/back` target. Twin of the fixed #2005 (cron store).

Two smaller defects in the same store, also called out in the issue: `save` used one fixed temp name (`active_sessions.json.tmp`) that two processes sharing a data dir could race, and it renamed without `sync_all` on the temp file or a directory fsync — so it could itself *produce* the truncated file the load path then swallowed.

## Root cause

Silent-default on parse failure (data-loss-on-next-save), fixed temp name (cross-process clobber), missing fsync (rename was atomic but not durable). All three are the exact pattern #2007 fixed for `cron.json`; that fix just wasn't applied to this store.

## Fix

Mirrors the merged #2007 (`cron_service.rs`) pattern:

- **`open`**: on parse failure, rename the file aside to `active_sessions.corrupt-<unix_ms>`, log at ERROR with path/error/size, and start empty. The bytes survive for manual recovery and a later save cannot overwrite them. Read errors still propagate via `?` (unchanged, deliberate — see below); a missing file stays a silent first run.
- **`save`**: unique per-save temp name (`json.<pid>-<seq>.tmp`, same argument as the existing `rewrite_tmp_path` for session JSONL), `sync_all` on the temp file before the rename, and a best-effort directory fsync after.

Scope note: the issue also floated extracting a shared `load_or_quarantine` helper across cron and this store. I deliberately did **not** do that here — it would have meant rewriting the already-merged cron fix in the same PR; the pattern is open-coded in 4 places today (cron, supervisor_store, memory_store, and now here), and consolidating belongs in its own change.

## Test evidence

New tests in `crates/octos-bus/src/session_tests.rs`:

- `corrupt_active_session_store_is_quarantined_not_silently_discarded` — RED against `origin/main` (fails: no quarantine file, store silently empty), GREEN after: the store still opens, the corrupt bytes are moved aside byte-identical, and a subsequent `switch_to` save does not clobber the quarantined evidence.
- `missing_active_session_store_is_not_treated_as_corruption` — first run stays silent, no quarantine artifact.
- `active_session_store_saves_leave_no_tmp_orphans` — two stores on one data dir saving alternately leave exactly `active_sessions.json`, no `*.tmp` orphans (added from review).

`cargo test -p octos-bus`: 236 passed, 0 failed. `cargo clippy -p octos-bus --all-targets`: no warnings. `cargo fmt --check`: clean.

**End-to-end** (real data path through the public `octos_bus::ActiveSessionStore` API on a real data dir, run as a throwaway cargo example, before/after via stash):

- BEFORE (origin/main): seed store with `telegram:12345 → research`, truncate the file mid-write, reopen → topic silently gone, `switch_to` → **original bytes permanently destroyed, no quarantine file**.
- AFTER (this branch): same scenario → corrupt file renamed to `active_sessions.corrupt-<ms>` with bytes intact, save proceeds without touching it. Output: `E2E PASS: quarantined "active_sessions.corrupt-1788335042127", bytes intact`.

## Review

One independent adversarial review pass (issue text + full diff + surrounding code, no author reasoning shared). Verdict: approve with nits; no HIGH/MEDIUM findings. Dispositions:

- *Read-error path deviates from the cron twin (which quarantines unreadable files too)* — deliberate: the issue scopes itself to the parse path and explicitly notes read-error propagation as correct; an unreadable store still fails gateway startup loudly, and no data is lost because a failed `open` can never `save`.
- *`exists()` → `read_to_string` TOCTOU* — pre-existing shape, unchanged semantics; left as-is to keep the diff scoped.
- *Unique temp names can orphan on kill -9 between write and rename* — same accepted trade-off as the cron twin; the next save no longer self-overwrites a fixed `.tmp`, noted as follow-up material.
- *Helper duplication (`write_and_sync`/`fsync_dir`)* — consistent with the 3 existing open-coded copies; consolidation is follow-up, per the scope note above.
- *Test gaps* — added the save-side no-orphans test (above); skipped a wrong-shape-JSON fixture (identical serde error path as the truncated fixture) and an unreadable-file test (permission-based fixtures are environment-dependent under root/CI).

Closes #2013