### PR TITLE
docs(guide): document mcp_servers stdio fields, env sanitization, timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Interactive clients talk to `octos serve` over **UI Protocol v1** — a JSON-RPC
     { "url": "https://mcp.example.com/mcp", "oauth": true }
   ]
   ```
+
+  Stdio children receive a **sanitized environment** — only the names explicitly listed under the server's `env` map are forwarded (injection vectors like `LD_PRELOAD` are stripped even from that map), so a server expecting inherited credentials must get them explicitly or read its own secrets file. Set `"concurrency_class": "exclusive"` to serialize a server's tools (default `"safe"` allows concurrent calls) — the right knob for a single-resource server such as a one-device driver. Handshake timeout is 30s and each `tools/call` times out after 60s, so long-running work should be started detached by the server and polled through read-only tools.
 - **`octos acp`** — the editor-facing direction: octos as an **[Agent Client Protocol](https://agentclientprotocol.com) (ACP)** agent over stdio, so ACP-speaking editors (Zed and others) run octos as their coding agent — with the **same capabilities as `octos chat`** (your tools + sandbox, long-term memory + `MEMORY.md`, skills/plugins, MCP, hooks, context compaction, provider failover). It appears in the editor's agent picker alongside Claude Code and Gemini CLI. See [Use octos in Zed](#use-octos-in-zed-acp).
 
 ### Use octos in Zed (ACP)

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -2080,8 +2080,25 @@ chmod +x .octos/skills/translator/main
   // 钩子
   "hooks": [],
 
-  // MCP 服务器
-  "mcp_servers": [],
+  // MCP 服务器 — octos 作为客户端接入的外部工具源。
+  // stdio: command + args(可选 env);HTTP: url(可选 headers 或 oauth)。
+  "mcp_servers": [
+    // {
+    //   "command": "/path/to/server",   // stdio 传输
+    //   "args": ["serve", "--root", "/path/to/repo"],
+    //   // stdio 子进程拿到的是消毒后的环境: 只转发此 map 里显式列出的变量,
+    //   // 注入向量(LD_PRELOAD、DYLD_INSERT_LIBRARIES、NODE_OPTIONS …)
+    //   // 即使写在这里也会被剥掉。指望继承环境拿密钥的服务会静默失败——
+    //   // 在这里显式传,或让服务自读它自己的 secrets 文件。
+    //   "env": {},
+    //   // "safe"(默认)并发调用本服务工具;"exclusive" 串行化——适合
+    //   // 单设备驱动等独占资源。未知值按 exclusive 兜底(fail-safe)。
+    //   "concurrency_class": "exclusive"
+    // },
+    // { "url": "https://mcp.example.com/mcp", "oauth": true, "scopes": [] }
+    // 超时: 握手 30s,单次 tools/call 60s——长任务应由服务端 detach 起跑
+    // (返回句柄),再用只读工具轮询结果。
+  ],
 
   // 沙箱 — 完整说明见 docs/SANDBOX.md。
   // 后端：bwrap（Linux）、sandbox-exec（macOS）、AppContainer（Windows，

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2173,8 +2173,28 @@ Bot: [uses translate tool with text="Hello world", target_lang="JA"]
   // Hooks
   "hooks": [],
 
-  // MCP servers
-  "mcp_servers": [],
+  // MCP servers — external tool providers octos connects to as a client.
+  // stdio: command + args (+ optional env). HTTP: url (+ headers, or oauth).
+  "mcp_servers": [
+    // {
+    //   "command": "/path/to/server",   // stdio transport
+    //   "args": ["serve", "--root", "/path/to/repo"],
+    //   // stdio children get a SANITIZED environment: only names listed in
+    //   // this map are forwarded, and injection vectors (LD_PRELOAD,
+    //   // DYLD_INSERT_LIBRARIES, NODE_OPTIONS, …) are stripped even from it.
+    //   // A server expecting inherited credentials fails silently — pass
+    //   // keys explicitly here or let the server read its own secrets file.
+    //   "env": {},
+    //   // "safe" (default) runs this server's tools concurrently;
+    //   // "exclusive" serializes them — right for a single-device driver or
+    //   // any one-at-a-time resource. Unknown values fail safe to exclusive.
+    //   "concurrency_class": "exclusive"
+    // },
+    // { "url": "https://mcp.example.com/mcp", "oauth": true, "scopes": [] }
+    // Timeouts: 30s handshake, 60s per tools/call — long-running work should
+    // be started detached by the server (return a handle) and polled via
+    // read-only tools.
+  ],
 
   // Sandbox — see docs/SANDBOX.md for full reference.
   // Backends: bwrap (Linux), sandbox-exec (macOS), AppContainer (Windows,


### PR DESCRIPTION
Closes #2211

## What

Docs-only PR. The `mcp_servers` config surface had no user-facing field reference — `concurrency_class` existed only as a source comment in `crates/octos-agent/src/mcp.rs`, and two operational behaviors were discoverable only by reading code:

1. **Env sanitization** — stdio children inherit a scrubbed environment; only names explicitly listed under the server's `env` map are forwarded, and injection vectors (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, …) are stripped even from that map. A server expecting inherited credentials fails silently.
2. **`concurrency_class`** — `"safe"` (default) vs `"exclusive"` (serializes the server's tools), fail-safe to `Exclusive` on unknown values.
3. **Timeouts** — 30s handshake, 60s per `tools/call`, pushing long-running server work toward a detach-and-poll design.

## Changes

- `docs/user-guide.md` §15.1: annotated `mcp_servers` stdio example covering `command`/`args`/`env`/`concurrency_class` + timeout note (+21/-1)
- `docs/user-guide-zh.md`: same block, mirrored (+21/-1)
- `README.md`: one behavior paragraph in the MCP client bullet (+2)

All statements verified against `crates/octos-agent/src/mcp.rs` (`sanitize_command_env` usage, `resolved_concurrency_class` fail-safe, `HANDSHAKE_TIMEOUT`/`TOOL_CALL_TIMEOUT` constants).

Surfaced by a real integration: attaching a local device-automation harness as a stdio MCP server needed `concurrency_class: "exclusive"` (single device) and a detached-start design to fit the 60s call timeout — none of which was written down.