### PR TITLE
fix(agent): merge persistent retry-state deltas on guard drop (#1655)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -254,9 +254,10 @@ pub(crate) enum LoopErrorAction {
 }
 
 /// Review A F-015 RAII guard. Loads a `LoopRetryState` from an optional
-/// shared `Arc<Mutex<...>>` at construction and writes back on drop so
-/// bucket counters persist across `process_message` / `run_task` calls
-/// for sessions that attach a persistent retry-state handle.
+/// shared `Arc<Mutex<...>>` at construction and merges the turn's delta
+/// back on drop so bucket counters persist across `process_message` /
+/// `run_task` calls for sessions that attach a persistent retry-state
+/// handle.
 ///
 /// The loop body accesses the owned `state` field via `Deref`/`DerefMut`
 /// so existing code keeps its `&mut retry_state` call pattern.
@@ -266,16 +267,38 @@ pub(crate) enum LoopErrorAction {
 /// nowhere on drop.
 struct PersistentRetryStateGuard {
     state: super::loop_state::LoopRetryState,
+    /// Snapshot taken at construction. `Drop` merges only the delta the
+    /// loop applied on top of it, and skips the write entirely when the
+    /// loop left the state untouched, so a clean turn can never clobber a
+    /// concurrent turn's increments (#1655).
+    loaded: super::loop_state::LoopRetryState,
     handle: Option<Arc<std::sync::Mutex<super::loop_state::LoopRetryState>>>,
+}
+
+/// Lock the shared retry state. A panicked prior holder poisons the mutex;
+/// recover the inner state with a warning instead of silently swallowing
+/// the corruption signal (#1655).
+fn lock_persistent_retry_state(
+    handle: &Arc<std::sync::Mutex<super::loop_state::LoopRetryState>>,
+) -> std::sync::MutexGuard<'_, super::loop_state::LoopRetryState> {
+    handle.lock().unwrap_or_else(|poisoned| {
+        warn!("persistent retry state mutex poisoned; recovering inner state");
+        poisoned.into_inner()
+    })
 }
 
 impl PersistentRetryStateGuard {
     fn new(handle: Option<Arc<std::sync::Mutex<super::loop_state::LoopRetryState>>>) -> Self {
         let state = handle
             .as_ref()
-            .map(|h| h.lock().unwrap_or_else(|e| e.into_inner()).clone())
+            .map(|h| lock_persistent_retry_state(h).clone())
             .unwrap_or_default();
-        Self { state, handle }
+        let loaded = state.clone();
+        Self {
+            state,
+            loaded,
+            handle,
+        }
     }
 }
 
@@ -295,8 +318,9 @@ impl std::ops::DerefMut for PersistentRetryStateGuard {
 impl Drop for PersistentRetryStateGuard {
     fn drop(&mut self) {
         if let Some(handle) = &self.handle {
-            let mut locked = handle.lock().unwrap_or_else(|e| e.into_inner());
-            *locked = self.state.clone();
+            if self.state != self.loaded {
+                lock_persistent_retry_state(handle).merge_turn_delta(&self.loaded, &self.state);
+            }
         }
     }
 }

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6733,3 +6733,118 @@ async fn non_empty_max_tokens_returns_content_unchanged() {
     .await;
     assert_eq!(content, "partial but real");
 }
+
+// --- PersistentRetryStateGuard shared-handle write-back (#1655) ---
+
+#[test]
+fn should_not_write_back_when_turn_left_retry_state_unmodified() {
+    // A turn that observed no errors must not touch the shared handle at
+    // all: a concurrent turn's increments landed after this guard loaded,
+    // and an unconditional write-back would silently discard them.
+    let handle = Arc::new(StdMutex::new(LoopRetryState::default()));
+    let guard = PersistentRetryStateGuard::new(Some(handle.clone()));
+
+    // Concurrent turn observes two rate-limits while `guard` is alive.
+    {
+        let mut shared = handle.lock().unwrap();
+        shared.counters.rate_limited = 2;
+    }
+
+    drop(guard);
+    assert_eq!(
+        handle.lock().unwrap().counters.rate_limited,
+        2,
+        "clean turn must not clobber concurrent increments"
+    );
+}
+
+#[test]
+fn should_preserve_both_turns_increments_when_turns_overlap() {
+    // Two turns sharing one handle, each observing different errors from
+    // the same base: the merged state must reflect BOTH turns' increments,
+    // so a bucket that crossed its limit cannot be rolled back to a
+    // pre-exhaustion count by the later drop.
+    let handle = Arc::new(StdMutex::new(LoopRetryState::default()));
+    let mut turn_a = PersistentRetryStateGuard::new(Some(handle.clone()));
+    let mut turn_b = PersistentRetryStateGuard::new(Some(handle.clone()));
+
+    turn_a.counters.rate_limited += 2;
+    turn_b.counters.rate_limited += 1;
+    turn_b.counters.network += 3;
+
+    drop(turn_a);
+    drop(turn_b);
+
+    let shared = handle.lock().unwrap();
+    assert_eq!(shared.counters.rate_limited, 3);
+    assert_eq!(shared.counters.network, 3);
+}
+
+#[test]
+fn should_write_back_exact_state_when_no_concurrent_writer() {
+    // Single-agent regression: with no concurrent writer the drop must
+    // reproduce today's byte-for-byte write-back, including the grace-call
+    // reset of `productive_tool_calls_since_last_grace` (a non-monotonic
+    // field, so a naive max-merge would corrupt it).
+    let handle = Arc::new(StdMutex::new(LoopRetryState {
+        productive_tool_calls_since_last_grace: 3,
+        ..Default::default()
+    }));
+    {
+        let mut guard = PersistentRetryStateGuard::new(Some(handle.clone()));
+        guard.observe_budget_exhaustion(); // fires the grace call, resets the counter
+        guard.counters.timeout += 1;
+    }
+
+    let shared = handle.lock().unwrap();
+    assert_eq!(shared.productive_tool_calls_since_last_grace, 0);
+    assert_eq!(shared.grace_calls_fired, 1);
+    assert_eq!(shared.counters.timeout, 1);
+}
+
+#[test]
+fn should_recover_state_from_poisoned_retry_state_mutex() {
+    // A panic while holding the lock poisons the mutex; the guard must
+    // still recover the inner state (with a warning) rather than panic or
+    // discard it.
+    let handle = Arc::new(StdMutex::new(LoopRetryState {
+        grace_calls_fired: 7,
+        ..Default::default()
+    }));
+    let poisoned = handle.clone();
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _guard = poisoned.lock().unwrap();
+        panic!("simulated panic while holding the retry-state lock");
+    }));
+    assert!(handle.is_poisoned());
+
+    let guard = PersistentRetryStateGuard::new(Some(handle.clone()));
+    assert_eq!(guard.grace_calls_fired, 7);
+    drop(guard);
+    assert_eq!(
+        handle
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .grace_calls_fired,
+        7
+    );
+
+    // A DIRTY guard must also recover on drop: the write-back path takes
+    // the same poisoned lock and must merge, not panic.
+    {
+        let mut dirty = PersistentRetryStateGuard::new(Some(handle.clone()));
+        dirty.counters.timeout += 1;
+    }
+    let shared = handle.lock().unwrap_or_else(|e| e.into_inner());
+    assert_eq!(shared.grace_calls_fired, 7);
+    assert_eq!(shared.counters.timeout, 1);
+}
+
+#[test]
+fn should_write_nowhere_when_no_handle_attached() {
+    // Legacy reset-per-turn behaviour: without a handle the guard owns a
+    // fresh state and its drop touches nothing.
+    let mut guard = PersistentRetryStateGuard::new(None);
+    guard.counters.internal += 1;
+    drop(guard); // must not panic
+}

--- a/crates/octos-agent/src/agent/loop_state.rs
+++ b/crates/octos-agent/src/agent/loop_state.rs
@@ -206,6 +206,65 @@ pub struct LoopRetryCounters {
     pub shell_spiral: u32,
 }
 
+impl LoopRetryCounters {
+    /// Add another turn's per-bucket increments (`turn` relative to the
+    /// `base` it loaded from) onto `self` (#1655). Buckets only ever
+    /// increment, so `saturating_sub` yields the turn's own increments and
+    /// two overlapping turns both land in the merged state.
+    fn saturating_add_turn_delta(&mut self, base: &Self, turn: &Self) {
+        self.rate_limited = self
+            .rate_limited
+            .saturating_add(turn.rate_limited.saturating_sub(base.rate_limited));
+        self.context_overflow = self
+            .context_overflow
+            .saturating_add(turn.context_overflow.saturating_sub(base.context_overflow));
+        self.authentication = self
+            .authentication
+            .saturating_add(turn.authentication.saturating_sub(base.authentication));
+        self.quota = self
+            .quota
+            .saturating_add(turn.quota.saturating_sub(base.quota));
+        self.invalid_request = self
+            .invalid_request
+            .saturating_add(turn.invalid_request.saturating_sub(base.invalid_request));
+        self.content_filtered = self
+            .content_filtered
+            .saturating_add(turn.content_filtered.saturating_sub(base.content_filtered));
+        self.provider_unavailable = self.provider_unavailable.saturating_add(
+            turn.provider_unavailable
+                .saturating_sub(base.provider_unavailable),
+        );
+        self.network = self
+            .network
+            .saturating_add(turn.network.saturating_sub(base.network));
+        self.timeout = self
+            .timeout
+            .saturating_add(turn.timeout.saturating_sub(base.timeout));
+        self.tool_execution = self
+            .tool_execution
+            .saturating_add(turn.tool_execution.saturating_sub(base.tool_execution));
+        self.plugin_spawn = self
+            .plugin_spawn
+            .saturating_add(turn.plugin_spawn.saturating_sub(base.plugin_spawn));
+        self.plugin_timeout = self
+            .plugin_timeout
+            .saturating_add(turn.plugin_timeout.saturating_sub(base.plugin_timeout));
+        self.plugin_protocol = self
+            .plugin_protocol
+            .saturating_add(turn.plugin_protocol.saturating_sub(base.plugin_protocol));
+        self.delegate_depth_exceeded = self.delegate_depth_exceeded.saturating_add(
+            turn.delegate_depth_exceeded
+                .saturating_sub(base.delegate_depth_exceeded),
+        );
+        self.internal = self
+            .internal
+            .saturating_add(turn.internal.saturating_sub(base.internal));
+        self.shell_spiral = self
+            .shell_spiral
+            .saturating_add(turn.shell_spiral.saturating_sub(base.shell_spiral));
+    }
+}
+
 /// Loop-level retry state machine. Owns one bounded counter per
 /// [`HarnessError`] variant plus the shell-spiral synthetic bucket, and
 /// tracks grace-call eligibility.
@@ -318,6 +377,34 @@ impl LoopRetryState {
     /// `record_productive_tool_call`.
     pub fn counters(&self) -> LoopRetryCounters {
         self.counters
+    }
+
+    /// Merge the delta one turn applied on top of `base` (the state that
+    /// turn loaded) into `self`, which a concurrent turn may have advanced
+    /// since the load (#1655). Bucket counters and `grace_calls_fired` are
+    /// monotonic, so the turn's increments add onto whatever `self` holds
+    /// now — a later write-back can no longer roll a bucket back below a
+    /// count an earlier turn already reached.
+    /// `productive_tool_calls_since_last_grace` is NOT monotonic (a grace
+    /// call resets it to zero), so its delta is applied with signed
+    /// saturation. `limits` is static configuration, taken from `turn` —
+    /// identical to the legacy whole-state write-back in every real flow.
+    ///
+    /// When `self == base` (no concurrent writer) the result is exactly
+    /// `turn`, keeping single-agent behaviour byte-identical.
+    pub fn merge_turn_delta(&mut self, base: &Self, turn: &Self) {
+        self.counters
+            .saturating_add_turn_delta(&base.counters, &turn.counters);
+        self.grace_calls_fired = self.grace_calls_fired.saturating_add(
+            turn.grace_calls_fired
+                .saturating_sub(base.grace_calls_fired),
+        );
+        let productive_delta = i64::from(turn.productive_tool_calls_since_last_grace)
+            - i64::from(base.productive_tool_calls_since_last_grace);
+        self.productive_tool_calls_since_last_grace =
+            (i64::from(self.productive_tool_calls_since_last_grace) + productive_delta)
+                .clamp(0, i64::from(u32::MAX)) as u32;
+        self.limits = turn.limits;
     }
 
     /// Emit a structured `HarnessEventPayload::Retry` event carrying the
@@ -764,5 +851,67 @@ mod tests {
         for err in samples {
             let _ = state.observe(&err);
         }
+    }
+
+    #[test]
+    fn merge_turn_delta_adds_increments_onto_concurrently_advanced_state() {
+        // Two turns loaded the same base; each bumped different buckets.
+        // Merging turn B's delta onto the state turn A already wrote must
+        // preserve BOTH turns' increments (#1655).
+        let base = LoopRetryState::default();
+        let mut turn = base.clone();
+        turn.counters.rate_limited = 1;
+        turn.counters.network = 3;
+
+        let mut shared = LoopRetryState {
+            counters: LoopRetryCounters {
+                rate_limited: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        shared.merge_turn_delta(&base, &turn);
+        assert_eq!(shared.counters.rate_limited, 3);
+        assert_eq!(shared.counters.network, 3);
+    }
+
+    #[test]
+    fn merge_turn_delta_applies_grace_reset_as_negative_delta() {
+        // `productive_tool_calls_since_last_grace` resets to zero when a
+        // grace call fires — the one non-monotonic field. Its delta must
+        // subtract, not clamp at the base.
+        let base = LoopRetryState {
+            productive_tool_calls_since_last_grace: 3,
+            ..Default::default()
+        };
+        let mut turn = base.clone();
+        turn.observe_budget_exhaustion(); // grace: resets the counter, fires once
+
+        let mut shared = base.clone();
+        shared.merge_turn_delta(&base, &turn);
+        assert_eq!(shared.productive_tool_calls_since_last_grace, 0);
+        assert_eq!(shared.grace_calls_fired, 1);
+    }
+
+    #[test]
+    fn merge_turn_delta_is_identity_without_concurrent_writer() {
+        // Single-agent regression (#1655): when the shared state still
+        // equals what the turn loaded, the merge reproduces the turn's
+        // state exactly — byte-identical to the legacy write-back.
+        let base = LoopRetryState {
+            counters: LoopRetryCounters {
+                timeout: 2,
+                ..Default::default()
+            },
+            productive_tool_calls_since_last_grace: 4,
+            ..Default::default()
+        };
+        let mut turn = base.clone();
+        turn.counters.timeout = 3;
+        turn.observe_budget_exhaustion();
+
+        let mut shared = base.clone();
+        shared.merge_turn_delta(&base, &turn);
+        assert_eq!(shared, turn);
     }
 }

--- a/crates/octos-agent/tests/retry_state_persistence.rs
+++ b/crates/octos-agent/tests/retry_state_persistence.rs
@@ -180,10 +180,97 @@ async fn should_reset_to_default_when_no_handle_attached() {
     );
 }
 
-// Silence "unused" warning for the LlmError import without suppressing
-// the unused_imports lint for the whole file — we need the type in scope
-// for the session-summary fixtures if they get added here later.
-#[allow(dead_code)]
-fn _force_llm_error_import() -> LlmError {
-    LlmError::new(LlmErrorKind::Authentication, "x")
+/// Provider whose first two `chat` calls rendezvous at a barrier and then
+/// fail with a timeout error, so two concurrent turns are guaranteed to be
+/// mid-flight (guards constructed, nothing written back yet) before either
+/// turn's first error is observed. The error is deliberately a Timeout with
+/// a message that matches none of the stream layer's retryable substrings,
+/// so it bubbles to the agent loop's retry-bucket machine on the FIRST
+/// failure instead of being retried transparently inside `call_llm`.
+struct BarrierTimeoutProvider {
+    barrier: Arc<tokio::sync::Barrier>,
+    chat_calls: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[async_trait]
+impl LlmProvider for BarrierTimeoutProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        let call = self
+            .chat_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if call < 2 {
+            self.barrier.wait().await;
+            return Err(LlmError::new(LlmErrorKind::Timeout, "provider deadline hit").into());
+        }
+        Ok(ChatResponse {
+            content: Some("ok".to_string()),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    fn context_window(&self) -> u32 {
+        128_000
+    }
+
+    fn model_id(&self) -> &str {
+        "barrier-timeout"
+    }
+
+    fn provider_name(&self) -> &str {
+        "barrier-timeout"
+    }
+}
+
+#[tokio::test]
+async fn should_merge_concurrent_agents_increments_through_real_turns() {
+    // #1655 end-to-end: two agents wired to the SAME persistent handle run
+    // real `process_message` turns concurrently; each turn observes exactly
+    // one timeout error. Pre-fix, the later guard drop overwrote the shared
+    // state with its own snapshot and one increment was lost (final counter
+    // 1); post-fix both deltas merge (final counter 2).
+    let state = Arc::new(Mutex::new(LoopRetryState::new()));
+    let provider: Arc<dyn LlmProvider> = Arc::new(BarrierTimeoutProvider {
+        barrier: Arc::new(tokio::sync::Barrier::new(2)),
+        chat_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+    });
+
+    let build = || async {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let memory = Arc::new(
+            EpisodeStore::open(tmp.path())
+                .await
+                .expect("open episode store"),
+        );
+        let tools = octos_agent::ToolRegistry::new();
+        Agent::new(
+            AgentId::new("test-retry-concurrent"),
+            provider.clone(),
+            tools,
+            memory,
+        )
+        .with_persistent_retry_state(state.clone())
+    };
+    let agent_a = build().await;
+    let agent_b = build().await;
+
+    let (result_a, result_b) = tokio::join!(
+        agent_a.process_message("a", &[], vec![]),
+        agent_b.process_message("b", &[], vec![]),
+    );
+    assert_eq!(result_a.expect("turn a").content, "ok");
+    assert_eq!(result_b.expect("turn b").content, "ok");
+    assert_eq!(
+        state.lock().unwrap().counters().timeout,
+        2,
+        "both concurrent turns' timeout increments must survive"
+    );
 }


### PR DESCRIPTION
## Problem

`PersistentRetryStateGuard` (the RAII guard that hydrates `LoopRetryState` from a session's shared `Arc<Mutex<…>>` and writes it back on drop) overwrote the shared state **unconditionally** with its local snapshot. Two overlapping turns sharing one handle (the scenario the session actor's persistent retry state is built for) silently lost each other's bucket increments — the later drop won, so a bucket that should have reached `Exhausted` could be rolled back to `Continue`, allowing retries past the configured limit. Poisoned mutexes were also recovered silently via `unwrap_or_else(|e| e.into_inner())` at both hydrate and write-back, swallowing the corruption signal.

## Root cause

The guard kept no record of what it loaded, so on drop it had no way to distinguish "I changed nothing" from "I own the whole state". Any write-back was necessarily a full overwrite of whatever the shared handle held at that moment — including a concurrent turn's increments.

Note: the issue's proposed literal check (`if *locked != self.state`) does not fix this — when a concurrent turn advanced the shared state, that predicate is true even for a *clean* turn, so the clobber still happens.

## Fix

- The guard snapshots the state it loaded. On drop:
  - **clean turn** (`state == loaded`): no write at all — a turn that observed no errors can never clobber a concurrent turn's increments;
  - **dirty turn**: `LoopRetryState::merge_turn_delta(loaded, state)` merges only this turn's delta onto the **live** shared state. Bucket counters and `grace_calls_fired` are monotonic, so each turn's increments add onto whatever the shared state holds now; `productive_tool_calls_since_last_grace` (reset to 0 by a grace call — the one non-monotonic field) is merged with signed (i64, clamped) saturation; `limits` is static configuration and is taken from the turn, matching the legacy write-back.
- When no concurrent writer touched the handle, the merge reduces exactly to the turn's state — single-agent behaviour is byte-identical (asserted by test).
- Poisoned-mutex recovery now goes through one helper that emits `tracing::warn!` at both hydrate (`new`) and write-back (`drop`).

## Test evidence

- New unit tests (red pre-fix, green post-fix):
  - `should_not_write_back_when_turn_left_retry_state_unmodified` — pre-fix: concurrent increments clobbered to 0.
  - `should_preserve_both_turns_increments_when_turns_overlap` — pre-fix: final counter 1 instead of 3.
  - `should_write_back_exact_state_when_no_concurrent_writer` — single-agent regression, incl. the grace-call reset of the non-monotonic counter.
  - `should_recover_state_from_poisoned_retry_state_mutex` — recovery at hydrate **and** at dirty write-back.
  - `merge_turn_delta_*` (3 tests) — merge semantics, negative-delta grace reset, identity without concurrent writer.
- **End-to-end** (`tests/retry_state_persistence.rs::should_merge_concurrent_agents_increments_through_real_turns`): two real `Agent`s share one persistent handle via the public `with_persistent_retry_state`; a barrier-backed mock provider guarantees both `process_message` turns are mid-flight when each observes one timeout error. **Pre-fix: shared counter ends at 1 (lost increment); post-fix: 2.** Verified both directions by stashing the source change.
- `cargo test -p octos-agent --no-fail-fast`: all test targets pass except 4 pre-existing environment/load failures, each reproduced or root-caused on clean `origin/main` and unrelated to this diff: 3 Docker-sandbox validator tests fail identically on `origin/main` (no Docker backend on this machine); `plugins::tool::tests::execute_preserves_plugin_structured_metadata` is the known flake tracked in #2093; `domain_hook` (hook 5s timeouts) and `exec_session_captures_all_output_when_process_exits_at_deadline` (a by-design 5ms-yield timing race) fail only under full-suite parallel load and pass in isolation on both `origin/main` and this branch.
- `cargo fmt --all -- --check`: clean. `cargo clippy -p octos-agent --all-targets -- -D warnings`: clean.

## Review

- Self-review of the full diff: scope strictly limited to the guard + merge + tests; no debug residue, no unrelated changes.
- Independent review by a fresh reviewer agent (issue text + diff only): no blockers; it confirmed the delta-merge is correct against every interleaving it could construct and that the single-agent path is provably byte-identical. Its findings were addressed (rustfmt violation fixed; poisoned-drop test coverage extended) or explicitly rejected with reason (asserting the `warn!` emission itself would require adding a tracing dev-dependency the crate's tests don't use; monotonicity-by-convention of the public counter fields predates this change).

Closes #1655