### PR TITLE
docs: remove stale LRU tool-deferral claims after RFC-0

### DIFF
--- a/ORG-README.md
+++ b/ORG-README.md
@@ -20,7 +20,7 @@ Connect your LLM API keys and messaging channels. Octos handles conversation rou
 - **Multi-tenant** — 200+ profiles on 16GB. Each profile is an isolated OS process. Family Plan sub-accounts
 - **Multi-LLM pipelines** — DOT graph workflows. Per-node model selection. Dynamic parallel fan-out
 - **Adaptive routing** — 3-layer failover with Hedge racing, Lane scoring, and circuit breakers
-- **LRU tool deferral** — 15 active tools for fast LLM reasoning, 34+ available on demand
+- **Profile-scoped tool surface** — every enabled tool's schema is sent each turn; the `coding` profile narrows the set, `coding-full` restores it
 - **14 channels** — Telegram, Discord, Slack, WhatsApp, Feishu, Email, WeCom, WeChat, Matrix, QQ Bot, Twilio, API, CLI
 - **3-layer memory** — Long-term (entity bank), episodic (task outcomes in redb), session (JSONL + LLM compaction)
 - **5 queue modes** — Followup, Collect, Steer, Interrupt, Speculative — per-session agent concurrency control

--- a/README-zh.md
+++ b/README-zh.md
@@ -30,7 +30,7 @@ Octos 是一个开源 AI Agent 平台，能将任何 LLM 变成多频道、多�
 - **多 LLM DOT 流水线**：DOT 图定义工作流。逐节点模型选择。动态并行扇出，带有限流以保证 Fleet 稳定性。
 - **Swarm 调度器**：将契约扇出到 N 个子 Agent，聚合产物，通过校验器审核，汇总成本——已接入 `/api/swarm/dispatch`。
 - **3 层提供者故障转移**：RetryProvider → ProviderChain → AdaptiveRouter。Hedge 竞速、Lane 评分、熔断器。
-- **LRU 工具延迟加载**：约 15 个活跃工具，约 50 个按需可用。空闲工具自动淘汰。`spawn_only` 工具自动转后台执行。
+- **静态、按配置收窄的工具面**：每轮向模型发送全部已启用工具的完整 schema（无动态淘汰——prompt 前缀保持缓存稳定）。`coding` 等运行时配置可收窄启用集合，`coding-full` 恢复完整工具面。`spawn_only` 工具自动转后台执行。
 - **5 种队列模式**：Followup、Collect、Steer、Interrupt、Speculative——通过 `/queue` 控制 Agent 并发。
 - **任意频道会话控制**：`/new`、`/s <名称>`、`/sessions`、`/back`——在 Telegram、Discord、Slack、WhatsApp、Matrix、飞书中可用。
 - **Sticky thread_id + committed_seq**：每个 SSE 事件都绑定到 thread；按提交序号确定性回放（M8.10）。

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Most agentic systems are single-tenant chat assistants — one user, one model, 
 - **Multi-LLM DOT pipelines**: Define workflows as DOT graphs. Per-node model selection. Dynamic parallel fan-out spawns N concurrent workers at runtime, with bounded concurrency for fleet stability.
 - **Multi-agent topologies**: sub-agents (in-process children you own), peer agents (sovereign sibling sessions via `peer_handoff`/`peer_gather`), and a **swarm dispatcher** (fan contracts to N workers — native or external `claude -p`/`codex exec` — validator-gated, cost rolled up, at `/api/swarm/dispatch`). See [Agent topologies](#agent-topologies-sub-agents-peers--swarm).
 - **3-layer provider failover**: RetryProvider → ProviderChain → AdaptiveRouter. Hedge racing, lane scoring, circuit breakers.
-- **LRU tool deferral**: ~15 active tools for fast LLM reasoning, ~50 on demand. Idle tools auto-evict. `spawn_only` tools auto-redirect to background execution.
+- **Static, profile-scoped tool surface**: every enabled tool's full schema is sent to the LLM each turn (no dynamic eviction — the prompt prefix stays cache-stable). Runtime profiles such as `coding` narrow the enabled set; `coding-full` restores the broad surface. `spawn_only` tools auto-redirect to background execution.
 - **5 queue modes per session**: Followup, Collect, Steer, Interrupt, Speculative — users control agent concurrency via `/queue`.
 - **Session control in any channel**: `/new`, `/s <name>`, `/sessions`, `/back` — works in Telegram, Discord, Slack, WhatsApp, DingTalk, Matrix, Feishu.
 - **Sticky thread_id + committed_seq**: Every SSE event is bound to a thread; replay is deterministic by committed sequence number (M8.10).
@@ -644,7 +644,7 @@ Runtime view:
          ├── LLM Provider (Anthropic, OpenAI, Gemini, DeepSeek, Moonshot, …)
          │   └── AdaptiveRouter → ProviderChain → RetryProvider
          ├── Tool Registry (~50 built-in + plugins + 8 app-skills)
-         │   └── LRU Deferral (~15 active, activate on demand)
+         │   └── Full enabled set emitted per turn (profiles narrow it)
          ├── Pipeline Engine (DOT graphs, per-node model, bounded fan-out)
          ├── Swarm Dispatcher (fan-out → aggregate → validator gate → cost rollup)
          ├── Sandbox (bwrap / Landlock+seccomp / sandbox-exec / Docker / AppContainer)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -683,7 +683,6 @@ pub struct ToolResult {
 | **configure_tool** | tool, settings | Per-tool runtime config overrides (source: `tools/tool_config.rs`) |
 | **delegate_task** | … | Scoped child agent (M8.7 sub-agent output router) |
 | **check_background_tasks** | — | Inspect outstanding background / `spawn_only` tasks held by `task_supervisor` |
-| **activate_tools** | groups | Pull deferred LRU-evicted tools back into the active registry |
 | **check_workspace_contract** | — | Verify the worktree against `workspace_contract.rs` invariants |
 | **workspace_log** | project, limit? | Git `log --oneline --all -n <limit>` for a workspace project (e.g. `slides/my-deck`, `sites/blog`). Default `limit=20`, capped at 100. Source: `tools/workspace_history.rs:101`. |
 | **workspace_show** | project, commit, file | Read a file at a specific commit (`git show <commit>:<file>`). All three fields required. Source: `tools/workspace_history.rs:199`. |
@@ -983,7 +982,7 @@ Plugin tools marked `spawn_only: true` in `manifest.json` are auto-intercepted d
 
 **Mechanism** (`execution.rs`): When a tool call targets a `spawn_only` tool, the execution loop wraps it in a background tokio task. The tool runs directly (not via a subagent LLM), and any `files_to_send` in the result are auto-dispatched via the session's outbound channel.
 
-**Visibility**: spawn_only tools remain visible in tool specs (the LLM can see and call them). They are protected from LRU eviction via `base_tools`.
+**Visibility**: spawn_only tools remain visible in tool specs (the LLM can see and call them) for the life of the session — there is no recency-based eviction that could hide them.
 
 ### Progress Reporting
 
@@ -1325,7 +1324,7 @@ Two first-class runtime types make profile scope and session scope explicit:
      6. Open per-session `SessionManager` at `<profile.data_dir>/users/<key>/`.
    - Cache hit → return existing `Arc<SessionRuntime>`.
 
-**Bootstrap path is shared between serve and gateway.** Both `commands/serve.rs::run_async` and the `ProcessManager`-spawned `octos gateway` subprocess call `ProfileRuntime::bootstrap` for per-profile state (memory, memory_store, tool_config, credentials, plugin env). Gateway-specific composition (`SwappableProvider`, `provider_router`, `SwitchModelTool`, admin tools, auto-defer, `pipeline_factory`, gateway tool-registry layering) stays as composition ON TOP of the profile runtime — nothing duplicates the LLM/credentials/skills/plugin assembly the runtime owns.
+**Bootstrap path is shared between serve and gateway.** Both `commands/serve.rs::run_async` and the `ProcessManager`-spawned `octos gateway` subprocess call `ProfileRuntime::bootstrap` for per-profile state (memory, memory_store, tool_config, credentials, plugin env). Gateway-specific composition (`SwappableProvider`, `provider_router`, `SwitchModelTool`, admin tools, `pipeline_factory`, gateway tool-registry layering) stays as composition ON TOP of the profile runtime — nothing duplicates the LLM/credentials/skills/plugin assembly the runtime owns.
 
 **Why this exists.** Before M11, `octos serve` ran a server-wide embedded `Agent` constructed by a no-longer-present `try_create_agent`. The agent had no notion of profile or session scope. A series of PRs (#866 / #867 / #868 / #869, all 2026-05-10) retrofitted profile awareness one transient `Config` field at a time. M11 replaced the embedded agent with the two-scope model and M11-F deleted the last of the overlay machinery. See the ADR for the full incident trail.
 
@@ -1529,7 +1528,7 @@ crates/
 │                        grep_tool, web_search, web_fetch, message,
 │                        spawn, delegate, browser, ssrf,
 │                        check_background_tasks, tool_config,
-│                        activate_tools, check_workspace_contract,
+│                        check_workspace_contract,
 │                        deep_search, site_crawl  (registers as deep_crawl),
 │                        recall_memory, save_memory, send_file,
 │                        code_structure, git, synthesize_research,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -83,7 +83,6 @@ cargo test -p octos-llm test_qos_ranking_changes_lane_selection -- --nocapture
 cargo test -p octos-llm test_derive_cold_start_catalog_assigns_non_zero_scores -- --nocapture
 cargo test -p octos-llm test_compatible_fallbacks_prefers_lower_seeded_qos_score -- --nocapture
 cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
-cargo test -p octos-agent --test activate_tools_regression -- --nocapture
 
 # 3. Focused M9 Rust tests.
 cargo test -p octos-core ui_protocol -- --nocapture

--- a/docs/app-skill-dev-guide-zh.md
+++ b/docs/app-skill-dev-guide-zh.md
@@ -217,7 +217,7 @@ console.log(JSON.stringify({ output: result, success: true }));
 3. 技能二进制在后台运行至完成，期间发送协议 v2 事件；
 4. 完成（或失败）时，监督者提交带 `committed_seq` 的 `session_result` 事件，必要时按 M8.9 运行时失败恢复重新驱动 LLM。
 
-`spawn_only` 工具不会被 LRU 工具寄存器淘汰；其 `SKILL.md` 自动注入到系统提示，让 LLM 知道如何调用。
+`spawn_only` 工具在会话全程对模型可见；其 `SKILL.md` 自动注入到系统提示，让 LLM 知道如何调用。
 
 ---
 

--- a/docs/app-skill-dev-guide.md
+++ b/docs/app-skill-dev-guide.md
@@ -1024,7 +1024,7 @@ The host resolves these keys from the active profile's auth store and passes the
 3. The skill binary runs to completion in the background, emitting protocol v2 events.
 4. On completion (or failure), the supervisor commits a `session_result` event with `committed_seq` and re-engages the LLM if needed (M8.9 runtime failure recovery).
 
-`spawn_only` tools cannot be evicted from the LRU tool registry, and their `SKILL.md` is auto-injected into the system prompt so the LLM knows how to use them.
+`spawn_only` tools stay visible in the tool specs for the life of the session, and their `SKILL.md` is auto-injected into the system prompt so the LLM knows how to use them.
 
 ### Multiple Tools in One Skill
 

--- a/docs/harness-context-efficiency.md
+++ b/docs/harness-context-efficiency.md
@@ -16,7 +16,7 @@ A published observation: the same model at the same reasoning effort, run on Cla
 | Per-turn injected extras | none | episodic recall ≤6 episodes (embedder-gated) |
 | **Fixed total** | **≈1.3 K tok** | **≈10.4–13.5 K tok** |
 
-The dominant octos cost is tool-schema emission. **RFC-0 (#1578) removed LRU tool deferral**, so `specs()` (`tools/registry.rs:661-665`) emits every enabled schema every round; the old 15-active/34-deferred behavior described in CLAUDE.md no longer exists. A `tools>25` warning exists but only logs (`loop_runner.rs:1022`).
+The dominant octos cost is tool-schema emission. **RFC-0 (#1289) removed LRU tool deferral**, so `specs()` (`tools/registry.rs`) emits every enabled schema every round; the old 15-active/34-deferred behavior no longer exists. A `tools>25` warning exists but only logs (`agent/loop_runner.rs`).
 
 For scale: `octos gateway` swaps in an 18 KB system prompt (≈4.5 K tok) on top of the same tool wall.
 

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -55,7 +55,7 @@ octos serve（控制面板 + 仪表盘，约 140 个 REST 端点）
        │
        ├── LLM 提供商（15 家，AdaptiveRouter → ProviderChain → RetryProvider）
        ├── 工具注册表（约 50 个内置 + 插件 + 9 个用户级 app-skill）
-       │      LRU 延迟加载保留约 15 个活跃；spawn_only 自动转后台
+       │      每轮发送全部已启用工具；spawn_only 自动转后台
        ├── 沙箱（bwrap / sandbox-exec / Docker / Windows AppContainer）
        ├── Pipeline 引擎（DOT 图，逐节点模型，限流扇出）
        ├── Swarm 调度器（/api/swarm/dispatch — 扇出到 N 个子 Agent）

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,7 +55,7 @@ octos serve (control plane + dashboard, ~140 REST endpoints)
        │
        ├── LLM Provider (15 providers via AdaptiveRouter → ProviderChain → RetryProvider)
        ├── Tool Registry (~50 built-ins + plugins + 9 user-facing app-skills)
-       │     LRU deferral keeps ~15 active; spawn_only auto-routes to background
+       │     Full enabled tool set sent each turn; spawn_only auto-routes to background
        ├── Sandbox (bwrap / sandbox-exec / Docker / Windows AppContainer)
        ├── Pipeline Engine (DOT graphs, per-node model, bounded fan-out)
        ├── Swarm Dispatcher (/api/swarm/dispatch — fan-out to N sub-agents)


### PR DESCRIPTION
## Problem

RFC-0 (#1289) removed LRU-by-recency tool deferral and the `activate_tools` meta-tool — every enabled tool's schema is now emitted statically each turn, and runtime profiles (`coding` / `coding-full`) narrow or restore the enabled set. Public and architecture docs still described the removed mechanism as a current differentiator:

- README.md / README-zh.md / ORG-README.md "Why Octos" bullets: "LRU tool deferral: ~15 active tools … idle tools auto-evict"
- README.md runtime architecture diagram: "LRU Deferral (~15 active, activate on demand)"
- docs/user-guide.md / user-guide-zh.md diagrams: "LRU deferral keeps ~15 active"
- docs/ARCHITECTURE.md: an `activate_tools` row in the tool table, a nonexistent `activate_tools.rs` in the source-tree listing, the removed auto-defer pass in the gateway composition list, and "protected from LRU eviction via `base_tools`" for spawn_only tools
- docs/app-skill-dev-guide.md (+ zh): "spawn_only tools cannot be evicted from the LRU tool registry"
- docs/TESTING.md: an invocation of the deleted `activate_tools_regression` test
- docs/harness-context-efficiency.md: RFC-0 cited as `#1578` instead of `#1289`

A reader evaluating octos as a coding harness would infer dynamic discovery/eviction behavior the runtime does not have.

## Root cause

Docs drift after RFC-0 (#1289) and the lean `coding` profile (#1641): the code and CLAUDE.md were updated, the user-facing docs were not.

## Fix

Docs-only; no code touched:

- Replace the stale bullets/diagram lines with the actual contract: every enabled tool's full schema is sent to the LLM each turn; profiles such as `coding` narrow the enabled set; `coding-full` restores the broad surface; `spawn_only` tools auto-redirect to background execution.
- Delete references to removed artifacts (the `activate_tools` tool/table row, its source-file listing, its regression-test invocation, the auto-defer pass).
- Reword the spawn_only visibility notes to the current guarantee: visible in `specs()` for the life of the session, no recency-based eviction.
- Correct the RFC-0 reference to `#1289` in docs/harness-context-efficiency.md.

Deliberately left untouched: legitimate historical records (CHANGELOG, ADRs, dated specs/release contracts, the book's explicitly marked "History" callouts) and the *real* session-store LRU cache (`SessionManager`, `SessionRuntimeCache`), which is unrelated to tool deferral.

## Test evidence

Docs-only change, so there is no runtime path whose behavior changes; instead the new wording was verified against the runtime it describes:

- `cargo test -p octos-agent --lib tools::registry` — 55 passed; `specs()` emits every enabled tool each turn (RFC-0 contract, registry.rs).
- `cargo test -p octos-agent --lib profile` — 75 passed, including `coding_profile_narrows_default_tool_set` and `coding_full_profile_produces_same_registry_as_default_builtins` (the two claims the new bullets make).
- `cargo fmt --all -- --check` — clean (no .rs files touched).
- Post-change sweep: no remaining unmarked `LRU deferral` / `activate_tools` / "15 active" claims in README*, ORG-README.md, docs/, book/, book-zh/ outside explicitly-historical material.

## Review

Independent adversarial review pass (given only the issue text and the diff) verified each new claim against the code and confirmed the deletions (no `activate_tools` tool registered, `activate_tools_regression.rs` absent, auto-defer pass gone per profile.rs:1373-1375). Its two actionable findings — stale line refs and a doubly-stale "described in CLAUDE.md" clause in the harness-context-efficiency.md sentence this PR already edits — were fixed (line ranges dropped in favor of file/function names, clause corrected). Out-of-scope observations for follow-up, not addressed here: the module comment at `crates/octos-cli/src/runtime/mod.rs:52` still lists "auto-defer" in the gateway composition list, and `crates/octos-cli/src/api/coding_tool_contract.rs` still catalogs `activate_tools` in its static spec list.

Closes #2107