### PR TITLE
fix(api): accept partial nested-section patches in self-service profile updates

### DIFF
--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -88,8 +88,13 @@ pub struct UpdateProfileRequest {
     pub enabled: Option<bool>,
     #[serde(default)]
     pub data_dir: Option<Option<String>>,
+    /// Parsed as opaque JSON on purpose: the typed round-trip happens in
+    /// `merge_profile_config_from_body` *after* the raw patch is merged over
+    /// the stored config (an invalid merged result is a 400), so a partial
+    /// nested-section patch (e.g. `{"email":{"smtp_host":…}}` without the
+    /// required `provider`) must still parse here (#1470).
     #[serde(default)]
-    pub config: Option<ProfileConfig>,
+    pub config: Option<serde_json::Value>,
     /// Set or update the email address for OTP login.
     #[serde(default)]
     pub email: Option<String>,
@@ -420,7 +425,8 @@ pub async fn update_profile(
     if let Some(data_dir) = req.data_dir {
         profile.data_dir = data_dir;
     }
-    merge_profile_config_from_body(&mut profile.config, &body, false);
+    merge_profile_config_from_body(&mut profile.config, &body, false)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
     // Relocate freshly-entered keychain-backed secrets (e.g. the Vertex SA
     // JSON) into the OS keychain before persisting, so an admin edit can't
     // write a private key into plaintext profile config.
@@ -1286,23 +1292,35 @@ pub(crate) fn merge_profile_config_from_body(
     config: &mut ProfileConfig,
     body: &str,
     env_vars_authoritative: bool,
-) {
+) -> Result<(), String> {
     let raw: serde_json::Value = serde_json::from_str(body).unwrap_or(serde_json::Value::Null);
-    if let Some(config_patch) = raw.get("config") {
-        if config_patch.is_object() {
-            let mut existing = serde_json::to_value(&mut *config).unwrap_or(serde_json::json!({}));
-            json_merge(&mut existing, config_patch);
-            if env_vars_authoritative {
-                if let Some(env_vars) = config_patch.get("env_vars").filter(|v| v.is_object()) {
-                    if let Some(existing_obj) = existing.as_object_mut() {
-                        existing_obj.insert("env_vars".to_string(), env_vars.clone());
-                    }
-                }
-            }
-            if let Ok(merged) = serde_json::from_value(existing) {
-                *config = merged;
+    let Some(config_patch) = raw.get("config") else {
+        return Ok(());
+    };
+    if config_patch.is_null() {
+        return Ok(());
+    }
+    if !config_patch.is_object() {
+        return Err("config must be an object".into());
+    }
+    let mut existing = serde_json::to_value(&mut *config).unwrap_or(serde_json::json!({}));
+    json_merge(&mut existing, config_patch);
+    if env_vars_authoritative {
+        if let Some(env_vars) = config_patch.get("env_vars").filter(|v| v.is_object()) {
+            if let Some(existing_obj) = existing.as_object_mut() {
+                existing_obj.insert("env_vars".to_string(), env_vars.clone());
             }
         }
+    }
+    // The request body parses `config` as opaque JSON (see UpdateProfileRequest),
+    // so this typed round-trip is the only validation gate: an invalid merged
+    // result must surface as an error instead of silently dropping the patch.
+    match serde_json::from_value(existing) {
+        Ok(merged) => {
+            *config = merged;
+            Ok(())
+        }
+        Err(e) => Err(format!("invalid config: {e}")),
     }
 }
 
@@ -5580,7 +5598,8 @@ mod tests {
             &mut config,
             r#"{"config":{"env_vars":{"SMTP_PASSWORD":"new"}}}"#,
             false,
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             config.env_vars.get("SMTP_PASSWORD").map(String::as_str),
@@ -5601,17 +5620,47 @@ mod tests {
         config.env_vars.insert("A".into(), "a".into());
         config.env_vars.insert("B".into(), "b".into());
 
-        merge_profile_config_from_body(&mut config, r#"{"config":{"env_vars":{"A":"a2"}}}"#, true);
+        merge_profile_config_from_body(&mut config, r#"{"config":{"env_vars":{"A":"a2"}}}"#, true)
+            .unwrap();
         assert_eq!(config.env_vars.get("A").map(String::as_str), Some("a2"));
         assert!(
             !config.env_vars.contains_key("B"),
             "authoritative replace drops omitted keys"
         );
 
-        merge_profile_config_from_body(&mut config, r#"{"config":{"env_vars":{}}}"#, true);
+        merge_profile_config_from_body(&mut config, r#"{"config":{"env_vars":{}}}"#, true).unwrap();
         assert!(
             config.env_vars.is_empty(),
             "an explicit empty map clears all entries"
+        );
+    }
+
+    // The request struct parses `config` as opaque JSON, so the merged
+    // typed round-trip is the only validation gate: patches that produce an
+    // invalid config must error (the handlers map this to 400) instead of
+    // silently dropping the patch. A literal `null` config stays a no-op.
+    #[test]
+    fn merge_config_rejects_invalid_patches() {
+        let mut config = ProfileConfig::default();
+        assert!(merge_profile_config_from_body(&mut config, r#"{"config":null}"#, false).is_ok());
+
+        let err =
+            merge_profile_config_from_body(&mut config, r#"{"config":42}"#, false).unwrap_err();
+        assert_eq!(err, "config must be an object");
+
+        // Merges fine as JSON but the result fails ProfileConfig's typed
+        // deserialization (`smtp_port` must be a number).
+        let err = merge_profile_config_from_body(
+            &mut config,
+            r#"{"config":{"email":{"provider":"smtp","smtp_port":"abc"}}}"#,
+            false,
+        )
+        .unwrap_err();
+        assert!(err.starts_with("invalid config:"), "got: {err}");
+        assert_eq!(
+            config,
+            ProfileConfig::default(),
+            "failed merge must not mutate"
         );
     }
 

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -1323,7 +1323,8 @@ pub async fn update_my_profile(
     if let Some(enabled) = req.enabled {
         profile.enabled = enabled;
     }
-    super::admin::merge_profile_config_from_body(&mut profile.config, &body, true);
+    super::admin::merge_profile_config_from_body(&mut profile.config, &body, true)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
     // Relocate freshly-entered keychain-backed secrets (e.g. the Vertex SA JSON,
     // including a private key pasted under a custom env name) into the OS
     // keychain before persisting. Uses the shared content-detecting helper so
@@ -3683,7 +3684,8 @@ pub async fn update_my_sub_account(
     if let Some(enabled) = req.enabled {
         sub.enabled = enabled;
     }
-    super::admin::merge_profile_config_from_body(&mut sub.config, &body, true);
+    super::admin::merge_profile_config_from_body(&mut sub.config, &body, true)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
     // Relocate keychain-backed secrets (e.g. the Vertex SA JSON) before
     // persisting so a sub-account never writes a private key to disk.
     let sub_id = sub.id.clone();
@@ -5736,6 +5738,109 @@ mod tests {
         assert_eq!(home["events"][0]["title"], "Dinner");
     }
 
+    // #1470: the strict `config: Option<ProfileConfig>` parse ran before the
+    // raw body merge, so a partial nested-section patch for a section with
+    // required fields (e.g. `email.provider`) 400'd before the merge could
+    // preserve the stored values.
+    #[tokio::test]
+    async fn my_profile_config_patch_accepts_partial_nested_email() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let mut profile = make_user_profile("tenant", "Tenant Owner");
+        profile.config.email = Some(crate::profiles::EmailSettings {
+            provider: "smtp".into(),
+            smtp_host: Some("smtp1.example.org".into()),
+            smtp_port: Some(587),
+            username: None,
+            password_env: None,
+            password: None,
+            from_address: Some("bot@example.org".into()),
+            feishu_app_id: None,
+            feishu_app_secret_env: None,
+            feishu_app_secret: None,
+            feishu_from_address: None,
+            feishu_region: None,
+        });
+        profile_store.save(&profile).unwrap();
+
+        let Json(resp) = update_my_profile(
+            State(Arc::new(state)),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            serde_json::json!({
+                "config": {
+                    "email": {
+                        "smtp_host": "smtp2.example.org"
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        let email = resp.profile.config.email.expect("email config");
+        assert_eq!(email.provider, "smtp");
+        assert_eq!(email.smtp_host.as_deref(), Some("smtp2.example.org"));
+        assert_eq!(email.smtp_port, Some(587));
+        assert_eq!(email.from_address.as_deref(), Some("bot@example.org"));
+    }
+
+    // The flip side of accepting partial nested patches: a patch that merges
+    // to an INVALID config (here a wrong-typed `smtp_port`) must 400 and
+    // leave the stored config untouched — the post-merge validation error
+    // must not be silently swallowed.
+    #[tokio::test]
+    async fn my_profile_config_patch_rejects_invalid_merged_config() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let mut profile = make_user_profile("tenant", "Tenant Owner");
+        profile.config.email = Some(crate::profiles::EmailSettings {
+            provider: "smtp".into(),
+            smtp_host: Some("smtp1.example.org".into()),
+            smtp_port: Some(587),
+            username: None,
+            password_env: None,
+            password: None,
+            from_address: None,
+            feishu_app_id: None,
+            feishu_app_secret_env: None,
+            feishu_app_secret: None,
+            feishu_from_address: None,
+            feishu_region: None,
+        });
+        profile_store.save(&profile).unwrap();
+
+        let err = update_my_profile(
+            State(Arc::new(state)),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            serde_json::json!({
+                "config": {
+                    "email": {
+                        "smtp_port": "not-a-port"
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .await;
+        let err = match err {
+            Ok(_) => panic!("invalid merged config unexpectedly succeeded"),
+            Err(err) => err,
+        };
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+
+        let stored = profile_store.get("tenant").unwrap().expect("profile");
+        let email = stored.config.email.expect("email config");
+        assert_eq!(email.smtp_host.as_deref(), Some("smtp1.example.org"));
+        assert_eq!(email.smtp_port, Some(587));
+    }
+
     // The config merge preserves sections the client omits (above), but a
     // provided `env_vars` map must still be able to DROP keys and clear the set
     // — otherwise secrets could never be removed via self-service. `env_vars` is
@@ -6023,6 +6128,64 @@ mod tests {
         assert_eq!(home["settings"]["city"], "Kyoto");
         assert_eq!(home["settings"]["clock_format"], "24h");
         assert_eq!(home["events"][0]["title"], "School pickup");
+    }
+
+    // #1470: same partial nested-section patch as above, but through the
+    // parent-managed sub-account endpoint.
+    #[tokio::test]
+    async fn managed_sub_account_config_patch_accepts_partial_nested_email() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let state = AppState {
+            process_manager: Some(Arc::new(crate::process_manager::ProcessManager::new(
+                profile_store.clone(),
+            ))),
+            ..state
+        };
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant Owner"))
+            .unwrap();
+        let mut child = make_user_profile("tenant--assistant", "Assistant");
+        child.parent_id = Some("tenant".into());
+        child.public_subdomain = Some("assistant".into());
+        child.config.email = Some(crate::profiles::EmailSettings {
+            provider: "smtp".into(),
+            smtp_host: Some("smtp1.example.org".into()),
+            smtp_port: None,
+            username: None,
+            password_env: None,
+            password: None,
+            from_address: None,
+            feishu_app_id: None,
+            feishu_app_secret_env: None,
+            feishu_app_secret: None,
+            feishu_from_address: None,
+            feishu_region: None,
+        });
+        profile_store.save(&child).unwrap();
+
+        let Json(resp) = update_my_sub_account(
+            State(Arc::new(state)),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            Path("tenant--assistant".into()),
+            serde_json::json!({
+                "config": {
+                    "email": {
+                        "smtp_host": "smtp2.example.org"
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        let email = resp.profile.config.email.expect("email config");
+        assert_eq!(email.provider, "smtp");
+        assert_eq!(email.smtp_host.as_deref(), Some("smtp2.example.org"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`PUT /api/my/profile` / `PUT /api/my/profile/sub-accounts/{id}` parse the request body as `UpdateProfileRequest`, whose `config: Option<ProfileConfig>` is strict, *before* `merge_profile_config_from_body` runs. A partial nested-section patch like `{"config":{"email":{"smtp_host":"smtp2"}}}` fails deserialization because `EmailSettings.provider` is required, returning 400 before the merge could preserve the stored `provider` (#1470, follow-up to #1467).

## Root cause

The typed `config` field on `UpdateProfileRequest` acted as a pre-merge validation gate, but the actual config update path never reads it — all three handlers (`update_my_profile`, `update_my_sub_account`, and admin `update_profile`, which shares the struct) apply config changes via `merge_profile_config_from_body`, which re-parses the raw body. So the strict parse only rejected patches that the raw merge would have handled correctly.

## Fix

- `UpdateProfileRequest.config` is now `Option<serde_json::Value>`: the body always parses, and the typed round-trip happens in `merge_profile_config_from_body` **after** the raw patch is merged over the stored config.
- `merge_profile_config_from_body` now returns `Result<(), String>`: a non-object `config`, or a patch that merges to an invalid `ProfileConfig` (wrong-typed field, unknown key in a `deny_unknown_fields` section), surfaces as a 400 instead of being silently dropped, and leaves the stored config untouched. A literal `"config": null` remains a no-op.

## Test evidence

Unit/integration (all in `octos-cli`, `--features api`):

- New: `my_profile_config_patch_accepts_partial_nested_email`, `managed_sub_account_config_patch_accepts_partial_nested_email` (red before the fix: `400 missing field provider`; green after), `my_profile_config_patch_rejects_invalid_merged_config` (400 + stored config untouched), `merge_config_rejects_invalid_patches`.
- Full suite: `cargo test -p octos-cli --features api --lib` → 3189 passed; the only failure is `autonomy::agent_orchestrator::tests::sovereignty_provider_fail_open_when_unowned_default_branch`, which fails identically on clean `origin/main` — root-caused to this host's Apple CLT system gitconfig setting `init.defaultBranch=main`, so the test's `git checkout -b main` collides with the branch `git init` already created. Unrelated to this diff.
- `cargo fmt --check` clean; `cargo clippy -p octos-cli --features api --all-targets -- -D warnings` zero warnings.

End-to-end (real `octos serve` binary, real HTTP, fresh data dir, bearer auth):

| Request | Baseline (`origin/main`) | This branch |
|---|---|---|
| PUT full `email` section | 200 | 200 |
| PUT `{"config":{"email":{"smtp_host":"smtp2.example.org"}}}` | **400** `missing field provider` | **200** |
| GET `/api/my/profile` after patch | unchanged | `provider`/`smtp_port`/`from_address` preserved, `smtp_host` updated |
| PUT `{"config":{"email":{"smtp_port":"not-a-port"}}}` | 400 | 400 `invalid config: invalid type: string "not-a-port", expected u16` |
| PUT `{"config":42}` | 400 | 400 `config must be an object` |

## Review

Self-reviewed the full diff line-by-line, then an independent reviewer subagent (issue text + diff only, no shared reasoning) flagged that removing the typed parse gate made the merge's silent-drop failure branch reachable — invalid patches would 200 with the config patch silently dropped. Fixed by making the merge fallible (the 400 rows above) and adding the failure-path tests; all verification re-ran green afterwards.

Closes #1470