### PR TITLE
fix(cli): classify tool_policy edits as restart-required in profile/config watchers (#2217)

### DIFF
--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -362,6 +362,15 @@ impl GatewayRuntime {
             config.hooks = resolved.config.hooks.clone();
             config.memory = resolved.config.memory.clone();
             config.approval_policy = resolved.config.approval_policy.clone();
+            // #2217: thread the inherited tool_policy too — the ConfigWatcher
+            // seed (below) is this flattened `config`, while `parse_first`
+            // re-layers defaults on every edit; a mismatch here would make a
+            // tool_policy-only defaults inheritance look like a policy edit
+            // and emit a spurious restart-required signal. ProfileRuntime
+            // already enforces the resolved policy, so this only aligns the
+            // seed with what runs. Pinned by
+            // config_watcher::tests::inherited_tool_policy_does_not_spuriously_restart_on_unrelated_edit.
+            config.tool_policy = resolved.config.tool_policy.clone();
             // OR-merge signing so neither the env-forced host policy (already
             // merged into `config.plugins` above) nor a defaults signing floor
             // is dropped.

--- a/crates/octos-cli/src/config_watcher.rs
+++ b/crates/octos-cli/src/config_watcher.rs
@@ -276,6 +276,12 @@ impl ConfigWatcher {
         if old.plugins != new.plugins {
             restart_fields.push("plugins".into());
         }
+        // #2217: tool_policy is applied to the tool registry at bootstrap
+        // (`apply_policy`); a live edit never reaches the running registry,
+        // so a policy-only change must surface as restart-required.
+        if old.tool_policy != new.tool_policy {
+            restart_fields.push("tool_policy".into());
+        }
 
         // Queue mode change requires restart (affects message processing loop)
         let old_queue_mode = old.gateway.as_ref().map(|g| &g.queue_mode);
@@ -490,6 +496,152 @@ mod tests {
                 );
             }
             other => panic!("expected RestartRequired, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_require_restart_when_tool_policy_changed() {
+        // #2217: tool_policy is applied to the tool registry at bootstrap
+        // (`apply_policy`), so a policy-only edit must surface as
+        // restart-required — otherwise the running gateway keeps enforcing
+        // the stale allow/deny list with no signal.
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, r#"{"provider": "anthropic"}"#);
+        let old_config = Config::from_file(&path).unwrap();
+
+        std::fs::write(
+            &path,
+            r#"{"provider": "anthropic", "tool_policy": {"deny": ["bash"]}}"#,
+        )
+        .unwrap();
+        let new_config = Config::from_file(&path).unwrap();
+
+        let (tx, rx) = watch::channel(None);
+        let watcher = ConfigWatcher::new(vec![path], old_config, tx);
+        watcher.diff_and_emit(&new_config);
+
+        let change = rx.borrow().clone();
+        match change {
+            Some(ConfigChange::RestartRequired(fields)) => {
+                assert!(
+                    fields.iter().any(|f| f == "tool_policy"),
+                    "expected tool_policy in restart fields, got: {fields:?}"
+                );
+            }
+            other => panic!("expected RestartRequired, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_policy_file_edit_emits_restart_required_via_check() {
+        // #2217: same guarantee through the real polling path — a
+        // tool_policy-only edit to the watched file must be picked up by
+        // `check()` and classified restart-required.
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, r#"{"provider": "anthropic"}"#);
+        let initial = Config::from_file(&path).unwrap();
+
+        let (tx, mut rx) = watch::channel(None);
+        let mut watcher = ConfigWatcher::new(vec![path.clone()], initial, tx);
+
+        std::fs::write(
+            &path,
+            r#"{"provider": "anthropic", "tool_policy": {"deny": ["bash"]}}"#,
+        )
+        .unwrap();
+        watcher.check();
+
+        match rx.borrow_and_update().clone() {
+            Some(ConfigChange::RestartRequired(fields)) => {
+                assert!(
+                    fields.iter().any(|f| f == "tool_policy"),
+                    "a tool_policy-only file edit must emit a tool_policy restart, got {fields:?}"
+                );
+            }
+            other => {
+                panic!("expected RestartRequired(tool_policy) from a file edit, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn inherited_tool_policy_does_not_spuriously_restart_on_unrelated_edit() {
+        // #2217 review: in profile-mode the gateway seeds the watcher with a
+        // flattened config whose tool_policy was ALREADY resolved through
+        // `profile-defaults.json` (the FIX 2 threading in gateway_runtime),
+        // while `parse_first` re-layers the same defaults on every edit. An
+        // unrelated edit must not diff the inherited policy as a change.
+        let dir = TempDir::new().unwrap();
+        let profile_path = dir.path().join("p.json");
+        std::fs::write(&profile_path, PROFILE_JSON).unwrap();
+        let defaults_path = dir.path().join("profile-defaults.json");
+        let defaults = ProfileConfig {
+            tool_policy: Some(octos_agent::ToolPolicy {
+                deny: vec!["bash".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        std::fs::write(&defaults_path, serde_json::to_string(&defaults).unwrap()).unwrap();
+
+        // Seed the way gateway_runtime does post-FIX 2: raw profile-derived
+        // config, with tool_policy threaded from the defaults-resolved view.
+        let buffers = ConfigWatcher::read_files(std::slice::from_ref(&profile_path));
+        let mut seed = ConfigWatcher::parse_first(&buffers, None).unwrap();
+        let resolved = ConfigWatcher::parse_first(&buffers, Some(&defaults)).unwrap();
+        seed.tool_policy = resolved.tool_policy.clone();
+        let (tx, mut rx) = watch::channel(None);
+        let mut watcher =
+            ConfigWatcher::new(vec![profile_path], seed, tx).with_profile_defaults(defaults_path);
+
+        // Unrelated edit: bump only `updated_at` — the file hash changes and
+        // the watcher re-parses, but the flattened config is identical. (A
+        // hot-reloadable edit would mask a spurious RestartRequired: the
+        // watch channel retains only the LAST send, and diff_and_emit emits
+        // HotReload after RestartRequired.)
+        std::fs::write(
+            dir.path().join("p.json"),
+            r#"{"id":"p","name":"p","enabled":true,"config":{},"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-02T00:00:00Z"}"#,
+        )
+        .unwrap();
+        watcher.check();
+
+        if let Some(ConfigChange::RestartRequired(fields)) = rx.borrow_and_update().clone() {
+            panic!(
+                "inherited tool_policy must not diff as changed on an unrelated edit, got {fields:?}"
+            );
+        }
+
+        // Control: the same edit against a watcher seeded WITHOUT the
+        // threading (raw profile-derived config, as gateway_runtime seeded
+        // before the #2217 fix) must surface the false positive — this keeps
+        // the seed construction above load-bearing.
+        let raw_seed = ConfigWatcher::parse_first(
+            &ConfigWatcher::read_files(std::slice::from_ref(&dir.path().join("p.json"))),
+            None,
+        )
+        .unwrap();
+        assert!(
+            raw_seed.tool_policy.is_none(),
+            "control requires the raw profile to carry no tool_policy"
+        );
+        let (tx2, mut rx2) = watch::channel(None);
+        let mut unthreaded = ConfigWatcher::new(vec![dir.path().join("p.json")], raw_seed, tx2)
+            .with_profile_defaults(dir.path().join("profile-defaults.json"));
+        std::fs::write(
+            dir.path().join("p.json"),
+            r#"{"id":"p","name":"p","enabled":true,"config":{},"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-03T00:00:00Z"}"#,
+        )
+        .unwrap();
+        unthreaded.check();
+        match rx2.borrow_and_update().clone() {
+            Some(ConfigChange::RestartRequired(fields)) => {
+                assert!(
+                    fields.iter().any(|f| f == "tool_policy"),
+                    "control: unthreaded seed must false-positive on tool_policy, got {fields:?}"
+                );
+            }
+            other => panic!("control: expected spurious RestartRequired, got {other:?}"),
         }
     }
 

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -3188,7 +3188,8 @@ pub enum ProfileChange {
 /// Compare two profiles and classify the nature of changes.
 ///
 /// Restart-required: llm, review, search, deep_crawl, apps, robot, channels,
-///   env_vars, email, hooks, sandbox, routing, credential_pool, plugins.
+///   env_vars, email, hooks, sandbox, routing, credential_pool, plugins,
+///   tool_policy.
 /// Hot-reloadable: system_prompt, max_history, max_iterations,
 ///   max_concurrent_sessions, browser_timeout_secs.
 pub fn diff_profiles(old: &UserProfile, new: &UserProfile) -> ProfileChange {
@@ -3261,6 +3262,13 @@ pub fn diff_profiles(old: &UserProfile, new: &UserProfile) -> ProfileChange {
     }
     if oc.lane_routing != nc.lane_routing {
         restart_fields.push("lane_routing".into());
+    }
+    // #2217: tool_policy is applied to the tool registry only at bootstrap
+    // (`apply_policy` in gateway setup), so a policy-only edit must trigger
+    // a restart — otherwise the running gateway keeps enforcing the stale
+    // allow/deny list indefinitely, with no signal.
+    if oc.tool_policy != nc.tool_policy {
+        restart_fields.push("tool_policy".into());
     }
 
     if !restart_fields.is_empty() {
@@ -5128,6 +5136,51 @@ mod tests {
         assert!(matches!(
             diff_profiles(&base, &changed),
             ProfileChange::HotReloadable
+        ));
+    }
+
+    #[test]
+    fn test_diff_profiles_tool_policy_requires_restart() {
+        // #2217: a tool_policy-only edit must classify as restart-required —
+        // the policy is applied to the tool registry at bootstrap
+        // (`apply_policy`), so without a restart the running gateway keeps
+        // enforcing the stale allow/deny list.
+        let base = UserProfile {
+            id: "diff-test".into(),
+            name: "Diff".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let mut changed = base.clone();
+        changed.config.tool_policy = Some(octos_agent::ToolPolicy {
+            deny: vec!["bash".into()],
+            ..Default::default()
+        });
+
+        assert!(matches!(
+            diff_profiles(&base, &changed),
+            ProfileChange::RestartRequired(fields) if fields == vec!["tool_policy"]
+        ));
+
+        // Policy-to-policy edit and policy removal are the same transition class.
+        let mut edited = changed.clone();
+        edited.config.tool_policy = Some(octos_agent::ToolPolicy {
+            allow: vec!["read_file".into()],
+            ..Default::default()
+        });
+        assert!(matches!(
+            diff_profiles(&changed, &edited),
+            ProfileChange::RestartRequired(fields) if fields == vec!["tool_policy"]
+        ));
+        assert!(matches!(
+            diff_profiles(&changed, &base),
+            ProfileChange::RestartRequired(fields) if fields == vec!["tool_policy"]
         ));
     }
 


### PR DESCRIPTION
## Problem

A profile file change that touches **only** `tool_policy` persisted to disk but was in neither differ list — `diff_profiles` (serve profile watcher) nor `ConfigWatcher::diff_and_emit` (gateway config watcher). The running gateway kept enforcing the **old** allow/deny list indefinitely: no restart, no hot-reload, no signal that anything was stale. This is reachable from the AppUI/self-service profile paths since #2203/#2216.

## Root cause

Both differs enumerate restart-required sections field by field, and `tool_policy` was never added to either list when it became a profile/defaults-inheritable field (#2168).

Restart-required (not hot-reload) is the correct classification: the policy is applied to the tool registry only at bootstrap (`apply_policy`, a destructive retain over the registry — gateway_runtime.rs:904/1329, runtime/profile.rs:1369) and per-session actors re-apply the startup-captured copy; nothing re-reads the file per turn.

## Fix

- `diff_profiles`: compare `tool_policy` → the serve profile watcher now restarts the gateway on a tool_policy-only edit (via the pre-existing `RestartRequired → pm.restart` dispatch).
- `ConfigWatcher::diff_and_emit`: compare `tool_policy` → a running gateway emits `RestartRequired(["tool_policy"])` on a policy-only file edit.
- `gateway_runtime` FIX 2 block: thread the defaults/parent-resolved `tool_policy` into the flattened `Config` that seeds the watcher. Without this, a profile-mode gateway whose policy comes from `profile-defaults.json` would emit a **spurious** restart-required on the first unrelated edit (seed has the raw profile's `None`; `parse_first` re-layers defaults on every poll). This aligns the seed with what `ProfileRuntime` already enforces; the inheritance guards (`is_none`) mean a profile's own policy always wins and is never clobbered. **Called-out behavior change:** in the `--model/--provider/--base-url` override path (which skips `ProfileRuntime::bootstrap`), the inline assembly now applies the parent/defaults-resolved policy instead of only the profile's raw one — this matches `resolve_runtime_profile`'s documented contract and closes a policy bypass in override mode, but it is an enforcement change beyond the literal diff-list fix.

## Test evidence

- New tests verified **RED** on the pre-fix baseline, **GREEN** after:
  - `test_diff_profiles_tool_policy_requires_restart` — covers `None→Some`, `Some(A)→Some(B)`, and `Some→None` transitions; asserts the exact `RestartRequired(["tool_policy"])` classification the serve watcher dispatches on.
  - `should_require_restart_when_tool_policy_changed` — `diff_and_emit` level.
  - `tool_policy_file_edit_emits_restart_required_via_check` — **end-to-end through the production polling path**: real file edit → `check()` hash poll → parse → diff → signal. On the baseline this emitted `None` (the reported bug); after the fix it emits `RestartRequired(["tool_policy"])`.
  - `inherited_tool_policy_does_not_spuriously_restart_on_unrelated_edit` — pins the seed-threading invariant with a **control half**: an unthreaded seed must false-positive (verified load-bearing by mutation — deleting the new `diff_and_emit` line fails the control). The unrelated edit bumps only `updated_at` because a hot-reloadable edit would mask a spurious `RestartRequired` (the watch channel retains only the last send, and `diff_and_emit` emits `HotReload` after `RestartRequired`).
- `cargo test -p octos-cli --lib`: 1629 passed, 6 ignored; 1 failure in `autonomy::agent_orchestrator::tests::sovereignty_provider_fail_open_when_unowned_default_branch` which is **pre-existing and environment-dependent** — it fails identically on a clean `origin/main` worktree because Apple Command Line Tools ships a system gitconfig with `init.defaultBranch=main`, so the test's `git init → commit → checkout -b main` sequence collides with the already-born `main`. Unrelated to this change (no shared code).
- `cargo fmt --check`: clean. `cargo clippy -p octos-cli --all-targets -- -D warnings`: zero warnings.
- A full serve-process E2E (edit profile file → observed gateway restart) requires spawning real per-profile gateway processes; there is no existing harness for it (all 20+ existing restart-required fields are covered at the same classification layer used here). The restart dispatch itself (`serve.rs` `RestartRequired → pm.restart`) is pre-existing, field-agnostic wiring.

## Review

Independent adversarial review (two rounds) verified: both paths closed, restart-required classification correct against the bootstrap/`apply_policy` consumption, no spurious-restart vectors after the seed threading, no regression risk (prior behavior was silent staleness; nothing depended on policy edits being ignored). Known, deliberately-out-of-scope follow-ups (all pre-existing, shared by sibling fields): `tool_policy_by_provider` staleness in standalone `--config` mode; parent-policy edits not restarting child gateways; defaults-only edits signalling without a serve-side restart.

Closes #2217