### PR TITLE
test(agent): guard retry-state delta merge against future fields + reverse-order drop test (#2221)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6781,6 +6781,29 @@ fn should_preserve_both_turns_increments_when_turns_overlap() {
 }
 
 #[test]
+fn should_preserve_both_turns_increments_when_dropped_in_reverse_order() {
+    // Reverse-order twin of
+    // `should_preserve_both_turns_increments_when_turns_overlap` (#2221):
+    // dropping turn B first exercises the same delta merge from the other
+    // side — `rate_limited`, the bucket BOTH turns incremented, must still
+    // accumulate 2 + 1 regardless of which drop runs the merge first.
+    let handle = Arc::new(StdMutex::new(LoopRetryState::default()));
+    let mut turn_a = PersistentRetryStateGuard::new(Some(handle.clone()));
+    let mut turn_b = PersistentRetryStateGuard::new(Some(handle.clone()));
+
+    turn_a.counters.rate_limited += 2;
+    turn_b.counters.rate_limited += 1;
+    turn_b.counters.network += 3;
+
+    drop(turn_b);
+    drop(turn_a);
+
+    let shared = handle.lock().unwrap();
+    assert_eq!(shared.counters.rate_limited, 3);
+    assert_eq!(shared.counters.network, 3);
+}
+
+#[test]
 fn should_write_back_exact_state_when_no_concurrent_writer() {
     // Single-agent regression: with no concurrent writer the drop must
     // reproduce today's byte-for-byte write-back, including the grace-call

--- a/crates/octos-agent/src/agent/loop_state.rs
+++ b/crates/octos-agent/src/agent/loop_state.rs
@@ -182,6 +182,11 @@ pub const SHELL_SPIRAL_VARIANT: &str = "shell_spiral";
 /// Per-variant counters. Each counter is bumped exactly once per observation
 /// and the corresponding limit from [`LoopRetryLimits`] is checked immediately
 /// so the caller never silently exceeds a bucket.
+///
+/// Fields are `pub` for direct reads and test/guard-path mutations, but the
+/// delta-merge (`saturating_add_turn_delta`) relies on every bucket being
+/// append-only: only ever increment, never decrement or reset (see its doc
+/// comment).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopRetryCounters {
     pub rate_limited: u32,
@@ -211,6 +216,12 @@ impl LoopRetryCounters {
     /// `base` it loaded from) onto `self` (#1655). Buckets only ever
     /// increment, so `saturating_sub` yields the turn's own increments and
     /// two overlapping turns both land in the merged state.
+    ///
+    /// Monotonicity is a load-bearing convention here (#2221): if a future
+    /// change ever decrements a bucket, `saturating_sub` clamps the negative
+    /// delta to zero and the decrement is silently dropped from the merge.
+    /// Bucket mutations must therefore only ever increment — all built-in
+    /// mutations go through `observe*` / `observe_shell_spiral`, which do.
     fn saturating_add_turn_delta(&mut self, base: &Self, turn: &Self) {
         self.rate_limited = self
             .rate_limited
@@ -677,6 +688,108 @@ mod tests {
         });
         assert_eq!(state.observe_shell_spiral(), LoopDecision::Escalate);
         assert_eq!(state.observe_shell_spiral(), LoopDecision::Exhausted);
+    }
+
+    #[test]
+    fn should_merge_every_field_when_turn_delta_applied() {
+        // Field-coverage guard (#2221): the literals below name EVERY field
+        // of `LoopRetryState`, `LoopRetryCounters`, and `LoopRetryLimits`
+        // with no `..Default::default()` spread, so adding a field to any of
+        // the three structs fails THIS test's compilation — forcing the
+        // author to extend `merge_turn_delta` (and
+        // `LoopRetryCounters::saturating_add_turn_delta`) in the same commit.
+        // `turn` also gives each field a DISTINCT delta over `base`
+        // (2 + field offset), so the final whole-struct equality catches
+        // both a forgotten merge line (the field keeps self's value) and a
+        // mis-wired one (a copy-pasted line reading the wrong base/turn
+        // field lands the wrong delta).
+        let uniform_counters = |v: u32| LoopRetryCounters {
+            rate_limited: v,
+            context_overflow: v,
+            authentication: v,
+            quota: v,
+            invalid_request: v,
+            content_filtered: v,
+            provider_unavailable: v,
+            network: v,
+            timeout: v,
+            tool_execution: v,
+            plugin_spawn: v,
+            plugin_timeout: v,
+            plugin_protocol: v,
+            delegate_depth_exceeded: v,
+            internal: v,
+            shell_spiral: v,
+        };
+        let offset_counters = |v: u32| LoopRetryCounters {
+            rate_limited: v,
+            context_overflow: v + 1,
+            authentication: v + 2,
+            quota: v + 3,
+            invalid_request: v + 4,
+            content_filtered: v + 5,
+            provider_unavailable: v + 6,
+            network: v + 7,
+            timeout: v + 8,
+            tool_execution: v + 9,
+            plugin_spawn: v + 10,
+            plugin_timeout: v + 11,
+            plugin_protocol: v + 12,
+            delegate_depth_exceeded: v + 13,
+            internal: v + 14,
+            shell_spiral: v + 15,
+        };
+        let uniform_limits = |v: u32| LoopRetryLimits {
+            rate_limited: v,
+            context_overflow: v,
+            authentication: v,
+            quota: v,
+            invalid_request: v,
+            content_filtered: v,
+            provider_unavailable: v,
+            network: v,
+            timeout: v,
+            tool_execution: v,
+            plugin_spawn: v,
+            plugin_timeout: v,
+            plugin_protocol: v,
+            delegate_depth_exceeded: v,
+            internal: v,
+            shell_spiral: v,
+        };
+
+        let base = LoopRetryState {
+            counters: uniform_counters(1),
+            limits: uniform_limits(100),
+            productive_tool_calls_since_last_grace: 1,
+            grace_calls_fired: 1,
+        };
+        let turn = LoopRetryState {
+            counters: offset_counters(3),
+            limits: uniform_limits(200),
+            productive_tool_calls_since_last_grace: 4,
+            grace_calls_fired: 2,
+        };
+        let mut merged = LoopRetryState {
+            counters: uniform_counters(10),
+            limits: uniform_limits(300),
+            productive_tool_calls_since_last_grace: 5,
+            grace_calls_fired: 5,
+        };
+        merged.merge_turn_delta(&base, &turn);
+
+        let expected = LoopRetryState {
+            // 10 + ((3 + i) - 1) = 12 + i: each bucket gains exactly its OWN
+            // turn delta, so a cross-field mis-wire flips the value.
+            counters: offset_counters(12),
+            // Static configuration, taken wholesale from `turn`.
+            limits: uniform_limits(200),
+            // 5 + (4 - 1): signed delta for the non-monotonic field.
+            productive_tool_calls_since_last_grace: 8,
+            // 5 + (2 - 1): monotonic saturating delta.
+            grace_calls_fired: 6,
+        };
+        assert_eq!(merged, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Follow-up nits from the post-merge review of #2213 (the persistent retry-state delta merge):

1. `merge_turn_delta` happened to cover all four `LoopRetryState` fields (and `saturating_add_turn_delta` all sixteen counter buckets), but nothing bound that coverage to the field set — a field added later and forgotten in the merge would silently drop concurrent deltas, with no compile-time or assertion protection.
2. The overlapping-turns guard-drop test only asserted drop order A→B; the reverse order was untested.
3. The merge's monotonicity assumption (buckets only ever increment; `saturating_sub` clamps a negative delta to zero) was convention-only and undocumented.

## Root cause

Not a runtime bug — a missing guard. The dirty check on guard drop is a whole-struct comparison, and the merge is a hand-written per-field list, so the two can drift apart silently as the structs evolve.

## Fix

Test + documentation only; no runtime behavior change.

- `loop_state.rs`: new `should_merge_every_field_when_turn_delta_applied` guard test. All literals name **every** field of `LoopRetryState` / `LoopRetryCounters` / `LoopRetryLimits` with no `..` spread, so adding a field fails **compilation** of this test and forces the merge to be extended in the same commit. `turn` gives each counter field a **distinct** delta over `base` (2 + field offset), so the final whole-struct equality catches both a forgotten merge line and a mis-wired one (e.g. a copy-pasted line reading the wrong `turn`/`base` field).
- `loop_runner_tests.rs`: new `should_preserve_both_turns_increments_when_dropped_in_reverse_order`, the B→A twin of the existing A→B overlap test.
- Doc comments on `LoopRetryCounters` and `saturating_add_turn_delta` now state the append-only convention explicitly: buckets must only ever increment; a decrement would be silently dropped by the saturating delta.

## Test evidence

- New tests pass: `should_merge_every_field_when_turn_delta_applied`, `should_preserve_both_turns_increments_when_dropped_in_reverse_order` (and the existing A→B twin still passes).
- The guard is mutation-verified, not just asserted:
  - Adding a probe field to `LoopRetryState` → 6 `E0063 missing field` compile errors (compile tripwire fires). Probe reverted.
  - Mis-wiring one merge line (`self.network` reading `turn.timeout - base.timeout`) → test **fails** (`network`: got 20, want 19). Mutation reverted.
  - A forgotten merge line leaves the field at self's value (10) vs expected 12 + i → fails.
- `cargo test -p octos-agent` (lib): 2803 passed, 0 failed. The only failures in the crate are 3 pre-existing Docker-daemon tests (`delegate`/`spawn`/`validators` sandbox-inheritance tests) that fail **identically on pristine `origin/main`** on this machine because no Docker daemon is running — verified by running them on a detached `origin/main` worktree.
- All 47 integration test targets pass (`--no-fail-fast`), including `retry_state_persistence::should_merge_concurrent_agents_increments_through_real_turns` (the real-turns path for the merge).
- `cargo fmt --check` clean; `cargo clippy -p octos-agent --all-targets -- -D warnings` clean.
- One transient note for transparency: in the first full-suite run, `exec_session_captures_all_output_when_process_exits_at_deadline` (a self-documented timing-sensitive test racing a 5ms yield against process exit, 40 trials) flaked once under full parallel load. It then passed 6/6 under deliberately induced load, in the second full-suite run, and in isolated runs on both this branch and the `origin/main` baseline. The diff here is test+docs only in an unrelated module and cannot affect exec timing.

## Review

- Round 1 self-review of the full diff against an anti-slop checklist (no debug residue, no unrelated changes, no comment padding, real behavioral assertions).
- Round 2 independent review by a fresh reviewer given only the issue text, the diff, and file paths. It raised one should-fix (uniform per-field values would miss a *mis-wired* merge line) and two nits (doc wording, test naming convention); all three were addressed — the distinct-delta redesign above is the result — and its four other concerns were rejected with verified reasoning. The redesign was confirmed by the same reviewer, including re-checking the expected-value arithmetic against the real implementation.
- Round 3: after the review-driven changes, the full verification above (fmt, clippy, lib + integration suites, both mutation probes) was re-run end to end.

End-to-end note: this change deliberately alters no runtime behavior, so there is no before/after CLI-observable difference; the end-to-end evidence for the issue's scenarios is the mutation testing above, which exercises exactly the failure modes the issue describes (added field → compile failure; forgotten/mis-wired merge line → test failure) on the real code.

Closes #2221
