### PR TITLE
feat(llm): minimax-cn provider family for the China endpoint (api.minimaxi.com)

### DIFF
--- a/ORG-README.md
+++ b/ORG-README.md
@@ -10,7 +10,7 @@ Connect your LLM API keys and messaging channels. Octos handles conversation rou
 
 | Repo | Description |
 |------|-------------|
-| **[octos](https://github.com/octos-org/octos)** | Core platform — Rust binary, 16 LLM providers, 14 channels, DOT pipeline engine, multi-tenant gateway, web dashboard |
+| **[octos](https://github.com/octos-org/octos)** | Core platform — Rust binary, 17 LLM providers, 14 channels, DOT pipeline engine, multi-tenant gateway, web dashboard |
 | **[octos-hub](https://github.com/octos-org/octos-hub)** | Community skill registry — install and share agent skills |
 | **[octos-web](https://github.com/octos-org/octos-web)** | Admin dashboard — React SPA for profile management, metrics, and fleet control |
 

--- a/book-zh/src/providers.md
+++ b/book-zh/src/providers.md
@@ -26,7 +26,7 @@ Octos 开箱即用地支持 17 家 LLM 服务商。每个服务商需要一个�
 
 **`vertex`** 使用 Google 服务账号 JSON 认证（通过 `VERTEX_SA_JSON` 解析——钥匙串标记、配置值或环境变量），而非 API 密钥；GCP 项目从 JSON 中读取，区域固定为 `global`。必须显式选择（`provider: "vertex"`）——裸的 `gemini-*` 模型名仍会解析到 AI Studio 的 `gemini` 服务商。**`r9s`** 是多协议代理：`claude-*` 模型自动走 Anthropic Messages API，其余走 OpenAI Chat Completions。
 
-**`minimax-cn`** 是 MiniMax 的中国区服务商（`https://api.minimaxi.com/v1`，而非国际站 `https://api.minimax.io/v1`）。MiniMax Token 套餐订阅密钥由中国平台（platform.minimaxi.com）签发且有区域绑定，只能用于 `minimax-cn`；国际站密钥仍使用 `minimax`。
+**`minimax-cn`** 是 MiniMax 的中国区服务商（`https://api.minimaxi.com/v1`，而非国际站 `https://api.minimax.io/v1`）。MiniMax Token 套餐订阅密钥由中国平台（platform.minimaxi.com）签发且有区域绑定，只能用于 `minimax-cn`；国际站密钥仍使用 `minimax`。MiniMax Coding 套餐密钥（`sk-cp-` 前缀）还必须使用 Anthropic 协议：在 `octos init` 中选择 **Anthropic** 协议，或设置 `api_type: "anthropic"` 并将 `base_url` 指向 `https://api.minimaxi.com/anthropic`——走默认的 OpenAI 协议会返回 401（见 octos#2115）。
 
 其他任何 OpenAI 或 Anthropic 兼容端点（如 `wisemodel`、Together、Fireworks、Azure）可通过在服务商上设置 `base_url` 接入——见[自定义端点](#自定义端点)。
 

--- a/book-zh/src/providers.md
+++ b/book-zh/src/providers.md
@@ -1,6 +1,6 @@
 # LLM 服务商与路由
 
-Octos 开箱即用地支持 16 家 LLM 服务商。每个服务商需要一个存储在环境变量中的 API 密钥（本地服务商如 Ollama、以及使用服务账号 JSON 的 Vertex AI 除外）。
+Octos 开箱即用地支持 17 家 LLM 服务商。每个服务商需要一个存储在环境变量中的 API 密钥（本地服务商如 Ollama、以及使用服务账号 JSON 的 Vertex AI 除外）。
 
 ## 支持的服务商
 
@@ -15,7 +15,8 @@ Octos 开箱即用地支持 16 家 LLM 服务商。每个服务商需要一个�
 | `groq` | `GROQ_API_KEY` | llama-3.3-70b-versatile | OpenAI 兼容 | -- |
 | `moonshot` | `MOONSHOT_API_KEY` | kimi-k2.5 | OpenAI 兼容 | `kimi` |
 | `dashscope` | `DASHSCOPE_API_KEY` | qwen-max | OpenAI 兼容 | `qwen` |
-| `minimax` | `MINIMAX_API_KEY` | MiniMax-Text-01 | OpenAI 兼容 | -- |
+| `minimax` | `MINIMAX_API_KEY` | MiniMax-M3 | OpenAI 兼容 | -- |
+| `minimax-cn` | `MINIMAX_CN_API_KEY` | MiniMax-M3 | OpenAI 兼容 | `minimaxi` |
 | `zhipu` | `ZHIPU_API_KEY` | glm-4-plus | OpenAI 兼容 | `glm` |
 | `zai` | `ZAI_API_KEY` | glm-5-turbo | Anthropic 兼容 | `z.ai` |
 | `r9s` | `R9S_API_KEY` | claude-sonnet-4-6 | 自动（Anthropic/OpenAI） | `r9s.ai` |
@@ -24,6 +25,8 @@ Octos 开箱即用地支持 16 家 LLM 服务商。每个服务商需要一个�
 | `vllm` | `VLLM_API_KEY` | *（须指定）* | OpenAI 兼容 | -- |
 
 **`vertex`** 使用 Google 服务账号 JSON 认证（通过 `VERTEX_SA_JSON` 解析——钥匙串标记、配置值或环境变量），而非 API 密钥；GCP 项目从 JSON 中读取，区域固定为 `global`。必须显式选择（`provider: "vertex"`）——裸的 `gemini-*` 模型名仍会解析到 AI Studio 的 `gemini` 服务商。**`r9s`** 是多协议代理：`claude-*` 模型自动走 Anthropic Messages API，其余走 OpenAI Chat Completions。
+
+**`minimax-cn`** 是 MiniMax 的中国区服务商（`https://api.minimaxi.com/v1`，而非国际站 `https://api.minimax.io/v1`）。MiniMax Token 套餐订阅密钥由中国平台（platform.minimaxi.com）签发且有区域绑定，只能用于 `minimax-cn`；国际站密钥仍使用 `minimax`。
 
 其他任何 OpenAI 或 Anthropic 兼容端点（如 `wisemodel`、Together、Fireworks、Azure）可通过在服务商上设置 `base_url` 接入——见[自定义端点](#自定义端点)。
 

--- a/book/src/providers.md
+++ b/book/src/providers.md
@@ -26,7 +26,7 @@ Octos supports 17 LLM providers out of the box. Each provider needs an API key s
 
 **`vertex`** authenticates with a Google service-account JSON (resolved via `VERTEX_SA_JSON` — keychain marker, config value, or env) instead of an API key; the GCP project is read from the JSON and the region is fixed to `global`. It must be selected explicitly (`provider: "vertex"`) — bare `gemini-*` model names still resolve to the AI Studio `gemini` provider. **`r9s`** is a multi-protocol proxy that auto-detects the Anthropic Messages API for `claude-*` models and OpenAI Chat Completions otherwise.
 
-**`minimax-cn`** is the China region of MiniMax (`https://api.minimaxi.com/v1` instead of the international `https://api.minimax.io/v1`). MiniMax Token-plan subscription keys are issued by the China platform (platform.minimaxi.com) and are region-bound, so they only work against `minimax-cn`; international keys stay on `minimax`.
+**`minimax-cn`** is the China region of MiniMax (`https://api.minimaxi.com/v1` instead of the international `https://api.minimax.io/v1`). MiniMax Token-plan subscription keys are issued by the China platform (platform.minimaxi.com) and are region-bound, so they only work against `minimax-cn`; international keys stay on `minimax`. MiniMax Coding-plan keys (`sk-cp-…`) additionally require the Anthropic protocol: choose protocol **Anthropic** during `octos init`, or set `api_type: "anthropic"` with `base_url: "https://api.minimaxi.com/anthropic"` — over the default OpenAI protocol they 401 (see octos#2115).
 
 Any other OpenAI- or Anthropic-compatible endpoint (e.g. `wisemodel`, Together, Fireworks, Azure) is reachable by setting `base_url` on a provider — see [Custom Endpoints](#custom-endpoints).
 

--- a/book/src/providers.md
+++ b/book/src/providers.md
@@ -1,6 +1,6 @@
 # LLM Providers & Routing
 
-Octos supports 16 LLM providers out of the box. Each provider needs an API key stored in an environment variable (except local providers like Ollama and Vertex AI, which uses a service-account JSON).
+Octos supports 17 LLM providers out of the box. Each provider needs an API key stored in an environment variable (except local providers like Ollama and Vertex AI, which uses a service-account JSON).
 
 ## Supported Providers
 
@@ -15,7 +15,8 @@ Octos supports 16 LLM providers out of the box. Each provider needs an API key s
 | `groq` | `GROQ_API_KEY` | llama-3.3-70b-versatile | OpenAI-compatible | -- |
 | `moonshot` | `MOONSHOT_API_KEY` | kimi-k2.5 | OpenAI-compatible | `kimi` |
 | `dashscope` | `DASHSCOPE_API_KEY` | qwen-max | OpenAI-compatible | `qwen` |
-| `minimax` | `MINIMAX_API_KEY` | MiniMax-Text-01 | OpenAI-compatible | -- |
+| `minimax` | `MINIMAX_API_KEY` | MiniMax-M3 | OpenAI-compatible | -- |
+| `minimax-cn` | `MINIMAX_CN_API_KEY` | MiniMax-M3 | OpenAI-compatible | `minimaxi` |
 | `zhipu` | `ZHIPU_API_KEY` | glm-4-plus | OpenAI-compatible | `glm` |
 | `zai` | `ZAI_API_KEY` | glm-5-turbo | Anthropic-compatible | `z.ai` |
 | `r9s` | `R9S_API_KEY` | claude-sonnet-4-6 | Auto (Anthropic/OpenAI) | `r9s.ai` |
@@ -24,6 +25,8 @@ Octos supports 16 LLM providers out of the box. Each provider needs an API key s
 | `vllm` | `VLLM_API_KEY` | *(must specify)* | OpenAI-compatible | -- |
 
 **`vertex`** authenticates with a Google service-account JSON (resolved via `VERTEX_SA_JSON` — keychain marker, config value, or env) instead of an API key; the GCP project is read from the JSON and the region is fixed to `global`. It must be selected explicitly (`provider: "vertex"`) — bare `gemini-*` model names still resolve to the AI Studio `gemini` provider. **`r9s`** is a multi-protocol proxy that auto-detects the Anthropic Messages API for `claude-*` models and OpenAI Chat Completions otherwise.
+
+**`minimax-cn`** is the China region of MiniMax (`https://api.minimaxi.com/v1` instead of the international `https://api.minimax.io/v1`). MiniMax Token-plan subscription keys are issued by the China platform (platform.minimaxi.com) and are region-bound, so they only work against `minimax-cn`; international keys stay on `minimax`.
 
 Any other OpenAI- or Anthropic-compatible endpoint (e.g. `wisemodel`, Together, Fireworks, Azure) is reachable by setting `base_url` on a provider — see [Custom Endpoints](#custom-endpoints).
 

--- a/crates/octos-cli/src/commands/docs.rs
+++ b/crates/octos-cli/src/commands/docs.rs
@@ -117,7 +117,7 @@ fn providers_list() -> Vec<(
         (
             "MiniMax",
             "MINIMAX_API_KEY",
-            "MiniMax-Text-01",
+            "MiniMax-M3",
             Some("https://api.minimax.io/v1"),
         ),
         (

--- a/crates/octos-cli/src/commands/docs.rs
+++ b/crates/octos-cli/src/commands/docs.rs
@@ -121,6 +121,12 @@ fn providers_list() -> Vec<(
             Some("https://api.minimax.io/v1"),
         ),
         (
+            "MiniMax-CN",
+            "MINIMAX_CN_API_KEY",
+            "MiniMax-M3",
+            Some("https://api.minimaxi.com/v1"),
+        ),
+        (
             "Zhipu",
             "ZHIPU_API_KEY",
             "glm-4-plus",

--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -51,7 +51,7 @@ const MINIMAX_API_TYPES: &[ApiTypeOption] = &[
     ApiTypeOption {
         value: Some("anthropic"),
         display: "Anthropic",
-        description: "Messages API",
+        description: "Messages API (required for sk-cp- Coding-plan keys)",
         base_url: Some("https://api.minimaxi.com/anthropic"),
     },
 ];
@@ -66,7 +66,7 @@ const MINIMAX_CN_API_TYPES: &[ApiTypeOption] = &[
     ApiTypeOption {
         value: Some("anthropic"),
         display: "Anthropic",
-        description: "Messages API",
+        description: "Messages API (required for sk-cp- Coding-plan keys)",
         base_url: Some("https://api.minimaxi.com/anthropic"),
     },
 ];

--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -56,6 +56,21 @@ const MINIMAX_API_TYPES: &[ApiTypeOption] = &[
     },
 ];
 
+const MINIMAX_CN_API_TYPES: &[ApiTypeOption] = &[
+    ApiTypeOption {
+        value: None,
+        display: "OpenAI",
+        description: "Chat Completions API",
+        base_url: Some("https://api.minimaxi.com/v1"),
+    },
+    ApiTypeOption {
+        value: Some("anthropic"),
+        display: "Anthropic",
+        description: "Messages API",
+        base_url: Some("https://api.minimaxi.com/anthropic"),
+    },
+];
+
 const PROVIDERS: &[ProviderInfo] = &[
     ProviderInfo {
         name: "openai",
@@ -120,6 +135,19 @@ const PROVIDERS: &[ProviderInfo] = &[
         base_url: Some("https://api.z.ai/api/anthropic"),
         api_type: Some("anthropic"),
         api_types: &[],
+    },
+    // Region variant of the `minimax` preset: MiniMax Token-plan keys are
+    // issued by the China platform and 401 against the international site
+    // (octos#2125). Appended last so every existing preset index keeps its
+    // number; only the trailing Custom entry (always `PROVIDERS.len() + 1`)
+    // moves.
+    ProviderInfo {
+        name: "minimax-cn",
+        display: "MiniMax China (Token Plan)",
+        api_key_env: "MINIMAX_CN_API_KEY",
+        base_url: Some("https://api.minimaxi.com/v1"),
+        api_type: None,
+        api_types: MINIMAX_CN_API_TYPES,
     },
 ];
 
@@ -1115,6 +1143,68 @@ mod tests {
     // rejected by real APIs (DeepSeek 400s on it). The catalog is now
     // embedded as a compile-time fallback, manual entry requires an explicit
     // model name, and --defaults errors instead of silently writing "auto".
+
+    // octos#2125: the MiniMax China preset is a first-class region variant —
+    // the Token-plan flow (preset -> protocol -> model -> config) must write
+    // the api.minimaxi.com endpoint with no manual base_url override.
+
+    #[test]
+    fn minimax_cn_preset_writes_the_china_endpoint() {
+        let info = provider("minimax-cn");
+        assert_eq!(info.api_key_env, "MINIMAX_CN_API_KEY");
+        assert_eq!(
+            default_api_type_selection(info).base_url,
+            Some("https://api.minimaxi.com/v1")
+        );
+        // Both protocols the China platform documents are offered, OpenAI
+        // first (the default).
+        assert_eq!(info.api_types.len(), 2);
+        let anthropic = select_api_type(info, "2");
+        assert_eq!(anthropic.api_type, Some("anthropic"));
+        assert_eq!(
+            anthropic.base_url,
+            Some("https://api.minimaxi.com/anthropic")
+        );
+
+        let config = build_config(
+            info,
+            "MiniMax-M3",
+            info.api_key_env,
+            default_api_type_selection(info),
+        );
+        assert_eq!(config["provider"], "minimax-cn");
+        assert_eq!(config["base_url"], "https://api.minimaxi.com/v1");
+        assert!(config.get("api_type").is_none());
+
+        // The catalog offers the Token-plan model for the family.
+        let catalog = embedded_catalog_models();
+        assert_eq!(
+            default_model_for("minimax-cn", &catalog).as_deref().ok(),
+            Some("MiniMax-M3")
+        );
+    }
+
+    #[test]
+    fn existing_preset_indices_do_not_shift() {
+        // Piped/scripted init flows select by number; only the trailing
+        // Custom entry (PROVIDERS.len() + 1) may move when a preset is added.
+        for (index, name) in [
+            "openai",
+            "anthropic",
+            "gemini",
+            "deepseek",
+            "moonshot",
+            "dashscope",
+            "minimax",
+            "zai",
+        ]
+        .iter()
+        .enumerate()
+        {
+            assert_eq!(PROVIDERS[index].name, *name, "preset {index} shifted");
+        }
+        assert_eq!(PROVIDERS.last().unwrap().name, "minimax-cn");
+    }
 
     #[test]
     fn should_resolve_models_from_embedded_catalog_when_no_disk_file() {

--- a/crates/octos-cli/src/commands/status.rs
+++ b/crates/octos-cli/src/commands/status.rs
@@ -38,6 +38,8 @@ const PROVIDER_ENV_VARS: &[(&str, &str)] = &[
     ("Moonshot", "KIMI_API_KEY"),
     ("DashScope", "DASHSCOPE_API_KEY"),
     ("MiniMax", "MINIMAX_API_KEY"),
+    // Label lowercases to the registry family id for the key-alias fallback.
+    ("MiniMax-CN", "MINIMAX_CN_API_KEY"),
     ("Zhipu", "ZHIPU_API_KEY"),
 ];
 

--- a/crates/octos-cli/tests/cli_tests.rs
+++ b/crates/octos-cli/tests/cli_tests.rs
@@ -20,6 +20,7 @@ fn clear_provider_env(cmd: &mut Command) {
         "KIMI_API_KEY",
         "DASHSCOPE_API_KEY",
         "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
         "ZAI_API_KEY",
     ] {
         cmd.env_remove(key);

--- a/crates/octos-llm/src/registry/minimax_cn.rs
+++ b/crates/octos-llm/src/registry/minimax_cn.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use eyre::Result;
+
+use crate::openai::OpenAIProvider;
+use crate::provider::LlmProvider;
+
+use super::{CreateParams, ProviderEntry};
+
+/// MiniMax **China** family. Distinct from the regular `minimax` family: it
+/// targets the China endpoint `https://api.minimaxi.com/v1` (OpenAI-compatible)
+/// rather than the international `https://api.minimax.io/v1`, because MiniMax
+/// Token-plan subscription keys are issued by the China platform
+/// (platform.minimaxi.com) and are region-bound — the international site
+/// rejects them with a 401. Mirrors the `moonshot` / `moonshot-coding` split.
+pub const ENTRY: ProviderEntry = ProviderEntry {
+    name: "minimax-cn",
+    aliases: &["minimaxi"],
+    api_key_env: Some("MINIMAX_CN_API_KEY"),
+    key_env_aliases: &["MINIMAX_API_KEY"],
+    default_base_url: Some("https://api.minimaxi.com/v1"),
+    requires_api_key: true,
+    requires_base_url: false,
+    requires_model: false,
+    // Selected explicitly by family, not auto-detected: the models share the
+    // base family's `MiniMax-*` names, so `detect_provider` keeps resolving
+    // them to `minimax` (international) and the China endpoint is opt-in.
+    detect_patterns: &[],
+    model_discovery: crate::discovery::OPENAI_MODELS,
+    create,
+};
+
+fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
+    let http_timeout = p.http_timeout();
+    let key = p
+        .api_key
+        .ok_or_else(|| eyre::eyre!("MINIMAX_CN_API_KEY (MiniMax China) not set"))?;
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
+    let url = p
+        .base_url
+        .unwrap_or_else(|| "https://api.minimaxi.com/v1".into());
+    let mut provider = OpenAIProvider::new(&key, &model)
+        .with_provider_label("minimax-cn")
+        .with_base_url(&url);
+    if let Some(hints) = p.model_hints {
+        provider = provider.with_hints(hints);
+    }
+    if let Some((t, c)) = http_timeout {
+        provider = provider.with_http_timeout(t, c);
+    }
+    Ok(Arc::new(provider))
+}

--- a/crates/octos-llm/src/registry/minimax_cn.rs
+++ b/crates/octos-llm/src/registry/minimax_cn.rs
@@ -27,6 +27,10 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // them to `minimax` (international) and the China endpoint is opt-in.
     detect_patterns: &[],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    // The Anthropic-protocol route (sk-cp- Coding-plan keys) is selected via
+    // the `api_type` override, not by model name — the family-wide
+    // declaration always rules.
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/mod.rs
+++ b/crates/octos-llm/src/registry/mod.rs
@@ -74,6 +74,7 @@ mod gemini;
 mod groq;
 mod local;
 mod minimax;
+mod minimax_cn;
 mod moonshot;
 mod moonshot_coding;
 mod nvidia;
@@ -204,6 +205,9 @@ static ALL: &[ProviderEntry] = &[
     moonshot_coding::ENTRY,
     moonshot::ENTRY,
     dashscope::ENTRY,
+    // Region-variant families FIRST so an explicit `minimax-cn` resolves to
+    // the China endpoint before the base family's name/aliases.
+    minimax_cn::ENTRY,
     minimax::ENTRY,
     zai_coding::ENTRY,
     zhipu::ENTRY,
@@ -285,6 +289,7 @@ mod tests {
             ("gemini", "gemini-2.5-flash"),
             ("local", "local-default"),
             ("minimax", "MiniMax-M3"),
+            ("minimax-cn", "MiniMax-M3"),
             ("moonshot-coding", "k3"),
             ("openai", "gpt-4o"),
             ("openrouter", "anthropic/claude-sonnet-4-6"),
@@ -440,7 +445,7 @@ mod tests {
 
     #[test]
     fn all_entries_count() {
-        assert_eq!(all_entries().len(), 19);
+        assert_eq!(all_entries().len(), 20);
     }
 
     /// Keyless = provider construction succeeds with no API key. The
@@ -478,6 +483,26 @@ mod tests {
         // The base families are unshadowed by the coding families.
         assert_eq!(lookup("kimi").map(|e| e.name), Some("moonshot"));
         assert_eq!(lookup("z.ai").map(|e| e.name), Some("zai"));
+    }
+
+    /// The China region family resolves to the api.minimaxi.com endpoint with
+    /// the Token-plan default model, its alias + key-env alias work, and it
+    /// neither shadows the international family nor steals its model
+    /// auto-detection (region selection is explicit, octos#2125).
+    #[test]
+    fn minimax_cn_resolves_to_the_china_endpoint() {
+        let cn = lookup("minimax-cn").expect("minimax-cn registered");
+        assert_eq!(cn.default_base_url, Some("https://api.minimaxi.com/v1"));
+        assert_eq!(cn.default_model(), Some("MiniMax-M3"));
+        assert_eq!(cn.api_key_env, Some("MINIMAX_CN_API_KEY"));
+        assert!(cn.is_known_key_env("MINIMAX_API_KEY"));
+        assert_eq!(lookup("minimaxi").map(|e| e.name), Some("minimax-cn"));
+
+        // The international family keeps its endpoint and its MiniMax-*
+        // model auto-detection — `minimax-cn` has no detect patterns.
+        let intl = lookup("minimax").expect("minimax registered");
+        assert_eq!(intl.default_base_url, Some("https://api.minimax.io/v1"));
+        assert_eq!(detect_provider("MiniMax-M3"), Some("minimax"));
     }
 
     #[test]

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -193,6 +193,14 @@
       { "id": "MiniMax-M2", "input": 0.2, "output": 1.1, "max_output": 16384 }
     ]
   },
+  "minimax-cn": {
+    "env": "MINIMAX_CN_API_KEY",
+    "models": [
+      { "id": "MiniMax-M3", "input": 0.15, "output": 1.5, "max_output": 131072, "endpoints": [
+        { "id": "minimax-cn", "label": "MiniMax China (Token Plan)", "base_url": "https://api.minimaxi.com/v1", "api_key_env": "MINIMAX_CN_API_KEY" }
+      ] }
+    ]
+  },
   "zai-coding": {
     "env": "ZAI_CODING_API_KEY",
     "models": [

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -184,7 +184,7 @@ export SMTP_PASSWORD="your-app-password"
 
 ## 3. 配置 LLM 提供商
 
-Octos 开箱即用支持 16 个 LLM 提供商家族。云端提供商需要设置对应的环境变量 API 密钥；本地服务器（见 [3.6](#36-本地模型llamacppollamavllmlm-studio)）无需密钥。
+Octos 开箱即用支持 17 个 LLM 提供商家族。云端提供商需要设置对应的环境变量 API 密钥；本地服务器（见 [3.6](#36-本地模型llamacppollamavllmlm-studio)）无需密钥。
 
 ### 3.1 支持的提供商
 

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -200,6 +200,7 @@ Octos 开箱即用支持 17 个 LLM 提供商家族。云端提供商需要设�
 | `moonshot` | `MOONSHOT_API_KEY` | kimi-k2.5 | OpenAI 兼容 | `kimi` |
 | `dashscope` | `DASHSCOPE_API_KEY` | qwen-max | OpenAI 兼容 | `qwen` |
 | `minimax` | `MINIMAX_API_KEY` | MiniMax-Text-01 | OpenAI 兼容 | — |
+| `minimax-cn` | `MINIMAX_CN_API_KEY` | MiniMax-M3 | OpenAI 兼容 | `minimaxi` |
 | `zhipu` | `ZHIPU_API_KEY` | glm-4-plus | OpenAI 兼容 | `glm` |
 | `zai` | `ZAI_API_KEY` | glm-5-turbo | Anthropic 兼容 | `z.ai` |
 | `nvidia` | `NVIDIA_API_KEY` | meta/llama-3.3-70b-instruct | OpenAI 兼容 | `nim` |
@@ -253,12 +254,12 @@ Octos 开箱即用支持 17 个 LLM 提供商家族。云端提供商需要设�
 5. 设置环境变量：`export ANTHROPIC_API_KEY="your-key"`
 
 **MiniMax（稀宇科技）：**
-1. 访问 [MiniMax 开放平台](https://platform.minimaxi.com/)
+1. 按密钥所属区域访问对应平台：[国际站](https://platform.minimax.io/)，或[国内站](https://platform.minimaxi.com/)——Token 套餐订阅密钥由国内站签发且有区域绑定（在国际端点会 401，需改用 `minimax-cn` 家族）
 2. 注册或登录
 3. 在控制台中进入 **API Keys** 管理页面
 4. 点击"创建 API Key"
 5. 复制密钥
-6. 设置环境变量：`export MINIMAX_API_KEY="your-key"`
+6. 设置环境变量：`export MINIMAX_API_KEY="your-key"`（国际站）或 `export MINIMAX_CN_API_KEY="your-key"`（国内站）
 
 **Z.AI：**
 1. 访问 [Z.AI 平台](https://z.ai/)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -246,7 +246,7 @@ Source: `crates/octos-cli/src/api/admin_setup.rs`, `dashboard/src/pages/wizard/`
 
 ## 3. Setting Up LLM Providers
 
-Octos supports 16 LLM provider families out of the box. Cloud providers require an API key set as an environment variable; local servers (see [3.6](#36-local-models-llamacpp-ollama-vllm-lm-studio)) need none.
+Octos supports 17 LLM provider families out of the box. Cloud providers require an API key set as an environment variable; local servers (see [3.6](#36-local-models-llamacpp-ollama-vllm-lm-studio)) need none.
 
 ### 3.1 Supported Providers
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -262,6 +262,7 @@ Octos supports 17 LLM provider families out of the box. Cloud providers require 
 | `moonshot` | `MOONSHOT_API_KEY` | kimi-k2.5 | OpenAI-compatible | `kimi` |
 | `dashscope` | `DASHSCOPE_API_KEY` | qwen-max | OpenAI-compatible | `qwen` |
 | `minimax` | `MINIMAX_API_KEY` | MiniMax-Text-01 | OpenAI-compatible | — |
+| `minimax-cn` | `MINIMAX_CN_API_KEY` | MiniMax-M3 | OpenAI-compatible | `minimaxi` |
 | `zhipu` | `ZHIPU_API_KEY` | glm-4-plus | OpenAI-compatible | `glm` |
 | `zai` | `ZAI_API_KEY` | glm-5-turbo | Anthropic-compatible | `z.ai` |
 | `nvidia` | `NVIDIA_API_KEY` | meta/llama-3.3-70b-instruct | OpenAI-compatible | `nim` |
@@ -315,12 +316,12 @@ Octos supports 17 LLM provider families out of the box. Cloud providers require 
 5. Set it: `export ANTHROPIC_API_KEY="your-key"`
 
 **MiniMax:**
-1. Go to [MiniMax Open Platform](https://platform.minimaxi.com/)
+1. Go to the MiniMax platform for your key's region: [international](https://platform.minimax.io/), or [China](https://platform.minimaxi.com/) — Token-plan subscription keys are issued by the China platform and are region-bound (they 401 against the international endpoint and need the `minimax-cn` family)
 2. Sign up or log in
 3. Navigate to **API Keys** in the console
 4. Click "Create API Key"
 5. Copy the key
-6. Set it: `export MINIMAX_API_KEY="your-key"`
+6. Set it: `export MINIMAX_API_KEY="your-key"` (international) or `export MINIMAX_CN_API_KEY="your-key"` (China)
 
 **Z.AI:**
 1. Go to [Z.AI Platform](https://z.ai/)

--- a/model_catalog.json
+++ b/model_catalog.json
@@ -599,8 +599,8 @@
       "p95_ms": 0,
       "score": 0.0,
       "ds_output": 0,
-      "cost_in": 0.15,
-      "cost_out": 1.5,
+      "cost_in": 0.3,
+      "cost_out": 1.2,
       "context_window": 1000000,
       "max_output": 131072,
       "endpoints": [

--- a/model_catalog.json
+++ b/model_catalog.json
@@ -591,6 +591,28 @@
       "max_output": 131072
     },
     {
+      "provider": "minimax-cn/MiniMax-M3",
+      "type": "strong",
+      "default": true,
+      "stability": 1.0,
+      "tool_avg_ms": 0,
+      "p95_ms": 0,
+      "score": 0.0,
+      "ds_output": 0,
+      "cost_in": 0.15,
+      "cost_out": 1.5,
+      "context_window": 1000000,
+      "max_output": 131072,
+      "endpoints": [
+        {
+          "id": "minimax-cn",
+          "label": "MiniMax China (Token Plan)",
+          "base_url": "https://api.minimaxi.com/v1",
+          "api_key_env": "MINIMAX_CN_API_KEY"
+        }
+      ]
+    },
+    {
       "provider": "moonshot/kimi-k2.5",
       "type": "fast",
       "default": true,


### PR DESCRIPTION
## Problem

MiniMax Token-plan subscription keys are issued by the China platform (platform.minimaxi.com) and are region-bound. The only MiniMax preset pinned the international `https://api.minimax.io/v1`, so every China user got a 401 until they discovered the manual `base_url` override. The China platform documents an OpenAI-compatible endpoint `https://api.minimaxi.com/v1` (model ID `MiniMax-M3`) and an Anthropic-compatible `https://api.minimaxi.com/anthropic` (for `sk-cp-` Coding-plan keys).

## Root cause

No registry family existed for the China region — `registry::lookup("minimax-cn")` returned `None`, so the CLI refused the name outright, and the single `minimax` family hard-pinned the international host.

## Fix

A first-class `minimax-cn` family (alias `minimaxi`), mirroring the established `moonshot` / `moonshot-coding` split (the issue's option A):

- **Registry** (`minimax_cn.rs`, `mod.rs`): entry targeting `https://api.minimaxi.com/v1` (OpenAI-compatible), default model `MiniMax-M3` resolved from the catalog; `MINIMAX_CN_API_KEY` primary with `MINIMAX_API_KEY` as key-env alias (the variable CN users were historically told to use). Empty `detect_patterns`: `MiniMax-*` model names keep auto-resolving to the international `minimax` family — the China endpoint is an explicit opt-in, nothing is re-routed silently. Registered directly ahead of `minimax` per the split-family convention.
- **Catalog** (`model_catalog.json`): `minimax-cn/MiniMax-M3` default row carrying the China endpoint metadata, so the AppUI/onboarding catalog (derived catalog × registry) and the dashboard picker surface it. `dashboard/src/providers.json` updated; `scripts/sync-dashboard-providers.py` re-run — 0 appended, exit 0 (no drift, CI parity check passes).
- **`octos init`**: `MiniMax China (Token Plan)` preset offering both protocols the China platform documents (OpenAI → `api.minimaxi.com/v1` default, Anthropic → `api.minimaxi.com/anthropic`). Appended last so every existing preset index keeps its number (only the computed trailing Custom entry moves; pinned by a new test).
- **Docs**: `minimax-cn` row + region-split note in `book/src/providers.md` and `book-zh/src/providers.md`; provider counts bumped 16 → 17 in the READMEs and user guides (the old count was exact before this family); stale `minimax` default `MiniMax-Text-01` → `MiniMax-M3` fixed in the touched tables and `octos docs` (the registry resolves `MiniMax-M3` from the catalog).

## Test evidence

- New registry test (`minimax_cn_resolves_to_the_china_endpoint`): **red** when the entry is unregistered, **green** after — asserts the CN default URL, catalog default model, key env + alias, `minimaxi` alias, and that the international family keeps its endpoint and `MiniMax-M3` auto-detection. Two new `init` tests pin the preset's written config (China URL, no `api_type` on default), the protocol menu, the catalog-derived default model, and that existing preset indices never shift.
- `cargo test -p octos-llm --lib`: 607 passed, 0 failed.
- `cargo test -p octos-cli --lib`: 1627 passed, 1 failed — the failure is `autonomy::agent_orchestrator::tests::sovereignty_provider_fail_open_when_unowned_default_branch`, a **pre-existing environment issue unrelated to this change**: its helper does `git init` + commit + `git checkout -b main`, and on this machine Apple Git 2.50.1 initializes the default branch as `main` (even with `GIT_CONFIG_GLOBAL=/dev/null`), so the branch already exists. Reproduced with pure git, and the same test fails identically on two test binaries built from pristine main-line code before this branch existed.
- `cargo fmt --check` clean; `cargo clippy -p octos-llm -p octos-cli --all-targets -- -D warnings` zero warnings.

## End-to-end evidence (real binary, before → after)

- **Before** (real binary built from main-line code, `octos 2.0.3-rc.10`): `octos chat --provider minimax-cn` → `unknown provider: minimax-cn`.
- **After** (this branch's binary, dummy key, no overrides): `octos chat --provider minimax-cn --message "say hi"` → the request reaches the **real** `api.minimaxi.com` and MiniMax's server answers with its own 401 (`login fail: Please carry the API secret key...`), labeled `minimax-cn@api/MiniMax-M3` — family resolution, catalog default model, and the default China URL all live; only the key is missing. `--provider minimaxi` (alias) resolves identically.
- **Full turn**: against a local mock OpenAI endpoint via `--base-url` override, `minimax-cn` completes a real chat turn (mock reply rendered, token accounting logged).
- **`octos init`**: menu shows `9. MiniMax China (Token Plan)`; selecting it prompts protocol (OpenAI default / Anthropic), offers `MiniMax-M3` from the catalog, defaults `MINIMAX_CN_API_KEY`, and writes `{provider: "minimax-cn", model: "MiniMax-M3", api_key_env: "MINIMAX_CN_API_KEY", base_url: "https://api.minimaxi.com/v1"}` — no manual override.

## Review

Two review rounds: self-review of the full diff, then an independent adversarial review (issue text + diff + file paths only). Its nine findings were dispositioned as: fixed — init Custom-index documentation + index-pinning test, CN Anthropic protocol option in init, provider-count docs drift, stale `minimax` default in touched tables, init test gap. Rejected with rationale — env auto-detection region guessing (no reliable signal; international `MINIMAX_API_KEY` must not route to CN), the `MINIMAX_API_KEY` key-env alias (mirrors `moonshot-coding`; serves CN keys already in that variable), init's key-preflight reading only the primary env (pre-existing pattern, affects `moonshot` identically), catalog row priced at M3's documented rates rather than 0.0 (same model/same vendor rates are the best available data; 0.0 would understate pay-as-you-go CN keys).

Closes #2125
