### PR TITLE
fix(llm): resolve r9s model discovery per model — claude-* probes the Anthropic strategy + root

### DIFF
--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -1209,12 +1209,17 @@ pub async fn provider_models(
     }
     // Protocol-aware discovery shared with the AppUI `profile/llm/
     // fetch_models` surface — the strategy resolves from the route (api_type
-    // override, then the family's declared protocol), never from the literal
-    // family id, so the two clients cannot drift.
-    let discovery =
-        octos_llm::discovery::resolve_model_discovery(Some(&req.provider), req.api_type.as_deref());
+    // override, then the family's declared protocol — per-model for families
+    // like r9s that pick the wire protocol by model name), never from the
+    // literal family id, so the two clients cannot drift.
+    let route = octos_llm::discovery::resolve_model_discovery(
+        Some(&req.provider),
+        req.api_type.as_deref(),
+        (!req.model.trim().is_empty()).then_some(req.model.trim()),
+        req.base_url.as_deref(),
+    );
     let outcome = octos_llm::discovery::discover_models(
-        discovery,
+        &route,
         &api_key,
         req.base_url.as_deref(),
         Some(&req.provider),

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -9169,6 +9169,116 @@ async fn profile_llm_fetch_models_zai_never_gets_a_bearer_v1_models_probe() {
 }
 
 #[tokio::test]
+async fn profile_llm_fetch_models_r9s_claude_selection_probes_the_anthropic_root() {
+    let (root, captured) =
+        spawn_discovery_fixture("200 OK", r#"{"data":[{"id":"claude-sonnet-4"}]}"#).await;
+    let state = Arc::new(AppState::empty_for_tests());
+    // r9s serves claude-* over the Anthropic Messages protocol at a rewritten
+    // `{base}/anthropic` root — the probe must follow the SELECTED model
+    // (octos#2185), not the family-wide OpenAI declaration.
+    let request = RpcRequest::new(
+        "1",
+        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+        json!({
+            "selection": {
+                "family_id": "r9s",
+                "model_id": "claude-sonnet-4",
+                "route": {
+                    "route_id": "official",
+                    "base_url": format!("{root}/v1")
+                }
+            },
+            "api_key": "r9s-secret-key"
+        }),
+    );
+
+    let result = raw_profile_llm_fetch_models(&state, &request, Some("ada"))
+        .await
+        .expect("fetch_models result");
+
+    assert_eq!(result["status"], json!("discovered"));
+    assert_eq!(result["models"], json!(["claude-sonnet-4"]));
+    let requests = captured.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/anthropic/v1/models");
+    assert!(
+        requests[0].authorization.is_none(),
+        "r9s claude-* speaks Anthropic Messages — never a Bearer probe"
+    );
+    assert_eq!(requests[0].x_api_key.as_deref(), Some("r9s-secret-key"));
+}
+
+#[tokio::test]
+async fn profile_llm_fetch_models_r9s_non_claude_selection_keeps_the_openai_listing() {
+    let (root, captured) = spawn_discovery_fixture("200 OK", r#"{"data":[{"id":"gpt-5"}]}"#).await;
+    let state = Arc::new(AppState::empty_for_tests());
+    let request = RpcRequest::new(
+        "1",
+        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+        json!({
+            "selection": {
+                "family_id": "r9s",
+                "model_id": "gpt-5",
+                "route": {
+                    "route_id": "official",
+                    "base_url": format!("{root}/v1")
+                }
+            },
+            "api_key": "r9s-secret-key"
+        }),
+    );
+
+    let result = raw_profile_llm_fetch_models(&state, &request, Some("ada"))
+        .await
+        .expect("fetch_models result");
+
+    assert_eq!(result["status"], json!("discovered"));
+    let requests = captured.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/v1/models");
+    assert_eq!(
+        requests[0].authorization.as_deref(),
+        Some("Bearer r9s-secret-key")
+    );
+}
+
+/// The admin REST `/api/my/provider-models` surface shares the per-model
+/// resolution verbatim with the AppUI RPC — including passing the selected
+/// model through (octos#2185).
+#[tokio::test]
+async fn admin_provider_models_r9s_claude_selection_probes_the_anthropic_root() {
+    let (root, captured) =
+        spawn_discovery_fixture("200 OK", r#"{"data":[{"id":"claude-sonnet-4"}]}"#).await;
+    let state = Arc::new(AppState::empty_for_tests());
+
+    let response = crate::api::admin::provider_models(
+        axum::extract::State(state),
+        None,
+        axum::Json(crate::api::admin::TestProviderRequest {
+            provider: "r9s".into(),
+            model: "claude-sonnet-4".into(),
+            api_key: Some("r9s-secret-key".into()),
+            api_key_env: None,
+            base_url: Some(format!("{root}/v1")),
+            api_type: None,
+            profile_id: None,
+        }),
+    )
+    .await
+    .expect("provider-models result");
+
+    assert_eq!(response.0, vec!["claude-sonnet-4".to_string()]);
+    let requests = captured.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/anthropic/v1/models");
+    assert!(
+        requests[0].authorization.is_none(),
+        "r9s claude-* speaks Anthropic Messages — never a Bearer probe"
+    );
+    assert_eq!(requests[0].x_api_key.as_deref(), Some("r9s-secret-key"));
+}
+
+#[tokio::test]
 async fn profile_llm_fetch_models_does_not_duplicate_version_segments_on_v4_roots() {
     let (root, captured) =
         spawn_discovery_fixture("200 OK", r#"{"data":[{"id":"glm-5.2"}]}"#).await;

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -12668,14 +12668,19 @@ async fn raw_profile_llm_fetch_models(
 
     // Protocol-aware discovery, shared verbatim with the admin REST
     // `/api/my/provider-models` surface: the strategy resolves from the route
-    // (api_type override, then the family's declared protocol), and the typed
-    // outcome keeps "enter the model id manually" distinguishable from
+    // (api_type override, then the family's declared protocol — per-model for
+    // families like r9s that pick the wire protocol by model name), and the
+    // typed outcome keeps "enter the model id manually" distinguishable from
     // "credential/endpoint invalid" — instead of collapsing every failure
     // into an empty list + `provider_unavailable`.
-    let discovery =
-        octos_llm::discovery::resolve_model_discovery(Some(&family_id), api_type.as_deref());
+    let route = octos_llm::discovery::resolve_model_discovery(
+        Some(&family_id),
+        api_type.as_deref(),
+        nonempty(params.selection.model_id).as_deref(),
+        base_url.as_deref(),
+    );
     let outcome = octos_llm::discovery::discover_models(
-        discovery,
+        &route,
         &api_key,
         base_url.as_deref(),
         Some(&family_id),

--- a/crates/octos-llm/src/discovery.rs
+++ b/crates/octos-llm/src/discovery.rs
@@ -14,8 +14,11 @@
 //! `create_provider_with_api_type`: an `api_type` of `anthropic` forces the
 //! Anthropic Messages strategy, everything else follows the family's declared
 //! protocol (unknown families fall back to OpenAI-compatible, exactly like the
-//! runtime's custom-provider fallback). URL joining is relative to the
-//! configured API root — no heuristic version stripping/appending.
+//! runtime's custom-provider fallback). Families whose protocol is selected by
+//! MODEL NAME (r9s: `claude-*` → Anthropic) additionally carry a per-model
+//! resolver so the probe follows the selected model's protocol AND rewritten
+//! API root. URL joining is relative to the configured API root — no
+//! heuristic version stripping/appending.
 //!
 //! Discovery is ADVISORY: `Unsupported` or a discovery-only 404 must never
 //! mark a configured model unavailable and must never block manual model-id
@@ -58,6 +61,38 @@ pub const OPENAI_MODELS: ModelDiscovery =
     ModelDiscovery::Supported(DiscoveryProtocol::OpenAICompatible);
 /// Shorthand for registry entries: Gemini listing discovery.
 pub const GEMINI_MODELS: ModelDiscovery = ModelDiscovery::Supported(DiscoveryProtocol::GeminiList);
+
+/// Per-model discovery resolver stored on
+/// [`crate::registry::ProviderEntry::model_discovery_for_model`], for families
+/// that pick the wire protocol by MODEL NAME (r9s serves `claude-*` over the
+/// Anthropic Messages API). Given the selected model and the configured base
+/// URL (`None` = the family default root), returns the listing strategy and,
+/// when that strategy speaks against a DIFFERENT root than the configured
+/// one, that root — mirroring the rewrite the family's `create` applies.
+pub type ModelDiscoveryForModel =
+    fn(model: &str, base_url: Option<&str>) -> (ModelDiscovery, Option<String>);
+
+/// The resolved discovery route: which listing strategy to speak AND, for
+/// per-model-protocol families, the API root to speak it against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryRoute {
+    /// The listing strategy the probe must use.
+    pub discovery: ModelDiscovery,
+    /// Rewritten API root from a per-model resolver (r9s `claude-*` →
+    /// `{base}/anthropic`). When set it WINS over the caller's base_url and
+    /// the family default — it is derived from them, never a third source.
+    pub base_url: Option<String>,
+}
+
+impl From<ModelDiscovery> for DiscoveryRoute {
+    /// A plain family-wide declaration routes with no root rewrite.
+    fn from(discovery: ModelDiscovery) -> Self {
+        DiscoveryRoute {
+            discovery,
+            base_url: None,
+        }
+    }
+}
 
 /// The typed result of one discovery attempt. Every failure carries a safe,
 /// redacted message (never a credential) so callers can show it verbatim.
@@ -122,7 +157,7 @@ impl DiscoveryOutcome {
     }
 }
 
-/// Resolve the discovery strategy for a selected route.
+/// Resolve the discovery route for a selected route + model.
 ///
 /// Mirrors `create_provider_with_api_type`'s precedence exactly: an explicit
 /// `api_type: "anthropic"` overrides any family (the runtime bypasses the
@@ -131,19 +166,48 @@ impl DiscoveryOutcome {
 /// `custom` families fall back to the OpenAI-compatible strategy, matching the
 /// runtime's custom-provider default. The protocol is never inferred from a
 /// single literal family id.
-pub fn resolve_model_discovery(family: Option<&str>, api_type: Option<&str>) -> ModelDiscovery {
+///
+/// Families that select the wire protocol by MODEL NAME (r9s: `claude-*` →
+/// Anthropic Messages at a rewritten `{base}/anthropic` root) carry a
+/// per-model resolver on their registry entry; a selected model is resolved
+/// through it so the probe follows the same protocol AND root the provider
+/// factory would use. No model yet (listing before selection) uses the
+/// family-wide declaration.
+pub fn resolve_model_discovery(
+    family: Option<&str>,
+    api_type: Option<&str>,
+    model: Option<&str>,
+    base_url: Option<&str>,
+) -> DiscoveryRoute {
     if api_type == Some("anthropic") {
-        return ANTHROPIC_MODELS;
+        return ANTHROPIC_MODELS.into();
     }
+    // Normalize like `discover_models` does before handing the base URL to a
+    // per-model resolver — an empty/whitespace override must fall through to
+    // the family default root, never reach the resolver as `Some("")`.
+    let base_url = base_url.map(str::trim).filter(|root| !root.is_empty());
     match family
         .map(str::trim)
         .filter(|f| !f.is_empty())
         .and_then(crate::registry::lookup)
     {
-        Some(entry) => entry.model_discovery,
+        Some(entry) => {
+            // The model is matched RAW (no trim), exactly like provider
+            // construction's `prefers_anthropic` — a whitespace-padded model
+            // is served OpenAI at runtime, so discovery must not diverge.
+            let model = model.filter(|m| !m.is_empty());
+            if let (Some(resolver), Some(model)) = (entry.model_discovery_for_model, model) {
+                let (discovery, base_url) = resolver(model, base_url);
+                return DiscoveryRoute {
+                    discovery,
+                    base_url,
+                };
+            }
+            entry.model_discovery.into()
+        }
         // Unknown family / `custom` without an anthropic override: the runtime
         // builds an OpenAI-compatible provider, so discovery matches that.
-        None => OPENAI_MODELS,
+        None => OPENAI_MODELS.into(),
     }
 }
 
@@ -164,28 +228,34 @@ pub fn models_url(root: &str, protocol: DiscoveryProtocol) -> String {
     }
 }
 
-/// Run one discovery attempt against the resolved strategy.
+/// Run one discovery attempt against the resolved route.
 ///
 /// `api_key` may be empty for keyless families — the auth header is then
 /// suppressed rather than sent as a literal `Bearer ` (mirroring the
-/// connection-test path). `base_url` wins over the family's registered
-/// default root. Never includes the credential in any returned message.
+/// connection-test path). The route's rewritten root (per-model families)
+/// wins, then `base_url`, then the family's registered default root. Never
+/// includes the credential in any returned message.
 pub async fn discover_models(
-    discovery: ModelDiscovery,
+    route: &DiscoveryRoute,
     api_key: &str,
     base_url: Option<&str>,
     family: Option<&str>,
 ) -> DiscoveryOutcome {
-    let protocol = match discovery {
+    let protocol = match route.discovery {
         ModelDiscovery::Unsupported(reason) => {
             return DiscoveryOutcome::Unsupported(reason.to_string());
         }
         ModelDiscovery::Supported(protocol) => protocol,
     };
-    let root = base_url
-        .map(str::trim)
-        .filter(|root| !root.is_empty())
-        .map(str::to_string)
+    let root = route
+        .base_url
+        .clone()
+        .or_else(|| {
+            base_url
+                .map(str::trim)
+                .filter(|root| !root.is_empty())
+                .map(str::to_string)
+        })
         .or_else(|| {
             family
                 .map(str::trim)
@@ -323,9 +393,12 @@ mod tests {
         // The registry entry — not a `provider == "anthropic"` literal —
         // declares the protocol, so the Anthropic-protocol zai family resolves
         // to the Anthropic Messages strategy even though its id differs.
-        assert_eq!(resolve_model_discovery(Some("zai"), None), ANTHROPIC_MODELS);
         assert_eq!(
-            resolve_model_discovery(Some("zai-coding"), None),
+            resolve_model_discovery(Some("zai"), None, None, None).discovery,
+            ANTHROPIC_MODELS
+        );
+        assert_eq!(
+            resolve_model_discovery(Some("zai-coding"), None, None, None).discovery,
             ANTHROPIC_MODELS
         );
     }
@@ -338,8 +411,8 @@ mod tests {
                 _ => "zai-coding",
             };
             assert_eq!(
-                resolve_model_discovery(Some(alias), None),
-                resolve_model_discovery(Some(canonical), None),
+                resolve_model_discovery(Some(alias), None, None, None),
+                resolve_model_discovery(Some(canonical), None, None, None),
                 "alias {alias} must resolve like {canonical}"
             );
         }
@@ -350,12 +423,12 @@ mod tests {
         // The runtime's `create_provider_with_api_type` bypasses the registry
         // for `api_type: "anthropic"`; discovery mirrors that override.
         assert_eq!(
-            resolve_model_discovery(Some("openai"), Some("anthropic")),
+            resolve_model_discovery(Some("openai"), Some("anthropic"), None, None).discovery,
             ANTHROPIC_MODELS
         );
         // And a registered Anthropic-protocol family stays on-strategy.
         assert_eq!(
-            resolve_model_discovery(Some("zai"), Some("anthropic")),
+            resolve_model_discovery(Some("zai"), Some("anthropic"), None, None).discovery,
             ANTHROPIC_MODELS
         );
     }
@@ -367,15 +440,15 @@ mod tests {
         // AnthropicProvider, so discovery must NOT take the bait either
         // (saved AppUI routes default api_type to "openai").
         assert_eq!(
-            resolve_model_discovery(Some("zai"), Some("openai")),
+            resolve_model_discovery(Some("zai"), Some("openai"), None, None).discovery,
             ANTHROPIC_MODELS
         );
         assert_eq!(
-            resolve_model_discovery(Some("zhipu"), Some("openai")),
+            resolve_model_discovery(Some("zhipu"), Some("openai"), None, None).discovery,
             OPENAI_MODELS
         );
         assert_eq!(
-            resolve_model_discovery(Some("anthropic"), Some("openai")),
+            resolve_model_discovery(Some("anthropic"), Some("openai"), None, None).discovery,
             // The literal anthropic family's native protocol is Messages, but
             // its route explicitly says the openai override… which for a
             // registered family is ignored at runtime — native rules.
@@ -385,26 +458,32 @@ mod tests {
 
     #[test]
     fn should_fall_back_to_openai_strategy_for_unknown_and_custom_families() {
-        assert_eq!(resolve_model_discovery(Some("custom"), None), OPENAI_MODELS);
         assert_eq!(
-            resolve_model_discovery(Some("custom"), Some("openai")),
+            resolve_model_discovery(Some("custom"), None, None, None).discovery,
             OPENAI_MODELS
         );
         assert_eq!(
-            resolve_model_discovery(Some("custom"), Some("anthropic")),
+            resolve_model_discovery(Some("custom"), Some("openai"), None, None).discovery,
+            OPENAI_MODELS
+        );
+        assert_eq!(
+            resolve_model_discovery(Some("custom"), Some("anthropic"), None, None).discovery,
             ANTHROPIC_MODELS
         );
         assert_eq!(
-            resolve_model_discovery(Some("not-a-family"), None),
+            resolve_model_discovery(Some("not-a-family"), None, None, None).discovery,
             OPENAI_MODELS
         );
-        assert_eq!(resolve_model_discovery(None, None), OPENAI_MODELS);
+        assert_eq!(
+            resolve_model_discovery(None, None, None, None).discovery,
+            OPENAI_MODELS
+        );
     }
 
     #[test]
     fn should_declare_unsupported_discovery_for_vertex() {
-        let discovery = resolve_model_discovery(Some("vertex"), None);
-        match discovery {
+        let discovery = resolve_model_discovery(Some("vertex"), None, None, None);
+        match discovery.discovery {
             ModelDiscovery::Unsupported(reason) => {
                 assert!(
                     reason.contains("manually"),
@@ -542,7 +621,7 @@ mod tests {
         // Base root exactly as the zai family spells it (no /v1 suffix).
         let url = format!("{root}/api/anthropic");
         let outcome = discover_models(
-            resolve_model_discovery(Some("zai"), Some("openai")),
+            &resolve_model_discovery(Some("zai"), Some("openai"), None, None),
             "zai-key-secret",
             Some(&url),
             Some("zai"),
@@ -572,7 +651,7 @@ mod tests {
         let (root, captured) = spawn_fixture("200 OK", r#"{"data":[{"id":"glm-5.2"}]}"#).await;
         let url = format!("{root}/api/paas/v4");
         let outcome = discover_models(
-            resolve_model_discovery(Some("zhipu"), None),
+            &resolve_model_discovery(Some("zhipu"), None, None, None),
             "zhipu-key",
             Some(&url),
             Some("zhipu"),
@@ -593,7 +672,7 @@ mod tests {
     async fn should_map_401_to_authentication_failed_and_404_to_unsupported() {
         let (root, _) = spawn_fixture("401 Unauthorized", r#"{"error":{}}"#).await;
         let outcome = discover_models(
-            OPENAI_MODELS,
+            &OPENAI_MODELS.into(),
             "bad-key",
             Some(&format!("{root}/v1")),
             Some("openai"),
@@ -603,7 +682,7 @@ mod tests {
 
         let (root, _) = spawn_fixture("404 Not Found", "nope").await;
         let outcome = discover_models(
-            OPENAI_MODELS,
+            &OPENAI_MODELS.into(),
             "k",
             Some(&format!("{root}/v1")),
             Some("openai"),
@@ -618,7 +697,7 @@ mod tests {
     async fn should_map_rate_limit_transport_and_malformed_responses_distinctly() {
         let (root, _) = spawn_fixture("429 Too Many Requests", "{}").await;
         let outcome = discover_models(
-            OPENAI_MODELS,
+            &OPENAI_MODELS.into(),
             "k",
             Some(&format!("{root}/v1")),
             Some("openai"),
@@ -628,7 +707,7 @@ mod tests {
 
         // Nothing listens on port 1 — transport failure, not an auth problem.
         let outcome = discover_models(
-            OPENAI_MODELS,
+            &OPENAI_MODELS.into(),
             "k",
             Some("http://127.0.0.1:1/v1"),
             Some("openai"),
@@ -638,7 +717,7 @@ mod tests {
 
         let (root, _) = spawn_fixture("200 OK", "<html>not json</html>").await;
         let outcome = discover_models(
-            OPENAI_MODELS,
+            &OPENAI_MODELS.into(),
             "k",
             Some(&format!("{root}/v1")),
             Some("openai"),
@@ -649,7 +728,7 @@ mod tests {
         // Shape mismatch: 200 + JSON without the expected array.
         let (root, _) = spawn_fixture("200 OK", r#"{"models":"bogus"}"#).await;
         let outcome = discover_models(
-            OPENAI_MODELS,
+            &OPENAI_MODELS.into(),
             "k",
             Some(&format!("{root}/v1")),
             Some("openai"),
@@ -662,7 +741,7 @@ mod tests {
     async fn should_keep_empty_successful_catalogs_distinguishable_from_failures() {
         let (root, _) = spawn_fixture("200 OK", r#"{"data":[]}"#).await;
         let outcome = discover_models(
-            OPENAI_MODELS,
+            &OPENAI_MODELS.into(),
             "k",
             Some(&format!("{root}/v1")),
             Some("openai"),
@@ -677,7 +756,7 @@ mod tests {
     async fn should_return_declared_unsupported_without_any_outbound_request() {
         let (root, captured) = spawn_fixture("200 OK", r#"{"data":[]}"#).await;
         let outcome = discover_models(
-            resolve_model_discovery(Some("vertex"), None),
+            &resolve_model_discovery(Some("vertex"), None, None, None),
             "sa-json",
             Some(&root),
             Some("vertex"),
@@ -693,6 +772,109 @@ mod tests {
             captured.lock().await.is_empty(),
             "manual-only families must never be probed"
         );
+    }
+
+    /// r9s picks its wire protocol by model name (`claude-*` → Anthropic
+    /// Messages at `{base}/anthropic`); the discovery route must follow the
+    /// selected model, not the family-wide OpenAI declaration (octos#2185).
+    #[test]
+    fn should_resolve_r9s_discovery_per_model() {
+        // claude-* → Anthropic strategy against the rewritten root, derived
+        // from the configured base URL when one is set…
+        let route = resolve_model_discovery(
+            Some("r9s"),
+            None,
+            Some("claude-sonnet-4"),
+            Some("https://proxy.example.com/v1"),
+        );
+        assert_eq!(route.discovery, ANTHROPIC_MODELS);
+        assert_eq!(
+            route.base_url.as_deref(),
+            Some("https://proxy.example.com/anthropic")
+        );
+        // …and from the family default root when none is.
+        let route = resolve_model_discovery(Some("r9s"), None, Some("claude-sonnet-4"), None);
+        assert_eq!(route.discovery, ANTHROPIC_MODELS);
+        assert_eq!(
+            route.base_url.as_deref(),
+            Some("https://api.r9s.ai/anthropic")
+        );
+
+        // An empty/whitespace base_url override normalizes away BEFORE the
+        // resolver sees it — `Some("")` must never rewrite to "/anthropic"
+        // and strand the probe on a relative URL.
+        for base in [Some(""), Some("   ")] {
+            let route = resolve_model_discovery(Some("r9s"), None, Some("claude-sonnet-4"), base);
+            assert_eq!(
+                route.base_url.as_deref(),
+                Some("https://api.r9s.ai/anthropic"),
+                "empty base_url {base:?} must fall back to the family default root"
+            );
+        }
+        // A padded base_url is trimmed so the `/v1` suffix strip still lands.
+        let route = resolve_model_discovery(
+            Some("r9s"),
+            None,
+            Some("claude-sonnet-4"),
+            Some("  https://proxy.example.com/v1  "),
+        );
+        assert_eq!(
+            route.base_url.as_deref(),
+            Some("https://proxy.example.com/anthropic")
+        );
+
+        // A non-claude model keeps the family-wide OpenAI listing with no
+        // root rewrite — as does no model yet (listing before selection).
+        // Models are matched RAW like `create` does: a whitespace-padded
+        // model is served OpenAI at runtime, so discovery must not diverge.
+        for model in [
+            Some("gpt-5"),
+            Some("Claude-sonnet-4"),
+            Some(" claude-sonnet-4"),
+            None,
+            Some(""),
+        ] {
+            let route = resolve_model_discovery(Some("r9s"), None, model, None);
+            assert_eq!(
+                route,
+                OPENAI_MODELS.into(),
+                "model {model:?} must use the family-wide OpenAI route"
+            );
+        }
+
+        // The explicit api_type override still wins over per-model resolution,
+        // exactly like it bypasses the registry at runtime.
+        let route = resolve_model_discovery(Some("r9s"), Some("anthropic"), Some("gpt-5"), None);
+        assert_eq!(route.discovery, ANTHROPIC_MODELS);
+    }
+
+    /// The r9s claude probe must hit the Anthropic listing at the rewritten
+    /// root with Anthropic header semantics — never `{base}/models` with a
+    /// Bearer header (octos#2185).
+    #[tokio::test]
+    async fn should_probe_anthropic_root_for_r9s_claude_selection_without_bearer() {
+        let (root, captured) =
+            spawn_fixture("200 OK", r#"{"data":[{"id":"claude-sonnet-4"}]}"#).await;
+        // Configured base exactly as the r9s family spells it (`{base}/v1`).
+        let url = format!("{root}/v1");
+        let outcome = discover_models(
+            &resolve_model_discovery(Some("r9s"), None, Some("claude-sonnet-4"), Some(&url)),
+            "r9s-key",
+            Some(&url),
+            Some("r9s"),
+        )
+        .await;
+
+        assert_eq!(outcome.status_label(), "discovered");
+        let requests = captured.lock().await;
+        assert_eq!(requests.len(), 1);
+        let only = &requests[0];
+        assert_eq!(only.path, "/anthropic/v1/models");
+        assert!(
+            only.authorization.is_none(),
+            "r9s claude-* must never get a Bearer probe"
+        );
+        assert_eq!(only.x_api_key.as_deref(), Some("r9s-key"));
     }
 
     #[test]

--- a/crates/octos-llm/src/registry/anthropic.rs
+++ b/crates/octos-llm/src/registry/anthropic.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     detect_patterns: &["claude"],
     model_discovery: crate::discovery::ANTHROPIC_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/dashscope.rs
+++ b/crates/octos-llm/src/registry/dashscope.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     detect_patterns: &["qwen"],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/deepseek.rs
+++ b/crates/octos-llm/src/registry/deepseek.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     detect_patterns: &["deepseek"],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/gemini.rs
+++ b/crates/octos-llm/src/registry/gemini.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     detect_patterns: &["gemini"],
     model_discovery: crate::discovery::GEMINI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/groq.rs
+++ b/crates/octos-llm/src/registry/groq.rs
@@ -19,6 +19,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // Groq hosts many open-source models — llama and mixtral are common.
     detect_patterns: &["llama", "mixtral"],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/local.rs
+++ b/crates/octos-llm/src/registry/local.rs
@@ -37,6 +37,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // User-loaded models — nothing to pattern-match.
     detect_patterns: &[],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/minimax.rs
+++ b/crates/octos-llm/src/registry/minimax.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     detect_patterns: &["minimax"],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/mod.rs
+++ b/crates/octos-llm/src/registry/mod.rs
@@ -147,6 +147,13 @@ pub struct ProviderEntry {
     /// [`crate::discovery::resolve_model_discovery`] — the protocol is never
     /// inferred from the family id string.
     pub model_discovery: crate::discovery::ModelDiscovery,
+    /// Per-model discovery resolver for families that pick the wire protocol
+    /// by MODEL NAME (r9s serves `claude-*` over the Anthropic Messages API at
+    /// a rewritten `{base}/anthropic` root). Consulted by
+    /// [`crate::discovery::resolve_model_discovery`] ahead of the family-wide
+    /// `model_discovery` when a model is selected and no `api_type` override
+    /// applies; `None` means the family-wide declaration always rules.
+    pub model_discovery_for_model: Option<crate::discovery::ModelDiscoveryForModel>,
     /// Factory function with full control over provider construction.
     pub create: fn(CreateParams) -> Result<Arc<dyn LlmProvider>>,
 }

--- a/crates/octos-llm/src/registry/moonshot.rs
+++ b/crates/octos-llm/src/registry/moonshot.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     detect_patterns: &["kimi", "moonshot"],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/moonshot_coding.rs
+++ b/crates/octos-llm/src/registry/moonshot_coding.rs
@@ -27,6 +27,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // endpoint, which would reject a coding-plan key.
     detect_patterns: &[],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/nvidia.rs
+++ b/crates/octos-llm/src/registry/nvidia.rs
@@ -19,6 +19,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // Nvidia NIM hosts many models — no simple detect pattern.
     detect_patterns: &[],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/ollama.rs
+++ b/crates/octos-llm/src/registry/ollama.rs
@@ -20,6 +20,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // Ollama hosts user-pulled models — no detect pattern.
     detect_patterns: &[],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/openai.rs
+++ b/crates/octos-llm/src/registry/openai.rs
@@ -19,6 +19,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     detect_patterns: &["gpt"],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/openrouter.rs
+++ b/crates/octos-llm/src/registry/openrouter.rs
@@ -19,6 +19,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // OpenRouter hosts many models — no simple detect pattern.
     detect_patterns: &[],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/r9s.rs
+++ b/crates/octos-llm/src/registry/r9s.rs
@@ -8,6 +8,11 @@ use crate::provider::LlmProvider;
 
 use super::{CreateParams, ProviderEntry};
 
+/// The default OpenAI-compatible API root. ONE const behind the ENTRY
+/// declaration and both fallbacks (`create` + discovery) so serving and
+/// probing can never drift onto different roots.
+const DEFAULT_BASE_URL: &str = "https://api.r9s.ai/v1";
+
 /// Whether r9s serves `model` over the Anthropic Messages API.
 ///
 /// r9s auto-selects the Anthropic protocol for `claude-*` models and the
@@ -21,18 +26,54 @@ pub(crate) fn prefers_anthropic(model: &str) -> bool {
     model.starts_with("claude-")
 }
 
+/// The Anthropic-protocol API root: claude-* is served at `{base}/anthropic`
+/// (the `/v1` suffix belongs to the OpenAI-compatible root). ONE rewrite
+/// shared by provider construction and model discovery so the two can never
+/// probe/serve different roots.
+fn anthropic_root(base_url: &str) -> String {
+    base_url
+        .strip_suffix("/v1")
+        .map(|base| format!("{base}/anthropic"))
+        .unwrap_or_else(|| format!("{base_url}/anthropic"))
+}
+
+/// Per-model discovery resolution (octos#2185): a claude-* selection must be
+/// probed with the Anthropic Messages strategy against [`anthropic_root`] —
+/// the family-wide OpenAI declaration would probe `{base}/models` with a
+/// Bearer header the Anthropic endpoint does not speak. Anything else keeps
+/// the family-wide OpenAI-compatible listing with no root rewrite.
+fn discovery_for_model(
+    model: &str,
+    base_url: Option<&str>,
+) -> (crate::discovery::ModelDiscovery, Option<String>) {
+    if prefers_anthropic(model) {
+        // Default root from the ENTRY declaration; the const fallback
+        // mirrors `create` and is unreachable while the entry declares one.
+        let base = base_url
+            .or(ENTRY.default_base_url)
+            .unwrap_or(DEFAULT_BASE_URL);
+        (
+            crate::discovery::ANTHROPIC_MODELS,
+            Some(anthropic_root(base)),
+        )
+    } else {
+        (crate::discovery::OPENAI_MODELS, None)
+    }
+}
+
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "r9s",
     aliases: &["r9s.ai"],
     api_key_env: Some("R9S_API_KEY"),
     key_env_aliases: &[],
-    default_base_url: Some("https://api.r9s.ai/v1"),
+    default_base_url: Some(DEFAULT_BASE_URL),
     requires_api_key: true,
     requires_base_url: false,
     requires_model: false,
     // R9S hosts many providers — no simple detect pattern.
     detect_patterns: &[],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: Some(discovery_for_model),
     create,
 };
 
@@ -50,18 +91,14 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
                 ENTRY.name
             )
         })?;
-    let url = p.base_url.unwrap_or_else(|| "https://api.r9s.ai/v1".into());
+    let url = p.base_url.unwrap_or_else(|| DEFAULT_BASE_URL.into());
 
     // Auto-detect protocol: Anthropic Messages API for claude-* models,
     // OpenAI Chat Completions for everything else.
     if prefers_anthropic(&model) {
-        let anthropic_url = url
-            .strip_suffix("/v1")
-            .map(|base| format!("{base}/anthropic"))
-            .unwrap_or_else(|| format!("{url}/anthropic"));
         let mut provider = AnthropicProvider::new(&key, &model)
             .with_provider_label("r9s")
-            .with_base_url(&anthropic_url);
+            .with_base_url(anthropic_root(&url));
         if let Some((t, c)) = http_timeout {
             provider = provider.with_http_timeout(t, c);
         }

--- a/crates/octos-llm/src/registry/vertex.rs
+++ b/crates/octos-llm/src/registry/vertex.rs
@@ -31,6 +31,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     model_discovery: crate::discovery::ModelDiscovery::Unsupported(
         "Vertex AI lists models through project-scoped, service-account APIs - enter the model id manually",
     ),
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/vllm.rs
+++ b/crates/octos-llm/src/registry/vllm.rs
@@ -20,6 +20,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // vLLM hosts user-deployed models — no detect pattern.
     detect_patterns: &[],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/zai.rs
+++ b/crates/octos-llm/src/registry/zai.rs
@@ -20,6 +20,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // Z.AI hosts multiple model families — no simple detect pattern.
     detect_patterns: &[],
     model_discovery: crate::discovery::ANTHROPIC_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/zai_coding.rs
+++ b/crates/octos-llm/src/registry/zai_coding.rs
@@ -27,6 +27,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     // model, which the regular `zai`/`zhipu` families already handle.
     detect_patterns: &[],
     model_discovery: crate::discovery::ANTHROPIC_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 

--- a/crates/octos-llm/src/registry/zhipu.rs
+++ b/crates/octos-llm/src/registry/zhipu.rs
@@ -18,6 +18,7 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
     requires_model: false,
     detect_patterns: &["glm"],
     model_discovery: crate::discovery::OPENAI_MODELS,
+    model_discovery_for_model: None,
     create,
 };
 


### PR DESCRIPTION
## Problem

#2185 (follow-up from the #2183 review): r9s selects its wire protocol by **model name** — `claude-*` constructs an `AnthropicProvider` against a rewritten `{base}/anthropic` root, everything else uses OpenAI Chat Completions. But the registry entry declared `OPENAI_MODELS` discovery unconditionally, so a r9s + `claude-*` selection was probed at `{base}/models` with `Authorization: Bearer` instead of the Anthropic Messages listing (`{anthropic-root}/v1/models` with `x-api-key`).

## Root cause

`resolve_model_discovery` resolved the listing strategy from `(family, api_type)` only — it had no access to the selected model, so the family-wide declaration was the most specific answer it could give. The knowledge of the per-model protocol split lived only in r9s's `create` (and, for pricing, `prefers_anthropic`), unreachable from discovery.

## Fix

Per-model resolution, exactly as the issue's first suggestion:

- `ProviderEntry` gains `model_discovery_for_model: Option<ModelDiscoveryForModel>` — an optional per-model resolver consulted ahead of the family-wide `model_discovery` when a model is selected and no `api_type` override applies. The 18 other families declare `None` (behavior unchanged).
- r9s's resolver maps `claude-*` → `ANTHROPIC_MODELS` against `anthropic_root()`, the **same** root rewrite `create()` applies (extracted into one shared function), driven by the existing `prefers_anthropic` SSOT (raw, case-sensitive `claude-` prefix — identical to construction and pricing). The default root is now one shared const behind the ENTRY declaration and both fallbacks, so serving and probing can never drift onto different roots.
- `resolve_model_discovery(family, api_type, model, base_url)` returns a `DiscoveryRoute { discovery, base_url }`; `discover_models` resolves the probe root as route rewrite → caller `base_url` → family default. The base URL is normalized (trim + empty-filter) **before** the resolver sees it, so `base_url: ""` falls through to the family default instead of producing a relative `/anthropic` URL (caught in review).
- Both call surfaces (AppUI `profile/llm/fetch_models` RPC and admin REST `/api/my/provider-models`) pass the selected model through. The `api_type: "anthropic"` override still wins, mirroring the runtime bypass.

No model selected yet (listing before selection) and non-claude selections keep the family-wide OpenAI listing — unchanged.

## Test evidence

- New tests fail with the resolver disabled and pass with it (red/green verified):
  - `discovery::tests::should_resolve_r9s_discovery_per_model` — strategy + root per model, incl. empty/whitespace/padded `base_url`, mixed-case `Claude-*` (stays OpenAI), whitespace-padded model (stays OpenAI, matching runtime's raw match), no model, and the `api_type` override.
  - `discovery::tests::should_probe_anthropic_root_for_r9s_claude_selection_without_bearer` — loopback HTTP fixture asserts the probe path `/anthropic/v1/models`, `x-api-key` present, `Authorization` absent.
  - RPC level: `profile_llm_fetch_models_r9s_claude_selection_probes_the_anthropic_root` and `..._non_claude_selection_keeps_the_openai_listing` (AppUI), `admin_provider_models_r9s_claude_selection_probes_the_anthropic_root` (REST).
- `cargo test -p octos-llm --lib`: 608 passed, 0 failed.
- `cargo test -p octos-cli --lib --features api`: 3194 passed; 1 failure in `autonomy::agent_orchestrator::tests::sovereignty_provider_fail_open_when_unowned_default_branch` — pre-existing, environment-dependent (this machine's `git init` defaults to `main`, so the test's `git checkout -b main` fails with "branch already exists"); verified to fail identically on pristine `origin/main` in a module untouched by this diff.
- `cargo fmt --check` clean; `cargo clippy -p octos-llm / -p octos-cli --all-targets [--features api] -- -D warnings` clean.

**End-to-end** (real `octos serve` + loopback fixture server logging every request, `POST /api/my/provider-models` with `provider=r9s`, `base_url=http://127.0.0.1:…/v1`):

| request | before (origin/main binary) | after (this branch) |
|---|---|---|
| `model=claude-sonnet-4` | `GET /v1/models`, `Authorization: Bearer` — the mis-probe from the issue | `GET /anthropic/v1/models`, `x-api-key` + `anthropic-version: 2023-06-01`, no Bearer |
| `model=claude-sonnet-4`, padded base_url | — | same correct Anthropic probe (normalization) |
| `model=gpt-5` / no model | `GET /v1/models` + Bearer | unchanged: `GET /v1/models` + Bearer |

## Review

Independent adversarial review (given only the issue text + diff + file paths): initial REQUEST_CHANGES with one major finding (unnormalized `base_url` could regress `base_url: ""` to `endpoint_unreachable` on the REST surface) and four minor/nit findings (REST surface untested, model-trim divergence vs runtime, third hardcoded default root, comment accuracy). All five addressed; re-review verdict APPROVE.

Known limitation (out of scope): the shipped admin dashboard hardcodes `model: ''` when calling `/api/my/provider-models`, so the per-model path fires there only for API clients that send a model; the AppUI selection flow passes `model_id` through. Discovery remains advisory in all cases — a failed probe never blocks manual model-id entry, Test, or Save.

Closes #2185