### PR TITLE
feat(agent): Pi-aligned defaults for local providers (server-sampled temperature + no wall-clock cap)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -703,7 +703,16 @@ impl Agent {
     /// Build a `ChatConfig` with optional `chat_max_tokens` / `chat_temperature`
     /// overrides from `AgentConfig`. Delegates to [`build_chat_config`].
     fn chat_config(&self) -> ChatConfig {
-        build_chat_config(&self.config)
+        build_chat_config(&self.config, self.is_local_provider())
+    }
+
+    /// True when the active LLM provider is the built-in local/self-hosted
+    /// provider (metadata name `"local"`). Local reasoning models (e.g. Qwen
+    /// on llama.cpp) need Pi-aligned defaults (#2229) — server-sampled
+    /// temperature and no overall wall-clock cap — while cloud providers keep
+    /// the conservative defaults. An explicit operator override always wins.
+    pub(super) fn is_local_provider(&self) -> bool {
+        self.llm.provider_metadata().provider == "local"
     }
 
     /// Decide what to surface when the loop detector fires.
@@ -3954,16 +3963,24 @@ fn shell_retry_limit_message(content: &str) -> String {
 /// without constructing a full `Agent` — in particular the cloud-safety
 /// invariant (#2172): an unset `chat_temperature` must leave the built-in
 /// `0.0` default untouched, so cloud requests are byte-for-byte unchanged.
-fn build_chat_config(config: &crate::AgentConfig) -> ChatConfig {
+///
+/// `local_provider` (#2229): for the local/self-hosted provider, an unset
+/// `chat_temperature` leaves temperature UNSET rather than defaulting to `0.0`,
+/// so the server samples (Pi parity) — forced greedy degenerates local
+/// reasoning models. Cloud (`local_provider = false`) is unchanged.
+fn build_chat_config(config: &crate::AgentConfig, local_provider: bool) -> ChatConfig {
     let mut c = ChatConfig::default();
     if let Some(max) = config.chat_max_tokens {
         c.max_tokens = Some(max);
     }
-    // Temperature override. Unset → keep the built-in default (0.0), so cloud
-    // requests are unchanged; set → override, primarily to avoid forced-greedy
-    // repetition collapse on local models.
+    // Temperature. An explicit `chat_temperature` always wins. Otherwise: on a
+    // LOCAL provider leave it unset so the server samples (the request omits
+    // `temperature` via skip_serializing_if); on cloud keep the built-in `0.0`
+    // default so cloud requests are byte-for-byte unchanged.
     if let Some(temp) = config.chat_temperature {
         c.temperature = Some(temp);
+    } else if local_provider {
+        c.temperature = None;
     }
     // Extra sampler params (e.g. repeat_penalty) for OpenAI-compatible servers.
     // Unset → nothing added, cloud unchanged.

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6557,7 +6557,7 @@ fn build_chat_config_keeps_default_temperature_when_unset() {
         chat_temperature: None,
         ..AgentConfig::default()
     };
-    let chat = build_chat_config(&cfg);
+    let chat = build_chat_config(&cfg, false);
     assert_eq!(chat.temperature, ChatConfig::default().temperature);
     assert_eq!(chat.temperature, Some(0.0));
 }
@@ -6568,7 +6568,7 @@ fn build_chat_config_applies_temperature_override() {
         chat_temperature: Some(0.7),
         ..AgentConfig::default()
     };
-    let chat = build_chat_config(&cfg);
+    let chat = build_chat_config(&cfg, false);
     assert_eq!(chat.temperature, Some(0.7));
 }
 
@@ -6582,7 +6582,7 @@ fn build_chat_config_threads_sampling_params() {
         chat_sampling_params: Some(sp),
         ..AgentConfig::default()
     };
-    let chat = build_chat_config(&cfg);
+    let chat = build_chat_config(&cfg, false);
     assert_eq!(
         chat.sampling_params
             .as_ref()
@@ -6590,7 +6590,7 @@ fn build_chat_config_threads_sampling_params() {
         Some(&serde_json::json!(1.1))
     );
     assert_eq!(
-        build_chat_config(&AgentConfig::default()).sampling_params,
+        build_chat_config(&AgentConfig::default(), false).sampling_params,
         None
     );
 }
@@ -6603,9 +6603,34 @@ fn build_chat_config_applies_max_tokens_override_independently() {
         chat_temperature: Some(0.5),
         ..AgentConfig::default()
     };
-    let chat = build_chat_config(&cfg);
+    let chat = build_chat_config(&cfg, false);
     assert_eq!(chat.max_tokens, Some(4096));
     assert_eq!(chat.temperature, Some(0.5));
+}
+
+#[test]
+fn build_chat_config_local_provider_unsets_temperature() {
+    // #2229: on a local provider with no explicit chat_temperature, temperature
+    // is left UNSET (None) so the server samples — the request omits it — rather
+    // than forcing greedy 0.0 (which degenerates local reasoning models).
+    let cfg = AgentConfig {
+        chat_temperature: None,
+        ..AgentConfig::default()
+    };
+    let chat = build_chat_config(&cfg, true);
+    assert_eq!(chat.temperature, None);
+    // Cloud path is unchanged: still the built-in 0.0.
+    assert_eq!(build_chat_config(&cfg, false).temperature, Some(0.0));
+}
+
+#[test]
+fn build_chat_config_local_provider_respects_explicit_temperature() {
+    // An explicit override always wins, even on local.
+    let cfg = AgentConfig {
+        chat_temperature: Some(0.6),
+        ..AgentConfig::default()
+    };
+    assert_eq!(build_chat_config(&cfg, true).temperature, Some(0.6));
 }
 
 // --- #2174: conversation-loop recovery from a degenerate empty MaxTokens ---

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -97,11 +97,27 @@ impl Agent {
                 StreamTimeouts {
                     first_token_grace_secs: self.config.llm_first_token_grace.as_secs(),
                     inter_chunk_idle_secs: self.config.llm_stream_idle.as_secs(),
-                    overall_max_secs: self.config.llm_call_max.as_secs(),
+                    overall_max_secs: self.effective_llm_call_max_secs(),
                 }
             };
         self.consume_stream_inner(stream, iteration, input_tokens_estimate, thresholds)
             .await
+    }
+
+    /// Overall wall-clock cap for a normal (non-voice) turn.
+    ///
+    /// For a local provider (#2229) the cap is disabled by default (`0`) so a
+    /// slow-but-healthy reasoning stream is not guillotined mid-flight while
+    /// tokens are still flowing — Pi has no such cap, and the inter-chunk idle
+    /// and TTFT guards still catch a genuinely dead provider. An operator who
+    /// explicitly sets `OCTOS_LLM_CALL_MAX_SECS` gets exactly that value even on
+    /// local. Cloud keeps the `DEFAULT_LLM_CALL_MAX_SECS` (1200s) backstop.
+    fn effective_llm_call_max_secs(&self) -> u64 {
+        if self.is_local_provider() && std::env::var("OCTOS_LLM_CALL_MAX_SECS").is_err() {
+            0
+        } else {
+            self.config.llm_call_max.as_secs()
+        }
     }
 
     /// Test-only entry point: lets fixtures dial the timeouts down to


### PR DESCRIPTION
## What & why

Closes #2229. A fresh **local**-model user (llama.cpp via the `local` provider) had to hand-tweak config to get usable behavior, because two defaults tuned for cloud actively harm a slow local **reasoning** model:

1. **Forced greedy decoding** — `ChatConfig::default().temperature = Some(0.0)` is sent on every request; on a local reasoning model this drives the repetition collapse (`#2172/#2173`). Pi sends no temperature and lets the server sample.
2. **1200s overall wall-clock cap** — `DEFAULT_LLM_CALL_MAX_SECS = 1200` aborts a **healthy, actively-streaming** reasoning turn (it fires even while tokens flow). A whole-repo C→Rust reasoning turn on a 27B local model legitimately exceeds 20 min and got guillotined as `provider stalled`. Pi has no wall-clock cap.

Both are correct for cloud (greedy = reproducible; the cap backstops slow-trickle billing), so the fix makes them **provider-aware** — changing behavior only for `provider == "local"`.

## Change

- `Agent::is_local_provider()` — true when the active provider's metadata name is `"local"` (`self.llm.provider_metadata().provider`).
- **Temperature** (`build_chat_config`): gains a `local_provider` arg. An explicit `chat_temperature` still wins; otherwise, for local, temperature is left **unset** (`None`) so the request omits it (`skip_serializing_if`) and the server samples. Cloud keeps the built-in `0.0` default byte-for-byte.
- **Wall-clock cap** (`effective_llm_call_max_secs`): for local, defaults to **0 (disabled)** — the inter-chunk idle + TTFT guards still catch a genuinely dead provider — **unless** the operator explicitly set `OCTOS_LLM_CALL_MAX_SECS`. Cloud keeps 1200s.

Pairs with #2228 (so an explicit `OCTOS_LLM_CALL_MAX_SECS=0` also disables). Net effect: a fresh local user gets Pi-parity (server-sampled temperature, no wall-clock guillotine) with **zero config**, while cloud is unchanged.

## Cloud safety

Every cloud/remote path takes `local_provider = false` / `is_local_provider() == false`, so temperature stays `0.0` and the cap stays 1200s — byte-for-byte unchanged. Only `provider == "local"` gets the Pi-aligned defaults, and an explicit operator override wins for both knobs on either provider kind.

## Tests

- `build_chat_config_local_provider_unsets_temperature` — local + no override ⇒ `temperature == None`; same cfg on cloud ⇒ `Some(0.0)`.
- `build_chat_config_local_provider_respects_explicit_temperature` — explicit override wins on local.
- Existing `#2172` cloud-safety tests updated to pass `local_provider = false` and still assert the `0.0` default.

`cargo test -p octos-agent`, fmt, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
