### PR TITLE
fix(goals): goal_create treats archived as terminal; goal_update on archived points to a new goal (#2237)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ test_a2.md
 !CLAUDE.md
 !CHANGELOG.md
 !.octos/AGENTS.md
+!specs/task-issue-2237-goal-create-admits-archived.spec.md
 !specs/task-approval-post-tool-continuation.spec.md
 !specs/kv-cache-friendly-compaction.spec.md
 !specs/task-compaction-instruction-priority.spec.md

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -5674,6 +5674,12 @@ impl InProcessAgentOrchestrator {
                     ));
                 }
             }
+            if goal.status == "archived" {
+                // #2237 — an archived goal is terminal and operator-only;
+                // point the model at the create path instead of a generic
+                // stale-verdict refusal.
+                return Err("goal is archived; create a new goal instead".to_owned());
+            }
             if goal.status == "complete" {
                 return Err("goal is already complete".to_owned());
             }
@@ -8959,6 +8965,15 @@ impl InProcessAgentOrchestrator {
     /// when no goal exists or replaces the current goal when it is complete").
     /// Always creates an `active`, model-attributed goal owned by `profile_id` —
     /// pause/resume/budget stay user-owned exactly as in `model_transition_goal`.
+    /// #2237 — the TERMINAL goal statuses. Admission (and terminal
+    /// replacement) must key on "is this goal unfinished", not on a single
+    /// literal: an OPERATOR-ARCHIVED goal is just as finished as a complete
+    /// one, and refusing it dead-locked the session (issue #2237: no new
+    /// goal, no goal_update, no `/goal stop`).
+    fn goal_status_is_terminal(status: &str) -> bool {
+        matches!(status, "complete" | "archived")
+    }
+
     pub(crate) fn model_create_goal(
         &self,
         session_id: &SessionKey,
@@ -8989,7 +9004,9 @@ impl InProcessAgentOrchestrator {
                             .to_owned(),
                     );
                 }
-                if existing.status != "complete" {
+                // #2237 — ANY terminal status (complete | archived) admits a
+                // new goal; only genuinely unfinished states refuse.
+                if !Self::goal_status_is_terminal(&existing.status) {
                     return Err(format!(
                         "cannot create a new goal because this session has an unfinished goal \
                          (status `{}`); complete or clear the existing goal first",
@@ -9942,10 +9959,9 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
         // preserves the update branch's cross-profile guard (which still fires
         // for a mismatched profile because we only remove on a match).
         if requested_status != Some("complete")
-            && state
-                .goals
-                .get(&key)
-                .is_some_and(|g| g.status == "complete" && g.profile_id == request.profile_id)
+            && state.goals.get(&key).is_some_and(|g| {
+                Self::goal_status_is_terminal(&g.status) && g.profile_id == request.profile_id
+            })
         {
             state.goals.remove(&key);
         }
@@ -23223,6 +23239,175 @@ mod tests {
                 transition_actor: None,
             })
             .expect("user replace still works");
+    }
+
+    /// #2237 — archived is TERMINAL: creating a new goal after an operator
+    /// archive must succeed, mint a FRESH goal id, and leave the archived
+    /// record's ledger untouched.
+    #[tokio::test]
+    async fn model_create_goal_admits_after_archived() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "2237-arch");
+        let first = orchestrator
+            .model_create_goal(&session_id, "tenant-a", "first objective", Some(2_000))
+            .expect("initial create");
+        let first_id = first["goal_id"].as_str().expect("id").to_owned();
+
+        // Operator archive (the only archived-reachable path, #25).
+        orchestrator
+            .operator_transition_goal(
+                &session_id,
+                "tenant-a",
+                None,
+                "archive",
+                "test archive",
+                None,
+            )
+            .expect("operator archive");
+
+        // The admission that USED to refuse with (status `archived`).
+        let second = orchestrator
+            .model_create_goal(&session_id, "tenant-a", "second objective", Some(2_000))
+            .expect("create after archive must be admitted (#2237)");
+        let second_id = second["goal_id"].as_str().expect("new id").to_owned();
+        assert_ne!(second_id, first_id, "terminal replacement mints a fresh id");
+        assert_eq!(second["status"], json!("active"));
+
+        // The archived record's ledger is untouched by design (Fix B drops
+        // the in-memory record and never edits the old ledger); the fresh
+        // id + active status above are the pinned observables.
+    }
+
+    /// #2237 — complete stays admissible (behavior unchanged, now pinned).
+    #[tokio::test]
+    async fn model_create_goal_admits_after_complete_unchanged() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "2237-comp");
+        let first = orchestrator
+            .model_create_goal(&session_id, "tenant-a", "first", Some(2_000))
+            .expect("create");
+        let first_id = first["goal_id"].as_str().expect("id").to_owned();
+        orchestrator
+            .model_transition_goal(&session_id, "tenant-a", "complete", "done", None)
+            .await
+            .expect("complete");
+        let second = orchestrator
+            .model_create_goal(&session_id, "tenant-a", "second", Some(2_000))
+            .expect("create after complete");
+        assert_ne!(
+            second["goal_id"].as_str().expect("id"),
+            first_id,
+            "fresh id minted"
+        );
+    }
+
+    /// #2237 — active still refuses, with the unchanged message.
+    #[tokio::test]
+    async fn model_create_goal_rejects_active_unchanged() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "2237-active");
+        orchestrator
+            .model_create_goal(&session_id, "tenant-a", "one", None)
+            .expect("first");
+        let err = orchestrator
+            .model_create_goal(&session_id, "tenant-a", "two", None)
+            .expect_err("active refuses");
+        assert!(err.contains("unfinished goal (status `active`)"), "{err}");
+    }
+
+    /// #2237 — blocked and paused still refuse, each naming its status.
+    #[tokio::test]
+    async fn model_create_goal_rejects_blocked_and_paused() {
+        for (suffix, status) in [("blocked", "blocked"), ("paused", "paused")] {
+            let orchestrator = InProcessAgentOrchestrator::default();
+            let session_id = SessionKey::with_profile("tenant-a", "api", suffix);
+            orchestrator
+                .model_create_goal(&session_id, "tenant-a", "one", None)
+                .expect("first");
+            // blocked is model-reachable via model_transition_goal; paused is
+            // a user/backend state — set it through set_goal's status knob.
+            if status == "blocked" {
+                orchestrator
+                    .model_transition_goal(&session_id, "tenant-a", status, "test", None)
+                    .await
+                    .expect("blocked transition");
+            } else {
+                orchestrator
+                    .set_goal(GoalSetRequest {
+                        session_id: session_id.clone(),
+                        profile_id: "tenant-a".to_owned(),
+                        objective: "one".to_owned(),
+                        status: Some(status.to_owned()),
+                        token_budget: None,
+                        transition_actor: Some("backend".to_owned()),
+                    })
+                    .map(|_| ())
+                    .unwrap_or(());
+            }
+            let err = orchestrator
+                .model_create_goal(&session_id, "tenant-a", "two", None)
+                .expect_err("unfinished refuses");
+            assert!(
+                err.contains(&format!("status `{status}`")),
+                "{status} named in: {err}"
+            );
+        }
+    }
+
+    /// #2237 — budget_limited still refuses.
+    #[tokio::test]
+    async fn model_create_goal_rejects_budget_limited() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "2237-budget");
+        orchestrator
+            .model_create_goal(&session_id, "tenant-a", "one", Some(1_000))
+            .expect("first");
+        orchestrator.force_goal_tokens_used_for_test(&session_id, 1_000);
+        // Lower the budget below used → set_goal flips the goal to
+        // budget_limited (the pre-existing #2010 semantics, see the twin
+        // test `set_goal_flips_active_goal_to_budget_limited_when_budget_
+        // lowered_below_used`).
+        let _ = orchestrator.set_goal(GoalSetRequest {
+            session_id: session_id.clone(),
+            profile_id: "tenant-a".to_owned(),
+            objective: "one".to_owned(),
+            status: Some("budget_limited".to_owned()),
+            token_budget: Some(1_000),
+            transition_actor: Some("backend".to_owned()),
+        });
+        let err = orchestrator
+            .model_create_goal(&session_id, "tenant-a", "two", None)
+            .expect_err("budget_limited refuses");
+        assert!(err.contains("budget_limited"), "{err}");
+    }
+
+    /// #2237 — goal_update on an archived goal points at create-new instead
+    /// of a stale-verdict refusal.
+    #[tokio::test]
+    async fn goal_update_on_archived_says_create_new() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "2237-update");
+        orchestrator
+            .model_create_goal(&session_id, "tenant-a", "objective", None)
+            .expect("create");
+        orchestrator
+            .operator_transition_goal(
+                &session_id,
+                "tenant-a",
+                None,
+                "archive",
+                "test archive",
+                None,
+            )
+            .expect("archive");
+        let err = orchestrator
+            .model_transition_goal(&session_id, "tenant-a", "complete", "done", None)
+            .await
+            .expect_err("update on archived refuses");
+        assert!(
+            err.contains("goal is archived; create a new goal instead"),
+            "guidance message: {err}"
+        );
     }
 
     #[tokio::test]

--- a/specs/task-issue-2237-goal-create-admits-archived.spec.md
+++ b/specs/task-issue-2237-goal-create-admits-archived.spec.md
@@ -1,0 +1,84 @@
+spec: task
+name: "goal_create 准入把 archived 视为终态(issue #2237)"
+tags: [goals, autonomy, agent-orchestrator, octos-cli]
+estimate: 0.5d
+---
+
+## Intent
+
+`model_create_goal` 的准入判定写的是"现有 goal 状态是否为 `complete`",语义应是"是否
+未完成"。会话上一个 goal 为 `archived`(操作者归档,终态)时,新 goal 被拒绝
+`cannot create a new goal … (status \`archived\`)`,`goal_update` 也拒绝,master 只能裸驱
+peer、收工无法 `/goal stop`(2026-09-04 OLP #45 实证,issue #2237)。本任务把准入谓词
+改为"任一终态均可替换",并保持"未完成拒绝、替换终态必铸新 id"两条既有承诺不变。
+
+## Decisions
+
+- 终态集合定义为一个私有常量函数 `goal_status_is_terminal(status: &str) -> bool`,对
+  `"complete"` 与 `"archived"` 返回 true,其余(含 `active`、`blocked`、`paused`、
+  `budget_limited`)返回 false;放在 `agent_orchestrator.rs` 中 `model_create_goal` 附近,
+  并被 `model_create_goal` 的准入判定(现 L8992 `existing.status != "complete"`)调用。
+- 拒绝文案不变(`cannot create a new goal because this session has an unfinished goal …`),
+  只是不再对终态触发。
+- 替换终态 goal 走既有 Fix B 路径:铸新 goal id,旧 ledger 不触碰。
+- `goal_update` 对 `archived` goal 的拒绝文案改为
+  `goal is archived; create a new goal instead`(替换现有 stale-verdict 文案在该分支的用词),
+  其它分支不动。
+- 不改 TUI 头部投影(另立;本任务只修准入与 update 文案)。
+- 测试与既有 `model_create_goal_gates_on_unfinished_goal`(L23229 附近)同模块、同夹具风格。
+
+## Boundaries
+
+### Allowed Changes
+- crates/octos-cli/src/autonomy/agent_orchestrator.rs
+
+### Forbidden
+- 不改 goal 状态机的其它转移(archive/reopen/complete/blocked)。
+- 不改 goal ledger 的持久化格式与 wire 形状。
+- 不改 `goal_create` 的并发准入(#1935 round 7 的 set_goal 原子检查)。
+- 不引入新依赖。
+
+## Out of Scope
+
+- TUI 头部把 archived goal 当当前 goal 显示的投影修复。
+- 离线 `goal archive` 被 live cache 反盖(#43 已在线化)。
+
+## Acceptance Criteria
+
+Scenario: archived 之后可以创建新 goal(critical)
+  Tags: critical
+  Test: model_create_goal_admits_after_archived
+  Given 会话现有 goal 状态为 archived
+  When 以 actor model 调用 model_create_goal 创建新目标
+  Then 返回 Ok 且新 goal 的 id 不等于旧 goal 的 id
+  And 旧 goal 的 ledger 记录保持不变
+
+Scenario: complete 之后仍可创建新 goal
+  Test: model_create_goal_admits_after_complete_unchanged
+  Given 会话现有 goal 状态为 complete
+  When 调用 model_create_goal
+  Then 返回 Ok 且铸出新 id
+
+Scenario: active 仍被拒绝
+  Test: model_create_goal_rejects_active_unchanged
+  Given 会话现有 goal 状态为 active
+  When 调用 model_create_goal
+  Then 返回 Err 且错误文案含 "unfinished goal (status `active`)"
+
+Scenario: blocked 与 paused 仍被拒绝
+  Test: model_create_goal_rejects_blocked_and_paused
+  Given 会话现有 goal 状态分别为 blocked 与 paused
+  When 分别调用 model_create_goal
+  Then 两次均返回 Err 且文案各含对应状态
+
+Scenario: budget_limited 仍被拒绝
+  Test: model_create_goal_rejects_budget_limited
+  Given 会话现有 goal 状态为 budget_limited
+  When 调用 model_create_goal
+  Then 返回 Err 且文案含 "budget_limited"
+
+Scenario: goal_update 对 archived 给出明确指引
+  Test: goal_update_on_archived_says_create_new
+  Given 会话现有 goal 状态为 archived
+  When 以 actor model 调用 goal_update
+  Then 返回 Err 且文案含 "goal is archived; create a new goal instead"


### PR DESCRIPTION
Fixes #2237

## Summary

`model_create_goal` admitted a new goal only when the existing goal's status was exactly `complete`. An `archived` goal (operator archive, a terminal state everywhere else in the orchestrator) therefore blocked creation with "cannot create a new goal because this session has an unfinished goal (status `archived`)", and `goal_update` rejected it as a stale verdict. Observed 2026-09-04 (OLP #45): the master could not open a goal envelope and drove peers without one.

Changes (one file, `crates/octos-cli/src/autonomy/agent_orchestrator.rs`):

- New private predicate `goal_status_is_terminal(status)` = `complete | archived`; the admission check and the terminal-replacement path in `set_goal` (the "Fix B mints a fresh id" sibling) both use it. `active`, `blocked`, `paused`, `budget_limited` are still refused with the unchanged message.
- Replacing a terminal goal mints a fresh goal id; the old ledger is untouched.
- `goal_update` on an archived goal now says `goal is archived; create a new goal instead`.
- The TUI header projection (archived goal shown as current) is out of scope and tracked in the issue.

## Tests

Six contract-bound tests (`model_create_goal_admits_after_archived`, `…_admits_after_complete_unchanged`, `…_rejects_active_unchanged`, `…_rejects_blocked_and_paused`, `…_rejects_budget_limited`, `goal_update_on_archived_says_create_new`). Gates: `cargo test -p octos-cli --features api --lib model_create_goal` 7/0 and `goal_update` 5/0, clippy `-D warnings`, fmt; `agent-spec lifecycle` 6/6. Independently re-verified in an isolated worktree by the outer loop.

Contract: `specs/task-issue-2237-goal-create-admits-archived.spec.md` (un-ignored in `.gitignore` per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zbAVTB1tkMF49Zr52UB7Z
