### PR TITLE
ci: add the 'CI required' aggregate gate job the branch ruleset expects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1311,3 +1311,45 @@ jobs:
         run: |
           echo "Running 24 security integration tests on macOS (sandbox-exec SBPL)"
           cargo test -p octos-agent --test security_sandbox -- --nocapture
+
+  # Aggregate gate for the `default-branch-protection` ruleset, whose required
+  # status context is literally "CI required". Until now nothing produced that
+  # context, so every PR sat on "Expected — waiting for status" until a
+  # maintainer posted it by hand. This job runs after every PR-relevant job and
+  # reports the single required status automatically: skipped upstream jobs
+  # (event-gated ARM/RISC-V/release builds) are fine, any failure or
+  # cancellation fails the gate.
+  ci-required:
+    name: CI required
+    if: always() && github.event_name != 'schedule'
+    needs:
+      - dashboard
+      - swarm-app
+      - typos
+      - ux-gate-report
+      - windows-deploy-script
+      - web-app-base-url-windows
+      - check
+      - test-octos-agent
+      - test-octos-cli
+      - check-matrix
+      - check-windows
+      - e2e-changes
+      - e2e-tool-regression
+      - security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | python3 -c '
+          import json, sys
+          needs = json.load(sys.stdin)
+          bad = {k: v["result"] for k, v in needs.items() if v["result"] in ("failure", "cancelled")}
+          for k, v in sorted(needs.items()):
+              print(f"{k}: {v[\"result\"]}")
+          if bad:
+              print("gate: FAIL ->", bad); sys.exit(1)
+          print("gate: all required jobs succeeded or were skipped by event gating")
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1343,13 +1343,17 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "$NEEDS_JSON" | python3 -c '
-          import json, sys
-          needs = json.load(sys.stdin)
-          bad = {k: v["result"] for k, v in needs.items() if v["result"] in ("failure", "cancelled")}
-          for k, v in sorted(needs.items()):
-              print(f"{k}: {v[\"result\"]}")
+          python3 - <<'PY'
+          import json, os, sys
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          bad = {}
+          for name in sorted(needs):
+              result = needs[name]["result"]
+              print(name + ": " + result)
+              if result in ("failure", "cancelled"):
+                  bad[name] = result
           if bad:
-              print("gate: FAIL ->", bad); sys.exit(1)
-          print("gate: all required jobs succeeded or were skipped by event gating")
-          '
+              print("gate: FAIL -> " + json.dumps(bad))
+              sys.exit(1)
+          print("gate: all required jobs succeeded (event-gated skips are fine)")
+          PY


### PR DESCRIPTION
## Why

The `default-branch-protection` ruleset requires a status context named **`CI required`**, but no workflow in the repo produces it. Every PR therefore sits on "CI required — Expected — Waiting for status to be reported" until someone posts that status by hand (that is how #2216/#2230/#2232 got merged: a manually posted `CI required: success` with no creator/target URL).

## What

Adds an aggregate job `ci-required` (display name `CI required`) at the end of `ci.yml`. It `needs` every PR-relevant job, runs with `if: always()` (not on the nightly schedule), treats event-gated skips (ARM/RISC-V/release builds) as fine, and fails if any needed job failed or was cancelled. The ruleset does not change; the required context is now produced automatically on every PR, and `strict_required_status_checks_policy` keeps the up-to-date-with-main requirement as before.

This PR's own run exercises the job, so the gate reports on itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zbAVTB1tkMF49Zr52UB7Z
