### PR TITLE
fix(test): master_continuation_tick_reenters_actor_loop — condition-based wait instead of fixed 10-yield spin

### DIFF
--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -2498,11 +2498,21 @@ async fn master_continuation_tick_reenters_actor_loop() {
         })
         .unwrap();
 
-    for _ in 0..10 {
+    // #2011: `advance` moves VIRTUAL time, but the tick → drain →
+    // process_inbound → persist chain also needs REAL scheduling (blocking
+    // I/O threads), so a fixed iteration budget races machine load and
+    // flaked ~25% under high load. Bound the wait by a wall-clock deadline
+    // (std Instant — tokio's clock is paused in this test) and pace each
+    // virtual advance with a real sleep so starved OS threads get CPU.
+    // Pacing is not what keeps the actor alive: the pre-loop upsert is
+    // synchronous, the first interval tick drains it immediately (which
+    // resets idle_sleep), and idle_sleep cannot fire mid-turn — the
+    // deadline only has to cover [actor start → first drain].
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while provider.call_count.load(Ordering::Relaxed) == 0 && std::time::Instant::now() < deadline {
         tokio::time::advance(Duration::from_millis(250)).await;
-        if provider.call_count.load(Ordering::Relaxed) > 0 {
-            break;
-        }
+        tokio::task::yield_now().await;
+        std::thread::sleep(Duration::from_millis(10));
     }
 
     assert!(
@@ -2510,24 +2520,19 @@ async fn master_continuation_tick_reenters_actor_loop() {
         "periodic actor tick must drain queued child completion into process_inbound"
     );
 
-    // `process_inbound` persists through the real spawn-blocking JSONL path.
-    // This test uses a paused Tokio clock, so advancing virtual time alone
-    // cannot guarantee that the blocking-pool completion has been observed.
-    // Poll in bounded real-time slices, matching the goal-continuation test
-    // below, instead of racing the durable append.
-    for _ in 0..500 {
-        tokio::task::spawn_blocking(|| {
-            std::thread::sleep(Duration::from_millis(2));
-        })
-        .await
-        .unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
         let session_handle = SessionHandle::open(dir.path(), &session_id);
         if session_handle.session().messages.iter().any(|message| {
             message.role == MessageRole::Assistant
                 && message.content.contains("child progress summary")
-        }) {
+        }) || std::time::Instant::now() >= deadline
+        {
             break;
         }
+        tokio::time::advance(Duration::from_millis(250)).await;
+        tokio::task::yield_now().await;
+        std::thread::sleep(Duration::from_millis(10));
     }
     let session_handle = SessionHandle::open(dir.path(), &session_id);
     let session = session_handle.session();


### PR DESCRIPTION
## Problem

`session_actor::tests::master_continuation_tick_reenters_actor_loop` failed ~25% of the time on unmodified `main` under machine load (#2011). It waited for the tick → drain → `process_inbound` → persist chain with a fixed 10-iteration `advance(250ms)` + `yield_now` budget. `tokio::time::advance` moves **virtual** time while the chain also needs **real** scheduling (blocking I/O threads), so under load the budget expired before the work landed and the assertion fired with `: []` — producing false attributions on unrelated branches.

## Root cause

A fixed iteration budget on virtual time races real-world scheduling. Ten cooperative yields grant the chain essentially zero wall-clock time; on a loaded machine the persistence write (blocking pool thread) has not run when the assertion fires.

## Fix

Test-only change, confined to the one test. Both waits are now bounded by a 10s **wall-clock** deadline (`std::time::Instant` — tokio's clock is paused in this `start_paused` test), and each virtual `advance` is paced with a real 10ms `std::thread::sleep` so starved OS threads get CPU. On timeout the loops fall through to the **original assertions unchanged**, so a genuine regression still fails with the same diagnostic messages (including the full message dump).

The comment also records what actually keeps the actor alive during the wait (verified against `session_actor.rs`): the pre-loop `upsert_agent` is synchronous, the first `interval` tick drains it immediately and resets `idle_sleep`, and `idle_sleep` cannot fire mid-turn — so the deadline only has to cover [actor start → first drain].

The sweep for the same pattern elsewhere is deliberately **not** in this PR: the `format_after_edit` rustfmt-budget cases are tracked by #2053, and no other `for _ in 0..N { yield_now }`-before-assert instance of this shape exists in this test file.

## Test evidence

Reproduced and verified on an 8-core macOS host under artificial load (16 CPU spinners, load average ~60-90), running the compiled test binary directly:

- **Before** (unmodified `origin/main` @ e08c2715): **4/24 runs failed**, with the exact signature from the issue — `panicked at crates/octos-cli/src/session_actor_tests.rs:2525:5: master continuation should persist the model-generated progress summary: []`.
- **After**: **0/30 runs failed**, and 0/30 again in a second load run after the review-driven comment edit (60/60 total) — exceeds the issue's 20/20-under-load acceptance bar.
- `cargo test -p octos-cli --lib --features api`: **3202 passed, 0 failed** (2 filtered out — see below).
- `cargo test -p octos-cli --lib` (default features; this test is `api`-gated and not compiled): 1637 passed, 1 failed — the failure is `sovereignty_provider_fail_open_when_unowned_default_branch`, a **pre-existing, unrelated** environmental failure: Apple Git's system gitconfig sets `init.defaultbranch=main`, so that test's fixture `git checkout -b main` collides with the already-existing branch. Root-caused and filed separately as #2251; its code path is untouched by this diff.
- `cargo fmt --check`: clean. `cargo clippy -p octos-cli --all-targets --features api -- -D warnings`: zero warnings (run twice, before and after the comment edit).

## End-to-end note

The fix target is itself an integration-level test (real `SessionActor\::run loop, real `SessionHandle` file persistence, mock LLM provider), so the load-loop runs above **are** the end-to-end evidence of the behavior difference: same binary path, before = 4/24 red with the issue's exact signature, after = 60/60 green under the same load.

## Review

- Round 1 self-review: full `git diff origin/main` read line-by-line; no debug residue, no unrelated changes, failure paths keep the original assertions.
- Round 2 independent review (fresh-eyes subagent given only the issue text + diff + file paths): no blockers; one NIT — the original comment misattributed the idle-timeout safety to pacing. Corrected to credit the actual invariants (synchronous pre-loop upsert, reset-on-drain, no mid-turn idle fire).
- Round 3: after that comment edit, reran the 30x load loop (0/30), the full `--features api` lib suite (3202/3202), and clippy (clean).

Closes #2011