### PR TITLE
test(agent): make sovereignty repo helper independent of platform default branch (#2251)

### DIFF
--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -33646,7 +33646,10 @@ mod tests {
         std::fs::write(root.join("seed.txt"), "seed\n").unwrap();
         run(&["add", "."]);
         run(&["commit", "-q", "-m", "init"]);
-        run(&["checkout", "-q", "-b", branch]);
+        // `-B` (create-or-reset), not `-b`: the platform default branch may
+        // already BE `branch` (Apple Git's system gitconfig sets
+        // `init.defaultBranch=main`), and `-b` would exit 128 there.
+        run(&["checkout", "-q", "-B", branch]);
     }
 
     /// #20c — the installed provider scans MULTIPLE goals' ledgers for the


### PR DESCRIPTION
## 问题

`autonomy::agent_orchestrator::tests::sovereignty_provider_fail_open_when_unowned_default_branch` 在 macOS 上确定性失败：

```
git ["checkout", "-q", "-b", "main"] failed
```

## 根因

测试辅助函数 `init_repo_on_branch`（`crates/octos-cli/src/autonomy/agent_orchestrator.rs`）执行 `git init` 后 `git checkout -b <branch>`。Apple Git（2.50.1, Apple Git-155）的系统级 gitconfig（`/Library/Developer/CommandLineTools/usr/share/git-core/gitconfig`）设置了 `init.defaultBranch=main`，因此初始提交已经创建了 `main` 分支，`checkout -b main` 以 128 退出（`fatal: a branch named 'main' already exists`）。CI（ubuntu，默认 `master`）不触发，测试隐含假设了平台默认分支不是 `main`。

## 修复

`checkout -q -b <branch>` 改为 `checkout -q -B <branch>`（create-or-reset）：

- 平台默认分支为 `master` 时（CI）：行为与 `-b` 完全一致——新建 `main` 并切换。
- 平台默认分支已是 `main` 时（macOS）：对当前分支做指向同一 seed 提交的 no-op reset，git 明确允许（与 `git branch -f` 不同），exit 0。
- `-B` 在远古版本 git 中即存在，比 issue 建议的另一方案 `git init -b`（需 git ≥ 2.28）更具可移植性。
- 该辅助函数只在全新 `init` 的仓库上运行（单个 seed 提交），`-B` 的 reset 语义不可能掩盖任何真实问题。

改动仅此一行（外加 3 行注释），严格限于 issue 范围。

## 测试证据

- **修复前**：在本机（macOS + Apple Git 2.50.1，系统 gitconfig 含 `init.defaultBranch=main`）对未修改的 `origin/main`（b47b6671）运行 `cargo test -p octos-cli --lib --features api sovereignty_provider_fail_open_when_unowned_default_branch` → 失败，报错与 issue 一致。
- **修复后（macOS 真实环境，真实 git 二进制）**：同一命令通过；全部 4 个 sovereignty 相关测试通过。
- **模拟 CI 方向**（`GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=master` 覆盖默认分支为 master）：4 个测试全部通过，两个方向都验证到。
- `cargo test -p octos-cli --lib --features api`：**3220 passed, 0 failed**，一遍通过。
- `cargo fmt --check` 干净；`cargo clippy -p octos-cli --all-targets --features api -- -D warnings` 零 warning。

端到端说明：本 issue 是测试基础设施问题，其真实路径就是测试二进制在本机调用真实 git——上述「修复前红 / 修复后绿 + 双默认分支方向」即端到端验证。

## 审查结论

- 轮 1 自查：diff 全量逐行过，仅一行改动 + 注释，无调试残留、无无关改动。
- 轮 2 独立审查（子代理，只给 issue 原文 + diff + 文件路径）：**APPROVE**，无 blocker；独立复现了 4 种（分支 × 默认分支）组合确认行为一致，并确认 `checkout -B` 作用于当前分支合法、仓库内其余 `checkout -b` 调用点不受影响。

Closes #2251