### PR TITLE
fix(skills): resolve ./-prefixed skill hook argv elements beyond argv[0] against the skill dir

### DIFF
--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -235,19 +235,20 @@ fn resolve_hook(def: &SkillHookDef, skill_dir: &Path) -> Option<HookConfig> {
         _ => return None,
     };
 
-    // Resolve the first element of command if it's a relative path.
+    // Resolve every `./`/`../` element against the skill dir; bare commands
+    // (e.g. "python3") are left for PATH. The hook process's cwd is the
+    // payload's workspace root when the payload carries one
+    // (after_tool_call / user_prompt_submit), otherwise the daemon's cwd —
+    // never the skill dir — so a script argument like
+    // `["python3", "./hooks/x.py"]` must resolve here too; resolving only
+    // argv[0] leaves it pointing at the wrong root.
     let command: Vec<String> = def
         .command
         .iter()
-        .enumerate()
-        .map(|(i, arg)| {
-            if i == 0 {
-                let p = Path::new(arg);
-                if p.is_relative() && (arg.starts_with("./") || arg.starts_with("../")) {
-                    skill_dir.join(p).to_string_lossy().into_owned()
-                } else {
-                    arg.clone()
-                }
+        .map(|arg| {
+            let p = Path::new(arg);
+            if p.is_relative() && (arg.starts_with("./") || arg.starts_with("../")) {
+                skill_dir.join(p).to_string_lossy().into_owned()
             } else {
                 arg.clone()
             }
@@ -359,6 +360,45 @@ mod tests {
                 hook.command[0]
             );
         }
+    }
+
+    #[test]
+    fn test_resolve_hook_relative_args() {
+        // The hook process's cwd is never the skill dir, so every
+        // `./`/`../` argv element — not just argv[0] — must resolve against
+        // the skill dir, otherwise `["python3", "./hooks/x.py"]` fails to
+        // find the script.
+        let def = SkillHookDef {
+            event: "after_tool_call".into(),
+            command: vec![
+                "python3".into(),
+                "./hooks/audit.py".into(),
+                "../shared/lib.py".into(),
+                "-c".into(),
+                "/abs/path.cfg".into(),
+                "plain-arg".into(),
+            ],
+            timeout_ms: 3000,
+            tool_filter: vec![],
+        };
+        let hook = resolve_hook(&def, Path::new("/skills/s")).unwrap();
+        assert_eq!(hook.command[0], "python3");
+        assert!(
+            hook.command[1] == "/skills/s/./hooks/audit.py"
+                || hook.command[1] == "/skills/s\\./hooks/audit.py",
+            "unexpected resolved arg: {}",
+            hook.command[1]
+        );
+        assert!(
+            hook.command[2] == "/skills/s/../shared/lib.py"
+                || hook.command[2] == "/skills/s\\../shared/lib.py",
+            "unexpected resolved arg: {}",
+            hook.command[2]
+        );
+        // Flags, absolute paths, and plain arguments stay untouched.
+        assert_eq!(hook.command[3], "-c");
+        assert_eq!(hook.command[4], "/abs/path.cfg");
+        assert_eq!(hook.command[5], "plain-arg");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A skill manifest hook declared as `["python3", "./hooks/x.py"]` never worked: `plugins/extras.rs::resolve_hook` joined `skill_dir` onto `command[0]` only, leaving every later argv element untouched. The script then resolved against the hook process's cwd (the payload's workspace root, or the daemon cwd) and failed on every call with `can't open file` — under `after_tool_call` the failure was even fed back to the model as `[hook]` output. The documented contract (`SkillHookDef::command`: "Relative paths resolved against skill directory") makes no argv[0] exception.

## Root cause

`resolve_hook` applied the `./`/`../` → `skill_dir` join inside an `i == 0` arm and passed every later element through unchanged.

## Fix

Apply the same join to **every** argv element that starts with `./` or `../` (bare commands like `python3` are still left for PATH; flags, absolute paths, and plain arguments pass through untouched). This is the resolution the issue suggested and matches the documented contract. No behavior change for commands that only use `./` in argv[0] (the only in-tree skill hook, `app-skills/skill-evolve`, is of that shape).

One deliberate behavior alignment: a non-first `./` arg that *intentionally* referenced a workspace-relative file (undocumented; contradicted by the manifest docs) now resolves against the skill dir instead.

## Test evidence

- New unit test `plugins::extras::tests::test_resolve_hook_relative_args`: **red before** (`./hooks/audit.py` left unresolved), **green after**. Covers mid-argv `./` and `../` resolution plus negative cases (`-c` flag, absolute path, plain arg stay untouched).
- `cargo test -p octos-agent`: 2808 passed; the only 3 failures (`docker_sandbox_fails_command_validator_closed`, `spawn_/delegate_threads_configured_sandbox_into_validator_registry`) are pre-existing on clean `origin/main` on this host — they require a Docker-capable sandbox backend and fail identically without this change. All integration test targets pass.
- `cargo fmt --check` clean; `cargo clippy -p octos-agent --all-targets -- -D warnings` clean.
- **End-to-end (real CLI binary, before vs after)**: fixture skill at `<cwd>/.octos/skills/hooktest/` with manifest hook `["python3", "./hooks/deny.py"]` on `user_prompt_submit` (prints `blocked-by-skill-hook`, exit 1), run via `octos chat --cwd <project> --provider local -m hi`:
  - **Before** (`origin/main` binary): `python3: can't open file '/private/tmp/.../project/./hooks/deny.py': [Errno 2]` — the hook errors out, the deny is silently lost, and the turn proceeds to the LLM call (fails later with connection refused, no local server running).
  - **After** (this branch): `WARN user_prompt_submit hook denied prompt reason=blocked-by-skill-hook` and the CLI surfaces `[HOOK DENIED] Prompt was blocked by a user_prompt_submit hook: blocked-by-skill-hook` — the script is found, the policy is enforced, the LLM is never called.

## Review

Two rounds: self-review of the full diff (caught and corrected an over-broad cwd claim in the new comment), then an independent adversarial review subagent given only the issue text + diff + file paths. Its findings: no blockers; confirmed no security regression from `../` (same semantics as the pre-existing argv[0] join; skills are trusted code); flagged the comment's cwd overgeneralization (fixed — only `after_tool_call`/`user_prompt_submit` payloads carry a workspace root); noted the same argv-resolution gap exists for skill MCP server `args` in `resolve_mcp_server` (deliberately out of scope, to be filed as a follow-up).

Closes #2245