### PR TITLE
fix(skills): resolve ./-prefixed MCP server args against the skill dir

### DIFF
--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -51,8 +51,8 @@ pub struct SkillExtras {
 
 /// Resolve manifest extras against the skill directory.
 ///
-/// - MCP: resolves relative commands against `skill_dir`, looks up env var names
-///   from the process environment.
+/// - MCP: resolves relative commands and `./`/`../` arg elements against
+///   `skill_dir`, looks up env var names from the process environment.
 /// - Hooks: parses event strings into `HookEvent`, resolves relative command paths.
 /// - Discovery: renders a short 5-line skill card (PR-F) preceded by a
 ///   generic exploration preamble emitted once per call.
@@ -175,17 +175,35 @@ fn render_skill_card(
     card
 }
 
+/// Resolve a `./`/`../`-prefixed relative path against the skill dir;
+/// anything else (bare commands like "node", flags, absolute paths, plain
+/// arguments) passes through verbatim.
+fn resolve_skill_path(arg: &str, skill_dir: &Path) -> String {
+    let p = Path::new(arg);
+    if p.is_relative() && (arg.starts_with("./") || arg.starts_with("../")) {
+        skill_dir.join(p).to_string_lossy().into_owned()
+    } else {
+        arg.to_owned()
+    }
+}
+
 /// Convert a skill MCP server declaration into a runtime `McpServerConfig`.
 fn resolve_mcp_server(srv: &SkillMcpServer, skill_dir: &Path) -> McpServerConfig {
     // Resolve relative command paths against skill dir; bare commands (e.g. "node") left for PATH.
-    let command = srv.command.as_ref().map(|cmd| {
-        let p = Path::new(cmd);
-        if p.is_relative() && (cmd.starts_with("./") || cmd.starts_with("../")) {
-            skill_dir.join(p).to_string_lossy().into_owned()
-        } else {
-            cmd.clone()
-        }
-    });
+    let command = srv
+        .command
+        .as_ref()
+        .map(|cmd| resolve_skill_path(cmd, skill_dir));
+
+    // `connect_stdio` sets no `current_dir`, so the server process runs with
+    // the daemon's cwd — never the skill dir. Every `./`/`../` arg element
+    // must resolve here too; resolving only `command` leaves a script path
+    // like `["node", "./server.js"]` pointing at the wrong root.
+    let args = srv
+        .args
+        .iter()
+        .map(|arg| resolve_skill_path(arg, skill_dir))
+        .collect();
 
     // Resolve env var NAMES to actual values from the process environment.
     let mut env = HashMap::new();
@@ -197,7 +215,7 @@ fn resolve_mcp_server(srv: &SkillMcpServer, skill_dir: &Path) -> McpServerConfig
 
     McpServerConfig {
         command,
-        args: srv.args.clone(),
+        args,
         env,
         url: srv.url.clone(),
         headers: srv.headers.clone(),
@@ -298,6 +316,50 @@ mod tests {
             cmd == "/skills/my-skill/./bin/server" || cmd == "/skills/my-skill\\./bin/server",
             "unexpected resolved command: {cmd}"
         );
+    }
+
+    #[test]
+    fn test_resolve_mcp_relative_args() {
+        // `connect_stdio` sets no `current_dir`, so the server process runs
+        // with the daemon's cwd — never the skill dir. Every `./`/`../` arg
+        // element must resolve against the skill dir, otherwise
+        // `["./server.js"]` fails to find the script (issue #2255).
+        let srv = SkillMcpServer {
+            command: Some("node".into()),
+            args: vec![
+                "./server.js".into(),
+                "../shared/lib.js".into(),
+                "--port".into(),
+                "--config=./other.cfg".into(),
+                "..".into(),
+                "/abs/path.cfg".into(),
+                "plain-arg".into(),
+            ],
+            env: vec![],
+            url: None,
+            headers: HashMap::new(),
+        };
+        let config = resolve_mcp_server(&srv, Path::new("/skills/my-skill"));
+        assert!(
+            config.args[0] == "/skills/my-skill/./server.js"
+                || config.args[0] == "/skills/my-skill\\./server.js",
+            "unexpected resolved arg: {}",
+            config.args[0]
+        );
+        assert!(
+            config.args[1] == "/skills/my-skill/../shared/lib.js"
+                || config.args[1] == "/skills/my-skill\\../shared/lib.js",
+            "unexpected resolved arg: {}",
+            config.args[1]
+        );
+        // Flags, absolute paths, and plain arguments stay untouched.
+        assert_eq!(config.args[2], "--port");
+        // An embedded `./` after a flag value is not a leading path prefix.
+        assert_eq!(config.args[3], "--config=./other.cfg");
+        // A bare `..` (no trailing separator) matches neither prefix.
+        assert_eq!(config.args[4], "..");
+        assert_eq!(config.args[5], "/abs/path.cfg");
+        assert_eq!(config.args[6], "plain-arg");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A skill manifest declaring an MCP server with a skill-relative script in `args` — e.g. `{"command": "node", "args": ["./server.js"]}` — failed to start: `resolve_mcp_server` resolved only the `command` field against the skill dir while `args` passed through verbatim, and `connect_stdio` (`mcp.rs`) sets no `current_dir`, so the child process resolved `./server.js` against the daemon's cwd. This is the MCP-side twin of the hook bug fixed in #2254.

## Root cause

`plugins/extras.rs::resolve_mcp_server` applied the `./`/`../` → `skill_dir` join to `command` only; `args: srv.args.clone()` went out unchanged.

## Fix

Extract the existing resolution predicate into a shared `resolve_skill_path(arg, skill_dir)` helper (as suggested in the issue) and apply it to `command` and to every `args` element. Bare commands (`node`), flags (`--port`), flag values with embedded `./` (`--config=./other.cfg`), absolute paths, and plain arguments pass through verbatim — identical predicate to the pre-existing `command` behavior and to the hook-side resolution, so manifest semantics stay uniform. `resolve_hook` is deliberately untouched: open PR #2254 is rewriting that function, and whichever lands second should unify it onto the helper.

Known limitation (pre-existing, shared with `command` and the hook side): only `/`-spelled `./`/`../` prefixes resolve; Windows-native `.`/`..` spellings do not. Portable manifests use `/`, which Windows accepts.

## Test evidence

- New unit test `test_resolve_mcp_relative_args`: **red before the fix** (args came back verbatim), green after. Pins `./` and `../` resolution plus negative cases (`--port`, `--config=./other.cfg`, bare `..`, `/abs/path.cfg`, `plain-arg`).
- `cargo test -p octos-agent`: 2808 passed; the only 3 failures (`docker_sandbox_fails_command_validator_closed` and two sandbox-threading tests) fail identically on unmodified `origin/main` — they require a Docker sandbox backend this macOS host doesn't provide. Unrelated to this change.
- `cargo fmt --check` clean; `cargo clippy -p octos-agent --all-targets -- -D warnings` zero warnings.

## End-to-end evidence

Drove the real production path (`PluginLoader::load_into` → `resolve_extras` → `McpClient::start` → `connect_stdio` spawn) with a real skill dir containing `manifest.json` (`{"command": "python3", "args": ["./server.py"]}`) and a stub MCP stdio server that writes marker files on spawn and on answering `initialize`:

- **Before the fix**: resolved args `["./server.py"]`; the child died (`python3` can't open the file relative to the daemon cwd) — no marker files, server silently skipped.
- **After the fix**: resolved args `["<skill_dir>/./server.py"]`; spawn marker shows the script executed with the daemon's cwd, and the MCP `initialize` handshake completed.

## Review

Multi-round review: self-review of the full diff, then an independent reviewer subagent (issue text + diff + file paths only, no author reasoning). Its findings and dispositions: Windows `.` spelling gap (kept the conventional predicate for consistency with `command`/#2254; disclosed above), cwd-relative-arg semantic change (accepted — it's the requested behavior and docs already promised skill-relative resolution), test gaps (fixed: added embedded-`./` and bare-`..` negative cases), `resolve_hook` duplication (deferred to avoid conflicting with #2254). Full suite, fmt, clippy, and the end-to-end run were all repeated green after the review-driven test changes.

Closes #2255