### PR TITLE
fix(auth): restore macOS-gated WrapErr import in keychain.rs (#2258)

### DIFF
--- a/crates/octos-cli/src/auth/keychain.rs
+++ b/crates/octos-cli/src/auth/keychain.rs
@@ -16,6 +16,10 @@
 use std::collections::HashMap;
 
 use eyre::Result;
+// #2258 — `wrap_err` is only used by the macOS-gated helpers below; keep the
+// trait import gated too so Linux clippy (unused_imports) and macOS rustc agree.
+#[cfg(target_os = "macos")]
+use eyre::WrapErr;
 
 /// Sentinel prefix stored in profile `env_vars` to indicate that the real
 /// secret lives in the macOS Keychain.


### PR DESCRIPTION
## Summary

Fixes #2258. #2239 (b5db3121) removed `WrapErr` from the `eyre` import because it became unused on Linux, but the `#[cfg(target_os = "macos")]` helpers `macos_unlock` / `macos_set_secret` still call `.wrap_err(...)`, so `octos-cli` stopped compiling on macOS (seen on #2257's macos-14 `e2e-tool-regression` job).

One change: a macOS-gated `use eyre::WrapErr;` next to the existing `use eyre::Result;`, so Linux clippy (`unused_imports`, `-D warnings`) and macOS rustc agree.

## Verification

- Linux: `cargo check -p octos-cli` and `cargo clippy -p octos-cli -- -D warnings` clean.
- macOS: not buildable locally; the macOS `e2e-tool-regression` job on this PR (if `e2e-changes` fires) or a maintainer's local macOS build is the proof. #2259 tracks making a macOS compile a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zbAVTB1tkMF49Zr52UB7Z