### PR TITLE
fix(auth): preserve credentials and harden secret storage after #2239

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,6 +769,16 @@ jobs:
       - name: Build (octos-cli + all features)
         run: cargo build -p octos-cli --features ${{ env.FEATURES }}
 
+      # #2239: default-feature tests never compile the API's test-only secret
+      # hooks. Exercise those callers on Windows too, using isolated fixtures.
+      - name: Test API auth and secret-store fixtures
+        if: ${{ !cancelled() }}
+        run: cargo test -p octos-cli --features api --lib auth
+
+      - name: Test API credential relocation fixtures
+        if: ${{ !cancelled() }}
+        run: cargo test -p octos-cli --features api --lib relocate
+
       # Sharded per-crate tests — same rationale as the `check` job.
       #
       # Every test step runs even after an earlier one fails. GitHub aborts a

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -5536,6 +5536,9 @@ mod tests {
 
     #[test]
     fn relocate_keychain_backed_secrets_never_persists_raw_vertex_json_off_macos() {
+        let secrets = tempfile::tempdir().unwrap();
+        let _secrets_root =
+            crate::auth::keychain::test_override_secrets_root(secrets.path().to_path_buf());
         // #2234/45a — the availability predicate is now `keychain::is_available()`
         // (true on Linux: the file backend exists), NOT `cfg!(macos)`. The
         // never-plaintext contract holds where NO backend exists (unsupported
@@ -5585,8 +5588,9 @@ mod tests {
         // INJECTED temp root) the JSON is legitimately relocated: Ok, the
         // slot becomes a keychain marker, the raw value never remains.
         // Hosts with NO backend keep the rejection.
+        let secrets = tempfile::tempdir().unwrap();
         let _secrets_root =
-            crate::auth::keychain::test_override_secrets_root(tempfile::tempdir().unwrap().keep());
+            crate::auth::keychain::test_override_secrets_root(secrets.path().to_path_buf());
         let mut env = std::collections::HashMap::new();
         env.insert(
             "VERTEX_API_KEY".to_string(),

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -4573,20 +4573,43 @@ mod tests {
         std::fs::create_dir_all(&clone_dir).unwrap();
         let clone_path = clone_dir.join("mine.wav");
         std::fs::write(&clone_path, b"fake").unwrap();
-        let json = format!(
-            r#"{{
-              "default_voice": "doubao",
-              "models_base_path": "{base}",
-              "voices": {{
-                "doubao": {{ "ref_audio": "ref_audios/doubao_ref.wav", "ref_text": "x", "aliases": ["vivian"] }},
-                "ghost":  {{ "ref_audio": "ref_audios/ghost_ref.wav", "ref_text": "y", "aliases": [] }},
-                "other-clone": {{ "ref_audio": "{clone}", "ref_text": "z", "aliases": [] }}
-              }}
-            }}"#,
-            base = dir.to_string_lossy(),
-            clone = clone_path.to_string_lossy()
-        );
+        let json = readiness_registry_json(&dir.to_string_lossy(), &clone_path.to_string_lossy());
         octos_llm::ominix::VoicesRegistry::parse(&json).unwrap()
+    }
+
+    fn readiness_registry_json(base: &str, clone: &str) -> String {
+        serde_json::json!({
+            "default_voice": "doubao",
+            "models_base_path": base,
+            "voices": {
+                "doubao": { "ref_audio": "ref_audios/doubao_ref.wav", "ref_text": "x", "aliases": ["vivian"] },
+                "ghost": { "ref_audio": "ref_audios/ghost_ref.wav", "ref_text": "y", "aliases": [] },
+                "other-clone": { "ref_audio": clone, "ref_text": "z", "aliases": [] }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn should_preserve_paths_when_serializing_readiness_registry_fixture() {
+        // These are serialization inputs, not directories to create: Windows
+        // paths and JSON-special characters are exercised on every test host.
+        for (base, clone) in [
+            (r"C:\Users\ci\models", r"C:\Users\ci\profiles\mine.wav"),
+            (r"\\server\voices\models", r"\\server\voices\mine.wav"),
+            (
+                r#"/models/"quoted"\backslash"#,
+                r#"/voices/"mine"\audio.wav"#,
+            ),
+        ] {
+            let json = readiness_registry_json(base, clone);
+            let registry = octos_llm::ominix::VoicesRegistry::parse(&json)
+                .expect("readiness fixture paths must produce valid JSON");
+            assert_eq!(registry.models_base_path, base);
+            assert_eq!(registry.voices["other-clone"].ref_audio, clone);
+            assert_eq!(registry.default_voice, "doubao");
+            assert_eq!(registry.voices["doubao"].aliases, ["vivian"]);
+        }
     }
 
     #[test]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -6034,8 +6034,9 @@ mod tests {
         // legitimately relocated: the call succeeds and the slot becomes a
         // keychain marker, never the raw value. Hosts with NO backend keep
         // the rejection.
+        let secrets = tempfile::tempdir().unwrap();
         let _secrets_root =
-            crate::auth::keychain::test_override_secrets_root(tempfile::tempdir().unwrap().keep());
+            crate::auth::keychain::test_override_secrets_root(secrets.path().to_path_buf());
         let (_dir, state, _user_store, profile_store) = temp_app_state();
         profile_store
             .save(&make_user_profile("tenant", "Tenant Owner"))

--- a/crates/octos-cli/src/auth/keychain.rs
+++ b/crates/octos-cli/src/auth/keychain.rs
@@ -16,6 +16,8 @@
 use std::collections::HashMap;
 
 use eyre::Result;
+#[cfg(target_os = "macos")]
+use eyre::WrapErr;
 
 /// Sentinel prefix stored in profile `env_vars` to indicate that the real
 /// secret lives in the macOS Keychain.
@@ -102,6 +104,10 @@ pub fn backend_name() -> &'static str {
 
 /// Whether a secret-store backend exists on this platform.
 pub fn is_available() -> bool {
+    #[cfg(test)]
+    if test_store::root().is_some() {
+        return true;
+    }
     #[cfg(target_os = "macos")]
     {
         true
@@ -130,6 +136,10 @@ fn unsupported_store_error(op: &str) -> eyre::Report {
 ///
 /// No-op on Linux (the file store has no lock); unsupported elsewhere.
 pub fn unlock(password: &str) -> Result<()> {
+    #[cfg(test)]
+    if test_store::root().is_some() {
+        return Ok(());
+    }
     #[cfg(target_os = "macos")]
     {
         macos_unlock(password)
@@ -150,6 +160,10 @@ pub fn unlock(password: &str) -> Result<()> {
 
 /// Store a secret in the platform secret store.
 pub fn set_secret(name: &str, secret: &str) -> Result<()> {
+    #[cfg(test)]
+    if test_store::root().is_some() {
+        return test_store::set_secret(name, secret);
+    }
     #[cfg(target_os = "macos")]
     {
         macos_set_secret(name, secret)
@@ -170,6 +184,10 @@ pub fn set_secret(name: &str, secret: &str) -> Result<()> {
 /// Returns `Ok(Some(secret))` on success, `Ok(None)` if not found,
 /// or `Err` on unexpected failures (keychain locked, etc.).
 pub fn get_secret(name: &str) -> Result<Option<String>> {
+    #[cfg(test)]
+    if test_store::root().is_some() {
+        return test_store::get_secret(name);
+    }
     #[cfg(target_os = "macos")]
     {
         macos_get_secret(name)
@@ -189,6 +207,10 @@ pub fn get_secret(name: &str) -> Result<Option<String>> {
 ///
 /// Returns `Ok(true)` if deleted, `Ok(false)` if not found.
 pub fn delete_secret(name: &str) -> Result<bool> {
+    #[cfg(test)]
+    if test_store::root().is_some() {
+        return test_store::delete_secret(name);
+    }
     #[cfg(target_os = "macos")]
     {
         macos_delete_secret(name)
@@ -206,6 +228,10 @@ pub fn delete_secret(name: &str) -> Result<bool> {
 
 /// Check if the secret store is accessible (unlocked / usable).
 pub fn is_accessible() -> bool {
+    #[cfg(test)]
+    if test_store::root().is_some() {
+        return test_store::is_accessible();
+    }
     #[cfg(target_os = "macos")]
     {
         macos_is_accessible()
@@ -225,56 +251,26 @@ pub fn is_accessible() -> bool {
 // `<octos home>/secrets/<account>` — one file per secret, 0600, directory
 // 0700. The root mirrors the `ProfileStore::octos_home_dir()` the CLI auth
 // commands use (`~/.octos`): same resolver, `secrets/` sibling of `profiles/`.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", all(test, unix)))]
 pub(crate) mod linux_file {
-    use std::io::Write as _;
-    use std::path::{Path, PathBuf};
+    use std::io::{Read as _, Write as _};
+    use std::os::fd::OwnedFd;
+    use std::path::PathBuf;
 
     use eyre::{Result, WrapErr};
+    use rustix::fs::{
+        AtFlags, Mode, OFlags, fchmod, fsync, mkdirat, open, openat, renameat, unlinkat,
+    };
 
-    const DIR_MODE: u32 = 0o700;
-    const FILE_MODE: u32 = 0o600;
-
-    #[cfg(test)]
-    thread_local! {
-        // #2234: thread-local override — a global single-slot TEST_ROOT let
-        // PARALLEL tests stomp each other's temp root (one drops, the next
-        // op in a sibling test hits ENOENT). Per-thread slots make every
-        // test's injection independent; cargo's thread-per-test model
-        // guarantees isolation.
-        static TEST_ROOT: std::cell::RefCell<Option<PathBuf>> =
-            const { std::cell::RefCell::new(None) };
-    }
-
-    /// Test-only pin of the secrets root. The guard serializes concurrent
-    /// tests (they contend on the same mutex) and restores the default
-    /// resolution when dropped.
-    #[cfg(test)]
-    /// #2234: RootGuard holds NOTHING (lock-free) — the override is set on
-    /// entry and cleared on drop via short lock acquisitions only, so
-    /// secrets_root's read never contends with a held lock (same-thread
-    /// re-entrant deadlock was the roundtrip hang).
-    pub(crate) fn override_root_for_tests(dir: PathBuf) -> RootGuard {
-        TEST_ROOT.with(|slot| *slot.borrow_mut() = Some(dir));
-        RootGuard
-    }
-
-    #[cfg(test)]
-    pub(crate) struct RootGuard;
-
-    #[cfg(test)]
-    impl Drop for RootGuard {
-        fn drop(&mut self) {
-            TEST_ROOT.with(|slot| *slot.borrow_mut() = None);
-        }
-    }
+    const DIR_MODE: Mode = Mode::RWXU;
+    const FILE_MODE: Mode = Mode::RUSR.union(Mode::WUSR);
 
     /// The secrets root: `<octos home>/secrets`, with the octos home resolved
     /// exactly as `ProfileStore::octos_home_dir()` does for the CLI auth
     /// commands (`~/.octos`).
     fn secrets_root() -> Result<PathBuf> {
         #[cfg(test)]
-        if let Some(dir) = TEST_ROOT.with(|slot| slot.borrow().clone()) {
+        if let Some(dir) = super::test_store::root() {
             return Ok(dir);
         }
         let home = dirs::home_dir()
@@ -291,84 +287,219 @@ pub(crate) mod linux_file {
         Ok(())
     }
 
-    fn ensure_root(root: &Path) -> Result<()> {
-        use std::os::unix::fs::PermissionsExt as _;
-        std::fs::create_dir_all(root)
-            .wrap_err_with(|| format!("failed to create secrets dir: {}", root.display()))?;
-        // Re-assert 0700 even when the dir already existed (umask could have
-        // loosened it at creation).
-        std::fs::set_permissions(root, std::fs::Permissions::from_mode(DIR_MODE))
-            .wrap_err_with(|| format!("failed to restrict secrets dir: {}", root.display()))?;
-        Ok(())
+    fn open_root(create: bool) -> Result<Option<OwnedFd>> {
+        use std::os::unix::fs::DirBuilderExt as _;
+        let root = secrets_root()?;
+        let parent = root
+            .parent()
+            .ok_or_else(|| eyre::eyre!("secret root has no parent"))?;
+        let leaf = root
+            .file_name()
+            .ok_or_else(|| eyre::eyre!("secret root has no name"))?;
+        if create {
+            // The production parent is ~/.octos. Refuse a symlink at that
+            // boundary below, rather than following it while chmod'ing secrets.
+            std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(parent)
+                .wrap_err_with(|| {
+                    format!("failed to create secret-store parent: {}", parent.display())
+                })?;
+        }
+        let flags = OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC;
+        let parent = match open(parent, flags, Mode::empty()) {
+            Ok(parent) => parent,
+            Err(error) if !create && error == rustix::io::Errno::NOENT => return Ok(None),
+            Err(error) => {
+                return Err(error).wrap_err_with(|| {
+                    format!("failed to open secret-store parent for {}", root.display())
+                });
+            }
+        };
+        if create {
+            match mkdirat(&parent, leaf, DIR_MODE) {
+                Ok(()) | Err(rustix::io::Errno::EXIST) => {}
+                Err(error) => {
+                    return Err(error).wrap_err_with(|| {
+                        format!("failed to create secrets dir: {}", root.display())
+                    });
+                }
+            }
+        }
+        let dir = match openat(&parent, leaf, flags, Mode::empty()) {
+            Ok(dir) => dir,
+            Err(error) if !create && error == rustix::io::Errno::NOENT => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .wrap_err_with(|| format!("failed to open secrets dir: {}", root.display()));
+            }
+        };
+        if create {
+            // Restrict the opened inode, never a path that could be swapped.
+            fchmod(&dir, DIR_MODE).wrap_err("failed to restrict secrets directory")?;
+        }
+        Ok(Some(dir))
     }
 
+    #[cfg(target_os = "linux")]
     pub fn is_available() -> bool {
         secrets_root().is_ok()
     }
 
     pub fn is_accessible() -> bool {
-        secrets_root().and_then(|root| ensure_root(&root)).is_ok()
+        open_root(true).is_ok()
     }
 
     pub fn set_secret(name: &str, secret: &str) -> Result<()> {
-        use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
         validate_name(name)?;
-        let root = secrets_root()?;
-        ensure_root(&root)?;
-        let path = root.join(name);
-        // mode() applies 0600 atomically at creation; the later
-        // set_permissions re-asserts it in case a umask quirk loosened it.
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(FILE_MODE)
-            .open(&path)
-            .wrap_err_with(|| format!("failed to create secret file: {}", path.display()))?;
-        file.write_all(secret.as_bytes())
-            .wrap_err_with(|| format!("failed to write secret file: {}", path.display()))?;
-        file.sync_all()
-            .wrap_err_with(|| format!("failed to sync secret file: {}", path.display()))?;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(FILE_MODE))
-            .wrap_err_with(|| format!("failed to restrict secret file: {}", path.display()))?;
+        let dir = open_root(true)?.expect("create opens a directory or returns an error");
+        let temporary = format!(".secret-{}.tmp", uuid::Uuid::new_v4());
+        let fd = openat(
+            &dir,
+            temporary.as_str(),
+            OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            FILE_MODE,
+        )
+        .wrap_err("failed to create private temporary secret file")?;
+        let mut file = std::fs::File::from(fd);
+        let written = (|| -> Result<()> {
+            // Creation can only be MORE restrictive under umask. Restore the
+            // owner's read/write bits on this opened inode before writing.
+            fchmod(&file, FILE_MODE).wrap_err("failed to restrict secret file")?;
+            file.write_all(secret.as_bytes())
+                .wrap_err("failed to write secret file")?;
+            file.sync_all().wrap_err("failed to sync secret file")?;
+            // All operations use the SAME directory fd, even if its path is
+            // concurrently renamed. Rename replaces a symlink/hardlink itself;
+            // it never truncates another inode or exposes a partially written key.
+            renameat(&dir, temporary.as_str(), &dir, name)
+                .wrap_err("failed to replace secret file")?;
+            fsync(&dir).wrap_err("failed to sync secret directory")?;
+            Ok(())
+        })();
+        if written.is_err() {
+            let _ = unlinkat(&dir, temporary.as_str(), AtFlags::empty());
+        }
+        written?;
         Ok(())
     }
 
     pub fn get_secret(name: &str) -> Result<Option<String>> {
         validate_name(name)?;
-        let path = secrets_root()?.join(name);
-        let bytes = match std::fs::read(&path) {
-            Ok(bytes) => bytes,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(e) => {
-                return Err(eyre::eyre!(
-                    "failed to read secret file {}: {e}",
-                    path.display()
-                ));
-            }
+        let Some(dir) = open_root(false)? else {
+            return Ok(None);
         };
-        String::from_utf8(bytes)
-            .map(Some)
-            .wrap_err_with(|| format!("secret file {} is not valid UTF-8", path.display()))
+        let fd = match openat(
+            &dir,
+            name,
+            OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+            Mode::empty(),
+        ) {
+            Ok(fd) => fd,
+            Err(error) if error == rustix::io::Errno::NOENT => return Ok(None),
+            Err(error) => return Err(error).wrap_err("failed to open secret file"),
+        };
+        let mut file = std::fs::File::from(fd);
+        if !file.metadata()?.is_file() {
+            eyre::bail!("secret account is not a regular file");
+        }
+        let mut value = String::new();
+        file.read_to_string(&mut value)
+            .wrap_err("failed to read UTF-8 secret file")?;
+        Ok(Some(value))
     }
 
     pub fn delete_secret(name: &str) -> Result<bool> {
         validate_name(name)?;
-        let path = secrets_root()?.join(name);
-        match std::fs::remove_file(&path) {
+        let Some(dir) = open_root(false)? else {
+            return Ok(false);
+        };
+        match unlinkat(&dir, name, AtFlags::empty()) {
             Ok(()) => Ok(true),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(e) => Err(eyre::eyre!(
-                "failed to delete secret file {}: {e}",
-                path.display()
-            )),
+            Err(error) if error == rustix::io::Errno::NOENT => Ok(false),
+            Err(error) => Err(error).wrap_err("failed to delete secret file"),
         }
     }
 }
 
-/// Test hook: pin the Linux secrets root to a temp dir (no-op elsewhere).
-#[cfg(all(test, target_os = "linux"))]
-pub(crate) use linux_file::override_root_for_tests as test_override_secrets_root;
+/// Explicit, thread-local test backend on EVERY host; never a no-op that falls
+/// through to the login Keychain. Keep the tempdir alive until the guard drops.
+#[cfg(test)]
+pub(crate) use test_store::override_root as test_override_secrets_root;
+
+#[cfg(test)]
+mod test_store {
+    use std::path::PathBuf;
+
+    thread_local! {
+        static ROOT: std::cell::RefCell<Option<PathBuf>> = const { std::cell::RefCell::new(None) };
+    }
+
+    pub(super) fn root() -> Option<PathBuf> {
+        ROOT.with(|slot| slot.borrow().clone())
+    }
+
+    pub(crate) fn override_root(dir: PathBuf) -> RootGuard {
+        RootGuard {
+            previous: ROOT.with(|slot| slot.replace(Some(dir))),
+            // Restoring a thread-local override on another thread is invalid.
+            _not_send: std::marker::PhantomData,
+        }
+    }
+
+    pub(crate) struct RootGuard {
+        previous: Option<PathBuf>,
+        _not_send: std::marker::PhantomData<std::rc::Rc<()>>,
+    }
+
+    impl Drop for RootGuard {
+        fn drop(&mut self) {
+            ROOT.with(|slot| *slot.borrow_mut() = self.previous.take());
+        }
+    }
+
+    #[cfg(unix)]
+    pub(super) use super::linux_file::{delete_secret, get_secret, is_accessible, set_secret};
+
+    // Unsupported production hosts still need an explicitly isolated fixture
+    // backend. Encode account names (scoped names contain ':' on Windows).
+    #[cfg(not(unix))]
+    fn path(name: &str) -> eyre::Result<PathBuf> {
+        let root = root().expect("test backend requires an explicit override");
+        std::fs::create_dir_all(&root)?;
+        let leaf: String = name.bytes().map(|byte| format!("{byte:02x}")).collect();
+        Ok(root.join(format!("fixture-{leaf}")))
+    }
+
+    #[cfg(not(unix))]
+    pub(super) fn set_secret(name: &str, value: &str) -> eyre::Result<()> {
+        Ok(std::fs::write(path(name)?, value)?)
+    }
+
+    #[cfg(not(unix))]
+    pub(super) fn get_secret(name: &str) -> eyre::Result<Option<String>> {
+        match std::fs::read_to_string(path(name)?) {
+            Ok(value) => Ok(Some(value)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    #[cfg(not(unix))]
+    pub(super) fn delete_secret(name: &str) -> eyre::Result<bool> {
+        match std::fs::remove_file(path(name)?) {
+            Ok(()) => Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    #[cfg(not(unix))]
+    pub(super) fn is_accessible() -> bool {
+        root().is_some_and(|root| std::fs::create_dir_all(root).is_ok())
+    }
+}
 
 /// Unlock the login keychain so subsequent operations succeed from SSH.
 ///
@@ -641,7 +772,190 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
+    fn should_isolate_and_restore_nested_test_stores_on_every_host() {
+        let outer = tempfile::tempdir().unwrap();
+        let _outer = test_override_secrets_root(outer.path().to_path_buf());
+        assert!(is_available());
+        assert!(is_accessible());
+        set_secret("FIXTURE::profile", "outer-fixture").unwrap();
+        {
+            let inner = tempfile::tempdir().unwrap();
+            let _inner = test_override_secrets_root(inner.path().to_path_buf());
+            assert_eq!(get_secret("FIXTURE::profile").unwrap(), None);
+            set_secret("FIXTURE::profile", "inner-fixture").unwrap();
+            assert_eq!(
+                get_secret("FIXTURE::profile").unwrap().as_deref(),
+                Some("inner-fixture")
+            );
+        }
+        assert_eq!(
+            get_secret("FIXTURE::profile").unwrap().as_deref(),
+            Some("outer-fixture")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_reject_read_through_account_symlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("secrets");
+        std::fs::create_dir(&root).unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::write(&outside, "outside-fixture").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("KEY")).unwrap();
+        let _root = test_override_secrets_root(root);
+        assert!(get_secret("KEY").is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_replace_account_symlink_without_touching_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("secrets");
+        std::fs::create_dir(&root).unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::write(&outside, "outside-fixture").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("KEY")).unwrap();
+        let _root = test_override_secrets_root(root.clone());
+        set_secret("KEY", "new-fixture").unwrap();
+        assert_eq!(std::fs::read_to_string(outside).unwrap(), "outside-fixture");
+        assert!(
+            std::fs::symlink_metadata(root.join("KEY"))
+                .unwrap()
+                .is_file()
+        );
+        assert_eq!(get_secret("KEY").unwrap().as_deref(), Some("new-fixture"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_refuse_symlinked_secret_directory_without_chmod_or_write() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::set_permissions(&outside, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let root = tmp.path().join("secrets");
+        std::os::unix::fs::symlink(&outside, &root).unwrap();
+        let _root = test_override_secrets_root(root);
+        assert!(set_secret("KEY", "fixture").is_err());
+        assert!(get_secret("KEY").is_err());
+        assert!(delete_secret("KEY").is_err());
+        assert!(!is_accessible());
+        assert_eq!(
+            std::fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+        assert_eq!(std::fs::read_dir(outside).unwrap().count(), 0);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_replace_hardlinked_account_without_changing_other_link() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("secrets");
+        std::fs::create_dir(&root).unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::write(&outside, "outside-fixture").unwrap();
+        std::fs::hard_link(&outside, root.join("KEY")).unwrap();
+        let _root = test_override_secrets_root(root);
+        set_secret("KEY", "new-fixture").unwrap();
+        assert_eq!(std::fs::read_to_string(outside).unwrap(), "outside-fixture");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_leave_no_temporary_secret_when_atomic_replace_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("KEY")).unwrap();
+        let _root = test_override_secrets_root(tmp.path().to_path_buf());
+        assert!(set_secret("KEY", "fixture").is_err());
+        let names: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(names, vec![std::ffi::OsString::from("KEY")]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_reject_fifo_account_without_blocking() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(
+            std::process::Command::new("mkfifo")
+                .arg(tmp.path().join("KEY"))
+                .status()
+                .unwrap()
+                .success()
+        );
+        let _root = test_override_secrets_root(tmp.path().to_path_buf());
+        assert!(get_secret("KEY").is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_not_create_missing_store_during_read_or_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("missing");
+        let _root = test_override_secrets_root(root.clone());
+        assert_eq!(get_secret("KEY").unwrap(), None);
+        assert!(!delete_secret("KEY").unwrap());
+        assert!(!root.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_keep_owner_read_write_permissions_under_restrictive_umask() {
+        use std::os::unix::fs::PermissionsExt;
+        const CHILD_ROOT: &str = "OCTOS_TEST_SECRET_UMASK_ROOT";
+        if let Some(root) = std::env::var_os(CHILD_ROOT) {
+            let root = std::path::PathBuf::from(root);
+            let _root = test_override_secrets_root(root.clone());
+            set_secret("KEY", "fixture").unwrap();
+            assert_eq!(
+                std::fs::metadata(root.join("KEY"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+            assert_eq!(get_secret("KEY").unwrap().as_deref(), Some("fixture"));
+            return;
+        }
+        // umask is process-global: change it ONLY in a dedicated child, never
+        // in the parallel test runner. The existing root is owned by this test.
+        let root = tempfile::tempdir().unwrap();
+        let status = std::process::Command::new("sh")
+            .args(["-c", "umask 777; exec \"$@\"", "secret-fixture"])
+            .arg(std::env::current_exe().unwrap())
+            .args([
+                "should_keep_owner_read_write_permissions_under_restrictive_umask",
+                "--nocapture",
+            ])
+            .env(CHILD_ROOT, root.path())
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_refuse_symlinked_store_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        let parent = tmp.path().join("octos-home");
+        std::os::unix::fs::symlink(&outside, &parent).unwrap();
+        let _root = test_override_secrets_root(parent.join("secrets"));
+        assert!(set_secret("KEY", "fixture").is_err());
+        assert!(get_secret("KEY").is_err());
+        assert!(delete_secret("KEY").is_err());
+        assert_eq!(std::fs::read_dir(outside).unwrap().count(), 0);
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn linux_file_backend_roundtrip_with_permissions() {
         use std::os::unix::fs::PermissionsExt as _;
 
@@ -685,7 +999,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(unix)]
     fn linux_file_backend_rejects_path_escaping_names() {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = test_override_secrets_root(tmp.path().to_path_buf());

--- a/crates/octos-cli/src/commands/auth.rs
+++ b/crates/octos-cli/src/commands/auth.rs
@@ -322,6 +322,31 @@ fn unsafe_tty_check() -> bool {
     std::io::stdin().is_terminal()
 }
 
+/// Restore the account, not merely its existence. Never print credential bytes.
+fn restore_secret(account: &str, previous: Option<&str>) -> Result<()> {
+    match previous {
+        Some(previous) => keychain::set_secret(account, previous),
+        None => keychain::delete_secret(account).map(|_| ()),
+    }
+}
+
+fn replace_secret(account: &str, secret: &str) -> Result<Option<String>> {
+    let previous = keychain::get_secret(account)?;
+    if let Err(store_error) = keychain::set_secret(account, secret) {
+        // A backend can fail after changing the account (e.g. a sync failure).
+        // Preserve the prior credential in that case too.
+        return match restore_secret(account, previous.as_deref()) {
+            Ok(()) => Err(eyre::eyre!(
+                "secret store failed; rolled back the account: {store_error}"
+            )),
+            Err(rollback_error) => Err(eyre::eyre!(
+                "secret store failed ({store_error}); rollback also failed ({rollback_error}); check the account before retrying"
+            )),
+        };
+    }
+    Ok(previous)
+}
+
 /// #2234/45c — injectable profile-save seam (issue Tests requested:
 /// "Profile-save failure rolls back the newly stored secret"). Production
 /// passes the direct store save; tests inject a failing closure to pin the
@@ -369,27 +394,42 @@ fn set_key_with_save(
 
     // Shared keys: store once up front (also covers the orphan / no-profile
     // case). Scoped keys are stored per profile in the loop below.
-    if !scoped {
-        keychain::set_secret(name, &secret)?;
-    }
+    let shared_previous = if !scoped {
+        replace_secret(name, &secret)?
+    } else {
+        None
+    };
 
     // Update profile(s) to use the keychain marker
     let mut updated_count = 0;
     for mut profile in profiles {
         if profile_references_key(&profile, name) {
             let (account, marker) = keychain_target(name, &profile.id, &secret);
-            if scoped {
-                keychain::set_secret(&account, &secret)?;
-            }
+            let previous = if scoped {
+                replace_secret(&account, &secret)?
+            } else {
+                shared_previous.clone()
+            };
             profile.config.env_vars.insert(name.to_string(), marker);
             profile.updated_at = chrono::Utc::now();
-            // #2234/45b — store-then-save with rollback: if the profile
-            // save fails after the secret landed, delete the freshly
-            // stored account so a half-applied update leaves no orphan.
+            // Per-account rollback, not an all-profile transaction: earlier
+            // successful saves remain committed. In particular, a shared key
+            // must stay available once any successful save references it.
             if let Err(save_err) = save_profile(&profile) {
-                let _ = keychain::delete_secret(&account);
+                if !scoped && updated_count > 0 {
+                    return Err(eyre::eyre!(
+                        "profile '{}' save failed; {updated_count} profile(s) updated; shared secret retained for those profiles: {save_err}",
+                        profile.id
+                    ));
+                }
+                if let Err(rollback_error) = restore_secret(&account, previous.as_deref()) {
+                    return Err(eyre::eyre!(
+                        "profile '{}' save failed ({save_err}); secret rollback also failed ({rollback_error}); {updated_count} profile(s) updated; check the account before retrying",
+                        profile.id
+                    ));
+                }
                 return Err(eyre::eyre!(
-                    "profile '{}' save failed; rolled back the stored secret: {save_err}",
+                    "profile '{}' save failed; rolled back that account's secret; {updated_count} profile(s) updated: {save_err}",
                     profile.id
                 ));
             }
@@ -826,7 +866,6 @@ mod tests {
     /// scoped secret was stored, the save fails, the freshly stored account
     /// is deleted (rollback), and the error names the rollback.
     #[test]
-    #[cfg(target_os = "linux")]
     fn save_failure_rolls_back_stored_secret() {
         let tmp = tempfile::tempdir().unwrap();
         // Point BOTH the secret store and the profile store at the temp dir:
@@ -870,6 +909,153 @@ mod tests {
         // Profile JSON bytes unchanged (the injected save never ran).
         let after = std::fs::read_to_string(&json_path).unwrap_or_default();
         assert_eq!(profile_json_before, after, "profile bytes must not change");
+    }
+
+    #[test]
+    fn should_restore_existing_secret_when_profile_save_fails() {
+        for (name, account, secret) in [
+            ("SHARED_KEY", "SHARED_KEY", "new-fixture"),
+            (
+                "VERTEX_SA_JSON",
+                "VERTEX_SA_JSON::fixture",
+                "{\"type\":\"service_account\",\"private_key\":\"fixture\"}",
+            ),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let _root = keychain::test_override_secrets_root(tmp.path().join("secrets"));
+            let store = ProfileStore::open_unified(&tmp.path().join("profiles-home")).unwrap();
+            let mut profile = profile_with_llm("fixture", None);
+            profile
+                .config
+                .env_vars
+                .insert(name.into(), keychain::marker_for(account));
+            store.save(&profile).unwrap();
+            keychain::set_secret(account, "old-fixture").unwrap();
+            let err = set_key_with_save(name, Some(secret.into()), Some("fixture"), &store, |_| {
+                Err(eyre::eyre!("injected profile save failure"))
+            })
+            .unwrap_err();
+            assert!(err.to_string().contains("rolled back"));
+            assert_eq!(
+                keychain::get_secret(account).unwrap().as_deref(),
+                Some("old-fixture")
+            );
+            assert_eq!(
+                store.get("fixture").unwrap().unwrap().config.env_vars[name],
+                keychain::marker_for(account)
+            );
+        }
+    }
+
+    #[test]
+    fn should_keep_shared_secret_when_an_earlier_profile_save_succeeded() {
+        for old in [None, Some("old-fixture")] {
+            let tmp = tempfile::tempdir().unwrap();
+            let _root = keychain::test_override_secrets_root(tmp.path().join("secrets"));
+            let store = ProfileStore::open_unified(&tmp.path().join("profiles-home")).unwrap();
+            for id in ["first", "second"] {
+                let mut profile = profile_with_llm(id, None);
+                profile
+                    .config
+                    .env_vars
+                    .insert("SHARED_KEY".into(), "placeholder".into());
+                store.save(&profile).unwrap();
+            }
+            if let Some(old) = old {
+                keychain::set_secret("SHARED_KEY", old).unwrap();
+            }
+            let saved = std::cell::RefCell::new(Vec::new());
+            let err = set_key_with_save(
+                "SHARED_KEY",
+                Some("new-fixture".into()),
+                None,
+                &store,
+                |profile| {
+                    if !saved.borrow().is_empty() {
+                        eyre::bail!("injected second profile save failure");
+                    }
+                    store.save(profile)?;
+                    saved.borrow_mut().push(profile.id.clone());
+                    Ok(())
+                },
+            )
+            .unwrap_err();
+            assert_eq!(saved.borrow().len(), 1);
+            assert_eq!(
+                keychain::get_secret("SHARED_KEY").unwrap().as_deref(),
+                Some("new-fixture"),
+                "a successfully saved marker must not dangle or silently rotate back"
+            );
+            assert!(err.to_string().contains("1 profile(s) updated"));
+            assert!(err.to_string().contains("retained"));
+            let saved_profile = store.get(&saved.borrow()[0]).unwrap().unwrap();
+            assert_eq!(
+                keychain::resolve_value("SHARED_KEY", &saved_profile.config.env_vars["SHARED_KEY"])
+                    .as_deref(),
+                Some("new-fixture")
+            );
+        }
+    }
+
+    #[test]
+    fn should_delete_only_new_uncommitted_shared_secret_on_save_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _root = keychain::test_override_secrets_root(tmp.path().join("secrets"));
+        let store = ProfileStore::open_unified(&tmp.path().join("profiles-home")).unwrap();
+        let mut profile = profile_with_llm("fixture", None);
+        profile
+            .config
+            .env_vars
+            .insert("KEY".into(), "placeholder".into());
+        store.save(&profile).unwrap();
+        let err = set_key_with_save(
+            "KEY",
+            Some("fixture".into()),
+            Some("fixture"),
+            &store,
+            |_| Err(eyre::eyre!("injected save failure")),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("rolled back"));
+        assert_eq!(keychain::get_secret("KEY").unwrap(), None);
+        assert_eq!(
+            store.get("fixture").unwrap().unwrap().config.env_vars["KEY"],
+            "placeholder"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_report_rollback_failure_instead_of_claiming_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("secrets");
+        let _root = keychain::test_override_secrets_root(root.clone());
+        let store = ProfileStore::open_unified(&tmp.path().join("profiles-home")).unwrap();
+        let mut profile = profile_with_llm("fixture", None);
+        profile
+            .config
+            .env_vars
+            .insert("KEY".into(), "keychain:".into());
+        store.save(&profile).unwrap();
+        keychain::set_secret("KEY", "old-fixture").unwrap();
+        let err = set_key_with_save(
+            "KEY",
+            Some("new-fixture".into()),
+            Some("fixture"),
+            &store,
+            |_| {
+                // Deterministic I/O failure during restoration; only this fixture
+                // account is removed. A directory cannot be replaced by a file.
+                std::fs::remove_file(root.join("KEY"))?;
+                std::fs::create_dir(root.join("KEY"))?;
+                eyre::bail!("injected save failure")
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("rollback also failed"));
+        assert!(!err.to_string().contains("rolled back"));
+        assert!(!err.to_string().contains("old-fixture"));
+        assert!(!err.to_string().contains("new-fixture"));
     }
 
     /// #2234/45c — secret-store failure leaves profile JSON bytes UNCHANGED


### PR DESCRIPTION
## Summary

Follow-up to the five confirmed findings in #2239:

- Restore the macOS-gated `eyre::WrapErr` import so ordinary macOS builds compile.
- Snapshot and restore existing credentials on failed profile saves; remove only newly created, uncommitted accounts. When an earlier profile has already saved a shared marker, retain that shared credential and report partial completion explicitly. Report rollback failures rather than claiming rollback succeeded.
- Make the test-store override available on every host and actually redirect operations away from the real credential store. On Unix it exercises the file backend; on Windows it uses encoded temporary fixture files. Guards are thread-local, non-Send, and restore nested overrides.
- Isolate all three changed API relocation tests and keep their temporary directories scoped for cleanup; add API auth/relocation test steps to the existing Windows CI job.
- Anchor file operations to no-follow directory descriptors. Write through an exclusive private temporary file, restrict its opened descriptor before writing, sync, and atomically rename within the same directory. Account symlinks/hardlinks cannot redirect writes; symlinked roots/parents and non-regular reads are refused. Failed replacement cleans up the temporary file.

This is per-account, single-command recovery, **not** an atomic multi-profile or concurrent-writer transaction. The restrictive-umask regression covers file permissions inside an already-owned existing root, not arbitrary ancestor initialization.

## Related work / merge coordination

Main was rechecked at `e64b531f16501f953d2d6a963833c7c3ef2785e7` before publication. #2260 is still open and independently contains the guarded `WrapErr` import; this branch temporarily includes that same semantic fix because it is needed to compile locally. If #2260 merges first, rebase/reconcile that import before merging this PR. No changes or comments were posted to #2260. The broader macOS CI gate tracked by #2259 is intentionally out of scope here.

## Validation

On macOS / aarch64, with fake fixture values only:

- TDD RED: API-enabled CLI auth run had 64 passing tests and 6 intended failures, proving existing/shared credential loss and symlink/hardlink escape.
- Final `cargo test -p octos-cli --features api --lib auth`: **221 passed, 3 ignored**.
- Final `cargo test -p octos-cli --features api --lib relocate`: **7 passed**.
- Exact-source Unix file-store harness: **26 passed, 3 ignored**. Additional child-only umask regression reproduced mode `000` before the descriptor permission fix and passed afterward; the parent test process's umask is never changed.
- `cargo check -p octos-cli`: passed (ordinary macOS production build).
- `cargo clippy -p octos-cli --features api --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

No real Keychain access, credentials, providers, or installed service processes were used for these fixtures. No binaries were installed. Native Linux/Windows execution is not claimed locally; the exact Unix backend runs under the macOS test adapter, and Windows API test coverage is added to CI.

### Full-suite limits (not a blanket all-targets pass)

The first full API-enabled parallel library run had **3,243 passed / 1 failed / 10 ignored**. Its untouched sovereignty test does `git init` followed by `git checkout -b main`, conflicting with this host's global `init.defaultBranch=main`. Focused RED and a process-only `init.defaultBranch=master` GREEN control confirmed that issue; no global Git configuration was changed.

A controlled full parallel run then had **3,242 passed / 2 failed / 10 ignored** in unchanged runtime tests: `closed_peer_park_produces_neither_wake_nor_escalation_row` (temporary ledger ENOENT) and `master_continuation_tick_reenters_actor_loop` (completion not yet persisted). The former passed focused; the latter also failed focused. These tests do not participate in the auth changes and are not modified or waived by this PR.

One bounded serial full audit completed with **3,241 passed / 3 failed / 10 ignored** (519 seconds): the unchanged `should_delete_primary_promote_fallback_and_reload_dynamic_profile_runtime`, `should_upsert_endpoint_edit_reload_dynamic_profile_runtime_for_next_turn`, and `master_continuation_tick_reenters_actor_loop` runtime tests failed. These full commands stopped at the library failure, so subsequent integration targets were not executed by them. The full audits preceded only the final descriptor-fchmod hardening; focused tests and strict clippy were rerun against the final commit. No blanket all-targets test pass is claimed.

All raw failures and successful focused logs are retained in the isolated local evidence directory. No unrelated OUP/runtime fixes or shared-worktree changes are included.
