### PR TITLE
test(bus): sort session ids before asserting in list_sessions hiding test

### DIFF
--- a/crates/octos-bus/src/api_channel_tests.rs
+++ b/crates/octos-bus/src/api_channel_tests.rs
@@ -3712,7 +3712,13 @@ async fn list_sessions_hides_internal_child_and_task_ledger_sessions() {
         .filter_map(|entry| entry.get("id").and_then(|id| id.as_str()))
         .collect();
 
-    assert_eq!(ids, vec!["web-123", "web-raw"]);
+    // #2267: the session list comes from unordered map iteration — the
+    // order differs per platform/run (flake on the nightly ARM64 lane).
+    // Assert as a sorted set; the hiding semantics under test do not
+    // depend on ordering.
+    let mut sorted_ids = ids.clone();
+    sorted_ids.sort_unstable();
+    assert_eq!(sorted_ids, vec!["web-123", "web-raw"]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Maintainer drive-by for the #2267 nightly ARM64 flake (family 1 of the three-night triage).

`list_sessions_hides_internal_child_and_task_ledger_sessions` asserts the session ids in map-iteration order — the order differs per platform/run, so the nightly ARM64 lane flaked (`['web-raw','web-123']` vs `['web-123','web-raw']`). The hiding semantics under test (internal child + task-ledger sessions excluded from the listing) do not depend on ordering, so the assertion becomes a sorted comparison.

Test-only, one hunk. The other two #2267 families (Windows deep-search fixtures; the AppUI RPC error-code contract question) remain with @ymote.