### PR TITLE
fix(peer-status): report current execution and outcomes from trusted evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,11 @@ test_a2.md
 !specs/task-approval-post-tool-continuation.spec.md
 !specs/kv-cache-friendly-compaction.spec.md
 !specs/task-compaction-instruction-priority.spec.md
+# peer-status SDD contract (task-evo-peer-turn-status) + consumer field
+# contract — consumed by tests and outer-loop verification; plan under
+# docs/superpowers stays local by convention.
+!specs/task-evo-peer-turn-status.spec.md
+!docs/peer-status-interface.json
 # User-facing docs only (internal analysis/audits stay local)
 !docs/user-guide.md
 !docs/user-guide-zh.md

--- a/.gitignore
+++ b/.gitignore
@@ -78,11 +78,6 @@ test_a2.md
 !specs/task-approval-post-tool-continuation.spec.md
 !specs/kv-cache-friendly-compaction.spec.md
 !specs/task-compaction-instruction-priority.spec.md
-# peer-status SDD contract (task-evo-peer-turn-status) + consumer field
-# contract — consumed by tests and outer-loop verification; plan under
-# docs/superpowers stays local by convention.
-!specs/task-evo-peer-turn-status.spec.md
-!docs/peer-status-interface.json
 # User-facing docs only (internal analysis/audits stay local)
 !docs/user-guide.md
 !docs/user-guide-zh.md

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -34517,7 +34517,7 @@ fn peer_gather_callback_composes_done_and_running_rows() {
     std::fs::write(gamma.join("result.md"), "partial result before close\n").unwrap();
     std::fs::write(gamma.join("closed"), "tenant-a:api:master\n1700000000\n").unwrap();
 
-    let callback = build_peer_gather_callback(peers_root.clone());
+    let callback = build_peer_gather_callback(peers_root.clone(), "octos".to_owned());
     let text = callback(None).expect("gather composes");
     assert!(text.contains("## peer alpha (done)"), "{text}");
     assert!(
@@ -34551,7 +34551,7 @@ fn peer_gather_callback_composes_done_and_running_rows() {
 #[test]
 fn peer_gather_callback_reports_empty_blackboard() {
     let tmp = tempfile::tempdir().unwrap();
-    let missing = build_peer_gather_callback(tmp.path().join("peers"));
+    let missing = build_peer_gather_callback(tmp.path().join("peers"), "octos".to_owned());
     assert_eq!(
         missing(None).expect("missing dir is not an error"),
         "No peers staged for this profile."
@@ -34559,8 +34559,88 @@ fn peer_gather_callback_reports_empty_blackboard() {
 
     let empty_root = tmp.path().join("peers2");
     std::fs::create_dir_all(&empty_root).unwrap();
-    let empty = build_peer_gather_callback(empty_root);
+    let empty = build_peer_gather_callback(empty_root, "octos".to_owned());
     assert_eq!(empty(None).unwrap(), "No peers staged for this profile.");
+}
+
+/// task-e...[credential-redacted] — serve ENTRY profile threading (outer-loop
+/// review): the `peer/gather` RPC (raw) and the `peer_gather` TOOL callback
+/// read the blackboard under the CALLER'S profile, so a valid lifetime under
+/// a NON-DEFAULT profile stays trusted instead of degrading to unknown. The
+/// raw entry's projection is directly observable in the JSON; the tool
+/// callback is exercised through the same custom profile (its composed rows
+/// come from the same profile-aware reader), and the peer_list tool text
+/// (which DOES render execution) pins the projection observably.
+#[tokio::test]
+async fn peer_gather_entries_thread_caller_profile_for_lifetime() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (state, runtime) = state_with_profile(tmp.path(), "gatherx").await;
+    let peers_root = runtime.data_dir.join("peers");
+    let dir = peers_root.join("gx");
+    std::fs::create_dir_all(&dir).unwrap();
+    crate::peers::peer_io::write_peer_file_atomic(&dir, "brief.md", "b").unwrap();
+    crate::peers::peer_io::write_peer_file_atomic(&dir, "originator", "master-gx").unwrap();
+    // Round-1 terminal evidence (production frontmatter shape).
+    let terminal = "---\nslug: gx\noutcome: completed\nupdated_unix: 100\nturn: 1\n---\n\nbody\n";
+    crate::peers::peer_io::write_peer_file_atomic(&dir, "result.md", terminal).unwrap();
+    crate::peers::peer_io::write_peer_file_atomic(&dir, "result-1.md", terminal).unwrap();
+    crate::peers::peer_io::append_peer_line(&dir, "turns.txt", "1 completed 100\n").unwrap();
+    // A VALID lifetime under the custom profile: round 2 RUNNING.
+    let lifetime = serde_json::json!({
+        "version": 1,
+        "task_id": "task-gx",
+        "registry_key": crate::peers::peer_wire_key("gatherx", "gx"),
+        "master": "master-gx",
+        "generation": 1,
+        "phase": "running",
+        "turn_id": "t2",
+        "result_digest": null,
+    });
+    crate::peers::peer_io::write_peer_file_atomic(&dir, "lifetime.json", &lifetime.to_string())
+        .unwrap();
+
+    // RAW entry under the caller's real profile: TRUSTED projection. (Under
+    // the pre-fix default-"octos" read this same disk degraded to unknown —
+    // the registry_key would not match — so this assertion discriminates.)
+    let gathered = raw_peer_gather(
+        &state,
+        &RpcRequest::new(
+            "gather-profiled".to_string(),
+            APPUI_METHOD_PEER_GATHER,
+            json!({ "profile_id": "gatherx" }),
+        ),
+        None,
+    )
+    .expect("raw gather");
+    let rows = gathered["peers"].as_array().expect("peers");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["execution"], "running", "trusted under gatherx");
+    assert_eq!(rows[0]["last_outcome"], "completed");
+    assert_eq!(rows[0]["round"], 2);
+    assert_eq!(rows[0]["master_session_id"], "master-gx");
+    assert_eq!(rows[0]["task_id"], "task-gx");
+    assert_eq!(rows[0]["generation"], 1);
+    assert_eq!(rows[0]["turn_id"], "t2");
+
+    // TOOL gather callback under the same custom profile composes the row
+    // through the real entry (same profile-aware blackboard read).
+    let tool = build_peer_gather_callback(peers_root.clone(), "gatherx".to_owned());
+    let text = tool(None).expect("tool gather composes");
+    assert!(text.contains("## peer gx (done)"), "{text}");
+
+    // The peer_list TOOL text renders execution — observable proof the
+    // serve-side callback threads the custom profile into the projection.
+    let list = build_peer_list_callback(
+        peers_root,
+        Vec::new(),
+        Arc::new(UiProtocolContractStores::default()),
+        "gatherx".to_owned(),
+    );
+    let text = list().expect("peer list composes");
+    assert!(
+        text.contains("· exec=running"),
+        "current execution visible: {text}"
+    );
 }
 
 /// #436 hardening — a peer slug is a single path component; reject anything
@@ -34735,7 +34815,9 @@ async fn peer_terminal_wake_should_not_wake_master_when_gathered_peer_is_closed(
     });
     let task_id =
         bind_peer_supervised_task(&supervisor, peer_wire_key(profile, slug), &master.0).unwrap();
-    let gathered = build_peer_gather_callback(root.clone())(Some(vec![slug.into()])).unwrap();
+    let gathered =
+        build_peer_gather_callback(root.clone(), "octos".to_owned())(Some(vec![slug.into()]))
+            .unwrap();
     assert!(gathered.contains("Actual peer result"));
     let close_supervisor = supervisor.clone();
     let close = build_peer_close_callback(
@@ -34766,7 +34848,7 @@ async fn peer_terminal_wake_should_not_wake_master_when_gathered_peer_is_closed(
         "closing an already-read peer must not schedule follow-up answers: {pending:?}"
     );
     assert!(
-        build_peer_gather_callback(root)(Some(vec![slug.into()]))
+        build_peer_gather_callback(root, "octos".to_owned())(Some(vec![slug.into()]))
             .unwrap()
             .contains("Actual peer result"),
         "closing keeps the actual result readable"
@@ -34785,8 +34867,11 @@ async fn peer_consumption_should_not_wake_when_foreground_gathers_and_completes(
     std::fs::write(dir.join("brief.md"), "Read README").unwrap();
     std::fs::write(dir.join("originator"), &master.0).unwrap();
     let gathered = GatheredPeerResults::default();
-    let gather =
-        build_peer_gather_callback_for_turn(root.clone(), Some((master.clone(), gathered.clone())));
+    let gather = build_peer_gather_callback_for_turn(
+        root.clone(),
+        Some((master.clone(), gathered.clone())),
+        "octos".to_owned(),
+    );
     assert!(gather(None).unwrap().contains("still running"));
     let body = "---\nslug: reader\noutcome: completed\nupdated_unix: 123\nturn: 1\n---\n\nACTUAL-README-RESULT\n";
     std::fs::write(dir.join("result.md"), body).unwrap();
@@ -34860,7 +34945,12 @@ async fn peer_consumption_should_preserve_wake_when_final_is_not_successfully_co
         let root = runtime.data_dir.join("peers");
         stage_peer_consumption_result(&root, &master, "reader", 1);
         let gathered = GatheredPeerResults::default();
-        build_peer_gather_callback_for_turn(root.clone(), Some((master.clone(), gathered.clone())))(None).unwrap();
+        build_peer_gather_callback_for_turn(
+            root.clone(),
+            Some((master.clone(), gathered.clone())),
+            "octos".to_owned(),
+        )(None)
+        .unwrap();
         assert_eq!(gathered.lock().unwrap().len(), 1);
         let mut done = peer_consumption_done();
         let terminal = match label {
@@ -34908,9 +34998,11 @@ async fn peer_consumption_should_keep_unseen_newer_round_when_version_index_lags
     std::fs::write(root.join("reader/result-1.md"), "previous result").unwrap();
     write_peer_fleet_synthesis_marks(&root, &master.0, &[("reader".into(), 1)]).unwrap();
     let gathered = GatheredPeerResults::default();
-    build_peer_gather_callback_for_turn(root.clone(), Some((master.clone(), gathered.clone())))(
-        None,
-    )
+    build_peer_gather_callback_for_turn(
+        root.clone(),
+        Some((master.clone(), gathered.clone())),
+        "octos".to_owned(),
+    )(None)
     .unwrap();
     assert_eq!(
         gathered.lock().unwrap()["reader"].round,
@@ -34962,6 +35054,7 @@ fn peer_consumption_should_not_acknowledge_nonowned_or_truncated_reads() {
         let output = build_peer_gather_callback_for_turn(
             root.to_owned(),
             Some((reader.clone(), gathered.clone())),
+            "octos".to_owned(),
         )(None)
         .unwrap();
         assert!(
@@ -34983,9 +35076,11 @@ fn peer_consumption_should_not_acknowledge_nonowned_or_truncated_reads() {
         + &"x".repeat(PEER_GATHER_RESULT_CAP);
     std::fs::write(root.join("reader/result.md"), body).unwrap();
     let gathered = GatheredPeerResults::default();
-    build_peer_gather_callback_for_turn(root.to_owned(), Some((master.clone(), gathered.clone())))(
-        None,
-    )
+    build_peer_gather_callback_for_turn(
+        root.to_owned(),
+        Some((master.clone(), gathered.clone())),
+        "octos".to_owned(),
+    )(None)
     .unwrap();
     assert!(
         gathered.lock().unwrap().is_empty(),
@@ -34996,8 +35091,12 @@ fn peer_consumption_should_not_acknowledge_nonowned_or_truncated_reads() {
         "legacy result without authoritative round",
     )
     .unwrap();
-    build_peer_gather_callback_for_turn(root.to_owned(), Some((master, gathered.clone())))(None)
-        .unwrap();
+    build_peer_gather_callback_for_turn(
+        root.to_owned(),
+        Some((master, gathered.clone())),
+        "octos".to_owned(),
+    )(None)
+    .unwrap();
     assert!(
         gathered.lock().unwrap().is_empty(),
         "do not guess legacy result identities"
@@ -35021,9 +35120,11 @@ async fn peer_consumption_should_retire_queued_synthesis_only_for_exact_consumed
         .clone();
     assert!(!peer_synthesis_was_consumed(&state, &queued, &HashMap::new()).await);
     let gathered = GatheredPeerResults::default();
-    build_peer_gather_callback_for_turn(root.clone(), Some((master.clone(), gathered.clone())))(
-        None,
-    )
+    build_peer_gather_callback_for_turn(
+        root.clone(),
+        Some((master.clone(), gathered.clone())),
+        "octos".to_owned(),
+    )(None)
     .unwrap();
     commit_gathered_peer_results(
         &root,
@@ -35083,7 +35184,12 @@ fn peer_consumption_should_merge_concurrent_receipts_without_losing_other_peers_
     for slug in ["first", "second"] {
         stage_peer_consumption_result(&root, &master, slug, 2);
         let gathered = GatheredPeerResults::default();
-        build_peer_gather_callback_for_turn(root.clone(), Some((master.clone(), gathered.clone())))(Some(vec![slug.into()])).unwrap();
+        build_peer_gather_callback_for_turn(
+            root.clone(),
+            Some((master.clone(), gathered.clone())),
+            "octos".to_owned(),
+        )(Some(vec![slug.into()]))
+        .unwrap();
         let root = root.clone();
         let master = master.clone();
         let barrier = barrier.clone();
@@ -35106,9 +35212,11 @@ fn peer_consumption_should_merge_concurrent_receipts_without_losing_other_peers_
     assert_eq!(read_peer_consumption(&root, &master).results.len(), 2);
     stage_peer_consumption_result(&root, &master, "first", 1);
     let old = GatheredPeerResults::default();
-    build_peer_gather_callback_for_turn(root.clone(), Some((master.clone(), old.clone())))(Some(
-        vec!["first".into()],
-    ))
+    build_peer_gather_callback_for_turn(
+        root.clone(),
+        Some((master.clone(), old.clone())),
+        "octos".to_owned(),
+    )(Some(vec!["first".into()]))
     .unwrap();
     stage_peer_consumption_result(&root, &master, "first", 3);
     commit_gathered_peer_results(
@@ -35141,9 +35249,11 @@ async fn peer_consumption_should_retire_prequeued_synthesis_when_gathered_peer_c
         .unwrap()
         .clone();
     let gathered = GatheredPeerResults::default();
-    build_peer_gather_callback_for_turn(root.clone(), Some((master.clone(), gathered.clone())))(
-        None,
-    )
+    build_peer_gather_callback_for_turn(
+        root.clone(),
+        Some((master.clone(), gathered.clone())),
+        "octos".to_owned(),
+    )(None)
     .unwrap();
     build_peer_close_callback(
         root.clone(),
@@ -35184,6 +35294,7 @@ fn peer_consumption_should_accept_current_receipt_when_peer_slug_is_restaged_at_
         build_peer_gather_callback_for_turn(
             root.to_owned(),
             Some((master.clone(), gathered.clone())),
+            "octos".to_owned(),
         )(None)
         .unwrap();
         commit_gathered_peer_results(
@@ -35208,9 +35319,11 @@ async fn peer_consumption_should_not_consume_when_interrupt_wins_the_actual_term
     let master = SessionKey::with_profile("consumption-terminal-race", "api", "master");
     stage_peer_consumption_result(root, &master, "reader", 1);
     let gathered = GatheredPeerResults::default();
-    build_peer_gather_callback_for_turn(root.to_owned(), Some((master.clone(), gathered.clone())))(
-        None,
-    )
+    build_peer_gather_callback_for_turn(
+        root.to_owned(),
+        Some((master.clone(), gathered.clone())),
+        "octos".to_owned(),
+    )(None)
     .unwrap();
     let (ack, wait_ack) = tokio::sync::oneshot::channel();
     let state = TokioMutex::new(TurnState::Interrupting {
@@ -35580,7 +35693,7 @@ fn peer_list_and_gather_surface_display_name() {
     );
     assert!(list.contains("(edison)"), "list annotates the slug: {list}");
 
-    let gather_cb = build_peer_gather_callback(peers.clone());
+    let gather_cb = build_peer_gather_callback(peers.clone(), "seed".to_owned());
     let gather = gather_cb(None).unwrap();
     assert!(
         gather.contains("## peer Edison [edison]"),
@@ -36075,6 +36188,8 @@ fn peer_list_caps_rows_and_summarizes_overflow() {
             closed: false,
             turn_history: None,
             model_lane: None,
+            // Synthetic disk-less row: no execution assertions.
+            execution_facet: unknown_peer_execution_facet(),
         }
     }
     let over = PEER_LIST_MAX_ROWS + 5;
@@ -36114,7 +36229,7 @@ fn peer_gather_callback_caps_total_output_evenly() {
         std::fs::write(dir.join("brief.md"), format!("Task {slug}.")).unwrap();
         std::fs::write(dir.join("result.md"), "r".repeat(30 * 1024)).unwrap();
     }
-    let callback = build_peer_gather_callback(peers_root);
+    let callback = build_peer_gather_callback(peers_root, "octos".to_owned());
     let text = callback(None).unwrap();
     assert!(
         text.len() <= PEER_GATHER_TOOL_OUTPUT_CAP,
@@ -36633,6 +36748,8 @@ fn peer_list_row(slug: &str, model_lane: Option<&str>) -> PeerBlackboardRow {
         closed: false,
         turn_history: None,
         model_lane: model_lane.map(str::to_owned),
+        // Synthetic disk-less row: no execution assertions.
+        execution_facet: unknown_peer_execution_facet(),
     }
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -15906,32 +15906,44 @@ fn raw_peer_gather(
         )));
     };
     let peers_root = runtime.data_dir.join("peers");
-    let peers: Vec<Value> = read_peer_blackboard(&peers_root, params.slugs.as_deref())
-        .into_iter()
-        .map(|row| {
-            json!({
-                "slug": row.slug,
-                "name": row.name,
-                "topic": format!("peer-{}", row.slug),
-                "brief": row.brief,
-                "brief_truncated": row.brief_truncated,
-                "result": row.result,
-                "result_truncated": row.result_truncated,
-                "result_updated_unix": row.result_updated_unix,
-                "has_worktree": row.has_worktree,
-                "closed": row.closed,
-                "turn_history": row.turn_history.as_ref().map(|history| {
-                    history.iter().map(|(count, outcome, ts)| {
-                        json!({
-                            "turn": count,
-                            "outcome": outcome,
-                            "updated_unix": ts,
-                        })
-                    }).collect::<Vec<_>>()
-                }),
+    let peers: Vec<Value> =
+        read_peer_blackboard_with_profile(&peers_root, params.slugs.as_deref(), &profile_id)
+            .into_iter()
+            .map(|row| {
+                json!({
+                    "slug": row.slug,
+                    "name": row.name,
+                    "topic": format!("peer-{}", row.slug),
+                    "brief": row.brief,
+                    "brief_truncated": row.brief_truncated,
+                    "result": row.result,
+                    "result_truncated": row.result_truncated,
+                    "result_updated_unix": row.result_updated_unix,
+                    "has_worktree": row.has_worktree,
+                    "closed": row.closed,
+                    "turn_history": row.turn_history.as_ref().map(|history| {
+                        history.iter().map(|(count, outcome, ts)| {
+                            json!({
+                                "turn": count,
+                                "outcome": outcome,
+                                "updated_unix": ts,
+                            })
+                        }).collect::<Vec<_>>()
+                    }),
+                    // task-evo-peer-turn-status — the execution facet fields
+                    // (same derivation as the CLI rows; see
+                    // docs/peer-status-interface.json).
+                    "execution": row.execution_facet.execution,
+                    "last_outcome": row.execution_facet.last_outcome,
+                    "round": row.execution_facet.round,
+                    "rounds_delivered": row.execution_facet.rounds_delivered,
+                    "master_session_id": row.execution_facet.master_session_id,
+                    "task_id": row.execution_facet.task_id,
+                    "generation": row.execution_facet.generation,
+                    "turn_id": row.execution_facet.turn_id,
+                })
             })
-        })
-        .collect();
+            .collect();
     Ok(json!({ "profile_id": profile_id, "peers": peers }))
 }
 
@@ -16177,13 +16189,17 @@ fn commit_gathered_peer_results(
 }
 
 #[cfg(test)]
-fn build_peer_gather_callback(peers_root: PathBuf) -> octos_agent::PeerGatherCallback {
-    build_peer_gather_callback_for_turn(peers_root, None)
+fn build_peer_gather_callback(
+    peers_root: PathBuf,
+    profile_id: String,
+) -> octos_agent::PeerGatherCallback {
+    build_peer_gather_callback_for_turn(peers_root, None, profile_id)
 }
 
 fn build_peer_gather_callback_for_turn(
     peers_root: PathBuf,
     consumption: Option<(SessionKey, GatheredPeerResults)>,
+    profile_id: String,
 ) -> octos_agent::PeerGatherCallback {
     Arc::new(move |idents: Option<Vec<String>>| {
         // The model may pass peer NAMES or slugs; resolve each to a slug for
@@ -16194,7 +16210,10 @@ fn build_peer_gather_callback_for_turn(
                 .filter_map(|ident| resolve_peer_name_to_slug(&peers_root, ident))
                 .collect::<Vec<_>>()
         });
-        let rows = read_peer_blackboard(&peers_root, slugs.as_deref());
+        // task-evo-peer-turn-status — the gather tool reads under the
+        // CALLER'S profile so non-default profiles' valid lifetimes are not
+        // demoted to unknown by an "octos" default (outer-loop review).
+        let rows = read_peer_blackboard_with_profile(&peers_root, slugs.as_deref(), &profile_id);
         let (output, output_truncated) = compose_peer_gather_text_with_truncation(&rows);
         // A budget-capped gather is not proof the model saw every result.
         if !output_truncated
@@ -33907,6 +33926,7 @@ async fn run_standalone_turn(
             let gather = build_peer_gather_callback_for_turn(
                 session_runtime.profile.data_dir.join("peers"),
                 Some((session_id.clone(), gathered_peer_results.clone())),
+                session_runtime.profile.profile_id.clone(),
             );
             tool_registry.register(octos_agent::PeerGatherTool::new(gather));
         }

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod oup_peers;
 pub(crate) mod oup_session;
 #[cfg(feature = "api")]
 mod oup_text;
+#[cfg_attr(test, allow(unused_imports))]
 mod peer;
 mod profile;
 #[cfg(feature = "api")]
@@ -80,7 +81,10 @@ pub use mcp_serve::McpServeCommand;
 pub use memory::MemoryCommand;
 pub(crate) use obs_resolve as obs;
 pub use office::OfficeCommand;
+#[cfg_attr(not(test), allow(unused_imports))]
 pub use peer::PeerCommand;
+#[cfg(test)]
+pub(crate) use peer::peer_list_for_test;
 pub use profile::ProfileCommand;
 #[cfg(feature = "api")]
 pub use serve::ServeCommand;

--- a/crates/octos-cli/src/commands/peer.rs
+++ b/crates/octos-cli/src/commands/peer.rs
@@ -69,7 +69,9 @@ pub(crate) struct PeerListRow {
     pub name: Option<String>,
     pub model_lane: Option<String>,
     /// Trusted-lifetime identity (anti cross-runtime/same-slug fencing);
-    /// null when the projection is untrusted.
+    /// null when the projection is untrusted — and also for the `closed`
+    /// branch, which intentionally reports identity-free (the closed marker
+    /// takes precedence over the projection; conservative contract).
     pub master_session_id: Option<String>,
     pub task_id: Option<String>,
     pub generation: Option<u64>,

--- a/crates/octos-cli/src/commands/peer.rs
+++ b/crates/octos-cli/src/commands/peer.rs
@@ -44,7 +44,7 @@ pub struct PeerListArgs {
 
 /// One peer row. Field names are part of the machine contract
 /// (docs/peer-status-interface.json).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct PeerListRow {
     pub slug: String,
     /// running | done | closed (a closed peer is reported even if results
@@ -152,6 +152,30 @@ pub(crate) fn peer_list_for_test(data_dir: &Path, profile_id: &str) -> Vec<PeerL
     list_peers(data_dir, profile_id)
 }
 
+/// ONE production renderer for a peer row's table line (shared by
+/// `print_table`; asserted directly by the shared-assembly contract test —
+/// the test must NOT re-implement the mapping).
+fn render_table_line(row: &PeerListRow) -> String {
+    // Table rendering maps (interface contract): unknown execution shows
+    // "?", a null outcome shows "-" — both asserted by the shared-
+    // assembly test via this function.
+    let execution = if row.execution == "unknown" {
+        "?".to_owned()
+    } else {
+        row.execution.clone()
+    };
+    let outcome = row.last_outcome.clone().unwrap_or_else(|| "-".to_owned());
+    format!(
+        "{:<24} {:<8} {:<8} {:<12} {:<7} {}",
+        row.slug,
+        row.status,
+        execution,
+        outcome,
+        row.rounds_delivered,
+        row.name.as_deref().unwrap_or("-")
+    )
+}
+
 fn print_table(rows: &[PeerListRow]) {
     if rows.is_empty() {
         println!("(no staged peers)");
@@ -162,25 +186,27 @@ fn print_table(rows: &[PeerListRow]) {
         "SLUG", "STATUS", "CURRENT", "OUTCOME", "ROUNDS"
     );
     for row in rows {
-        // Table rendering maps (interface contract): unknown execution shows
-        // "?", a null outcome shows "-" — both asserted by the shared-
-        // assembly test.
-        let execution = if row.execution == "unknown" {
-            "?".to_owned()
-        } else {
-            row.execution.clone()
-        };
-        let outcome = row.last_outcome.clone().unwrap_or_else(|| "-".to_owned());
-        println!(
-            "{:<24} {:<8} {:<8} {:<12} {:<7} {}",
-            row.slug,
-            row.status,
-            execution,
-            outcome,
-            row.rounds_delivered,
-            row.name.as_deref().unwrap_or("-")
-        );
+        println!("{}", render_table_line(row));
     }
+}
+
+/// Resolve the CLI routing for `peer list` from the RAW parsed args:
+/// returns `(data_dir, profile_id)` exactly as `execute` uses them.
+/// Extracted so the `--data-dir` + `--profile` COMBINATION test can exercise
+/// the REAL routing (outer-loop review: a test calling `list_peers(temp,
+/// profile)` directly bypasses the CLI layer entirely).
+fn route_peer_list(
+    args: &PeerListArgs,
+    state_home: &Path,
+    cwd: &Path,
+) -> (std::path::PathBuf, String) {
+    let profile_id = args
+        .profile
+        .clone()
+        .unwrap_or_else(|| super::obs::DEFAULT_PROFILE_ID.to_owned());
+    let data_dir = super::obs::resolve_profile_data_root(state_home, cwd, &profile_id);
+    let data_dir = args.data_dir.clone().unwrap_or(data_dir);
+    (data_dir, profile_id)
 }
 
 impl Executable for PeerCommand {
@@ -188,23 +214,18 @@ impl Executable for PeerCommand {
         match self.action {
             PeerAction::List(args) => {
                 // 整改: shared per-instance profile data root (see goal.rs).
-                // task-evo-peer-turn-status: the profile id for lifetime
+                // task-e...[credential-redacted]: the profile id for lifetime
                 // projection validation comes from --profile (explicit) or
                 // the default — NEVER derived from the data-dir path. The
                 // SAME id also drives the data-root resolution, so
                 // `--profile octosfix` without --data-dir reads the octosfix
                 // profile's directory (outer-loop review: passing the
                 // constant here made --profile a no-op for resolution).
-                let profile_id = args
-                    .profile
-                    .clone()
-                    .unwrap_or_else(|| super::obs::DEFAULT_PROFILE_ID.to_owned());
-                let data_dir = super::obs::resolve_profile_data_root(
+                let (data_dir, profile_id) = route_peer_list(
+                    &args,
                     &super::resolve_data_dir(None)?,
                     &std::env::current_dir()?,
-                    &profile_id,
                 );
-                let data_dir = args.data_dir.unwrap_or(data_dir);
                 // 整改要求 2: a missing peers dir is an ERROR with the
                 // resolved path (never a silent empty list).
                 let peers_root = data_dir.join("peers");
@@ -247,6 +268,35 @@ mod tests {
         dir
     }
 
+    /// Stage a single NON-EMPTY row so the JSON contract test can observe a
+    /// real serialized object (an empty list serializes to `[]` and reveals
+    /// no field names). REAL done+errored shape (spec critical scenario):
+    /// terminal round-1 errored evidence + trusted Failed lifetime — the
+    /// row renders execution=failed, last_outcome=errored.
+    fn stage_fixture_row_for_contract(data_dir: &Path) -> std::path::PathBuf {
+        let dir = stage_peer(data_dir, "contract-fixture");
+        let text = "---\nslug: contract-fixture\noutcome: errored\nupdated_unix: 100\nturn: 1\n---\n\nbody\n";
+        crate::peers::peer_io::write_peer_file_atomic(&dir, "result-1.md", text).expect("result-1");
+        crate::peers::peer_io::write_peer_file_atomic(&dir, "result.md", text).expect("result");
+        crate::peers::peer_io::append_peer_line(&dir, "turns.txt", "1 errored 100\n")
+            .expect("turns");
+        let lifetime = serde_json::json!({
+            "version": 1,
+            "task_id": "task-contract-fixture",
+            "registry_key": crate::peers::peer_wire_key("octos", "contract-fixture"),
+            "master": "master-cf",
+            "generation": 1,
+            "phase": "failed",
+            "turn_id": Some("t1"),
+            "result_digest": null,
+        });
+        crate::peers::peer_io::write_peer_file_atomic(&dir, "lifetime.json", &lifetime.to_string())
+            .expect("lifetime");
+        crate::peers::peer_io::write_peer_file_atomic(&dir, "originator", "master-cf")
+            .expect("originator");
+        dir
+    }
+
     /// Contract: peers/ 目录直读 — brief staged, result versions counted,
     /// closed marker is terminal. No serve involved.
     #[test]
@@ -278,6 +328,91 @@ mod tests {
         assert!(json[0].get("status").is_some());
     }
 
+    /// Spec Decisions: `--data-dir` (arbitrary custom root) + `--profile
+    /// <non-default>` must COMBINE — exercising the REAL CLI parse and the
+    /// production routing (`route_peer_list`, the same fn `execute` calls),
+    /// not a direct `list_peers(temp, profile)` call that bypasses the CLI
+    /// layer (outer-loop review finding). A lifetime minted for profile
+    /// "octosfix" under a custom root: trusted under --profile octosfix,
+    /// UNKNOWN under the default — proving the profile reaches the
+    /// projection validation intact while --data-dir supplies the root.
+    #[test]
+    fn peer_list_custom_data_dir_with_explicit_profile_combination() {
+        use clap::Parser as _;
+        // REAL clap parse of the full CLI surface: octos peer list
+        // --data-dir <custom> --profile octosfix
+        let custom_root = tempfile::tempdir().expect("custom root");
+        let custom_str = custom_root.path().to_str().expect("utf8 path").to_owned();
+        let parsed = crate::commands::Args::try_parse_from([
+            "octos",
+            "peer",
+            "list",
+            "--data-dir",
+            &custom_str,
+            "--profile",
+            "octosfix",
+        ])
+        .expect("cli parse");
+        let crate::commands::Command::Peer(peer) = parsed.command else {
+            panic!("expected peer command");
+        };
+        #[expect(
+            irrefutable_let_patterns,
+            reason = "PeerAction is single-variant; the let-else documents the invariant for future subcommands"
+        )]
+        let crate::commands::peer::PeerAction::List(args) = peer.action else {
+            panic!(
+                "unreachable: PeerAction has only the List variant today; \
+                    kept as a binding so adding a subcommand fails HERE, not silently"
+            )
+        };
+        assert_eq!(args.profile.as_deref(), Some("octosfix"));
+        assert_eq!(args.data_dir.as_deref(), Some(custom_root.path()));
+
+        // Production routing: --data-dir wins for the root, --profile flows
+        // through for projection validation (cwd/state_home irrelevant when
+        // --data-dir is explicit).
+        let state_home = tempfile::tempdir().expect("state home");
+        let cwd = tempfile::tempdir().expect("cwd");
+        let (data_dir, profile_id) = super::route_peer_list(&args, state_home.path(), cwd.path());
+        assert_eq!(data_dir, custom_root.path());
+        assert_eq!(profile_id, "octosfix");
+
+        // And the routed pair feeds the projection: a lifetime minted for
+        // "octosfix" under the custom root is trusted (running); the SAME
+        // disk state under the DEFAULT profile fails registry_key
+        // validation → fail-closed unknown + identity null.
+        let peers_root = custom_root.path().join("peers");
+        let dir = peers_root.join("combo");
+        std::fs::create_dir_all(&dir).expect("peer dir");
+        std::fs::write(dir.join("brief.md"), "task brief").expect("brief");
+        std::fs::write(dir.join("originator"), "m1").expect("originator");
+        let lifetime = serde_json::json!({
+            "version": 1,
+            "task_id": "task-combo",
+            "registry_key": crate::peers::peer_wire_key("octosfix", "combo"),
+            "master": "m1",
+            "generation": 1,
+            "phase": "running",
+            "turn_id": "t-combo-1",
+            "result_digest": null
+        });
+        std::fs::write(
+            dir.join("lifetime.json"),
+            serde_json::to_string(&lifetime).expect("lifetime json"),
+        )
+        .expect("lifetime");
+
+        let rows = list_peers(&data_dir, &profile_id);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].execution, "running");
+
+        let rows_default = list_peers(&data_dir, "octos");
+        assert_eq!(rows_default.len(), 1);
+        assert_eq!(rows_default[0].execution, "unknown");
+        assert!(rows_default[0].master_session_id.is_none());
+    }
+
     /// Empty / missing peers dir -> empty JSON array, exit-0 shape.
     #[test]
     fn olp_obs_peer_list_empty_dir_is_empty_array() {
@@ -285,5 +420,127 @@ mod tests {
         let rows = list_peers(temp.path(), "octos");
         assert!(rows.is_empty());
         assert_eq!(serde_json::to_string(&rows).expect("json"), "[]");
+    }
+
+    /// Spec filter: peer_list_fields_match_status_interface_contract —
+    /// the serialized PeerListRow key set MUST equal the tracked contract
+    /// docs/peer-status-interface.json's declared output_fields. A drift in
+    /// either direction (missing or extra field) fails, so the JSON machine
+    /// contract can never silently diverge from the tracked document.
+    #[test]
+    fn peer_list_fields_match_status_interface_contract() {
+        let contract: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../docs/peer-status-interface.json"
+            ))
+            .expect("tracked contract file"),
+        )
+        .expect("contract json");
+        let mut expected: Vec<String> = contract["output_fields"]
+            .as_object()
+            .expect("output_fields object")
+            .keys()
+            .map(|k| k.to_string())
+            .collect();
+        expected.sort();
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Serialize a NON-empty row: field visibility requires real values.
+        // (An empty dir serializes to `[]`, so the key set is derived from a
+        // staged fixture row.)
+        let _dir = stage_fixture_row_for_contract(temp.path());
+        let rows = list_peers(temp.path(), "octos");
+        assert_eq!(rows.len(), 1);
+        let mut actual: Vec<String> = serde_json::to_value(&rows)
+            .expect("json")
+            .as_array()
+            .expect("rows array")
+            .first()
+            .expect("one row")
+            .as_object()
+            .expect("row object")
+            .keys()
+            .map(|k| k.to_string())
+            .collect();
+        actual.sort();
+        assert_eq!(
+            actual, expected,
+            "PeerListRow serialized keys must equal the tracked contract"
+        );
+    }
+
+    /// Spec filter: peer_list_json_and_table_share_assembly — --json and the
+    /// human table are TWO RENDERINGS of the SAME rows. Calls the PRODUCTION
+    /// renderer (render_table_line, the same fn print_table loops over) —
+    /// the test never re-implements the mapping (outer-loop review caught a
+    /// tautological earlier draft). Fixtures cover all three renderings:
+    /// unknown execution → "?", null outcome → "-", real outcome as-is.
+    #[test]
+    fn peer_list_json_and_table_share_assembly() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // done + errored fixture (spec critical scenario): result.md exists
+        // AND turns.txt tail is errored with a trusted Failed lifetime.
+        let _dir = stage_fixture_row_for_contract(temp.path());
+        let rows = list_peers(temp.path(), "octos");
+        assert_eq!(rows.len(), 1);
+
+        // JSON rendering: full contract field set present, raw values
+        // (execution/last_outcome as-is; no borrow-after-move: serialize a
+        // clone).
+        let json = serde_json::to_value(&rows).expect("json");
+        let obj = json[0].as_object().expect("row object");
+        for field in [
+            "slug",
+            "status",
+            "execution",
+            "last_outcome",
+            "round",
+            "rounds_delivered",
+            "has_brief",
+            "result_versions",
+            "name",
+            "model_lane",
+            "master_session_id",
+            "task_id",
+            "generation",
+            "turn_id",
+        ] {
+            assert!(obj.contains_key(field), "json missing {field}");
+        }
+
+        // PRODUCTION table renderer over the same rows: the errored outcome
+        // renders as-is — asserted COLUMN-WISE (tokens in header order:
+        // SLUG/STATUS/CURRENT/OUTCOME/ROUNDS/NAME), never `any('-')` (NAME
+        // may legitimately be '-' and would mask an OUTCOME mapping error).
+        let line = super::render_table_line(&rows[0]);
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        assert!(tokens.len() >= 6, "six columns rendered: {line}");
+        assert_eq!(tokens[0], "contract-fixture", "SLUG column: {line}");
+        assert_eq!(
+            tokens[2], "failed",
+            "CURRENT column (trusted failed): {line}"
+        );
+        assert_eq!(
+            tokens[3], "errored",
+            "OUTCOME column (real outcome as-is): {line}"
+        );
+
+        // And the mapped renderings on synthetic rows via the SAME
+        // production fn: unknown execution → "?" in CURRENT, null outcome
+        // → "-" in OUTCOME — column-positional, so NAME="-" cannot mask it.
+        let mut unknown_null = rows[0].clone();
+        unknown_null.execution = "unknown".to_owned();
+        unknown_null.last_outcome = None;
+        unknown_null.name = None; // renders '-' in NAME — must not satisfy OUTCOME
+        let mapped = super::render_table_line(&unknown_null);
+        let mtokens: Vec<&str> = mapped.split_whitespace().collect();
+        assert_eq!(mtokens[2], "?", "CURRENT maps unknown→'?': {mapped}");
+        assert_eq!(mtokens[3], "-", "OUTCOME maps null→'-': {mapped}");
+
+        // Shared-assembly invariant: the JSON object was serialized from
+        // the SAME rows the renderer consumes.
+        assert_eq!(json[0]["slug"].as_str().unwrap(), rows[0].slug);
+        assert_eq!(json[0]["execution"].as_str().unwrap(), rows[0].execution);
     }
 }

--- a/crates/octos-cli/src/commands/peer.rs
+++ b/crates/octos-cli/src/commands/peer.rs
@@ -34,69 +34,122 @@ pub struct PeerListArgs {
     /// Data-dir override (defaults to the standard resolution).
     #[arg(long, value_name = "DIR")]
     pub data_dir: Option<PathBuf>,
+    /// Profile id used to validate peer lifetime projections
+    /// (task-evo-peer-turn-status). The lifetime's registry_key must match
+    /// `<profile>:peer:<slug>`; the profile is NEVER derived from the
+    /// data-dir path. Defaults to the standard default profile ("octos").
+    #[arg(long, value_name = "ID")]
+    pub profile: Option<String>,
 }
 
-/// One peer row. Field names are part of the machine contract.
+/// One peer row. Field names are part of the machine contract
+/// (docs/peer-status-interface.json).
 #[derive(Debug, Serialize)]
 pub(crate) struct PeerListRow {
     pub slug: String,
     /// running | done | closed (a closed peer is reported even if results
     /// exist — closed is the terminal, operator-visible truth).
     pub status: String,
+    /// queued | running | idle | failed | closed | unknown — the CURRENT
+    /// execution state from the trusted lifetime projection (fail-closed;
+    /// unknown whenever no trusted authority exists).
+    pub execution: String,
+    /// completed | errored | interrupted | rate_limited | null — the most
+    /// recent TERMINATED round's outcome, from the strict terminal evidence
+    /// (turns.txt tail × highest result-<n>.md cross-check).
+    pub last_outcome: Option<String>,
+    /// Current round (queued/running: delivered+1; else the terminated
+    /// round's number).
+    pub round: u32,
+    /// Delivered rounds = count(result-<n>.md), floored at 1 for a bare
+    /// result.md (#2024).
+    pub rounds_delivered: u32,
     pub has_brief: bool,
     pub result_versions: u32,
     pub name: Option<String>,
     pub model_lane: Option<String>,
+    /// Trusted-lifetime identity (anti cross-runtime/same-slug fencing);
+    /// null when the projection is untrusted.
+    pub master_session_id: Option<String>,
+    pub task_id: Option<String>,
+    pub generation: Option<u64>,
+    pub turn_id: Option<String>,
 }
 
 /// Assemble the peer list straight from the `peers/` directory. Symlinked
 /// or unstaged entries are skipped (same safety gate as serve's scans).
-pub(crate) fn list_peers(data_dir: &Path) -> Vec<PeerListRow> {
+/// `profile_id` validates the lifetime projection's registry_key — supplied
+/// EXPLICITLY by the caller (`--profile` / the resolved default), never
+/// derived from the data-dir path (task-evo-peer-turn-status).
+pub(crate) fn list_peers(data_dir: &Path, profile_id: &str) -> Vec<PeerListRow> {
+    // Single assembly: the CLI rows are a projection of the shared
+    // blackboard read (same source as serve's peer_list/peer_gather), so the
+    // three consumers can never drift.
+    let rows =
+        crate::peers::read_peer_blackboard_with_profile(&data_dir.join("peers"), None, profile_id);
     let peers_root = data_dir.join("peers");
-    let mut rows = Vec::new();
-    let Ok(read_dir) = std::fs::read_dir(&peers_root) else {
-        return rows; // no peers dir at all -> empty list, not an error
-    };
-    for entry in read_dir.flatten() {
-        let slug = entry.file_name().to_string_lossy().into_owned();
-        let Some(dir) = crate::peers::staged_peer_dir(&peers_root, &slug) else {
-            continue;
-        };
-        use crate::peers::peer_io as io;
-        let has_brief = io::peer_regular_file_exists(&dir, "brief.md");
-        if !has_brief {
-            continue; // not a staged peer (the staging contract)
-        }
-        let closed = io::peer_regular_file_exists(&dir, "closed");
-        let result_versions = crate::peers::count_peer_result_versions(&dir);
-        // A turn's latest finding lands in the bare `result.md`
-        // (overwritten per terminal); numbered `result-<n>.md` are older
-        // versions. Either proves delivery.
-        let has_result = result_versions > 0 || io::peer_regular_file_exists(&dir, "result.md");
-        let status = if closed {
-            "closed"
-        } else if has_result {
-            "done"
-        } else {
-            "running"
-        };
-        let name = io::read_peer_file(&dir, "name", io::PEER_FILE_READ_CAP_SMALL)
-            .map(|s| s.trim().to_owned())
-            .filter(|s| !s.is_empty());
-        let model_lane = io::read_peer_file(&dir, "model", io::PEER_FILE_READ_CAP_SMALL)
-            .map(|s| s.trim().to_owned())
-            .filter(|s| !s.is_empty());
-        rows.push(PeerListRow {
-            slug,
-            status: status.to_owned(),
-            has_brief,
-            result_versions,
-            name,
-            model_lane,
-        });
-    }
+    let mut rows: Vec<PeerListRow> = rows
+        .into_iter()
+        .map(|row| {
+            // RAW numbered-version count (the original `result_versions`
+            // contract: count(result-<n>.md) with NO #2024 floor) — kept
+            // distinct from `rounds_delivered`, which applies the floor.
+            let result_versions =
+                crate::peers::count_peer_result_versions(&peers_root.join(&row.slug));
+            // LEGACY status semantics, preserved EXACTLY (outer-loop
+            // review): done = a numbered result-<n>.md exists OR the bare
+            // result.md exists. The blackboard row's `result` field only
+            // carries the BARE file (an oversized/unreadable bare file
+            // yields None there but still proves delivery), so the version
+            // count participates too — a numbered-only peer must stay done.
+            let has_result = row.execution_facet.rounds_delivered > 0 || row.result.is_some();
+            let status = if row.closed {
+                "closed"
+            } else if has_result {
+                "done"
+            } else {
+                "running"
+            };
+            // name: the ORIGINAL optional-name semantics — Some only when a
+            // non-empty `name` file was recorded (including content == slug,
+            // the operator's explicit choice); None when absent/empty. The
+            // blackboard collapses a missing name onto the slug for
+            // ADDRESSING; the CLI contract keeps the distinction.
+            let raw_name = crate::peers::peer_io::read_peer_file(
+                &peers_root.join(&row.slug),
+                "name",
+                crate::peers::peer_io::PEER_FILE_READ_CAP_SMALL,
+            )
+            .map(|n| n.trim().to_owned())
+            .filter(|n| !n.is_empty());
+            PeerListRow {
+                slug: row.slug.clone(),
+                status: status.to_owned(),
+                execution: row.execution_facet.execution.to_owned(),
+                last_outcome: row.execution_facet.last_outcome,
+                round: row.execution_facet.round,
+                rounds_delivered: row.execution_facet.rounds_delivered,
+                has_brief: true,
+                result_versions,
+                name: raw_name,
+                model_lane: row.model_lane,
+                master_session_id: row.execution_facet.master_session_id,
+                task_id: row.execution_facet.task_id,
+                generation: row.execution_facet.generation,
+                turn_id: row.execution_facet.turn_id,
+            }
+        })
+        .collect();
     rows.sort_by(|a, b| a.slug.cmp(&b.slug));
     rows
+}
+
+/// Test-visible alias for [`list_peers`] — the module is private to
+/// `commands`, but the peers-module contract tests need the REAL CLI
+/// assembly (status semantics + name preservation) over real dirs.
+#[cfg(test)]
+pub(crate) fn peer_list_for_test(data_dir: &Path, profile_id: &str) -> Vec<PeerListRow> {
+    list_peers(data_dir, profile_id)
 }
 
 fn print_table(rows: &[PeerListRow]) {
@@ -104,13 +157,27 @@ fn print_table(rows: &[PeerListRow]) {
         println!("(no staged peers)");
         return;
     }
-    println!("{:<24} {:<8} {:<8} NAME", "SLUG", "STATUS", "RESULTS");
+    println!(
+        "{:<24} {:<8} {:<8} {:<12} {:<7} NAME",
+        "SLUG", "STATUS", "CURRENT", "OUTCOME", "ROUNDS"
+    );
     for row in rows {
+        // Table rendering maps (interface contract): unknown execution shows
+        // "?", a null outcome shows "-" — both asserted by the shared-
+        // assembly test.
+        let execution = if row.execution == "unknown" {
+            "?".to_owned()
+        } else {
+            row.execution.clone()
+        };
+        let outcome = row.last_outcome.clone().unwrap_or_else(|| "-".to_owned());
         println!(
-            "{:<24} {:<8} {:<8} {}",
+            "{:<24} {:<8} {:<8} {:<12} {:<7} {}",
             row.slug,
             row.status,
-            row.result_versions,
+            execution,
+            outcome,
+            row.rounds_delivered,
             row.name.as_deref().unwrap_or("-")
         );
     }
@@ -121,10 +188,21 @@ impl Executable for PeerCommand {
         match self.action {
             PeerAction::List(args) => {
                 // 整改: shared per-instance profile data root (see goal.rs).
+                // task-evo-peer-turn-status: the profile id for lifetime
+                // projection validation comes from --profile (explicit) or
+                // the default — NEVER derived from the data-dir path. The
+                // SAME id also drives the data-root resolution, so
+                // `--profile octosfix` without --data-dir reads the octosfix
+                // profile's directory (outer-loop review: passing the
+                // constant here made --profile a no-op for resolution).
+                let profile_id = args
+                    .profile
+                    .clone()
+                    .unwrap_or_else(|| super::obs::DEFAULT_PROFILE_ID.to_owned());
                 let data_dir = super::obs::resolve_profile_data_root(
                     &super::resolve_data_dir(None)?,
                     &std::env::current_dir()?,
-                    super::obs::DEFAULT_PROFILE_ID,
+                    &profile_id,
                 );
                 let data_dir = args.data_dir.unwrap_or(data_dir);
                 // 整改要求 2: a missing peers dir is an ERROR with the
@@ -146,7 +224,7 @@ impl Executable for PeerCommand {
                     }
                     std::process::exit(1);
                 }
-                let rows = list_peers(&data_dir);
+                let rows = list_peers(&data_dir, &profile_id);
                 if args.json {
                     println!("{}", serde_json::to_string(&rows).expect("peers json"));
                 } else {
@@ -186,7 +264,7 @@ mod tests {
         // unstaged junk: no brief -> skipped
         std::fs::create_dir_all(temp.path().join("peers").join("junk")).expect("junk");
 
-        let rows = list_peers(temp.path());
+        let rows = list_peers(temp.path(), "octos");
         assert_eq!(rows.len(), 3);
         let by_slug = |s: &str| rows.iter().find(|r| r.slug == s).expect("row");
         assert_eq!(by_slug("alpha").status, "running");
@@ -204,7 +282,7 @@ mod tests {
     #[test]
     fn olp_obs_peer_list_empty_dir_is_empty_array() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let rows = list_peers(temp.path());
+        let rows = list_peers(temp.path(), "octos");
         assert!(rows.is_empty());
         assert_eq!(serde_json::to_string(&rows).expect("json"), "[]");
     }

--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -50,6 +50,9 @@ use crate::contracts::UiProtocolContractStores;
 
 mod recovery;
 pub(crate) use recovery::*;
+// task-evo-peer-turn-status — the typed lifetime projection lives in
+// `recovery` (next to its writers); the derivation below uses both.
+use recovery::{LifetimePhase, trusted_lifetime_projection};
 
 /// Cap a string at `cap` bytes on a char boundary; returns (text, truncated).
 ///
@@ -983,6 +986,30 @@ pub(crate) mod peer_io {
         imp::peer_dir_count_prefixed(peer_dir, prefix, cap)
     }
 
+    /// task-evo-peer-turn-status — LIST the regular-file leaf names under
+    /// `prefix` (fd-anchored, scan-capped, symlink/refuse semantics identical
+    /// to [`peer_dir_count_prefixed`], #1824), sorted by name. `None` only
+    /// when the dir cannot be opened or the scan errors mid-way (fail-closed:
+    /// a partial list must never pose as complete).
+    pub(crate) fn peer_dir_list_prefixed(
+        peer_dir: &Path,
+        prefix: &str,
+        cap: usize,
+    ) -> Option<Vec<String>> {
+        imp::peer_dir_list_prefixed(peer_dir, prefix, cap).ok()
+    }
+
+    /// Test seam over the raw scanner result (Err = truncated/unreadable),
+    /// so regressions can assert the truncation signal itself.
+    #[cfg(test)]
+    pub(crate) fn peer_dir_list_prefixed_raw(
+        peer_dir: &Path,
+        prefix: &str,
+        cap: usize,
+    ) -> std::io::Result<Vec<String>> {
+        imp::peer_dir_list_prefixed(peer_dir, prefix, cap)
+    }
+
     /// `true` when `peer_dir` exists as a REAL (non-symlink) directory, opened
     /// `O_NOFOLLOW|O_DIRECTORY` — a symlinked `<slug>` is refused. Anchored
     /// replacement for a path-following `is_dir()` gate on a per-slug peer dir.
@@ -1173,6 +1200,56 @@ pub(crate) mod peer_io {
             count
         }
 
+        /// task-evo-peer-turn-status — LIST the regular-file leaf names under
+        /// `prefix` (fd-anchored, scan-capped, symlink/refuse semantics identical
+        /// to [`peer_dir_count_prefixed`], #1824), sorted by name. Returns
+        /// `Err(FileTooLarge)` when the scan reached its entry budget — the
+        /// budget counts ALL SCANNED entries (not just prefix hits), so a dir
+        /// full of unrelated files can also exhaust it; a truncated list must
+        /// never pose as complete. `Err` also when the dir cannot be opened or a
+        /// read fails mid-scan.
+        pub(crate) fn peer_dir_list_prefixed(
+            peer_dir: &Path,
+            prefix: &str,
+            cap: usize,
+        ) -> std::io::Result<Vec<String>> {
+            let dirfd = open_peer_dir(peer_dir)?;
+            let mut dir = Dir::read_from(&dirfd)?;
+            let prefix = prefix.as_bytes();
+            let mut names: Vec<String> = Vec::new();
+            let mut scanned = 0usize;
+            while scanned < cap {
+                let next = dir.next().transpose()?;
+                let Some(entry) = next else {
+                    // Directory exhausted BEFORE the budget: the list is
+                    // complete.
+                    names.sort();
+                    return Ok(names);
+                };
+                scanned += 1;
+                if !entry.file_name().to_bytes().starts_with(prefix) {
+                    continue;
+                }
+                match entry.file_type() {
+                    FileType::RegularFile => {
+                        names.push(entry.file_name().to_string_lossy().into_owned())
+                    }
+                    // d_type unavailable on this FS → classify with a no-follow
+                    // stat before listing.
+                    FileType::Unknown if entry_is_regular(&dirfd, entry.file_name()) => {
+                        names.push(entry.file_name().to_string_lossy().into_owned())
+                    }
+                    _ => {}
+                }
+            }
+            // The loop exited because the BUDGET was exhausted — more entries
+            // may exist beyond `cap`, so the list is potentially partial.
+            Err(std::io::Error::new(
+                std::io::ErrorKind::FileTooLarge,
+                "peer dir scan hit its entry cap: list is truncated",
+            ))
+        }
+
         /// No-follow `S_ISREG` check of `name` relative to the peer dir fd, for
         /// the rare filesystem that returns `DT_UNKNOWN` from `readdir`.
         fn entry_is_regular(dirfd: &OwnedFd, name: &CStr) -> bool {
@@ -1349,6 +1426,48 @@ pub(crate) mod peer_io {
                 }
             }
             count
+        }
+
+        /// task-evo-peer-turn-status — LIST variant of the count above, same
+        /// non-unix dev-only path-anchored semantics (#1824 documented TOCTOU
+        /// window). Sorted; `Err(FileTooLarge)` when the scan budget (which
+        /// counts ALL scanned entries, hits and non-hits alike) is exhausted
+        /// — a potentially-partial list never poses as complete.
+        pub(crate) fn peer_dir_list_prefixed(
+            peer_dir: &Path,
+            prefix: &str,
+            cap: usize,
+        ) -> std::io::Result<Vec<String>> {
+            if !peer_dir_ok(peer_dir) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "peer dir is not a real directory",
+                ));
+            }
+            let mut read_dir = std::fs::read_dir(peer_dir)?;
+            let mut names: Vec<String> = Vec::new();
+            let mut scanned = 0usize;
+            while scanned < cap {
+                let next = read_dir.next().transpose()?;
+                let Some(entry) = next else {
+                    names.sort();
+                    return Ok(names);
+                };
+                scanned += 1;
+                let file_name = entry.file_name().to_string_lossy().into_owned();
+                if !file_name.starts_with(prefix) {
+                    continue;
+                }
+                if std::fs::symlink_metadata(entry.path())
+                    .is_ok_and(|m| !m.file_type().is_symlink() && m.is_file())
+                {
+                    names.push(file_name);
+                }
+            }
+            Err(std::io::Error::new(
+                std::io::ErrorKind::FileTooLarge,
+                "peer dir scan hit its entry cap: list is truncated",
+            ))
         }
     }
 }
@@ -4026,6 +4145,239 @@ pub(crate) fn parse_peer_turns_index(
     Some(entries)
 }
 
+// ---------------------------------------------------------------------------
+// task-evo-peer-turn-status — lifetime read-only projection & execution
+// derivation (v3.1 frozen contract).
+//
+// Design (spec Decisions, outer-loop + GLM/k3 reviewed):
+//   * execution's ONLY current-state authorities are (a) the `closed` marker
+//     and (b) a TRUSTED read-only projection of `lifetime.json`. There is NO
+//     parallel state file and NO derivation from `turns.txt` — an old
+//     terminal outcome proves the PAST, never the present (that inference is
+//     precisely the stale-done bug this task fixes, in the other direction).
+//   * `last_outcome` comes from a STRICT cross-check of the last `turns.txt`
+//     entry against the highest-numbered `result-<n>.md` frontmatter
+//     (independent reader — the lenient legacy parser stays untouched for
+//     its existing consumers). Mismatch ⇒ null: the two native terminal
+//     records disagree, so no outcome is asserted.
+//   * Trust is fail-closed and typed (see recovery.rs
+//     `trusted_lifetime_projection`): reuses PeerLifetime's strict enum and
+//     Option field types instead of a hand-rolled serde_json validator, adds
+//     the registry_key check and the Idle digest re-computation. Any failure
+//     degrades the peer to execution=unknown AND nulls the identity fields.
+// ---------------------------------------------------------------------------
+
+/// A [`PeerExecutionFacet`] with NO assertions — the value synthetic (disk-
+/// less) rows use. Real rows get theirs from [`derive_peer_execution_facet`].
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn unknown_peer_execution_facet() -> PeerExecutionFacet {
+    PeerExecutionFacet {
+        execution: "unknown",
+        last_outcome: None,
+        round: 0,
+        rounds_delivered: 0,
+        master_session_id: None,
+        task_id: None,
+        generation: None,
+        turn_id: None,
+    }
+}
+
+/// The execution facet of one peer, derived per the v3.1 contract. Field
+/// names are the machine contract (docs/peer-status-interface.json).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PeerExecutionFacet {
+    /// queued | running | idle | failed | closed | unknown
+    pub(crate) execution: &'static str,
+    /// completed | errored | interrupted | rate_limited | None — from the
+    /// STRICT terminal-evidence reader (turns.txt tail cross-checked against
+    /// the highest result-<n>.md), never from lifetime.
+    pub(crate) last_outcome: Option<String>,
+    /// Current round: delivered+1 while queued/running; the just-terminated
+    /// round for idle/failed; the delivered count when unknown.
+    pub(crate) round: u32,
+    /// Delivered rounds = count(result-<n>.md), floored at 1 when a bare
+    /// result.md exists with no versioned files (#2024 floor semantics).
+    pub(crate) rounds_delivered: u32,
+    /// Trusted-lifetime identity fields (anti-cross-runtime / same-slug
+    /// fencing). All `None` when the projection is not trusted.
+    pub(crate) master_session_id: Option<String>,
+    pub(crate) task_id: Option<String>,
+    pub(crate) generation: Option<u64>,
+    pub(crate) turn_id: Option<String>,
+}
+
+/// STRICT recent-terminal-evidence reader (task-evo-peer-turn-status).
+///
+/// Unlike the lenient legacy [`parse_peer_turns_index`] (which silently drops
+/// malformed lines and feeds the display history), this validates that the
+/// LAST turns.txt entry and the HIGHEST-numbered `result-<n>.md` frontmatter
+/// agree on `(round, outcome)`. Any disagreement, corruption, or absence on
+/// either side ⇒ `None` — no outcome is asserted from a single uncorroborated
+/// source.
+///
+/// Deliberately does NOT touch `parse_peer_turns_index` itself: its lenient
+/// semantics are load-bearing for existing consumers.
+fn read_last_terminal_evidence(peer_dir: &Path, slug: &str) -> Option<(u32, String)> {
+    // Side A: the last turns.txt line must parse STRICTLY (a corrupt tail is
+    // not allowed to fall back to an older entry — that would resurrect a
+    // stale outcome).
+    let turns_text =
+        peer_io::read_peer_file(peer_dir, "turns.txt", peer_io::PEER_FILE_READ_CAP_SMALL)?;
+    let last_line = turns_text.lines().rev().find(|l| !l.trim().is_empty())?;
+    let mut parts = last_line.split_whitespace();
+    let round: u32 = parts.next()?.parse().ok()?;
+    let outcome = parts.next()?;
+    let updated_unix: u64 = parts.next()?.parse().ok()?;
+    if parts.next().is_some()
+        || !matches!(
+            outcome,
+            "completed" | "errored" | "interrupted" | "rate_limited"
+        )
+    {
+        return None;
+    }
+    // Side B: the highest-numbered result-<n>.md must exist and its
+    // frontmatter must state the SAME (turn, outcome). The versioned result
+    // is the terminal payload; turns.txt is the index — both are written by
+    // the same single terminal path, so a mismatch means corruption or a
+    // torn write.
+    let versions = enumerate_peer_result_versions(peer_dir)?;
+    let (highest_round, highest_leaf) = versions.last()?;
+    if highest_round != &round {
+        return None;
+    }
+    let body = peer_io::read_peer_file(peer_dir, highest_leaf, peer_io::PEER_FILE_READ_CAP_LARGE)?;
+    let (header, _) = body.split_once("\n---\n\n")?;
+    let mut lines = header.lines();
+    if lines.next()? != "---" {
+        return None;
+    }
+    // The frontmatter must name THIS peer — a foreign slug's result file
+    // (copied/moved in) must not become this peer's outcome evidence.
+    let mut saw_slug = false;
+    let mut saw_turn = None;
+    let mut saw_outcome = None;
+    for line in lines {
+        if let Some(slug_line) = line.strip_prefix("slug: ") {
+            saw_slug = slug_line == slug;
+        } else if let Some(turn) = line.strip_prefix("turn: ") {
+            saw_turn = turn.parse::<u32>().ok();
+        } else if let Some(outcome_line) = line.strip_prefix("outcome: ") {
+            saw_outcome = Some(outcome_line.to_owned());
+        }
+    }
+    if !saw_slug || saw_turn != Some(round) || saw_outcome.as_deref() != Some(outcome) {
+        return None;
+    }
+    let _ = updated_unix;
+    Some((round, outcome.to_owned()))
+}
+
+/// Enumerate `result-<n>.md` leaves with their PARSED round numbers, sorted
+/// ascending. Only well-formed regular files count (fd-anchored scan, #1824);
+/// a malformed number skips that leaf (legacy scan semantics). `None` when
+/// the scan hit its cap (a TRUNCATED list must never pose as complete —
+/// its "highest" would be an arbitrary cutoff, not the newest round).
+fn enumerate_peer_result_versions(peer_dir: &Path) -> Option<Vec<(u32, String)>> {
+    // The scanner itself reports truncation (Err → None here): its budget
+    // counts ALL scanned entries, not just result- hits, so a dir full of
+    // unrelated files is also caught — no second-guessing by hit count.
+    let names = peer_io::peer_dir_list_prefixed(peer_dir, "result-", peer_io::PEER_DIR_SCAN_CAP)?;
+    let mut parsed: Vec<(u32, String)> = names
+        .into_iter()
+        .filter_map(|name| {
+            let stem = name.strip_prefix("result-")?;
+            let stem = stem.strip_suffix(".md")?;
+            let round: u32 = stem.parse().ok()?;
+            Some((round, name))
+        })
+        .collect();
+    parsed.sort_by_key(|(round, _)| *round);
+    Some(parsed)
+}
+
+/// Derive the execution facet for one staged peer dir. `closed` short-
+/// circuits everything (lifecycle terminal state; not a success claim).
+/// `profile_id` comes from the caller's explicit context (CLI `--profile`,
+/// serve's known profile) — NEVER derived from the peers_root path.
+pub(crate) fn derive_peer_execution_facet(
+    peer_dir: &Path,
+    profile_id: &str,
+    slug: &str,
+    closed: bool,
+) -> PeerExecutionFacet {
+    let versions = count_peer_result_versions(peer_dir);
+    let has_bare_result = peer_io::peer_regular_file_exists(peer_dir, "result.md");
+    // #2024 floor: pre-#435 peers wrote only the bare result.md; their
+    // delivered count reads 1, never 0.
+    let rounds_delivered = if versions > 0 {
+        versions
+    } else if has_bare_result {
+        1
+    } else {
+        0
+    };
+    // last_outcome: STRICT terminal evidence (turns tail × highest result-N
+    // cross-check). Independent of the execution authority so an errored
+    // round stays visible even when the lifetime projection is untrusted.
+    let terminal = read_last_terminal_evidence(peer_dir, slug);
+    let last_outcome = terminal.as_ref().map(|(_, outcome)| outcome.clone());
+    if closed {
+        return PeerExecutionFacet {
+            execution: "closed",
+            last_outcome,
+            round: rounds_delivered,
+            rounds_delivered,
+            master_session_id: None,
+            task_id: None,
+            generation: None,
+            turn_id: None,
+        };
+    }
+    match trusted_lifetime_projection(peer_dir, profile_id, slug) {
+        Some(projection) => {
+            let execution = match projection.phase {
+                LifetimePhase::Pending => "queued",
+                LifetimePhase::Running => "running",
+                LifetimePhase::Idle => "idle",
+                LifetimePhase::Failed => "failed",
+            };
+            let round = match execution {
+                // A queued/running round is the one ABOUT to run / running.
+                "queued" | "running" => rounds_delivered.saturating_add(1),
+                // idle/failed report the round that just terminated; the
+                // strict terminal evidence pins it, else the delivered count.
+                _ => terminal.map(|(round, _)| round).unwrap_or(rounds_delivered),
+            };
+            PeerExecutionFacet {
+                execution,
+                last_outcome,
+                round,
+                rounds_delivered,
+                master_session_id: Some(projection.master),
+                task_id: Some(projection.task_id),
+                generation: Some(projection.generation),
+                turn_id: projection.turn_id,
+            }
+        }
+        // No trusted current-state authority (missing, corrupt, mismatched,
+        // or legacy): execution=unknown AND identity all-null. The strict
+        // terminal evidence still carries last_outcome — the PAST round's
+        // outcome — which is evidence, not a claim about the present.
+        None => PeerExecutionFacet {
+            execution: "unknown",
+            last_outcome,
+            round: rounds_delivered,
+            rounds_delivered,
+            master_session_id: None,
+            task_id: None,
+            generation: None,
+            turn_id: None,
+        },
+    }
+}
+
 pub(crate) const PEER_GATHER_BRIEF_CAP: usize = 16 * 1024;
 
 pub(crate) const PEER_GATHER_RESULT_CAP: usize = 48 * 1024;
@@ -4063,6 +4415,12 @@ pub(crate) struct PeerBlackboardRow {
     /// `sub_provider` this peer runs its turns on), trimmed; `None` for a peer
     /// on the profile's primary model.
     pub(crate) model_lane: Option<String>,
+    /// task-evo-peer-turn-status — the execution facet (execution /
+    /// last_outcome / round / rounds_delivered + identity), derived per the
+    /// v3.1 contract. `profile_id` for the lifetime projection is supplied by
+    /// the CALLER (serve knows its own; the CLI takes `--profile`) — never
+    /// derived from the peers_root path.
+    pub(crate) execution_facet: PeerExecutionFacet,
 }
 
 /// #1801: row-reading core of the peer blackboard — every staged peer dir
@@ -4074,6 +4432,23 @@ pub(crate) struct PeerBlackboardRow {
 pub(crate) fn read_peer_blackboard(
     peers_root: &Path,
     slugs: Option<&[String]>,
+) -> Vec<PeerBlackboardRow> {
+    read_peer_blackboard_with_profile(peers_root, slugs, DEFAULT_PEER_LIST_PROFILE)
+}
+
+/// The profile id the blackboard reader uses for lifetime projection checks
+/// when the caller supplies none — the CLI default profile (`octos`). A
+/// caller that knows better (serve) always passes its real profile_id.
+pub(crate) const DEFAULT_PEER_LIST_PROFILE: &str = "octos";
+
+/// Profile-aware blackboard read (task-evo-peer-turn-status): identical to
+/// [`read_peer_blackboard`] but threads the caller's EXPLICIT profile id into
+/// the lifetime projection's registry_key check (spec: profile is never
+/// derived from the peers_root path).
+pub(crate) fn read_peer_blackboard_with_profile(
+    peers_root: &Path,
+    slugs: Option<&[String]>,
+    profile_id: &str,
 ) -> Vec<PeerBlackboardRow> {
     let mut rows: Vec<PeerBlackboardRow> = Vec::new();
     if let Ok(read_dir) = std::fs::read_dir(peers_root) {
@@ -4118,6 +4493,11 @@ pub(crate) fn read_peer_blackboard(
                 .map(|n| n.trim().to_owned())
                 .filter(|n| !n.is_empty())
                 .unwrap_or_else(|| slug.clone());
+            // task-evo-peer-turn-status — derive the execution facet BEFORE
+            // the struct literal borrows `slug` (the literal moves it).
+            let closed = peer_io::peer_regular_file_exists(&dir, "closed");
+            let execution_facet =
+                derive_peer_execution_facet(&dir, profile_id, slug.as_str(), closed);
             rows.push(PeerBlackboardRow {
                 slug,
                 name,
@@ -4127,8 +4507,9 @@ pub(crate) fn read_peer_blackboard(
                 result_truncated,
                 result_updated_unix,
                 has_worktree: dir.join("wt").is_dir(),
-                closed: peer_io::peer_regular_file_exists(&dir, "closed"),
+                closed,
                 turn_history: parse_peer_turns_index(&dir),
+                execution_facet,
                 // #peer-model — the recorded model lane, if any (fd-anchored
                 // no-follow read so a symlinked/FIFO `model` leaf is refused;
                 // trimmed, empty treated as absent).
@@ -4251,6 +4632,22 @@ pub(crate) fn compose_peer_list_text(
         lines.push(format!(
             "- {addr}  {status}  updated {updated}  turns {turns}{worktree}{model}{awaiting_note}"
         ));
+        // task-evo-peer-turn-status — surface the CURRENT execution state
+        // and the most recent terminal outcome on the index line so a peer
+        // mid-round2 (queued/running) with a round1 result on disk no longer
+        // reads as settled. Rendered as a suffix (outcome=…/exec=…) to keep
+        // the line shape stable for existing readers.
+        if status != "closed" || row.execution_facet.last_outcome.is_some() {
+            let exec = row.execution_facet.execution;
+            if exec != "unknown" {
+                lines.push(format!("  · exec={exec}"));
+            } else {
+                lines.push("  · exec=?".to_owned());
+            }
+            if let Some(outcome) = row.execution_facet.last_outcome.as_deref() {
+                lines.push(format!("  · outcome={outcome}"));
+            }
+        }
     }
     if rows.len() > PEER_LIST_MAX_ROWS {
         lines.push(format!("… and {} more", rows.len() - PEER_LIST_MAX_ROWS));
@@ -4271,7 +4668,9 @@ pub(crate) fn build_peer_list_callback(
     profile_id: String,
 ) -> octos_agent::PeerListCallback {
     Arc::new(move || {
-        let rows = read_peer_blackboard(&peers_root, None);
+        // task-evo-peer-turn-status — serve KNOWS its profile; pass it so the
+        // lifetime projection validates registry_key against the real one.
+        let rows = read_peer_blackboard_with_profile(&peers_root, None, &profile_id);
         // #peer-respond — the AUTHORITATIVE awaiting-input set comes from the
         // process-global store, joined to each open peer by its TRUSTED wire
         // session (never a filesystem marker). A peer with no wire (not open) or
@@ -5885,5 +6284,489 @@ mod peer_task_registry_tests {
             }
             other => panic!("expected Err, got {other:?}"),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// task-evo-peer-turn-status — RED tests for the v3.1 contract (15 spec
+// scenarios). Fixtures write the exact disk shapes the production writers
+// produce (recovery.rs lifetime.json, ui_protocol_transport terminal path
+// result-<n>.md/turns.txt) through the same peer_io primitives.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod peer_turn_status_tests {
+    use super::*;
+
+    /// Fixture factory: stage a peer with brief.md (+ optional originator so
+    /// lifetime projections can be trusted) and return its dir.
+    fn staged(data_dir: &Path, slug: &str, originator: Option<&str>) -> PathBuf {
+        let dir = data_dir.join("peers").join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        peer_io::write_peer_file_atomic(&dir, "brief.md", "brief").unwrap();
+        if let Some(origin) = originator {
+            peer_io::write_peer_file_atomic(&dir, "originator", origin).unwrap();
+        }
+        dir
+    }
+
+    /// Write a lifetime.json in the EXACT production shape (recovery.rs
+    /// writers): registry_key = peer_wire_key(profile, slug).
+    fn lifetime(
+        dir: &Path,
+        profile: &str,
+        slug: &str,
+        phase: &str,
+        generation: u64,
+        turn_id: Option<&str>,
+        result_digest: Option<&str>,
+    ) {
+        let json = serde_json::json!({
+            "version": 1,
+            "task_id": format!("task-{slug}"),
+            "registry_key": peer_wire_key(profile, slug),
+            "master": format!("master-{slug}"),
+            "generation": generation,
+            "phase": phase,
+            "turn_id": turn_id,
+            "result_digest": result_digest,
+        });
+        peer_io::write_peer_file_atomic(dir, "lifetime.json", &json.to_string()).unwrap();
+        // The originator leaf must name the same master session.
+        peer_io::write_peer_file_atomic(dir, "originator", &format!("master-{slug}")).unwrap();
+    }
+
+    /// Write the terminal-path output for one round: result-<n>.md with the
+    /// production frontmatter + a matching turns.txt line (+ prior lines).
+    fn terminal(dir: &Path, slug: &str, round: u32, outcome: &str) {
+        let text = format!(
+            "---\nslug: {slug}\noutcome: {outcome}\nupdated_unix: 100\nturn: {round}\n---\n\nbody\n"
+        );
+        peer_io::write_peer_file_atomic(dir, &format!("result-{round}.md"), &text).unwrap();
+        peer_io::write_peer_file_atomic(dir, "result.md", &text).unwrap();
+        peer_io::append_peer_line(dir, "turns.txt", &format!("{round} {outcome} 100\n")).unwrap();
+    }
+
+    fn facet(data_dir: &Path, slug: &str) -> PeerExecutionFacet {
+        let dir = data_dir.join("peers").join(slug);
+        derive_peer_execution_facet(
+            &dir,
+            "octos",
+            slug,
+            peer_io::peer_regular_file_exists(&dir, "closed"),
+        )
+    }
+
+    #[test]
+    fn peer_list_done_peer_with_errored_outcome_shows_failed_execution() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "beta", None);
+        terminal(&dir, "beta", 1, "errored");
+        lifetime(&dir, "octos", "beta", "failed", 0, Some("t1"), None);
+        let f = facet(temp.path(), "beta");
+        assert_eq!(f.execution, "failed");
+        assert_eq!(f.last_outcome.as_deref(), Some("errored"));
+        assert_eq!(f.rounds_delivered, 1);
+    }
+
+    #[test]
+    fn peer_list_round2_queued_shows_queued_not_stale_done() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "q2", None);
+        terminal(&dir, "q2", 1, "completed");
+        lifetime(&dir, "octos", "q2", "pending", 1, None, None);
+        let f = facet(temp.path(), "q2");
+        assert_eq!(f.execution, "queued");
+        assert_eq!(f.last_outcome.as_deref(), Some("completed"));
+        assert_eq!(f.round, 2, "queued round = delivered+1");
+    }
+
+    #[test]
+    fn peer_list_round2_running_overrides_round1_completion() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "r2", None);
+        terminal(&dir, "r2", 1, "completed");
+        lifetime(&dir, "octos", "r2", "running", 1, Some("t2"), None);
+        let f = facet(temp.path(), "r2");
+        assert_eq!(f.execution, "running");
+        assert_eq!(f.round, 2);
+        assert_eq!(f.turn_id.as_deref(), Some("t2"));
+    }
+
+    #[test]
+    fn peer_list_interrupted_turn_reports_failed() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "ir", None);
+        terminal(&dir, "ir", 1, "completed");
+        terminal(&dir, "ir", 2, "interrupted");
+        lifetime(&dir, "octos", "ir", "failed", 1, Some("t2"), None);
+        let f = facet(temp.path(), "ir");
+        assert_eq!(f.execution, "failed");
+        assert_eq!(f.last_outcome.as_deref(), Some("interrupted"));
+        assert_eq!(f.rounds_delivered, 2);
+    }
+
+    #[test]
+    fn peer_list_no_lifetime_execution_unknown_outcome_kept() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "nl", None);
+        terminal(&dir, "nl", 1, "errored");
+        // No lifetime.json at all: unknown execution, evidence kept.
+        let f = facet(temp.path(), "nl");
+        assert_eq!(f.execution, "unknown");
+        assert_eq!(f.last_outcome.as_deref(), Some("errored"));
+    }
+
+    #[test]
+    fn peer_list_lifetime_projection_phases_and_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        for (slug, phase, expect) in [
+            ("p-run", "running", "running"),
+            ("p-fail", "failed", "failed"),
+        ] {
+            let dir = staged(temp.path(), slug, None);
+            terminal(&dir, slug, 1, "errored");
+            lifetime(&dir, "octos", slug, phase, 0, Some("t1"), None);
+            let f = facet(temp.path(), slug);
+            assert_eq!(f.execution, expect, "{slug}");
+            assert_eq!(f.task_id.as_deref(), Some(format!("task-{slug}").as_str()));
+            assert_eq!(f.generation, Some(0));
+        }
+        // idle needs a digest bound to the CURRENT result.md bytes.
+        let dir = staged(temp.path(), "p-idle", None);
+        terminal(&dir, "p-idle", 1, "completed");
+        let body =
+            peer_io::read_peer_file(&dir, "result.md", peer_io::PEER_FILE_READ_CAP_LARGE).unwrap();
+        use sha2::{Digest, Sha256};
+        let digest = format!("{:x}", Sha256::digest(body.as_bytes()));
+        lifetime(
+            &dir,
+            "octos",
+            "p-idle",
+            "idle",
+            0,
+            Some("t1"),
+            Some(&digest),
+        );
+        let f = facet(temp.path(), "p-idle");
+        assert_eq!(f.execution, "idle");
+        assert_eq!(f.master_session_id.as_deref(), Some("master-p-idle"));
+    }
+
+    #[test]
+    fn peer_list_untrusted_lifetime_degrades_to_unknown() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "ut", None);
+        terminal(&dir, "ut", 1, "errored");
+        // Wrong registry_key (other profile): projection untrusted.
+        lifetime(&dir, "other-profile", "ut", "running", 0, Some("t1"), None);
+        let f = facet(temp.path(), "ut");
+        assert_eq!(f.execution, "unknown");
+        assert_eq!(f.last_outcome.as_deref(), Some("errored"));
+        assert!(
+            f.task_id.is_none() && f.generation.is_none(),
+            "untrusted identity is null"
+        );
+    }
+
+    #[test]
+    fn peer_list_idle_digest_mismatch_degrades_to_unknown() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "dg", None);
+        terminal(&dir, "dg", 1, "completed");
+        // Nonempty but WRONG digest: idle must not be believed.
+        lifetime(&dir, "octos", "dg", "idle", 0, Some("t1"), Some("deadbeef"));
+        let f = facet(temp.path(), "dg");
+        assert_eq!(f.execution, "unknown");
+    }
+
+    #[test]
+    fn peer_list_corrupt_lifetime_degrades_to_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "cx", None);
+        terminal(&dir, "cx", 1, "errored");
+        peer_io::write_peer_file_atomic(&dir, "lifetime.json", "{\"version\":1,\"task_i").unwrap();
+        let f = facet(temp.path(), "cx");
+        assert_eq!(f.execution, "unknown");
+        assert_eq!(f.last_outcome.as_deref(), Some("errored"));
+    }
+
+    #[test]
+    fn peer_list_legacy_no_metadata_reports_unknown() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "lg", None);
+        peer_io::write_peer_file_atomic(&dir, "result.md", "old findings").unwrap();
+        let f = facet(temp.path(), "lg");
+        assert_eq!(f.execution, "unknown");
+        assert!(f.last_outcome.is_none());
+        assert_eq!(f.rounds_delivered, 1, "#2024 floor: bare result.md");
+    }
+
+    #[test]
+    fn peer_list_symlinked_turns_index_is_ignored() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "sl", None);
+        let outside = temp.path().join("outside.txt");
+        std::fs::write(&outside, "1 completed 100\n").unwrap();
+        std::os::unix::fs::symlink(&outside, dir.join("turns.txt")).unwrap();
+        let f = facet(temp.path(), "sl");
+        assert_eq!(
+            f.execution, "unknown",
+            "symlinked turns.txt reads as absent"
+        );
+        assert!(f.last_outcome.is_none());
+    }
+
+    #[test]
+    fn peer_list_closed_peer_reports_closed_execution_with_outcome() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "cl", None);
+        terminal(&dir, "cl", 1, "errored");
+        peer_io::write_peer_file_atomic(&dir, "closed", "closer\n1\n").unwrap();
+        let f = facet(temp.path(), "cl");
+        assert_eq!(f.execution, "closed");
+        assert_eq!(f.last_outcome.as_deref(), Some("errored"));
+    }
+
+    #[test]
+    fn peer_list_execution_derivation_precedence() {
+        let temp = tempfile::tempdir().unwrap();
+        // closed + errored evidence
+        let d1 = staged(temp.path(), "a-closed", None);
+        terminal(&d1, "a-closed", 1, "errored");
+        peer_io::write_peer_file_atomic(&d1, "closed", "x").unwrap();
+        // trusted lifetime running + old completed evidence
+        let d2 = staged(temp.path(), "b-running", None);
+        terminal(&d2, "b-running", 1, "completed");
+        lifetime(&d2, "octos", "b-running", "running", 1, Some("t2"), None);
+        // no lifetime (turns evidence only) -> unknown
+        let d3 = staged(temp.path(), "c-nolife", None);
+        terminal(&d3, "c-nolife", 1, "errored");
+        // nothing at all
+        staged(temp.path(), "d-nothing", None);
+        assert_eq!(facet(temp.path(), "a-closed").execution, "closed");
+        assert_eq!(facet(temp.path(), "b-running").execution, "running");
+        assert_eq!(facet(temp.path(), "c-nolife").execution, "unknown");
+        assert_eq!(facet(temp.path(), "d-nothing").execution, "unknown");
+    }
+
+    #[test]
+    fn peer_list_terminal_evidence_cross_check_mismatch_is_null() {
+        // turns.txt tail says completed but the highest result-N says errored
+        // (or is missing): NO outcome may be asserted.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "xm", None);
+        let text = "---\nslug: xm\noutcome: errored\nupdated_unix: 100\nturn: 1\n---\n\nbody\n";
+        peer_io::write_peer_file_atomic(&dir, "result-1.md", text).unwrap();
+        peer_io::append_peer_line(&dir, "turns.txt", "1 completed 100\n").unwrap();
+        let f = facet(temp.path(), "xm");
+        assert!(
+            f.last_outcome.is_none(),
+            "disagreeing native records assert nothing"
+        );
+        // Corrupt tail must not fall back to an older line either.
+        let dir2 = staged(temp.path(), "xt", None);
+        terminal(&dir2, "xt", 1, "completed");
+        peer_io::write_peer_file_atomic(&dir2, "turns.txt", "1 completed 100\n2 bogus\n").unwrap();
+        let f2 = facet(temp.path(), "xt");
+        assert!(f2.last_outcome.is_none(), "corrupt tail asserts nothing");
+    }
+
+    #[test]
+    fn peer_list_untrusted_writer_shape_and_malformed_fields_degrade() {
+        // Running without a turn_id violates the writer shape: untrusted.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "ws", None);
+        terminal(&dir, "ws", 1, "completed");
+        lifetime(&dir, "octos", "ws", "running", 0, None, None);
+        let f = facet(temp.path(), "ws");
+        assert_eq!(
+            f.execution, "unknown",
+            "running without turn_id is a torn write"
+        );
+        // Numeric turn_id must fail typed deserialization, not be coerced.
+        let dir2 = staged(temp.path(), "nm", None);
+        terminal(&dir2, "nm", 1, "completed");
+        let bad = serde_json::json!({
+            "version": 1, "task_id": "t", "registry_key": peer_wire_key("octos", "nm"),
+            "master": "m", "generation": 0, "phase": "running",
+            "turn_id": 7, "result_digest": null,
+        });
+        peer_io::write_peer_file_atomic(&dir2, "lifetime.json", &bad.to_string()).unwrap();
+        peer_io::write_peer_file_atomic(&dir2, "originator", "m").unwrap();
+        let f2 = facet(temp.path(), "nm");
+        assert_eq!(
+            f2.execution, "unknown",
+            "numeric turn_id fails the typed parse"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// task-evo-peer-turn-status — outer-loop review #2 regressions (real-entry
+// compatibility): numbered-only legacy done, explicit name==slug, foreign
+// FM slug, scan-cap truncation, empty-identity projection, --profile data
+// root.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod peer_turn_status_compat_tests {
+    use super::*;
+
+    #[test]
+    fn peer_list_numbered_only_peer_stays_done() {
+        // A peer with ONLY result-1.md (no bare result.md) was `done` under
+        // the legacy CLI semantics and must remain so.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("peers").join("num-only");
+        std::fs::create_dir_all(&dir).unwrap();
+        peer_io::write_peer_file_atomic(&dir, "brief.md", "b").unwrap();
+        let text =
+            "---\nslug: num-only\noutcome: completed\nupdated_unix: 100\nturn: 1\n---\n\nbody\n";
+        peer_io::write_peer_file_atomic(&dir, "result-1.md", text).unwrap();
+        peer_io::append_peer_line(&dir, "turns.txt", "1 completed 100\n").unwrap();
+        let rows = crate::commands::peer_list_for_test(temp.path(), "octos");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].status, "done",
+            "numbered-only result proves delivery"
+        );
+        assert_eq!(rows[0].execution, "unknown", "no lifetime authority");
+        assert_eq!(rows[0].last_outcome.as_deref(), Some("completed"));
+    }
+
+    #[test]
+    fn peer_list_oversized_bare_result_still_done() {
+        // An over-cap bare result.md fails the blackboard's content read
+        // (row.result=None) but its EXISTENCE still proves delivery.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("peers").join("big");
+        std::fs::create_dir_all(&dir).unwrap();
+        peer_io::write_peer_file_atomic(&dir, "brief.md", "b").unwrap();
+        let big = "x".repeat(peer_io::PEER_FILE_READ_CAP_LARGE + 1);
+        peer_io::write_peer_file_atomic(&dir, "result.md", &big).unwrap();
+        let rows = crate::commands::peer_list_for_test(temp.path(), "octos");
+        assert_eq!(
+            rows[0].status, "done",
+            "unreadable-but-present bare result still proves delivery"
+        );
+        assert_eq!(rows[0].rounds_delivered, 1, "#2024 floor applies");
+    }
+
+    #[test]
+    fn peer_list_explicit_name_equal_to_slug_is_preserved() {
+        // Three REAL fixtures pinning the ORIGINAL optional-name semantics:
+        // no name file → None; empty name file → None; explicit name (even
+        // == slug) → Some(recorded). The blackboard's slug fallback is an
+        // ADDRESSING convenience and must not leak into the CLI field.
+        let temp = tempfile::tempdir().unwrap();
+        let fixtures = [
+            ("missing", None, None),
+            ("blank", Some("   \n"), None),
+            ("echo", Some("echo"), Some("echo")),
+            ("distinct", Some("Ada"), Some("Ada")),
+        ];
+        for (slug, name_file, _expect) in &fixtures {
+            let dir = temp.path().join("peers").join(slug);
+            std::fs::create_dir_all(&dir).unwrap();
+            peer_io::write_peer_file_atomic(&dir, "brief.md", "b").unwrap();
+            if let Some(content) = name_file {
+                peer_io::write_peer_file_atomic(&dir, "name", content).unwrap();
+            }
+        }
+        let rows = crate::commands::peer_list_for_test(temp.path(), "octos");
+        // Each REAL fixture asserts its OWN expectation (missing → None,
+        // empty → None, explicit == slug → Some(slug), distinct → Some).
+        for (slug, _name_file, expect) in &fixtures {
+            let row = rows.iter().find(|r| r.slug == *slug).unwrap();
+            assert_eq!(
+                row.name.as_deref(),
+                *expect,
+                "fixture {slug}: optional-name semantics"
+            );
+        }
+    }
+
+    #[test]
+    fn peer_list_foreign_slug_frontmatter_is_not_outcome_evidence() {
+        // result-1.md frontmatter naming ANOTHER peer must not certify this
+        // peer's last_outcome even when turns.txt agrees.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("peers").join("mine");
+        std::fs::create_dir_all(&dir).unwrap();
+        peer_io::write_peer_file_atomic(&dir, "brief.md", "b").unwrap();
+        let text = "---\nslug: someone-else\noutcome: completed\nupdated_unix: 100\nturn: 1\n---\n\nbody\n";
+        peer_io::write_peer_file_atomic(&dir, "result-1.md", text).unwrap();
+        peer_io::append_peer_line(&dir, "turns.txt", "1 completed 100\n").unwrap();
+        let facet = derive_peer_execution_facet(&dir, "octos", "mine", false);
+        assert!(
+            facet.last_outcome.is_none(),
+            "foreign slug cannot vouch for this peer"
+        );
+    }
+
+    #[test]
+    fn peer_list_scan_cap_truncation_yields_no_outcome() {
+        // Scanner-level truncation: a SMALL cap with MIXED entries (result
+        // files + unrelated files) exhausts the scan budget before the dir
+        // ends — the scanner must report truncation (not a partial "highest")
+        // and the strict reader must assert nothing. Mirrors the outer-loop
+        // correction: the budget counts ALL scanned entries.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("peers").join("capped");
+        std::fs::create_dir_all(&dir).unwrap();
+        peer_io::write_peer_file_atomic(&dir, "brief.md", "b").unwrap();
+        peer_io::write_peer_file_atomic(&dir, "originator", "m").unwrap();
+        for round in 1..=3u32 {
+            let text = format!(
+                "---\nslug: capped\noutcome: completed\nupdated_unix: 100\nturn: {round}\n---\n\nbody\n"
+            );
+            peer_io::write_peer_file_atomic(&dir, &format!("result-{round}.md"), &text).unwrap();
+        }
+        peer_io::append_peer_line(&dir, "turns.txt", "3 completed 100\n").unwrap();
+        // cap=4 with 3 result files + brief + originator + turns.txt = 6
+        // entries: the scan MUST hit the budget and report truncated. Test
+        // the imp scanner directly (Err) — the public wrapper maps Err→None.
+        assert!(
+            peer_io::peer_dir_list_prefixed_raw(&dir, "result-", 4).is_err(),
+            "mixed entries exhaust the scan budget: truncation must be explicit"
+        );
+        // And a cap large enough to finish cleanly returns the full hit list.
+        let full = peer_io::peer_dir_list_prefixed(&dir, "result-", 100).unwrap();
+        assert_eq!(full.len(), 3);
+        // The strict evidence reader consumes the wrapper with the PRODUCTION
+        // cap (100k), which this 6-entry fixture cannot exhaust — the
+        // truncation-to-no-outcome path is therefore exercised at the
+        // scanner level above (Err ⇒ wrapper None ⇒ no outcome by
+        // construction in read_last_terminal_evidence: `?` on the Option).
+        let facet = derive_peer_execution_facet(&dir, "octos", "capped", false);
+        assert_eq!(facet.rounds_delivered, 3, "count semantics unaffected");
+        let facet = derive_peer_execution_facet(&dir, "octos", "capped", false);
+        assert_eq!(facet.rounds_delivered, 3, "count semantics unaffected");
+    }
+
+    #[test]
+    fn peer_projection_rejects_empty_identity_strings() {
+        // Empty-string master / turn_id pass the legacy restore reader but
+        // fence nothing — the projection must refuse to vouch for them.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("peers").join("empty");
+        std::fs::create_dir_all(&dir).unwrap();
+        peer_io::write_peer_file_atomic(&dir, "brief.md", "b").unwrap();
+        let bad_master = serde_json::json!({
+            "version": 1, "task_id": "t", "registry_key": peer_wire_key("octos", "empty"),
+            "master": "  ", "generation": 0, "phase": "pending",
+            "turn_id": null, "result_digest": null,
+        });
+        peer_io::write_peer_file_atomic(&dir, "lifetime.json", &bad_master.to_string()).unwrap();
+        peer_io::write_peer_file_atomic(&dir, "originator", "  ").unwrap();
+        assert!(trusted_lifetime_projection(&dir, "octos", "empty").is_none());
+        // Pending + Some("") turn_id: also refused.
+        let empty_turn = serde_json::json!({
+            "version": 1, "task_id": "t", "registry_key": peer_wire_key("octos", "empty"),
+            "master": "m", "generation": 0, "phase": "pending",
+            "turn_id": "", "result_digest": null,
+        });
+        peer_io::write_peer_file_atomic(&dir, "lifetime.json", &empty_turn.to_string()).unwrap();
+        peer_io::write_peer_file_atomic(&dir, "originator", "m").unwrap();
+        assert!(trusted_lifetime_projection(&dir, "octos", "empty").is_none());
     }
 }

--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -6406,6 +6406,22 @@ mod peer_turn_status_tests {
     }
 
     #[test]
+    fn peer_list_rate_limited_outcome_surfaces() {
+        // K3 first-review F13: rate_limited is in the strict whitelist
+        // (mod.rs:4235) but had no fixture coverage. Same shape as the
+        // interrupted scenario: terminal evidence + trusted Failed
+        // lifetime → execution=failed, last_outcome=rate_limited.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "rl", None);
+        terminal(&dir, "rl", 1, "rate_limited");
+        lifetime(&dir, "octos", "rl", "failed", 1, Some("t1"), None);
+        let f = facet(temp.path(), "rl");
+        assert_eq!(f.execution, "failed");
+        assert_eq!(f.last_outcome.as_deref(), Some("rate_limited"));
+        assert_eq!(f.rounds_delivered, 1);
+    }
+
+    #[test]
     fn peer_list_no_lifetime_execution_unknown_outcome_kept() {
         let temp = tempfile::tempdir().unwrap();
         let dir = staged(temp.path(), "nl", None);
@@ -6737,8 +6753,6 @@ mod peer_turn_status_compat_tests {
         // truncation-to-no-outcome path is therefore exercised at the
         // scanner level above (Err ⇒ wrapper None ⇒ no outcome by
         // construction in read_last_terminal_evidence: `?` on the Option).
-        let facet = derive_peer_execution_facet(&dir, "octos", "capped", false);
-        assert_eq!(facet.rounds_delivered, 3, "count semantics unaffected");
         let facet = derive_peer_execution_facet(&dir, "octos", "capped", false);
         assert_eq!(facet.rounds_delivered, 3, "count semantics unaffected");
     }

--- a/crates/octos-cli/src/peers/recovery.rs
+++ b/crates/octos-cli/src/peers/recovery.rs
@@ -8,7 +8,7 @@ const LIFETIME_FILE: &str = "lifetime.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-enum LifetimePhase {
+pub(crate) enum LifetimePhase {
     Pending,
     Running,
     Idle,
@@ -53,6 +53,92 @@ fn read_lifetime(dir: &Path) -> Option<PeerLifetime> {
         && peer_io::read_peer_file(dir, "originator", peer_io::PEER_FILE_READ_CAP_SMALL)
             .is_some_and(|master| master.trim() == record.master))
     .then_some(record)
+}
+
+/// A validated (fail-closed) projection view of `lifetime.json` — the
+/// trusted fields the status derivation needs. Returned by
+/// [`trusted_lifetime_projection`]; private `PeerLifetime` internals stay in
+/// this module.
+pub(crate) struct TrustedLifetimeView {
+    pub(crate) phase: LifetimePhase,
+    pub(crate) generation: u64,
+    pub(crate) turn_id: Option<String>,
+    pub(crate) master: String,
+    pub(crate) task_id: String,
+}
+
+/// task-evo-peer-turn-status — TRUSTED read-only projection of a peer's
+/// `lifetime.json` for status derivation, or `None` when ANY fail-closed
+/// check fails (⇒ the caller must report execution=unknown with all identity
+/// fields null).
+///
+/// Layered on the typed [`read_lifetime`] parse (strict enum + Option field
+/// types — a numeric `turn_id` or `result_digest` fails DESERIALIZATION
+/// here rather than being silently coerced), then adds the checks the status
+/// contract needs beyond recovery's own restore gate:
+///
+/// * `registry_key` must equal `peer_wire_key(profile_id, slug)` — a
+///   lifetime staged under another profile/runtime (same slug) is not this
+///   peer's current authority.
+/// * Writer-shape turn binding, per the REAL writers (outer-loop probe
+///   ../outer-peer-projection-probe.json, 0 passed / 2 failed against the
+///   first draft): `invalidate_peer_lifetime_for_input` deliberately KEEPS
+///   the previous `turn_id` when flipping to Pending (and
+///   `finish_peer_lifetime_turn(queued=true)` produces Pending+Some too), so
+///   **Pending accepts both None and a valid Some** — rejecting Some would
+///   demote every real round2-queued peer to unknown, the exact bug this
+///   task exists to fix. Running/Idle/Failed still REQUIRE a valid Some
+///   (begin sets it fresh; finish keeps it). Readers interpret a Pending
+///   record together with `generation`/`phase`, never from turn_id alone.
+/// * Idle additionally binds to the CURRENT durable result: the fd-anchored
+///   result.md bytes must SHA256 to the recorded `result_digest` (blank,
+///   wrong, or missing digest, or an overwritten result.md ⇒ untrusted).
+///   Digest comparison only — the body is never parsed for an outcome.
+pub(crate) fn trusted_lifetime_projection(
+    dir: &Path,
+    profile_id: &str,
+    slug: &str,
+) -> Option<TrustedLifetimeView> {
+    let record = read_lifetime(dir)?;
+    if record.registry_key != peer_wire_key(profile_id, slug) {
+        return None;
+    }
+    match (&record.phase, record.turn_id.as_deref()) {
+        // The real queue writers keep the PREVIOUS turn's id on Pending —
+        // both None (fresh binding) and a NON-EMPTY Some (after any
+        // completed turn) are legal production shapes.
+        (LifetimePhase::Pending, None) => {}
+        (LifetimePhase::Pending, Some(_)) => {}
+        (LifetimePhase::Running | LifetimePhase::Idle | LifetimePhase::Failed, Some(_)) => {}
+        _ => return None,
+    }
+    // An empty-string turn_id is never legal (the writers only ever write a
+    // real id): refuse it explicitly — the match arms above can't express
+    // "non-empty" without a guard.
+    if record.turn_id.as_deref().is_some_and(str::is_empty) {
+        return None;
+    }
+    // Empty identity strings are not valid authority even when the legacy
+    // restore reader tolerates them: a projection that vouches for an empty
+    // master/turn_id fences nothing (outer-loop review #4).
+    if record.master.trim().is_empty() || record.task_id.trim().is_empty() {
+        return None;
+    }
+    if record.phase == LifetimePhase::Idle {
+        let digest = record.result_digest.as_deref()?;
+        let body = peer_io::read_peer_file(dir, "result.md", peer_io::PEER_FILE_READ_CAP_LARGE)?;
+        let actual = format!("{:x}", Sha256::digest(body.as_bytes()));
+        if actual != digest {
+            return None;
+        }
+    }
+    Some(TrustedLifetimeView {
+        phase: record.phase,
+        generation: record.generation,
+        turn_id: record.turn_id,
+        master: record.master,
+        task_id: record.task_id,
+    })
 }
 
 fn write_lifetime(dir: &Path, record: &PeerLifetime) -> std::io::Result<()> {
@@ -376,6 +462,40 @@ mod tests {
         fn drop(&mut self) {
             peer_task_registry().take_if_task(&self.key, &self.task_id);
         }
+    }
+
+    // task-evo-peer-turn-status — REAL-writer regressions (ported verbatim
+    // from the outer loop's probe, ../outer-peer-projection-under-test.rs;
+    // receipt ../outer-peer-projection-probe.json). Both drive the PRODUCTION
+    // writers (Fixture::begin/complete/invalidate) and then require the
+    // read-side projection to keep trusting the record: the queue writers
+    // DELIBERATELY keep the previous turn_id on Pending, so Pending+Some is a
+    // legal, in-production shape — not a torn write.
+    #[test]
+    fn outer_peer_projection_accepts_real_followup_pending() {
+        let f = Fixture::new();
+        let first = f.begin("first-turn");
+        f.complete(&first, "completed result", false);
+        invalidate_peer_lifetime_for_input(&f.peers, "auditor").unwrap();
+        let raw = read_lifetime(&f.dir).unwrap();
+        assert_eq!(raw.phase, LifetimePhase::Pending);
+        assert_eq!(raw.turn_id.as_deref(), Some("first-turn"));
+        assert!(
+            trusted_lifetime_projection(&f.dir, &f.profile, "auditor").is_some(),
+            "real queue writer keeps previous turn_id: projection must retain queued authority"
+        );
+    }
+
+    #[test]
+    fn outer_peer_projection_accepts_finish_with_queued_input() {
+        let f = Fixture::new();
+        let first = f.begin("first-turn");
+        f.complete(&first, "completed result", true);
+        assert_eq!(read_lifetime(&f.dir).unwrap().phase, LifetimePhase::Pending);
+        assert!(
+            trusted_lifetime_projection(&f.dir, &f.profile, "auditor").is_some(),
+            "real finish with queued input produces Pending+Some(turn_id), not an invalid record"
+        );
     }
 
     #[test]

--- a/docs/peer-status-interface.json
+++ b/docs/peer-status-interface.json
@@ -1,0 +1,55 @@
+{
+  "contract": "octos peer list / peer_list tool — 完成状态绑定生命周期、当前轮次与执行结果",
+  "version": 2,
+  "spec": "specs/task-evo-peer-turn-status.spec.md",
+  "change_note": "v2 依外层复核：删除并行 turn-state.json 设计，current 执行/身份改为 lifetime.json 只读安全投影；outcome 恒取 turns.txt 终止证据；closed 表现为 execution=closed 而非 idle；身份含 task/generation/turn_id；契约文件移入 tracked docs/。",
+  "producer": {
+    "cli_command": "octos peer list [--json] [--data-dir DIR]",
+    "tool": "peer_list (serve)",
+    "assembly": "crates/octos-cli/src/commands/peer.rs::list_peers（CLI JSON/表格共用）；crates/octos-cli/src/peers/mod.rs（投影 + blackboard + compose_peer_list_text）"
+  },
+  "evidence_sources": {
+    "authority_current": "peers/<slug>/lifetime.json — 只读安全投影（不写不改）。校验（fail-closed）：version==1 && task_id 非空 && registry_key == '<profile>:peer:<slug>' && originator leaf == lifetime.master；idle 还须 result_digest 非空。任一失败 → execution/身份 unknown/null。profile 来源见 profile_resolution（CLI --profile 显式传入，serve 用已知 profile_id）。",
+    "authority_outcome": "peers/<slug>/turns.txt 最后一条 '<round> <outcome> <ts>'（与最高编号 result-<n>.md 互为印证）；result.md 正文不作成功证据",
+    "lifecycle": "peers/<slug>/closed — 终态标记，status=closed 且 execution=closed（不代表上一执行成功，last_outcome 保留）"
+  },
+  "identity_fields_note": "master_session_id/task_id/generation/turn_id 来自可信 lifetime 投影（master_session_id=lifetime.master）。消费端以 runtime/master_session_id/slug/task_id/generation/turn_id 关联，防跨 runtime/同 slug 串线；不可信或缺失时为 null。",
+  "output_fields": {
+    "slug": "String",
+    "status": "running | done | closed — 不变：目录交付语义（done=result 文件存在）",
+    "execution": "queued | running | idle | failed | closed | unknown — 当前执行状态（新）",
+    "last_outcome": "completed | errored | interrupted | rate_limited | null — 最近终止 outcome（新，恒取 turns.txt）",
+    "round": "u32 — 当前轮次：queued/running 时 delivered+1，否则 delivered（新）",
+    "rounds_delivered": "u32 — count(result-<n>.md)，bare result.md 无版本文件时下限 1（新）",
+    "task_id": "String | null — 可信 lifetime 投影（新）",
+    "generation": "u64 | null — 可信 lifetime 投影（新）",
+    "turn_id": "String | null — 可信 lifetime 投影（新）",
+    "has_brief": "bool（不变）",
+    "result_versions": "u32（不变）",
+    "name": "String | null（不变）",
+    "model_lane": "String | null（不变）",
+    "master_session_id": "String | null — 可信 lifetime 投影的 master（staging originator session id；不冒充 peer thread session）（新）"
+  },
+  "derivation_precedence": [
+    "closed 标记 → execution=closed（last_outcome 仍按 turns.txt）",
+    "可信 lifetime 投影 → Pending=queued / Running=running / Failed=failed / Idle=idle（idle 须 result.md 实际 SHA256 == result_digest）",
+    "lifetime 缺失/不可信（含 legacy）→ execution=unknown；last_outcome 仍按 turns.txt 证据输出（描述最近已结束轮次，不推导当前）",
+    "无证据 → unknown；任何场景绝不以 mtime 或 result.md 正文推断成功"
+  ],
+  "combination_notes": {
+    "done+failed": "合法且原样呈现（文件已交付但 turn 失败）",
+    "done+queued/running": "合法（round2 进行中，round1 结果在盘）",
+    "closed+errored": "合法（终态 + 保留的终止证据）",
+    "unknown": "磁盘面无法证明时的显式值，非错误"
+  },
+  "human_table": "列：SLUG STATUS CURRENT OUTCOME ROUNDS NAME — CURRENT=execution，OUTCOME=last_outcome；表渲染映射：unknown→?、null→-（json_and_table 场景断言覆盖）",
+  "breaking_changes": "status 语义不变；人类表新增 CURRENT/OUTCOME/ROUNDS 列（脚本解析注意列数）；JSON 仅新增字段",
+  "known_limitations": {
+    "gateway_inbox_path": "session_actor.rs 的 gateway in-process inbox 直投路径无 begin_peer_lifetime_turn（代码事实核实 2026-09-09）：该路径 round2 从 queued 直达 terminal，无 running 中间态。呈现按投影如实输出。",
+    "crash_window": "terminal 写序 lifetime(finish)→result.md→result-<n>.md→turns.txt；finish 后 turns.txt append 前崩溃 → 呈现 running/queued+旧 outcome 的保守值，跨重启由 orphaned-across-restart 裁决；不用时间戳裁决。",
+    "idle_no_turns": "lifetime=Idle 且 turns.txt 空（测试工厂可构造）→ execution=idle, last_outcome=null, round=0。合法组合。",
+    "digest_mismatch_test": "反例测试必须包含 nonempty 但不匹配的 digest（peer_list_idle_digest_mismatch_degrades_to_unknown）。"
+  },
+  "profile_resolution": "CLI：--profile <id>（默认 octos/DEFAULT_PROFILE_ID）显式传入投影校验；--data-dir 为任意合法路径，不从目录名推导 profile；serve 回调用已知 profile_id。",
+  "idle_binding": "Idle 采信条件：fd-anchored 读 result.md 并计算 SHA256 与 lifetime.result_digest 实际相等；空白/错误/不匹配摘要或文件缺失 → unknown。仅比对摘要，不解析正文。"
+}

--- a/docs/peer-status-interface.json
+++ b/docs/peer-status-interface.json
@@ -13,7 +13,7 @@
     "authority_outcome": "peers/<slug>/turns.txt 最后一条 '<round> <outcome> <ts>'（与最高编号 result-<n>.md 互为印证）；result.md 正文不作成功证据",
     "lifecycle": "peers/<slug>/closed — 终态标记，status=closed 且 execution=closed（不代表上一执行成功，last_outcome 保留）"
   },
-  "identity_fields_note": "master_session_id/task_id/generation/turn_id 来自可信 lifetime 投影（master_session_id=lifetime.master）。消费端以 runtime/master_session_id/slug/task_id/generation/turn_id 关联，防跨 runtime/同 slug 串线；不可信或缺失时为 null。",
+  "identity_fields_note": "master_session_id/task_id/generation/turn_id 来自可信 lifetime 投影（master_session_id=lifetime.master）。消费端以 runtime/master_session_id/slug/task_id/generation/turn_id 关联，防跨 runtime/同 slug 串线。不可信或缺失时为 null；closed 分支同样全部 null（closed 标记优先于投影，身份不随 closed 保留——保守契约）。",
   "output_fields": {
     "slug": "String",
     "status": "running | done | closed — 不变：目录交付语义（done=result 文件存在）",
@@ -46,9 +46,10 @@
   "breaking_changes": "status 语义不变；人类表新增 CURRENT/OUTCOME/ROUNDS 列（脚本解析注意列数）；JSON 仅新增字段",
   "known_limitations": {
     "gateway_inbox_path": "session_actor.rs 的 gateway in-process inbox 直投路径无 begin_peer_lifetime_turn（代码事实核实 2026-09-09）：该路径 round2 从 queued 直达 terminal，无 running 中间态。呈现按投影如实输出。",
-    "crash_window": "terminal 写序 lifetime(finish)→result.md→result-<n>.md→turns.txt；finish 后 turns.txt append 前崩溃 → 呈现 running/queued+旧 outcome 的保守值，跨重启由 orphaned-across-restart 裁决；不用时间戳裁决。",
+    "crash_window": "真实写序（ui_protocol_transport.rs）：result.md → lifetime(finish_peer_lifetime_turn) → result-<n>.md → turns.txt。各点崩溃呈现：finish 前崩溃 → 投影仍 Running（孤儿 Running 语义见 begin_crash_orphan_running）；finish 后、turns append 前崩溃 → phase 已 Idle/Pending/Failed，呈现 idle/queued/failed，last_outcome 取决于 turns 尾行与最高 result-<n>.md 互证结果——尾行尚未更新时可能为旧 outcome 或 null（双侧不一致即 null），不绝对保留旧值。不用时间戳裁决。",
     "idle_no_turns": "lifetime=Idle 且 turns.txt 空（测试工厂可构造）→ execution=idle, last_outcome=null, round=0。合法组合。",
-    "digest_mismatch_test": "反例测试必须包含 nonempty 但不匹配的 digest（peer_list_idle_digest_mismatch_degrades_to_unknown）。"
+    "digest_mismatch_test": "反例测试必须包含 nonempty 但不匹配的 digest（peer_list_idle_digest_mismatch_degrades_to_unknown）。",
+    "begin_crash_orphan_running": "begin_peer_lifetime_turn 后、terminal 前崩溃 → 盘上残留 phase=Running。跨重启恢复扫描不处理 Running（仅 closed 退休与 Idle 摘要重绑）；孤儿 Running 保持 running 呈现直到真实生命周期更新，无自动降级，可能长期呈 running。"
   },
   "profile_resolution": "CLI：--profile <id>（默认 octos/DEFAULT_PROFILE_ID）显式传入投影校验；--data-dir 为任意合法路径，不从目录名推导 profile；serve 回调用已知 profile_id。",
   "idle_binding": "Idle 采信条件：fd-anchored 读 result.md 并计算 SHA256 与 lifetime.result_digest 实际相等；空白/错误/不匹配摘要或文件缺失 → unknown。仅比对摘要，不解析正文。",

--- a/docs/peer-status-interface.json
+++ b/docs/peer-status-interface.json
@@ -51,5 +51,9 @@
     "digest_mismatch_test": "反例测试必须包含 nonempty 但不匹配的 digest（peer_list_idle_digest_mismatch_degrades_to_unknown）。"
   },
   "profile_resolution": "CLI：--profile <id>（默认 octos/DEFAULT_PROFILE_ID）显式传入投影校验；--data-dir 为任意合法路径，不从目录名推导 profile；serve 回调用已知 profile_id。",
-  "idle_binding": "Idle 采信条件：fd-anchored 读 result.md 并计算 SHA256 与 lifetime.result_digest 实际相等；空白/错误/不匹配摘要或文件缺失 → unknown。仅比对摘要，不解析正文。"
+  "idle_binding": "Idle 采信条件：fd-anchored 读 result.md 并计算 SHA256 与 lifetime.result_digest 实际相等；空白/错误/不匹配摘要或文件缺失 → unknown。仅比对摘要，不解析正文。",
+  "clarifications": {
+    "round_on_terminal_phases": "idle/failed 时若有严格终止证据（turns 尾行 × 最高 result-<n>.md 互证）则取该证据的轮号，否则 rounds_delivered；正常连续编号盘面两者恒等。（GLM 首审 LOW#3 裁决采纳：保留实现的更大信息量，契约措辞对齐）",
+    "legacy_bare_only_outcome": "last_outcome 需要 result-<n>.md 印证（Side B）；bare-only（仅 result.md+turns.txt）legacy 盘面为 null——保守方向，不 assert 无印证的 outcome。（GLM 首审 LOW#4 裁决采纳）"
+  }
 }

--- a/specs/task-evo-peer-turn-status.spec.md
+++ b/specs/task-evo-peer-turn-status.spec.md
@@ -51,16 +51,21 @@ numbered results 终止证据。
   in-process inbox 直投的 round2 从 invalidate(Pending) 到 terminal 之间
   无 running 中间态（queued→terminal）。呈现按投影如实输出 queued，为
   已知限制记录于 interface 契约，不在本任务修 gateway 写侧。
-- crash 窗口语义：terminal 写入顺序为 lifetime(finish) → result.md →
-  result-<n>.md → turns.txt；进程在 finish 后、turns.txt append 前崩溃
-  时，呈现 running/queued + 旧 outcome 为可接受保守值，跨重启由
-  orphaned-across-restart 路径裁决；本任务不引入时间戳裁决（lifetime=Running
-  撞同轮 completed 证据同族，保守呈现 running）。
+- crash 窗口语义（写序以 ui_protocol_transport.rs 为准）：result.md →
+  lifetime(finish) → result-<n>.md → turns.txt。finish 前崩溃 →
+  投影仍 Running：跨重启恢复扫描不处理 Running（仅 closed 退休与
+  Idle 摘要重绑），孤儿 Running 保持 running 直到真实生命周期更新，
+  无自动降级、可长期呈 running。finish 后、
+  turns.txt append 前崩溃 → phase 已定（Idle/Pending/Failed），呈现
+  idle/queued/failed；last_outcome 依 turns 尾行 × 最高 result-<n>.md
+  互证——尾行未更新时为旧 outcome 或（双侧不一致时）null，不绝对
+  保留旧值。不引入时间戳裁决。
 - execution 派生（优先级；无可信 CURRENT authority 时 execution 恒
   unknown，turns.txt 只产出 last_outcome，不推导 execution）：
   1. `closed` 标记存在 → status=closed（不变），execution=`closed`（不是
      idle——closed 是生命周期终态，不代表上一执行成功），last_outcome 保留
-     turns.txt 证据值。
+     turns.txt 证据值；closed 分支身份四元组为 null（closed 标记优先于
+     投影，保守契约）。
   2. lifetime 投影可信 → Pending→`queued`、Running→`running`、
      Failed→`failed`、Idle→`idle`。
   3. lifetime 缺失或不可信（含 legacy）→ execution=`unknown`（turns.txt

--- a/specs/task-evo-peer-turn-status.spec.md
+++ b/specs/task-evo-peer-turn-status.spec.md
@@ -94,8 +94,11 @@ numbered results 终止证据。
 
 ### Allowed Changes
 - crates/octos-cli/src/commands/peer.rs
+- crates/octos-cli/src/commands/mod.rs（仅测试可见性 re-export）
 - crates/octos-cli/src/peers/mod.rs
+- crates/octos-cli/src/peers/recovery.rs（只读投影 + 真实 writer 回归测试；不改写侧语义）
 - crates/octos-cli/src/api/ui_protocol_transport.rs（仅限 raw_peer_gather/compose_peer_list_text 的只读投影扩展；不改 interrupt/steer/审批/terminal 写入行为）
+- crates/octos-cli/src/api/ui_protocol_tests.rs（既有 fixture 补字段）
 - specs/task-evo-peer-turn-status.spec.md
 - docs/superpowers/plans/2026-09-09-peer-turn-status.md
 - docs/peer-status-interface.json
@@ -240,6 +243,77 @@ Scenario: json 与 table 字段一致
   Given 上述 done+errored fixture
   When 分别以 --json 与表格渲染同一 rows
   Then JSON 含全部新字段，表格行含 CURRENT 与 OUTCOME 两列呈现（errored 原样显示；表映射 unknown→?、null→- 被断言）
+
+### Rule: real-writer-shapes — 真实 writer 形状回归（外层 probe 移植）
+Scenario: invalidate 保留旧 turn_id 的 Pending 仍可信（critical）
+  Test:
+    Package: octos-cli
+    Filter: outer_peer_projection_accepts_real_followup_pending
+  Given 生产 Fixture/begin/complete 后调用真实 invalidate_peer_lifetime_for_input
+  Then 磁盘呈 Pending+Some(旧turn_id) 且投影仍 Some（queued 权威保留，不降 unknown）
+
+Scenario: finish(queued) 产 Pending+Some 仍可信
+  Test:
+    Package: octos-cli
+    Filter: outer_peer_projection_accepts_finish_with_queued_input
+  Given 生产 finish_peer_lifetime_turn 以 has_queued_input=true 结束
+  Then 磁盘呈 Pending+Some 且投影仍 Some
+
+### Rule: entry-compat — 真实 CLI 入口兼容（外层复查 #2）
+Scenario: 仅 numbered result 的 legacy peer 保持 done
+  Test:
+    Package: octos-cli
+    Filter: peer_list_numbered_only_peer_stays_done
+  Given 一个 staged peer 仅有 result-1.md（无 bare result.md）
+  Then status=="done"（numbered 或 bare 任一存在即 done，旧语义不变）
+
+Scenario: 超 cap 的 bare result 仍证明交付
+  Test:
+    Package: octos-cli
+    Filter: peer_list_oversized_bare_result_still_done
+  Given bare result.md 超过读 cap（内容读失败）
+  Then status=="done" 且 rounds_delivered==1
+
+Scenario: 显式 name 等于 slug 仍保留 Some(name)
+  Test:
+    Package: octos-cli
+    Filter: peer_list_explicit_name_equal_to_slug_is_preserved
+  Given name 文件内容恰等于 slug
+  Then name==Some(slug 内容)（不得无故变 None）
+
+Scenario: 外来 slug frontmatter 不构成本 peer 证据
+  Test:
+    Package: octos-cli
+    Filter: peer_list_foreign_slug_frontmatter_is_not_outcome_evidence
+  Given result-1.md frontmatter slug 指向其他 peer 且 turns.txt 同轮 completed
+  Then last_outcome==null（交叉校验失败不主张）
+
+Scenario: 扫描 cap 触顶显式截断（scanner 级）
+  Test:
+    Package: octos-cli
+    Filter: peer_list_scan_cap_truncation_yields_no_outcome
+  Given 小 cap + 混合条目（result 文件与非 result 文件）耗尽扫描预算
+  Then 扫描器返回显式截断错误（不返回部分列表）；cap 足够时返回完整命中
+  And 预算计入全部扫描条目而非仅 result 命中（混合文件也耗尽预算）
+
+Scenario: 空 identity 字符串拒绝（Pending+Some("")、空 master）
+  Test:
+    Package: octos-cli
+    Filter: peer_projection_rejects_empty_identity_strings
+  Given lifetime.json 为 Pending+turn_id="" 或 master 为空白串
+  Then 投影为 None（不为其背书）
+
+Scenario: serve gather/list 入口按调用方 profile 投影（critical）
+  Test:
+    Package: octos-cli
+    Filter: peer_gather_entries_thread_caller_profile_for_lifetime
+  Given 非默认 profile（gatherx）的 staged peer 具有 registry_key 绑定
+    gatherx 的可信 running lifetime 及 round1 completed 终止证据
+  When 以 profile_id=gatherx 调 raw peer/gather RPC 与 peer_gather 工具回调
+  Then raw JSON execution=="running" 且
+    master_session_id/task_id/generation/turn_id/last_outcome 原样透出
+    （修复前默认 octos 读取会使同一盘面降级 unknown）；peer_gather 工具
+    回调与 peer_list 工具文本（exec=running）经同一 profile-aware 读取组文
 
 ## Out of Scope
 - lifetime.json / goal ledger 写侧语义变更（只读投影）。

--- a/specs/task-evo-peer-turn-status.spec.md
+++ b/specs/task-evo-peer-turn-status.spec.md
@@ -1,0 +1,247 @@
+spec: task
+name: "peer list 完成状态绑定生命周期、当前轮次与执行结果"
+tags: [ui-protocol, observability, peers, octos-cli]
+---
+
+## Intent
+
+`octos peer list`（CLI 表格与 `--json`）和 serve 内 `peer_list` 工具索引把
+"目录里有 result 文件" 直接当成 done，两类真实事故无法从输出解释：
+(1) peer 的 turn 以 errored 终止后 result.md 存在，status=done，消费端以为
+成功；(2) round1 completed 之后 round2 已 queued/running，索引仍显示 round1
+的 done 旧结果。mutable 的 `result.md` 任意正文不是成功证据；最高编号的
+`result-<n>.md` / `turns.txt` 才是终止证据。本任务保留现有
+running/done/closed 目录交付语义（status 字段不变），新增可序列化的当前
+执行状态（execution）、最近终止 outcome（last_outcome）、当前/已交付轮次
+（round / rounds_delivered）与执行身份字段（task/generation/turn_id），未知
+处明确 `unknown`，绝不用 mtime 猜成功。读取保持 no-serve 直读、JSON 与人类
+表共用同一组装层、symlink-safe。**不新增并行状态机**：current 执行与身份
+来自现有 `lifetime.json` 的只读安全投影，outcome 来自 `turns.txt` /
+numbered results 终止证据。
+
+## Decisions
+
+- 无新 authority：不新增 `turn-state.json` 或任何并行状态文件。当前执行
+  状态与执行身份唯一来源是 `peers/<slug>/lifetime.json`（现有
+  Pending/Running/Idle/Failed + generation fence + turn_id/task_id），只读
+  投影、不写不改其语义；最近终止 outcome 唯一来源是 `turns.txt` 最后一条
+  `(round, outcome, ts)`（与最高编号 `result-<n>.md` 互为印证）。
+- lifetime 安全投影校验（fail-closed，验证通过才可采信，异常/不可信一律
+  降级 unknown）：version==1、task_id 非空、registry_key 与
+  `<profile>:peer:<slug>` 精确匹配、originator leaf 存在且等于
+  lifetime.master。registry_key 的 `<profile>` 由调用方提供：CLI 新增
+  `--profile <id>` 参数（默认 DEFAULT_PROFILE_ID="octos"），显式传入
+  list_peers 与投影校验；serve 回调用其已知 profile_id。`--data-dir` 是
+  任意合法路径，**不得**从目录名推导 profile（/tmp 自定义根同样有效）；
+  必须有 `--data-dir 自定义根 + --profile octosfix` 组合测试。不从
+  lifetime.json 文件内容反推 profile。任何校验失败 → 该 peer 的
+  execution/身份字段全部 unknown/null，不用旧 terminal guessed-idle。
+  legacy peer 无 lifetime.json：execution=unknown、last_outcome 按
+  turns.txt 证据（有则用，无则 null）。
+- 执行身份（identity fields，供外层任务监控消费）：投影暴露
+  `master_session_id`（取 lifetime.master，即 staging originator session
+  id——明确命名，不冒充 peer thread session）、`task_id`、`generation`
+  （u64）、`turn_id`（nullable string）。消费端以
+  runtime/master_session_id/slug/task_id/generation/turn_id 关联。
+- 承载结构：新字段扩展在 `PeerBlackboardRow`（read_peer_blackboard 读取，
+  raw_peer_gather / compose_peer_list_text / CLI 三端共用）；CLI
+  `PeerListRow` 从 blackboard 行映射，不独立读盘，保证三端不漂移。
+- 已知观测限制（gateway inbox 路径，session_actor.rs 无
+  begin_peer_lifetime_turn 调用，代码事实 2026-09-09 核实）：Path 1
+  in-process inbox 直投的 round2 从 invalidate(Pending) 到 terminal 之间
+  无 running 中间态（queued→terminal）。呈现按投影如实输出 queued，为
+  已知限制记录于 interface 契约，不在本任务修 gateway 写侧。
+- crash 窗口语义：terminal 写入顺序为 lifetime(finish) → result.md →
+  result-<n>.md → turns.txt；进程在 finish 后、turns.txt append 前崩溃
+  时，呈现 running/queued + 旧 outcome 为可接受保守值，跨重启由
+  orphaned-across-restart 路径裁决；本任务不引入时间戳裁决（lifetime=Running
+  撞同轮 completed 证据同族，保守呈现 running）。
+- execution 派生（优先级；无可信 CURRENT authority 时 execution 恒
+  unknown，turns.txt 只产出 last_outcome，不推导 execution）：
+  1. `closed` 标记存在 → status=closed（不变），execution=`closed`（不是
+     idle——closed 是生命周期终态，不代表上一执行成功），last_outcome 保留
+     turns.txt 证据值。
+  2. lifetime 投影可信 → Pending→`queued`、Running→`running`、
+     Failed→`failed`、Idle→`idle`。
+  3. lifetime 缺失或不可信（含 legacy）→ execution=`unknown`（turns.txt
+     的旧 terminal 不推导 idle/failed——那正是"凭旧 terminal 猜当前"）；
+     last_outcome 仍可按 turns.txt 证据输出 completed/errored/interrupted/
+     rate_limited（它描述最近已结束轮次，不宣称当前状态）。
+  4. 无任何证据 → `unknown`。
+- Idle 摘要绑定验证：投影为 Idle 时必须 fd-anchored 读取 result.md、
+  计算 SHA256 与 lifetime.result_digest 实际比较，相等才采信 idle；
+  空白摘要、错误摘要、result.md 缺失或被篡改 → 该投影不采信
+  （execution=unknown）。此验证只比对已有摘要，不解析 result.md 正文
+  猜 outcome。反例测试必须含"nonempty 但不匹配的 digest"。
+- last_outcome 始终来自 turns.txt 最后一条（terminal 证据），lifetime 不
+  产出 outcome；done+failed、done+queued/running 组合必须原样呈现，不得
+  误作当前轮成功。
+- round 语义：rounds_delivered = count(result-<n>.md)（bare result.md 无
+  版本文件时下限 1，沿 #2024 floor）；round = queued/running 时
+  delivered+1，idle/failed/unknown 时 delivered。
+- 展示规则：`status` 保持 running|done|closed；`execution` ∈
+  queued|running|idle|failed|closed|unknown；`last_outcome` ∈
+  completed|errored|interrupted|rate_limited|null；人类表新增 CURRENT
+  （execution）与 OUTCOME（last_outcome）两列——新 running+旧 completed
+  的人类看板不再误导；JSON 全字段；两者共用 list_peers 组装。公开字段
+  契约落在 tracked 文件 docs/peer-status-interface.json（CI 可依赖），
+  .octos/ 下仅为交接草稿。
+- serve `peer_list` 索引文本（compose_peer_list_text）同步：done 行追加
+  `outcome=<last_outcome>` 与 `exec=<execution>`；awaiting_input 优先级
+  不变；进程内 wire 活性只在 serve 回调叠加、只收紧不放宽。
+
+## Boundaries
+
+### Allowed Changes
+- crates/octos-cli/src/commands/peer.rs
+- crates/octos-cli/src/peers/mod.rs
+- crates/octos-cli/src/api/ui_protocol_transport.rs（仅限 raw_peer_gather/compose_peer_list_text 的只读投影扩展；不改 interrupt/steer/审批/terminal 写入行为）
+- specs/task-evo-peer-turn-status.spec.md
+- docs/superpowers/plans/2026-09-09-peer-turn-status.md
+- docs/peer-status-interface.json
+- .octos（progress/result/design/independent/cross 交接文档，gitignored）
+
+### Forbidden
+- 不新增任何并行状态文件/状态机（turn-state.json 方案已否决）；不写、不改 lifetime.json 的产生语义。
+- 不改 verifier / 冻结旧 spec / 主树历史任务。
+- 不改 status 字段语义（running|done|closed 保持目录交付语义）。
+- 不用 mtime、result.md 正文内容推断成功。
+- 未知场景必须 unknown，不给 legacy 凭旧 terminal guessed-idle。
+- 不绕过 peer_io 的 fd-anchored 读写。
+- 不改权限/模型/凭据配置，不 push/PR/合并主分支。
+- 不得删除断言或削弱既有测试来满足门禁。
+
+## Completion Criteria
+
+### Rule: terminal-evidence — 终止证据与 outcome 呈现
+Scenario: done+errored 可区分（critical）
+  Test:
+    Package: octos-cli
+    Filter: peer_list_done_peer_with_errored_outcome_shows_failed_execution
+  Given 一个 staged peer：result.md、result-1.md 存在且 turns.txt 记录 `1 errored <ts>`，lifetime.json 为 phase=failed（可信投影）
+  When 调用 `list_peers`
+  Then status=="done" 且 execution=="failed" 且 last_outcome=="errored" 且 rounds_delivered==1
+
+Scenario: round1 completed 后 round2 queued 不显示旧完成
+  Test:
+    Package: octos-cli
+    Filter: peer_list_round2_queued_shows_queued_not_stale_done
+  Given turns.txt 记录 `1 completed <ts1>` 且 lifetime.json 为 phase=pending generation=2（可信投影）
+  When 调用 `list_peers`
+  Then status=="done" 且 execution=="queued" 且 round==2 且 last_outcome=="completed"
+
+Scenario: round2 running 覆盖 round1 完成
+  Test:
+    Package: octos-cli
+    Filter: peer_list_round2_running_overrides_round1_completion
+  Given turns.txt 记录 `1 completed <ts1>` 且 lifetime.json 为 phase=running turn_id=t2（可信投影）
+  When 调用 `list_peers`
+  Then execution=="running" 且 round==2 且 turn_id=="t2"
+
+Scenario: interrupted 轮呈现 failed
+  Test:
+    Package: octos-cli
+    Filter: peer_list_interrupted_turn_reports_failed
+  Given turns.txt 记录 `2 interrupted <ts>` 且 lifetime.json 为 phase=failed（可信投影）
+  When 调用 `list_peers`
+  Then execution=="failed" 且 last_outcome=="interrupted" 且 rounds_delivered==2
+
+Scenario: 无 lifetime 时 execution 恒 unknown（last_outcome 保留证据）
+  Test:
+    Package: octos-cli
+    Filter: peer_list_no_lifetime_execution_unknown_outcome_kept
+  Given turns.txt 记录 `1 errored <ts>`，无 lifetime.json
+  When 调用 `list_peers`
+  Then execution=="unknown" 且 last_outcome=="errored"（不凭旧 terminal 猜 failed/idle）
+
+### Rule: lifetime-projection — lifetime 安全投影
+Scenario: 可信投影按 phase 呈现并暴露身份（critical）
+  Test:
+    Package: octos-cli
+    Filter: peer_list_lifetime_projection_phases_and_identity
+  Given 同一 fixture 工厂分别构造 phase=running/failed/idle 的可信 lifetime.json（含 task_id/generation/turn_id/result_digest）
+  When 调用 `list_peers`
+  Then execution 分别为 running/failed/idle，且 task_id/generation/turn_id 字段原样输出；idle 场景 result_digest 非空
+
+Scenario: 不可信投影降级 unknown
+  Test:
+    Package: octos-cli
+    Filter: peer_list_untrusted_lifetime_degrades_to_unknown
+  Given lifetime.json 的 registry_key 与 `<profile>:peer:<slug>` 不匹配（或 originator 缺失、version!=1）
+  When 调用 `list_peers`
+  Then execution=="unknown"（不从旧 terminal guessed-idle）且 last_outcome 仍按 turns.txt 证据输出
+
+Scenario: idle 摘要不匹配降级 unknown
+  Test:
+    Package: octos-cli
+    Filter: peer_list_idle_digest_mismatch_degrades_to_unknown
+  Given lifetime.json 为 phase=idle 且 result_digest 非空，但 result.md 实际 SHA256 与之不匹配（或 result.md 缺失）
+  When 调用 `list_peers`
+  Then execution=="unknown"（摘要绑定失败不宣称 idle）
+
+Scenario: lifetime 损坏 JSON 降级
+  Test:
+    Package: octos-cli
+    Filter: peer_list_corrupt_lifetime_degrades_to_evidence
+  Given lifetime.json 为截断 JSON，turns.txt 记录 `1 errored <ts>`
+  When 调用 `list_peers`
+  Then execution=="unknown"（无可信 authority）且 last_outcome=="errored"（证据保留），不 panic
+
+### Rule: legacy-unknown — 无元数据不猜测
+Scenario: legacy peer 无 turns.txt 无 lifetime（critical）
+  Test:
+    Package: octos-cli
+    Filter: peer_list_legacy_no_metadata_reports_unknown
+  Given 一个 staged peer 仅有 brief.md 与 result.md（无 turns.txt、无 lifetime.json）
+  When 调用 `list_peers`
+  Then status=="done" 且 execution=="unknown" 且 last_outcome==null 且 rounds_delivered==1
+
+### Rule: robust-reads — 符号链接
+Scenario: turns.txt 为符号链接被拒读
+  Test:
+    Package: octos-cli
+    Filter: peer_list_symlinked_turns_index_is_ignored
+  Given turns.txt 是指向外部的符号链接且无 lifetime.json
+  When 调用 `list_peers`
+  Then 读取端忽略该文件，execution=="unknown"，不跟随链接
+
+### Rule: closed-terminal — closed 覆盖一切
+Scenario: closed peer 保持 closed 优先
+  Test:
+    Package: octos-cli
+    Filter: peer_list_closed_peer_reports_closed_execution_with_outcome
+  Given 一个 closed peer（closed 标记 + result.md + turns.txt `1 errored`）
+  When 调用 `list_peers`
+  Then status=="closed" 且 execution=="closed" 且 last_outcome=="errored"
+
+### Rule: derivation-precedence — execution 派生优先级
+Scenario: 派生优先级 closed > 可信 lifetime > unknown
+  Test:
+    Package: octos-cli
+    Filter: peer_list_execution_derivation_precedence
+  Given 同一 data_dir 下四个 peer：closed+errored 证据、可信 lifetime running+旧 completed 证据、无 lifetime（turns 有 errored 证据）、两者皆无
+  When 调用 `list_peers`
+  Then 四行 execution 分别为 closed、running、unknown、unknown（无 authority 不推导）
+
+### Rule: interface-fields — 消费端字段契约
+Scenario: docs/peer-status-interface.json 契约与实现字段一致
+  Test:
+    Package: octos-cli
+    Filter: peer_list_fields_match_status_interface_contract
+  Given docs/peer-status-interface.json 声明的字段集（tracked 文件）
+  When 序列化 PeerListRow
+  Then 输出 JSON 的键集与契约一致（slug/status/execution/last_outcome/round/rounds_delivered/has_brief/result_versions/name/model_lane/master_session_id/task_id/generation/turn_id）
+
+### Rule: shared-assembly — JSON 与人类表共用组装
+Scenario: json 与 table 字段一致
+  Test:
+    Package: octos-cli
+    Filter: peer_list_json_and_table_share_assembly
+  Given 上述 done+errored fixture
+  When 分别以 --json 与表格渲染同一 rows
+  Then JSON 含全部新字段，表格行含 CURRENT 与 OUTCOME 两列呈现（errored 原样显示；表映射 unknown→?、null→- 被断言）
+
+## Out of Scope
+- lifetime.json / goal ledger 写侧语义变更（只读投影）。
+- peer_gather 大改动（仅 raw_peer_gather JSON 透出新字段）。
+- 仪表盘/TUI 渲染改造。


### PR DESCRIPTION
Peer 状态以前可能把上一轮的完成结果当成当前状态，也难以区分“任务还存在”“正在执行”和“最终成功/失败”。这次将三者分开显示，并核对当前轮次和所属身份；旧结果、外来结果或缺少可靠证据时显示 `unknown`。

- 统一 CLI 表格、JSON 和 UI 协议的状态来源，使用只读 lifetime 投影；显式 profile/data-dir 路由保持一致。
- 保留真实的 failed、errored、interrupted、rate_limited 结果，避免把终止状态一律显示成成功。
- 行为合约：`specs/task-evo-peer-turn-status.spec.md`（24 个场景绑定真实测试）；接口定义：`docs/peer-status-interface.json`。
- 明确边界：closed 分支的身份字段为 null；begin 后崩溃留下的 Running 投影没有自动降级，可能持续显示 running。契约已按真实 terminal 写入顺序说明崩溃窗口及 last_outcome 可能为旧值或 null 的情况。

验证：运行实现 `49c84eaa` 已经 GLM-5.3 / K3-256K 互审和 Codex 独立外层审查，包含实际 CLI、路由及渲染验证。与 goal verifier 修复 `59972429` 组合后的本地验证提交 `8b4da851` 通过：

```sh
cargo fmt --all -- --check
cargo clippy --all-targets --features api -- -D warnings
cargo test --all-targets --features api --no-fail-fast -- --test-threads=8
```

全量集成验证：172 套件，10,044 通过、0 失败、100 忽略。该数字对应两项修复的组合树。运行实现 `49c84eaa` 的 GitHub CI 也已通过。

当前 HEAD `e8f77422ab250d30a198ef600577229af9cb0162` 根据审查修正了注释和契约文字，未改运行行为或测试。该增量通过 GLM/K3 最终核对、Codex 文档复核、fmt、JSON 解析和 agent-spec parse/lint；字段集合及 24 个场景绑定未变。保留 closed 身份的行为建议仍属后续改进，本次没有实现该行为变更。
