### PR TITLE
fix(goals): bound completion verification and isolate durable evidence by session

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -39983,7 +39983,10 @@ async fn interactive_sentinel_done_verdict_completes_scoped_goal() {
         None,
     )
     .await;
-    assert!(completed, "verified sentinel must complete the goal");
+    assert!(
+        completed.completed,
+        "verified sentinel must complete the goal"
+    );
     assert_eq!(
         orchestrator.goal_status_for_test(&pinned).as_deref(),
         Some("complete"),
@@ -40048,7 +40051,10 @@ async fn interactive_sentinel_notdone_verdict_leaves_goal_active() {
         None,
     )
     .await;
-    assert!(!completed, "NotDone verdict must refuse the completion");
+    assert!(
+        !completed.completed,
+        "NotDone verdict must refuse the completion"
+    );
     assert_eq!(
         orchestrator.goal_status_for_test(&wire).as_deref(),
         Some("active"),
@@ -40101,7 +40107,10 @@ async fn interactive_sentinel_refuses_stale_goal_binding() {
         None,
     )
     .await;
-    assert!(!completed, "stale binding must refuse the completion");
+    assert!(
+        !completed.completed,
+        "stale binding must refuse the completion"
+    );
     assert_eq!(
         orchestrator.goal_status_for_test(&wire).as_deref(),
         Some("active"),
@@ -40152,7 +40161,7 @@ async fn interactive_sentinel_skips_verifier_without_completion_claim() {
         None,
     )
     .await;
-    assert!(!completed);
+    assert!(!completed.completed);
     assert_eq!(
         calls.load(std::sync::atomic::Ordering::SeqCst),
         0,
@@ -42936,5 +42945,209 @@ async fn bc9_b6_reused_id_stale_connection_preserves_new_claim() {
     build_cache_slot_registry().release(
         &build_cache_slot_registry_key(&root, "reuse-connection"),
         crate::build_cache::pool::SlotOutcome::Cancelled,
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// evo-goal-verifier GAP-8 (spec Filter: ui_transport_sentinels_report_
+// verifier_failure_kind): the interactive sentinel station must surface
+// the structured failure kind — REAL path through
+// run_interactive_sentinel_completion, not a wrapper-only call.
+// ─────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn ui_transport_sentinels_report_verifier_failure_kind() {
+    use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+
+    let orchestrator = crate::autonomy::agent_orchestrator::InProcessAgentOrchestrator::default();
+    let key = octos_core::SessionKey("gap8-prof:api:gap8-sentinel".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: key.clone(),
+            profile_id: "gap8-prof".to_owned(),
+            objective: "surface kind on refusal".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal");
+    let snapshot = orchestrator
+        .goal_verification_snapshot(&key, "gap8-prof")
+        .expect("snapshot");
+
+    // Empty reply (reasoning-only) classifies empty_response; the wrapper
+    // retries once (transient) so attempt lands at 2/2.
+    struct EmptyReplyVerifier;
+    #[async_trait::async_trait]
+    impl octos_llm::LlmProvider for EmptyReplyVerifier {
+        async fn chat(
+            &self,
+            _m: &[octos_core::Message],
+            _t: &[octos_llm::ToolSpec],
+            _c: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            Ok(octos_llm::ChatResponse {
+                content: None,
+                reasoning_content: Some("thinking…".to_owned()),
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "empty-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "empty-verifier"
+        }
+    }
+
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let outcome = run_interactive_sentinel_completion(
+        &orchestrator,
+        std::sync::Arc::new(EmptyReplyVerifier),
+        &key,
+        "gap8-prof",
+        &snapshot.goal_id,
+        // A real completion CLAIM so the sentinel path actually runs.
+        "All tasks are complete. <goal:complete>",
+        Some(temp.path()),
+    )
+    .await;
+
+    // The goal must NOT have completed (empty verifier replies).
+    assert!(!outcome.completed, "empty replies never complete the goal");
+    // The structured failure leaves the station: kind + canonical line.
+    let (kind, line) = outcome
+        .failure
+        .expect("interactive sentinel must surface the structured failure");
+    assert_eq!(kind, "empty_response");
+    assert!(
+        line.contains("verifier empty_response (attempt 2/2)"),
+        "canonical Display line with kind+attempts, got: {line}"
+    );
+    // And the goal stays active — sentinel refusals never flip state.
+    let still = orchestrator
+        .goal_verification_snapshot(&key, "gap8-prof")
+        .expect("snapshot still resolvable");
+    assert_eq!(still.goal_id, snapshot.goal_id);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// evo-goal-verifier GAP-8b (root follow-up #5): the AUTONOMOUS consumer's
+// wire shape — the shared `goal_verifier_warning_event` constructor the
+// goal-turn accountant emits at :37553, driven through the REAL
+// `send_notification_ephemeral`, with a REAL verifier outcome produced by
+// the bounded wrapper (empty replies → empty_response, attempt 2/2).
+// ─────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn ui_transport_autonomous_consumer_emits_verifier_warning_wire_shape() {
+    use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+
+    let orchestrator = crate::autonomy::agent_orchestrator::InProcessAgentOrchestrator::default();
+    let key = octos_core::SessionKey("gap8b-prof:api:gap8b-auto".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: key.clone(),
+            profile_id: "gap8b-prof".to_owned(),
+            objective: "autonomous wire shape".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal");
+    let snapshot = orchestrator
+        .goal_verification_snapshot(&key, "gap8b-prof")
+        .expect("snapshot");
+
+    struct EmptyReplyVerifier;
+    #[async_trait::async_trait]
+    impl octos_llm::LlmProvider for EmptyReplyVerifier {
+        async fn chat(
+            &self,
+            _m: &[octos_core::Message],
+            _t: &[octos_llm::ToolSpec],
+            _c: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            Ok(octos_llm::ChatResponse {
+                content: None,
+                reasoning_content: Some("thinking…".to_owned()),
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "empty-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "empty-verifier"
+        }
+    }
+
+    // REAL outcome through the bounded wrapper — the same object the
+    // autonomous accountant holds at :37523-37530.
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let outcome = orchestrator
+        .verify_goal_completion_bounded(
+            &key,
+            "gap8b-prof",
+            &snapshot,
+            std::sync::Arc::new(EmptyReplyVerifier),
+            "All tasks are complete. <goal:complete>",
+            Some(temp.path()),
+        )
+        .await;
+    assert_eq!(outcome.kind.map(|k| k.as_str()), Some("empty_response"));
+    assert_eq!(outcome.attempts, 2);
+
+    // The shared constructor the autonomous station uses…
+    let notification = goal_verifier_warning_event(&key, &outcome);
+    // …through the REAL ephemeral send path, read back off the wire as a
+    // Text JSON frame (the same WsMessage shape a live client receives).
+    let (ws_tx, mut ws_rx) = tokio::sync::mpsc::channel(8);
+    let ws = WsConnection::new(ws_tx);
+    let ledger = UiProtocolLedger::new(16);
+    send_notification_ephemeral(&ws, &ledger, notification).expect("ephemeral send succeeds");
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(2), ws_rx.recv())
+        .await
+        .expect("wire frame arrives")
+        .expect("channel open");
+    let WsMessage::Text(text) = frame else {
+        panic!("expected a Text wire frame");
+    };
+    let json: serde_json::Value = serde_json::from_str(text.as_str()).expect("frame parses");
+    assert_eq!(json["method"], "warning");
+    assert_eq!(
+        json["params"]["code"], "goal_verifier_empty_response",
+        "params: {:?}",
+        json["params"]
+    );
+    let message = json["params"]["message"].as_str().unwrap_or("");
+    assert!(
+        message.contains("verifier empty_response (attempt 2/2)"),
+        "canonical Display line on the wire, got: {message}"
+    );
+
+    // And the goal stays ACTIVE — the sentinel refusal never flips state
+    // (the SessionGoalUpdated repaint the accountant sends next carries
+    // `active`, never `complete`).
+    let event_json = orchestrator.session_goal_updated_event_json(&key, "gap8b-prof");
+    let event = serde_json::from_value::<octos_core::ui_protocol::SessionGoalUpdatedEvent>(
+        event_json.expect("goal event json"),
+    )
+    .expect("goal event parses");
+    assert_ne!(
+        event.goal.status, "complete",
+        "an unverified claim never completes the goal"
     );
 }

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -32240,6 +32240,53 @@ impl ChildStreamCoalescer {
 ///   verifier call exactly like the autonomous sites (#1958 codex #3).
 ///
 /// Returns whether the goal was flipped to `complete`.
+/// Structured result of the interactive sentinel completion check
+/// (evo-goal-verifier M1/cross A2): `completed` keeps the old bool contract;
+/// `failure` carries the structured verifier outcome line when the agent
+/// CLAIMED completion but verification refused it — previously the kind was
+/// dropped at this station entirely.
+struct InteractiveSentinelOutcome {
+    /// Old bool contract preserved: did the goal actually flip to complete?
+    completed: bool,
+    /// Canonical Display line (`verifier {kind} (attempt n/2): …`) plus the
+    /// raw kind for callers that want to key off the classification.
+    failure: Option<(&'static str, String)>,
+}
+
+/// evo-goal-verifier M1: the canonical verifier-failure notification the
+/// sentinel stations emit on a claimed-but-unverified completion. ONE
+/// constructor shared by the interactive (:36659) and autonomous (:37553)
+/// consumers so the wire shape cannot drift between them.
+fn goal_verifier_warning_event(
+    session_id: &SessionKey,
+    outcome: &crate::autonomy::goal_loop_runtime::GoalVerifierOutcome,
+) -> UiNotification {
+    UiNotification::Warning(octos_core::ui_protocol::WarningEvent {
+        session_id: session_id.clone(),
+        turn_id: None,
+        code: format!(
+            "goal_verifier_{}",
+            outcome.kind.map(|k| k.as_str()).unwrap_or("unknown")
+        ),
+        message: format!("goal completion not verified — {outcome}"),
+    })
+}
+
+/// Same wire shape for the interactive consumer, which holds the already-
+/// rendered canonical (kind, line) pair from `InteractiveSentinelOutcome`.
+fn goal_verifier_failure_warning(
+    session_id: &SessionKey,
+    kind: &str,
+    line: &str,
+) -> UiNotification {
+    UiNotification::Warning(octos_core::ui_protocol::WarningEvent {
+        session_id: session_id.clone(),
+        turn_id: None,
+        code: format!("goal_verifier_{kind}"),
+        message: format!("goal completion not verified — {line}"),
+    })
+}
+
 async fn run_interactive_sentinel_completion(
     orchestrator: &InProcessAgentOrchestrator,
     verifier_provider: Arc<dyn octos_llm::LlmProvider>,
@@ -32248,17 +32295,23 @@ async fn run_interactive_sentinel_completion(
     bound_goal_id: &str,
     reply: &str,
     ledger_data_dir: Option<&Path>,
-) -> bool {
+) -> InteractiveSentinelOutcome {
     // Loop-engineering completion gate: only spend the INDEPENDENT verifier
     // LLM call when the agent actually CLAIMS completion.
     if !orchestrator.goal_completion_claimed(reply) {
-        return false;
+        return InteractiveSentinelOutcome {
+            completed: false,
+            failure: None,
+        };
     }
     // #1935 codex round 3 (TOCTOU) — one-lock snapshot of (goal_id,
     // objective); no goal / wrong profile ⇒ nothing to verify.
     let Some(snapshot) = orchestrator.goal_verification_snapshot(pinned_goal_key, charge_profile)
     else {
-        return false;
+        return InteractiveSentinelOutcome {
+            completed: false,
+            failure: None,
+        };
     };
     // Dispatch-time binding check: a goal cleared+recreated mid-turn must
     // neither be graded against the OLD turn's claim nor spend a verifier
@@ -32270,7 +32323,10 @@ async fn run_interactive_sentinel_completion(
             current_goal_id = %snapshot.goal_id,
             "interactive sentinel: goal changed since dispatch — stale claim refused"
         );
-        return false;
+        return InteractiveSentinelOutcome {
+            completed: false,
+            failure: None,
+        };
     }
     // #1958 (codex #3) — the sentinel verifier runs AFTER the turn's routing
     // scopes ended; restore originating-session attribution around it. The
@@ -32291,7 +32347,7 @@ async fn run_interactive_sentinel_completion(
         ),
     )
     .await;
-    orchestrator.maybe_complete_goal_from_model(
+    let completed = orchestrator.maybe_complete_goal_from_model(
         pinned_goal_key,
         charge_profile,
         reply,
@@ -32301,7 +32357,26 @@ async fn run_interactive_sentinel_completion(
         &snapshot,
         // #1957 (codex #1) — sync a sentinel completion into the ledger.
         ledger_data_dir,
-    )
+    );
+    InteractiveSentinelOutcome {
+        completed,
+        failure: if completed || outcome.is_done() {
+            None
+        } else {
+            // M1/cross A2: structured failure line leaves this station now —
+            // the kind is no longer dropped. Ephemeral consumer decides how
+            // to surface it (SessionGoalUpdated schema stays untouched).
+            tracing::warn!(
+                session_id = %pinned_goal_key,
+                goal_id = %snapshot.goal_id,
+                "interactive sentinel completion not verified: {outcome}"
+            );
+            Some((
+                outcome.kind.map(|k| k.as_str()).unwrap_or("unknown"),
+                outcome.to_string(),
+            ))
+        },
+    }
 }
 
 /// #1969 — resolve the token charge for a turn that may have been INTERRUPTED.
@@ -36599,7 +36674,7 @@ async fn run_standalone_turn(
                 .goal_verifier_llm
                 .clone()
                 .unwrap_or_else(|| llm_provider.clone());
-            let _ = run_interactive_sentinel_completion(
+            let sentinel_outcome = run_interactive_sentinel_completion(
                 default_agent_orchestrator(),
                 verifier_provider,
                 &turn_pinned_goal_key,
@@ -36612,6 +36687,22 @@ async fn run_standalone_turn(
                 Some(session_runtime.profile.data_dir.as_path()),
             )
             .await;
+            // evo-goal-verifier M1 (cross A2): surface the structured
+            // verifier failure (kind + canonical line) as an ephemeral note
+            // on the interactive path — SessionGoalUpdated schema untouched.
+            if sentinel_outcome.completed {
+                tracing::debug!(
+                    session_id = %turn_pinned_goal_key,
+                    "interactive sentinel flipped goal to complete"
+                );
+            }
+            if let Some((kind, line)) = sentinel_outcome.failure {
+                let _ = send_notification_ephemeral(
+                    &ws,
+                    &ledger,
+                    goal_verifier_failure_warning(&turn_pinned_goal_key, kind, &line),
+                );
+            }
         }
     }
     // #1650 — release the in-flight marker now that the charge has
@@ -37482,6 +37573,22 @@ async fn run_standalone_turn(
                     // #1957 (codex #1) — sync a sentinel completion into the ledger.
                     Some(goal_ledger_data_dir.as_path()),
                 );
+                // evo-goal-verifier M1 (cross A3): the AUTONOMOUS sentinel
+                // station also surfaces the structured failure kind — same
+                // canonical Display line, same ephemeral Warning channel,
+                // SessionGoalUpdated schema untouched.
+                if !outcome.is_done() {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        goal_id = %snapshot.goal_id,
+                        "autonomous sentinel completion not verified: {outcome}"
+                    );
+                    let _ = send_notification_ephemeral(
+                        &ws,
+                        &ledger,
+                        goal_verifier_warning_event(&session_id.clone(), &outcome),
+                    );
+                }
             }
         }
         // #1696/#1698 — push the post-turn goal snapshot to the OWNING

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -131,8 +131,8 @@ use crate::autonomy::agent_orchestrator::{
     LoopListRequest, MonitorControlKind, MonitorControlRequest, MonitorCreateRequest,
     MonitorListRequest, NativeSpecialistAppUiEvent, NativeSpecialistLaunchRequest,
     default_agent_orchestrator, master_continuation_prompt, master_continuation_reason_name,
-    monitor_invalid_spec_error, parse_agent_output_cursor, run_goal_completion_verifier_with_usage,
-    upsert_background_task_agent, wire_key_from_goal_key,
+    monitor_invalid_spec_error, parse_agent_output_cursor, upsert_background_task_agent,
+    wire_key_from_goal_key,
 };
 use crate::autonomy::master_continuation_scheduler::{
     MasterContinuationReason, MasterContinuationRuntimeState, QueuedMasterContinuation,
@@ -32275,28 +32275,27 @@ async fn run_interactive_sentinel_completion(
     // #1958 (codex #3) — the sentinel verifier runs AFTER the turn's routing
     // scopes ended; restore originating-session attribution around it. The
     // event carries the WIRE id, so strip the cwd scope off the pinned key.
-    let (verdict, verifier_usage) = octos_llm::with_router_context(
+    // evo-goal-verifier: the wrapper owns gate/charge/retry/ledger.
+    let outcome = octos_llm::with_router_context(
         octos_llm::RouterContext {
             session_id: Some(wire_key_from_goal_key(pinned_goal_key).to_string()),
             ..Default::default()
         },
-        run_goal_completion_verifier_with_usage(verifier_provider, &snapshot.objective, reply),
+        orchestrator.verify_goal_completion_bounded(
+            pinned_goal_key,
+            charge_profile,
+            &snapshot,
+            verifier_provider,
+            reply,
+            ledger_data_dir,
+        ),
     )
     .await;
-    // #1958 — fold the verifier's real spend into the goal before the flip.
-    // The returned chip event is intentionally dropped: the caller's
-    // unconditional interactive repaint pushes the final snapshot.
-    let _ = orchestrator.charge_goal_verifier_usage(
-        pinned_goal_key,
-        charge_profile,
-        Some(&snapshot.goal_id),
-        &verifier_usage,
-    );
     orchestrator.maybe_complete_goal_from_model(
         pinned_goal_key,
         charge_profile,
         reply,
-        &verdict,
+        &outcome.verdict,
         // #1935 codex round 3 — both snapshot fields are re-checked against
         // the live record inside; a mid-verify swap or objective edit refuses.
         &snapshot,
@@ -37451,31 +37450,23 @@ async fn run_standalone_turn(
                 // attribution around it (a failover would otherwise publish
                 // unattributed / under another session). Autonomous turns are
                 // Normal policy, so only the router context needs restoring.
-                let (verdict, verifier_usage) = octos_llm::with_router_context(
+                // evo-goal-verifier: the wrapper owns gate/charge/retry/ledger;
+                // per-attempt usage is charged inside it.
+                let outcome = octos_llm::with_router_context(
                     octos_llm::RouterContext {
                         session_id: Some(session_id.to_string()),
                         ..Default::default()
                     },
-                    run_goal_completion_verifier_with_usage(
+                    orchestrator.verify_goal_completion_bounded(
+                        goal_key,
+                        &goal_ctx.profile_id,
+                        &snapshot,
                         verifier_provider,
-                        &snapshot.objective,
                         &reply,
+                        Some(goal_ledger_data_dir.as_path()),
                     ),
                 )
                 .await;
-                // #1958 — the verifier call is real goal spend: fold it into
-                // the goal's tokens_used via the scoped key, BEFORE the
-                // completion flip below (a `complete` goal can no longer be
-                // charged). The returned chip event is dropped on purpose —
-                // the unconditional post-accountant push below emits the
-                // final snapshot (including this charge) to the owning
-                // connection.
-                let _ = orchestrator.charge_goal_verifier_usage(
-                    goal_key,
-                    &goal_ctx.profile_id,
-                    Some(&snapshot.goal_id),
-                    &verifier_usage,
-                );
                 // `maybe_complete_goal_from_model` is idempotent and only
                 // flips when `detect_goal_complete_sentinel` matches the
                 // tail of the reply AND the verdict is Done. The return value
@@ -37486,7 +37477,7 @@ async fn run_standalone_turn(
                     goal_key,
                     &goal_ctx.profile_id,
                     &reply,
-                    &verdict,
+                    &outcome.verdict,
                     &snapshot,
                     // #1957 (codex #1) — sync a sentinel completion into the ledger.
                     Some(goal_ledger_data_dir.as_path()),

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -4987,7 +4987,7 @@ impl InProcessAgentOrchestrator {
                     | Some(GoalVerifierFailureKind::EmptyResponse)
             ) && (call.kind != Some(GoalVerifierFailureKind::CallFailed)
                 || call.call_error_retryable)
-                && attempts < 2
+                && attempts < VERIFIER_MAX_ATTEMPTS
                 && self.goal_status_is_active(session_id, profile_id, snapshot);
             if retry {
                 continue;
@@ -16305,6 +16305,10 @@ pub(crate) struct SingleVerifierCall {
 }
 
 /// Max chars of a provider error kept in the structured result / ledger.
+/// evo-goal-verifier (bounded retry): a transient verifier failure earns at
+/// most ONE retry — two provider chats total, across every call site.
+pub(crate) const VERIFIER_MAX_ATTEMPTS: u32 = 2;
+
 pub(crate) const VERIFIER_CALL_ERROR_CHARS: usize = 400;
 
 pub(crate) async fn run_goal_completion_verifier_with_usage(
@@ -39768,6 +39772,608 @@ mod tests {
         assert_eq!(outcome.usage.reasoning_tokens, 33, "3 + 30");
         assert_eq!(outcome.usage.cache_read_tokens, 44, "4 + 40");
         assert_eq!(outcome.usage.cache_write_tokens, 55, "5 + 50");
+    }
+
+    /// Test util: read the EXACT ledger file for a session's verifier
+    /// scope (file name = scope fingerprint hex) — never a goal_id scan
+    /// across sessions (root fix ②: scope-exact rows).
+    fn read_scope_ledger_rows(
+        temp: &tempfile::TempDir,
+        session_id: &SessionKey,
+        profile_id: &str,
+        snapshot: &crate::autonomy::agent_orchestrator::GoalVerificationSnapshot,
+    ) -> Vec<String> {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let scope = orchestrator.verifier_scope(
+            Some(temp.path()),
+            session_id,
+            profile_id,
+            &snapshot.goal_id,
+        );
+        let path = verifier_ledger_path(temp.path(), &scope.fingerprint);
+        match std::fs::read_to_string(&path) {
+            Ok(text) => text
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| l.to_owned())
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// evo-goal-verifier GAP-1 (spec Filter): persistent double transient
+    /// failure is capped at exactly TWO provider chats.
+    #[tokio::test]
+    async fn goal_verifier_caps_attempts_at_two_on_persistent_call_failure() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "caps-two");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "caps attempts".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![
+                ScriptedReply::ErrRetryable("503 first"),
+                ScriptedReply::ErrRetryable("503 second"),
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(outcome.kind.map(|k| k.as_str()), Some("call_failed"));
+        assert_eq!(outcome.attempts, 2, "cap at two total attempts");
+        assert_eq!(provider.chats(), 2, "exactly two provider chats");
+    }
+
+    /// evo-goal-verifier GAP-2 (spec Filter): a goal already non-active
+    /// BEFORE the first retry decision never earns a second chat.
+    #[tokio::test]
+    async fn goal_verifier_skips_retry_when_goal_not_active_before_first_attempt() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "pre-limited");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "pre limited".into(),
+                // Real pre-limited edge: the goal is ALREADY budget_limited
+                // before the verifier's first retry decision. Policy
+                // rejects a zero budget, so seed a real budget and flip the
+                // goal to budget_limited through the sanctioned status set
+                // (same enum the per-attempt charge uses).
+                status: Some("budget_limited".into()),
+                token_budget: Some(10),
+                transition_actor: None,
+            })
+            .expect("set goal already budget-limited");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![
+                ScriptedReply::ErrRetryable("503 first"),
+                ScriptedReply::ErrRetryable("503 second"),
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(outcome.attempts, 1, "no retry when goal not active");
+        assert_eq!(provider.chats(), 1);
+        // K3 补强: the single failed attempt still lands a durable row so
+        // the "never retried" fact is itself auditable in the ledger.
+        assert_eq!(
+            outcome.kind.map(|k| k.as_str()),
+            Some("call_failed"),
+            "retryable error with the gate closed classifies CallFailed"
+        );
+        let rows = read_scope_ledger_rows(&temp, &session_id, "tenant-a", &snapshot);
+        assert_eq!(rows.len(), 1, "the single attempt is recorded");
+        let row: serde_json::Value = serde_json::from_str(&rows[0]).expect("row parses");
+        assert_eq!(row["outcome"], "call_failed");
+        assert_eq!(row["attempts"], 1, "durable row shows no second attempt");
+    }
+
+    /// evo-goal-verifier M3 (spec Filter): a first-token DONE with body is
+    /// InvalidResponse and must NOT be retried — exactly one chat.
+    #[tokio::test]
+    async fn goal_verifier_does_not_retry_invalid_response() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "no-retry-invalid");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "invalid no retry".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![
+                ScriptedReply::Ok {
+                    content: "DONE: but actually not finished",
+                    usage: usage_of(5, 2, 0, 0, 0),
+                },
+                ScriptedReply::Ok {
+                    content: "DONE",
+                    usage: usage_of(1, 1, 0, 0, 0),
+                },
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(
+            outcome.kind.map(|k| k.as_str()),
+            Some("invalid_response"),
+            "DONE with body is InvalidResponse"
+        );
+        assert_eq!(outcome.attempts, 1, "format errors never earn a retry");
+        assert_eq!(provider.chats(), 1);
+    }
+
+    /// evo-goal-verifier GAP-3 (spec Filter): the durable ledger row for a
+    /// FAILED verification records the failure kind and attempt count.
+    #[tokio::test]
+    async fn goal_verifier_ledger_records_failure_kind_and_attempts() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "fail-row");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "failure row".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "NOT_DONE: missing X",
+                usage: usage_of(3, 1, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence-fail",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(
+            outcome.kind.map(|k| k.as_str()),
+            Some("insufficient_evidence")
+        );
+        assert_eq!(outcome.attempts, 1);
+        // Read the durable JSONL back — scope-EXACT file (root fix ②).
+        let ledger_rows = read_scope_ledger_rows(&temp, &session_id, "tenant-a", &snapshot);
+        assert_eq!(ledger_rows.len(), 1, "one row for this scope");
+        let row: serde_json::Value = serde_json::from_str(&ledger_rows[0]).expect("row parses");
+        assert_eq!(row["version"], 3);
+        assert_eq!(row["outcome"], "insufficient_evidence");
+        assert_eq!(row["attempts"], 1);
+        assert!(
+            row["missing_evidence"]
+                .as_str()
+                .unwrap_or("")
+                .contains("missing X")
+        );
+
+        // ── root fix ①: the ORIGINAL cross gap is the CallFailed
+        // double-failure row — two retryable errors burn both attempts and
+        // the durable row must read back outcome=call_failed, attempts=2.
+        let session_b = SessionKey::with_profile("tenant-a", "api", "fail-row-callfailed");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_b.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "call failed row".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal b");
+        let snapshot_b = orchestrator
+            .goal_verification_snapshot(&session_b, "tenant-a")
+            .expect("snapshot b");
+        let provider_b = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![
+                ScriptedReply::ErrRetryable("503 first"),
+                ScriptedReply::ErrRetryable("503 second"),
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome_b = orchestrator
+            .verify_goal_completion_bounded(
+                &session_b,
+                "tenant-a",
+                &snapshot_b,
+                provider_b.clone(),
+                "evidence-callfailed",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(outcome_b.kind.map(|k| k.as_str()), Some("call_failed"));
+        assert_eq!(outcome_b.attempts, 2, "both attempts burned");
+        let rows_b = read_scope_ledger_rows(&temp, &session_b, "tenant-a", &snapshot_b);
+        assert_eq!(rows_b.len(), 1, "exactly one row for this scope");
+        let row_b: serde_json::Value = serde_json::from_str(&rows_b[0]).expect("row b parses");
+        assert_eq!(row_b["version"], 3);
+        assert_eq!(
+            row_b["outcome"], "call_failed",
+            "durable row carries the failure kind"
+        );
+        assert_eq!(row_b["attempts"], 2, "durable row carries both attempts");
+        // K3 补强: both attempts really reached the provider, and the row
+        // keeps the provider error summary for diagnosis.
+        assert_eq!(provider_b.chats(), 2, "both attempts hit the provider");
+        assert!(
+            row_b["error"].as_str().unwrap_or("").contains("503"),
+            "durable row carries the provider error summary, got: {row_b}"
+        );
+    }
+
+    /// evo-goal-verifier GAP-4 (spec Filter): the durable ledger is
+    /// append-only — a resumed goal with changed evidence keeps the old
+    /// rows intact (history preservation across resume).
+    #[tokio::test]
+    async fn goal_verifier_ledger_preserves_history_across_resume() {
+        // root fix ③: a REAL pause → resume round-trip on the SAME goal,
+        // not just changed evidence. The goal record walks active → paused
+        // → active; the durable ledger keeps every prior row; the resumed
+        // goal with UNCHANGED evidence still replays the pre-pause verdict
+        // (no false re-spend), and a post-resume NEW evidence row appends
+        // WITHOUT overwriting history.
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "resume-real");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "real resume".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let temp = tempfile::TempDir::new().expect("temp dir");
+
+        // Pre-pause verdict: DONE with evidence A.
+        let provider = ScriptedVerifierProvider::done();
+        let first = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider,
+                "evidence-A",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(first.is_done() && !first.replayed);
+
+        // ── real PAUSE: same goal id, status → paused via set_goal.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "real resume".into(),
+                status: Some("paused".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("pause the goal");
+        // Root correction ②: `goal_verification_snapshot` (agent_orchestrator
+        // :1837-1852) gates on PROFILE ONLY — a paused goal still yields a
+        // snapshot. Assert the REAL goal state instead: status == "paused"
+        // on the SAME goal id (both helpers re-scope the wire key
+        // internally, like `goal_fleet_id_for_test`).
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("paused"),
+            "the goal is really paused"
+        );
+        assert_eq!(
+            orchestrator.goal_id_for_test(&session_id).as_deref(),
+            Some(snapshot.goal_id.as_str()),
+            "pause keeps the same goal identity"
+        );
+
+        // ── real RESUME: status → active again, SAME goal identity.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "real resume".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("resume the goal");
+        let resumed_snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("resumed goal verifies again");
+        // Resume BUMPS the revision (set_goal mutates the goal record), so
+        // the evidence digest (objective+evidence+revision, :16455) changes:
+        // the contract (spec 218-225) promises only same-goal-id history
+        // retention — NEVER a pre-pause replay. Do not assert one.
+        assert_eq!(
+            resumed_snapshot.goal_id, snapshot.goal_id,
+            "resume keeps the same goal id"
+        );
+        assert_ne!(
+            resumed_snapshot.revision, snapshot.revision,
+            "resume bumps the revision → a new digest, no replay assumption"
+        );
+
+        // Post-resume verification runs FRESH (revision changed → digest
+        // changed → gate Miss) and its row APPENDS; history intact.
+        let provider_new = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "NOT_DONE: missing B",
+                usage: usage_of(2, 1, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let resumed_new = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &resumed_snapshot,
+                provider_new.clone(),
+                "evidence-A",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(
+            resumed_new.kind.map(|k| k.as_str()),
+            Some("insufficient_evidence"),
+            "post-resume call produces a fresh verdict"
+        );
+        assert!(
+            !resumed_new.replayed,
+            "revision bump → new digest → a real provider call, not a replay"
+        );
+        assert_eq!(provider_new.chats(), 1, "the provider was really called");
+
+        // Scope-exact ledger: TWO rows total under the SAME goal id —
+        // append-only across the pause/resume round-trip, old row intact.
+        let rows = read_scope_ledger_rows(&temp, &session_id, "tenant-a", &resumed_snapshot);
+        assert_eq!(rows.len(), 2, "both rows preserved across resume");
+        let row_a: serde_json::Value = serde_json::from_str(&rows[0]).expect("row A");
+        let row_b: serde_json::Value = serde_json::from_str(&rows[1]).expect("row B");
+        assert_eq!(row_a["outcome"], "done", "pre-pause row intact");
+        assert_eq!(row_b["outcome"], "insufficient_evidence");
+        assert_eq!(
+            row_a["goal_id"], row_b["goal_id"],
+            "both rows live under the same goal id (spec 218-225)"
+        );
+        // K3 补强: the original row is not a replay artifact, and the two
+        // rows carry DISTINCT evidence digests (revision bumped on resume).
+        assert_eq!(
+            row_a["replayed"], false,
+            "the pre-pause row is the original verdict, not a replay"
+        );
+        assert_ne!(
+            row_a["evidence_digest"], row_b["evidence_digest"],
+            "the resume revision bump changes the digest"
+        );
+    }
+
+    /// evo-goal-verifier GAP-5 (spec Filter): diagnostics/replay metadata
+    /// never leak into the evidence digest — same objective+evidence across
+    /// two fresh goals digests identically.
+    #[tokio::test]
+    async fn goal_verifier_diagnostics_do_not_mutate_evidence_digest() {
+        // Root correction ①: `verifier_evidence_digest(objective, evidence,
+        // revision)` (:16455) includes NO scope — the scope fingerprint is
+        // a DIFFERENT key (the ledger FILENAME, :16716). The old negative
+        // control (assert_ne! across two scopes) was a WRONG PREMISE: same
+        // (objective, evidence, revision) MUST digest identically across
+        // scopes. The real contract: diagnostics (missing_evidence) ride on
+        // the row but never enter the digest key.
+        //
+        // Two ISOLATED verifier scopes — two fresh orchestrators + two
+        // fresh data dirs (simpler: no replay suppression, revisions align
+        // trivially) — same objective/evidence, DIFFERENT NOT_DONE reasons.
+        let orch_a = InProcessAgentOrchestrator::default();
+        let orch_b = InProcessAgentOrchestrator::default();
+        let temp_a = tempfile::TempDir::new().expect("temp dir a");
+        let temp_b = tempfile::TempDir::new().expect("temp dir b");
+        let session_a = SessionKey::with_profile("tenant-a", "api", "digest-a");
+        let session_b = SessionKey::with_profile("tenant-a", "api", "digest-b");
+        orch_a
+            .set_goal(GoalSetRequest {
+                session_id: session_a.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "digest stability".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set goal a");
+        orch_b
+            .set_goal(GoalSetRequest {
+                session_id: session_b.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "digest stability".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set goal b");
+        let snapshot_a = orch_a
+            .goal_verification_snapshot(&session_a, "tenant-a")
+            .expect("snapshot a");
+        let snapshot_b = orch_b
+            .goal_verification_snapshot(&session_b, "tenant-a")
+            .expect("snapshot b");
+        assert_eq!(
+            snapshot_a.revision, snapshot_b.revision,
+            "fresh goals align revisions — digest inputs identical"
+        );
+        assert_eq!(snapshot_a.objective, snapshot_b.objective);
+
+        let provider_a = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "NOT_DONE: missing alpha",
+                usage: usage_of(2, 1, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let provider_b = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "NOT_DONE: missing beta",
+                usage: usage_of(2, 1, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome_a = orch_a
+            .verify_goal_completion_bounded(
+                &session_a,
+                "tenant-a",
+                &snapshot_a,
+                provider_a,
+                "evidence-fixed",
+                Some(temp_a.path()),
+            )
+            .await;
+        let outcome_b = orch_b
+            .verify_goal_completion_bounded(
+                &session_b,
+                "tenant-a",
+                &snapshot_b,
+                provider_b,
+                "evidence-fixed",
+                Some(temp_b.path()),
+            )
+            .await;
+        assert_eq!(
+            outcome_a.kind.map(|k| k.as_str()),
+            Some("insufficient_evidence")
+        );
+        assert_eq!(
+            outcome_b.kind.map(|k| k.as_str()),
+            Some("insufficient_evidence")
+        );
+
+        // Scope-exact rows from EACH scope's own ledger file.
+        let rows_a = read_scope_ledger_rows(&temp_a, &session_a, "tenant-a", &snapshot_a);
+        let rows_b = read_scope_ledger_rows(&temp_b, &session_b, "tenant-a", &snapshot_b);
+        assert_eq!(rows_a.len(), 1, "one row in scope a's ledger");
+        assert_eq!(rows_b.len(), 1, "one row in scope b's ledger");
+        let row_a: serde_json::Value = serde_json::from_str(&rows_a[0]).expect("row a");
+        let row_b: serde_json::Value = serde_json::from_str(&rows_b[0]).expect("row b");
+
+        // Scopes DIFFER (different sessions + data dirs → different
+        // fingerprints)…
+        assert_ne!(
+            row_a["scope"], row_b["scope"],
+            "two isolated verifier scopes have distinct fingerprints"
+        );
+        // …the diagnostic payloads genuinely DIFFER…
+        assert!(
+            row_a["missing_evidence"]
+                .as_str()
+                .unwrap_or("")
+                .contains("alpha"),
+            "row a keeps its own diagnostic"
+        );
+        assert!(
+            row_b["missing_evidence"]
+                .as_str()
+                .unwrap_or("")
+                .contains("beta"),
+            "row b keeps its own diagnostic"
+        );
+        assert_ne!(
+            row_a["missing_evidence"], row_b["missing_evidence"],
+            "the two NOT_DONE reasons differ"
+        );
+        // …and the evidence digests are EQUAL: the digest keys on
+        // (objective, evidence, revision) only — never on scope, never on
+        // the missing_evidence diagnostic.
+        assert_eq!(
+            row_a["evidence_digest"], row_b["evidence_digest"],
+            "same objective+evidence+revision digests identically across \
+             scopes and across different diagnostics"
+        );
+
+        // In-scope replay proof: an identical call in scope a hits the SAME
+        // digest and replays (attempts 0, zero usage) — the alpha payload
+        // on the stored row did not perturb the key.
+        let provider_replay = ScriptedVerifierProvider::done();
+        let replay = orch_a
+            .verify_goal_completion_bounded(
+                &session_a,
+                "tenant-a",
+                &snapshot_a,
+                provider_replay,
+                "evidence-fixed",
+                Some(temp_a.path()),
+            )
+            .await;
+        assert!(
+            replay.replayed,
+            "identical inputs → identical digest → replay"
+        );
+        assert_eq!(replay.attempts, 0);
+        assert_eq!(replay.usage.input_tokens, 0);
+        let rows_a2 = read_scope_ledger_rows(&temp_a, &session_a, "tenant-a", &snapshot_a);
+        assert_eq!(rows_a2.len(), 1, "a replay appends no row");
     }
 
     /// Budget exhausted by the FIRST attempt's charge must prevent the

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -4817,6 +4817,574 @@ impl InProcessAgentOrchestrator {
         self.charge_goal_tokens_gated(session_id, profile_id, expected_goal_id, tokens, 0, true)
     }
 
+    // ── evo-goal-verifier: bounded verification wrapper (spec v4 Decision 1) ──
+
+    /// The single shared recovery entry for goal-completion verification.
+    ///
+    /// v4 layering: the FREE function
+    /// ([`run_goal_completion_verifier_with_usage`]) performs exactly ONE
+    /// provider call and classifies it; this wrapper owns everything that
+    /// needs orchestrator state — the persistent same-evidence gate, the
+    /// per-attempt charge, the budget gate, the ≤2-attempt retry loop and
+    /// the ledger append. All four call sites (goal_update tool, the two
+    /// ui-protocol sentinels, the session-actor sentinel) route through
+    /// here so the gate/charge/append logic exists exactly once.
+    ///
+    /// Order of operations (gate precedence is deliberate — read failure
+    /// fail-closes BEFORE any cooldown logic, because an unreadable ledger
+    /// cannot be trusted to gate anything):
+    /// 1. compute `evidence_digest` (domain-labelled, length-bounded) and
+    ///    the full `VerifierScope` (data_dir storage identity + cwd-scoped
+    ///    session + profile + goal_id — VG-SCOPE: the persistent path and
+    ///    every record are bound to the whole tuple, so another session /
+    ///    profile can never replay this scope's durable Done);
+    /// 2. read the ledger — IO error / truncated tail / unknown version /
+    ///    foreign scope or goal_id → fail-closed diagnostic (no new chat,
+    ///    no Done, goal stays open);
+    /// 3. no matching (scope, digest) record → proceed; the persistent
+    ///    path also consults the in-process overlay (a previous append
+    ///    failure on this scope+digest replays inside the infra cooldown
+    ///    instead of re-spending against the same bad storage);
+    /// 4. semantic outcomes (done / insufficient_evidence /
+    ///    invalid_response) → replay permanently (idempotent verdicts);
+    /// 5. infra outcomes (call_failed / empty_response) → replay only
+    ///    within the 10-minute cooldown; after it a new call is allowed
+    ///    (a recovered provider must not stay wedged by a stale transient
+    ///    record);
+    /// 6. per-scope in-flight reservation (single-flight) — two concurrent
+    ///    gate misses share one provider call (NOT an append mutex, and no
+    ///    orchestrator state lock is held across the await);
+    /// 7. VG-PREFLIGHT: with a data_dir, prove the ledger is appendable
+    ///    (create dirs, open create+append, sync) BEFORE any provider
+    ///    chat — unusable storage fail-closes with 0 chats / 0 attempts /
+    ///    0 charge, no matter how often it is called;
+    /// 8. attempt 1 → charge its usage immediately → budget gate
+    ///    (`goal.status == active`, snapshot-bound goal_id) → retry once
+    ///    only for retryable CallFailed / EmptyResponse;
+    /// 9. append the outcome; write failure fail-closes (a Done that
+    ///    cannot be persisted is reported as a diagnostic failure, the
+    ///    goal stays open — the attempt's usage is already charged, which
+    ///    is the honest cost of the real call that happened) and is
+    ///    mirrored into the overlay so the SAME bad storage is not
+    ///    re-spent on every call.
+    ///
+    /// A truncated-tail ledger does NOT self-heal: fail-closed here is an
+    /// intentional one-time manual intervention point (repair or remove the
+    /// jsonl). The diagnostic names the path so operators can act on it.
+    pub(crate) async fn verify_goal_completion_bounded(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        snapshot: &GoalVerificationSnapshot,
+        provider: Arc<dyn LlmProvider>,
+        evidence: &str,
+        data_dir: Option<&std::path::Path>,
+    ) -> crate::autonomy::goal_loop_runtime::GoalVerifierOutcome {
+        use crate::autonomy::goal_loop_runtime::{
+            GoalCompletionVerdict, GoalVerifierFailureKind, GoalVerifierOutcome,
+        };
+
+        let digest = verifier_evidence_digest(&snapshot.objective, evidence, snapshot.revision);
+        let scope = self.verifier_scope(data_dir, session_id, profile_id, &snapshot.goal_id);
+
+        // ── single-flight — outer defect ①/④: a REAL per-scope async mutex.
+        // The registry's std map lock is held ONLY for the get-or-insert
+        // clone (never across an await); the returned owned guard IS held
+        // across the whole gate-read → preflight → attempts → append
+        // section. A second caller for the SAME scope parks on
+        // `lock_owned().await`, then re-reads the gate INSIDE the lock — it
+        // sees the first caller's freshly appended record and replays it
+        // instead of issuing a second provider chat. Different scopes
+        // (session / profile / goal_id / data_dir) never wait on each
+        // other. No raw pointers, no no-op RAII counter guard.
+        let _scope_guard = verifier_scope_guard(&scope.fingerprint).await;
+
+        // Read gate INSIDE the async lock (outer defect ④: the old code
+        // read the gate before reserving, so two concurrent callers could
+        // both see Miss and both chat).
+        match self.verifier_gate_lookup(data_dir, &scope, &digest).await {
+            VerifierGateLookup::FailClosed(diagnostic) => {
+                return GoalVerifierOutcome {
+                    verdict: GoalCompletionVerdict::NotDone {
+                        reason: diagnostic.clone(),
+                    },
+                    kind: Some(GoalVerifierFailureKind::CallFailed),
+                    attempts: 0,
+                    missing_evidence: None,
+                    replayed: false,
+                    replayed_of_ts_ms: None,
+                    diagnostic: Some(diagnostic),
+                    usage: octos_llm::TokenUsage::default(),
+                };
+            }
+            VerifierGateLookup::Replay(record) => {
+                // Replay: no new call, no charge, usage=0/attempts=0, the
+                // historical source ts is surfaced for the caller.
+                return GoalVerifierOutcome {
+                    verdict: record.verdict,
+                    kind: record.kind,
+                    attempts: 0,
+                    missing_evidence: record.missing_evidence,
+                    replayed: true,
+                    replayed_of_ts_ms: Some(record.ts_ms),
+                    diagnostic: None,
+                    usage: octos_llm::TokenUsage::default(),
+                };
+            }
+            VerifierGateLookup::Miss => {}
+        }
+
+        // ── VG-PREFLIGHT: with a data_dir, prove the ledger is appendable
+        // BEFORE any provider chat (still inside the single-flight guard).
+        // Unusable storage fail-closes here with zero spend — previously
+        // the IO checks only ran at append time, AFTER the chat, so a
+        // read-only ledger dir was paid one provider call per invocation
+        // forever.
+        if let Some(data_dir) = data_dir {
+            let ledger_path = verifier_ledger_path(data_dir, &scope.fingerprint);
+            if let Err(diagnostic) = verifier_ledger_preflight(data_dir, &ledger_path).await {
+                return GoalVerifierOutcome {
+                    verdict: GoalCompletionVerdict::NotDone {
+                        reason: diagnostic.clone(),
+                    },
+                    kind: Some(GoalVerifierFailureKind::CallFailed),
+                    attempts: 0,
+                    missing_evidence: None,
+                    replayed: false,
+                    replayed_of_ts_ms: None,
+                    diagnostic: Some(diagnostic),
+                    usage: octos_llm::TokenUsage::default(),
+                };
+            }
+        }
+
+        // ── bounded loop: at most TWO single calls. Retry only for
+        // retryable CallFailed or EmptyResponse, and only while the goal is
+        // still active after the previous per-attempt charge.
+        let mut attempts: u32 = 0;
+        let mut usage = octos_llm::TokenUsage::default();
+        let (verdict, outcome_kind, missing_evidence, call_error);
+        loop {
+            attempts += 1;
+            let call = run_goal_completion_verifier_with_usage(
+                provider.clone(),
+                &snapshot.objective,
+                evidence,
+            )
+            .await;
+            // Per-attempt charge BEFORE the budget decision (spec v4):
+            // the attempt's tokens are real spend the moment it returns.
+            let _ = self.charge_goal_verifier_usage(
+                session_id,
+                profile_id,
+                Some(&snapshot.goal_id),
+                &call.usage,
+            );
+            usage = sum_token_usage(&usage, &call.usage);
+            let retry = matches!(
+                call.kind,
+                Some(GoalVerifierFailureKind::CallFailed)
+                    | Some(GoalVerifierFailureKind::EmptyResponse)
+            ) && (call.kind != Some(GoalVerifierFailureKind::CallFailed)
+                || call.call_error_retryable)
+                && attempts < 2
+                && self.goal_status_is_active(session_id, profile_id, snapshot);
+            if retry {
+                continue;
+            }
+            verdict = call.verdict;
+            outcome_kind = call.kind;
+            missing_evidence = call.missing_evidence;
+            call_error = call.call_error;
+            break;
+        }
+
+        // ── append the outcome (fail-closed on write error).
+        let ts_ms = current_epoch_ms();
+        if let Err(diagnostic) = self
+            .verifier_ledger_append(
+                data_dir,
+                &scope,
+                VerifierLedgerRecord {
+                    version: VERIFIER_LEDGER_VERSION,
+                    scope: scope.fingerprint.clone(),
+                    goal_id: snapshot.goal_id.clone(),
+                    ts_ms,
+                    outcome: match (&verdict, outcome_kind) {
+                        (GoalCompletionVerdict::Done, _) => {
+                            crate::autonomy::goal_loop_runtime::GOAL_VERIFIER_OUTCOME_DONE
+                                .to_owned()
+                        }
+                        (_, Some(kind)) => kind.as_str().to_owned(),
+                        (_, None) => "invalid_response".to_owned(),
+                    },
+                    attempts,
+                    usage: usage.clone(),
+                    missing_evidence: missing_evidence.clone(),
+                    error: call_error.clone(),
+                    evidence_digest: digest.clone(),
+                    replayed: false,
+                },
+                CachedVerdict {
+                    verdict: verdict.clone(),
+                    kind: outcome_kind,
+                    missing_evidence: missing_evidence.clone(),
+                    ts_ms,
+                },
+            )
+            .await
+        {
+            // Composite outcome (k3 round-3 suggestion B): a Done verdict
+            // that could not be persisted is NOT reported as success — the
+            // gate would then replay a Done the ledger never stored. The
+            // failure is mirrored into the in-process overlay (infra class,
+            // 10-minute cooldown) so the SAME bad storage is not paid a
+            // fresh provider call on every invocation (VG-PREFLIGHT covers
+            // the common open-failure case before any chat; this covers
+            // write/flush/sync failures the preflight cannot detect).
+            if data_dir.is_some() {
+                verifier_memory_cache_insert(
+                    &scope.fingerprint,
+                    &digest,
+                    CachedVerdict {
+                        verdict: GoalCompletionVerdict::NotDone {
+                            reason: diagnostic.clone(),
+                        },
+                        kind: Some(GoalVerifierFailureKind::CallFailed),
+                        missing_evidence: None,
+                        ts_ms,
+                    },
+                );
+            }
+            tracing::error!(goal_id = %snapshot.goal_id, %diagnostic, "verifier ledger write failed (fail-closed)");
+            return GoalVerifierOutcome {
+                verdict: GoalCompletionVerdict::NotDone {
+                    reason: diagnostic.clone(),
+                },
+                kind: Some(GoalVerifierFailureKind::CallFailed),
+                attempts,
+                missing_evidence,
+                replayed: false,
+                replayed_of_ts_ms: None,
+                diagnostic: Some(diagnostic),
+                usage,
+            };
+        }
+
+        GoalVerifierOutcome {
+            verdict,
+            kind: outcome_kind,
+            attempts,
+            missing_evidence,
+            replayed: false,
+            replayed_of_ts_ms: None,
+            diagnostic: None,
+            usage,
+        }
+    }
+
+    /// The full real scope of one verification (VG-SCOPE): data_dir storage
+    /// identity + cwd-scoped session + profile + goal_id, fingerprinted
+    /// once. Used for the ledger path, the record's `scope` field, the
+    /// single-flight registry key and the memory-cache key.
+    fn verifier_scope(
+        &self,
+        data_dir: Option<&std::path::Path>,
+        session_id: &SessionKey,
+        profile_id: &str,
+        goal_id: &str,
+    ) -> VerifierScope {
+        let storage_identity = data_dir
+            .map(verifier_storage_identity)
+            .unwrap_or_else(|| "<memory>".to_owned());
+        let session_scope = self.scoped_goal_key(session_id).0;
+        let fingerprint =
+            verifier_scope_fingerprint(&storage_identity, &session_scope, profile_id, goal_id);
+        VerifierScope {
+            goal_id: goal_id.to_owned(),
+            fingerprint,
+        }
+    }
+
+    /// Retry gate for the verifier's second attempt (spec v4 Decision 3,
+    /// status-based): `true` only when the goal bound to the snapshot is
+    /// still `active`. The charge return value is deliberately NOT consulted
+    /// — it has five `None` branches that do not mean "not exhausted".
+    /// The goal must STILL be the exact incarnation the verifier snapshotted.
+    /// Three outer-review fixes over the original body:
+    /// 1. The lookup must go through `scoped_goal_key` — the goal store is
+    ///    keyed by the cwd-scoped key (#1666), so a scoped session's goal is
+    ///    INVISIBLE under its bare wire id (the old bare `get(session_id)`
+    ///    always returned false for scoped sessions... when the wire key
+    ///    itself held a DIFFERENT goal it could even gate on the wrong goal).
+    /// 2. Identity is the full snapshot (goal_id + objective + revision), not
+    ///    merely (id, status): a second chat is only safe when the goal the
+    ///    user sees is still the goal the first attempt judged.
+    fn goal_status_is_active(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        snapshot: &GoalVerificationSnapshot,
+    ) -> bool {
+        let key = self.scoped_goal_key(session_id);
+        let state = self.state();
+        state
+            .goals
+            .get(&key)
+            .map(|g| {
+                g.goal_id == snapshot.goal_id
+                    && g.objective == snapshot.objective
+                    && g.revision == snapshot.revision
+                    && g.profile_id == profile_id
+                    && g.status == "active"
+            })
+            .unwrap_or(false)
+    }
+
+    /// Read-side gate: look up the last record for (scope, digest) — must
+    /// be called while holding the scope's single-flight guard, so a
+    /// concurrent same-scope caller re-reads AFTER the first one's append.
+    async fn verifier_gate_lookup(
+        &self,
+        data_dir: Option<&std::path::Path>,
+        scope: &VerifierScope,
+        digest: &str,
+    ) -> VerifierGateLookup {
+        let Some(data_dir) = data_dir else {
+            // No data_dir — legacy ephemeral session: a REAL in-memory
+            // cache keyed by (full scope fingerprint, digest) (outer
+            // defect ②). The second call with identical evidence replays
+            // attempts=0/usage=0 instead of re-chattering. Explicitly NOT
+            // restart-durable — annotated as such, never claimed
+            // persistent. Same infra cooldown semantics as the JSONL path
+            // (outer fix ②).
+            return verifier_memory_cache_lookup(&scope.fingerprint, digest);
+        };
+        let path = verifier_ledger_path(data_dir, &scope.fingerprint);
+        let bytes = match tokio::fs::read(&path).await {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return VerifierGateLookup::Miss;
+            }
+            Err(err) => {
+                return VerifierGateLookup::FailClosed(format!(
+                    "verifier ledger unreadable ({}): {err} — refusing to verify without the gate; repair or remove the file",
+                    path.display()
+                ));
+            }
+        };
+        // Parse strictly (outer defect ③ + VG-SCOPE): an unparseable tail
+        // line, an unknown `version`, a record whose `scope` fingerprint or
+        // `goal_id` does not belong in this file, or an unknown `outcome`
+        // string is a fail-closed condition (never fall back to an old
+        // Done; never accept a foreign scope's/goal's Done; never map
+        // unknown outcomes onto InsufficientEvidence).
+        let mut last_for_digest: Option<VerifierLedgerRecord> = None;
+        for (idx, line) in bytes.split(|b| *b == b'\n').enumerate() {
+            if line.is_empty() {
+                continue;
+            }
+            let value: serde_json::Value = match serde_json::from_slice(line) {
+                Ok(value) => value,
+                Err(err) => {
+                    return VerifierGateLookup::FailClosed(format!(
+                        "verifier ledger line {} corrupt ({}): {err} — refusing to verify without the gate; repair or remove the file",
+                        idx + 1,
+                        path.display()
+                    ));
+                }
+            };
+            let version = value.get("version").and_then(|v| v.as_u64());
+            if version != Some(u64::from(VERIFIER_LEDGER_VERSION)) {
+                return VerifierGateLookup::FailClosed(format!(
+                    "verifier ledger line {} has unknown version {version:?} (expected {VERIFIER_LEDGER_VERSION}, {}): refusing to verify without the gate; repair or remove the file",
+                    idx + 1,
+                    path.display()
+                ));
+            }
+            let record: VerifierLedgerRecord = match serde_json::from_value(value) {
+                Ok(record) => record,
+                Err(err) => {
+                    return VerifierGateLookup::FailClosed(format!(
+                        "verifier ledger line {} invalid ({}): {err} — refusing to verify without the gate; repair or remove the file",
+                        idx + 1,
+                        path.display()
+                    ));
+                }
+            };
+            if record.scope != scope.fingerprint {
+                // Every line in `<scope-fingerprint>.jsonl` must belong to
+                // that exact scope (data_dir identity + cwd-scoped session
+                // + profile + goal_id). A foreign scope means the file was
+                // merged, moved, hard-linked or tampered with — fail closed
+                // rather than accept another session's/profile's Done.
+                return VerifierGateLookup::FailClosed(format!(
+                    "verifier ledger line {} carries a scope foreign to this ledger ({}): refusing to verify; repair or remove the file",
+                    idx + 1,
+                    path.display()
+                ));
+            }
+            if record.goal_id != scope.goal_id {
+                // Belt-and-braces under the scope check: the goal_id text
+                // must also match. A foreign goal_id means the file was
+                // merged, moved or tampered with — fail closed rather than
+                // accept another goal's Done.
+                return VerifierGateLookup::FailClosed(format!(
+                    "verifier ledger line {} carries goal_id {:?} foreign to this ledger ({}, {}): refusing to verify; repair or remove the file",
+                    idx + 1,
+                    record.goal_id,
+                    scope.goal_id,
+                    path.display()
+                ));
+            }
+            if !matches!(
+                record.outcome.as_str(),
+                "done"
+                    | "call_failed"
+                    | "empty_response"
+                    | "invalid_response"
+                    | "insufficient_evidence"
+            ) {
+                return VerifierGateLookup::FailClosed(format!(
+                    "verifier ledger line {} has unknown outcome {:?} ({}): refusing to verify without the gate; repair or remove the file",
+                    idx + 1,
+                    record.outcome,
+                    path.display()
+                ));
+            }
+            if record.evidence_digest != digest {
+                continue;
+            }
+            // Infra outcomes replay only within the cooldown window;
+            // semantic outcomes replay permanently.
+            if record.outcome == "call_failed" || record.outcome == "empty_response" {
+                let age_ms = current_epoch_ms().saturating_sub(record.ts_ms);
+                if age_ms > VERIFIER_INFRA_COOLDOWN_MS {
+                    continue;
+                }
+            }
+            last_for_digest = Some(record);
+        }
+        match last_for_digest {
+            None => {
+                // No replayable ledger record: consult the in-process
+                // overlay — a previous append FAILURE on this scope+digest
+                // is remembered there (infra class, 10-minute cooldown) so
+                // storage that cannot persist is not paid a fresh provider
+                // call on every invocation.
+                verifier_memory_cache_lookup(&scope.fingerprint, digest)
+            }
+            Some(record) => {
+                let kind = match record.outcome.as_str() {
+                    crate::autonomy::goal_loop_runtime::GOAL_VERIFIER_OUTCOME_DONE => None,
+                    "call_failed" => Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::CallFailed),
+                    "empty_response" => Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::EmptyResponse),
+                    "invalid_response" => Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::InvalidResponse),
+                    // The outcome string was validated against the five
+                    // known values above, so this arm is exactly
+                    // "insufficient_evidence" — never a silent fallback for
+                    // unknown outcomes (outer defect ③).
+                    _ => Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::InsufficientEvidence),
+                };
+                let verdict = if kind.is_none() {
+                    GoalCompletionVerdict::Done
+                } else {
+                    GoalCompletionVerdict::NotDone {
+                        reason: record
+                            .missing_evidence
+                            .clone()
+                            .or_else(|| record.error.clone())
+                            .unwrap_or_else(|| record.outcome.clone()),
+                    }
+                };
+                VerifierGateLookup::Replay(ReplayedVerdict {
+                    verdict,
+                    kind,
+                    missing_evidence: record.missing_evidence,
+                    ts_ms: record.ts_ms,
+                })
+            }
+        }
+    }
+
+    /// Append one record to the per-scope verifier ledger JSONL (fail-closed
+    /// on any IO error — the caller surfaces the diagnostic and keeps the
+    /// goal open).
+    async fn verifier_ledger_append(
+        &self,
+        data_dir: Option<&std::path::Path>,
+        scope: &VerifierScope,
+        record: VerifierLedgerRecord,
+        cached: CachedVerdict,
+    ) -> Result<(), String> {
+        let Some(data_dir) = data_dir else {
+            // No data_dir — legacy ephemeral session: remember the verdict
+            // in the REAL in-memory cache (outer defect ②) keyed by
+            // (full scope fingerprint, digest). Non-durable by construction
+            // (process-local); never claimed persistent.
+            verifier_memory_cache_insert(&scope.fingerprint, &record.evidence_digest, cached);
+            return Ok(());
+        };
+        let path = verifier_ledger_path(data_dir, &scope.fingerprint);
+        // Append-time IO recheck (brief ⑤). The wrapper already ran
+        // `verifier_ledger_preflight` BEFORE any provider chat; this is the
+        // same check re-run at append time so a data_dir that broke between
+        // preflight and append is still fail-closed. Creation/recording
+        // failure is fail-closed (the caller turns the Err into a NotDone
+        // diagnostic, preserving usage, never reporting Done).
+        if let Err(err) = tokio::fs::create_dir_all(data_dir).await {
+            return Err(format!(
+                "verifier data dir create failed ({}): {err}",
+                data_dir.display()
+            ));
+        }
+        let dir_meta = tokio::fs::metadata(data_dir).await.map_err(|err| {
+            format!(
+                "verifier data dir unreadable ({}): {err}",
+                data_dir.display()
+            )
+        })?;
+        if !dir_meta.is_dir() {
+            return Err(format!(
+                "verifier data dir is not a directory ({})",
+                data_dir.display()
+            ));
+        }
+        if let Some(parent) = path.parent() {
+            if let Err(err) = tokio::fs::create_dir_all(parent).await {
+                return Err(format!(
+                    "verifier ledger dir create failed ({}): {err}",
+                    parent.display()
+                ));
+            }
+        }
+        let mut line = serde_json::to_vec(&record)
+            .map_err(|err| format!("verifier ledger serialize failed: {err}"))?;
+        line.push(b'\n');
+        use tokio::io::AsyncWriteExt;
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await
+            .map_err(|err| format!("verifier ledger open failed ({}): {err}", path.display()))?;
+        file.write_all(&line)
+            .await
+            .map_err(|err| format!("verifier ledger write failed ({}): {err}", path.display()))?;
+        // Durable completion point (brief ⑤): the append is not 'recorded'
+        // until the bytes are flushed AND synced to the storage device. A
+        // crash between write_all and sync could otherwise lose a Done
+        // verdict while the caller already reported it. Sync failure is
+        // fail-closed like every other IO failure here.
+        file.flush()
+            .await
+            .map_err(|err| format!("verifier ledger flush failed ({}): {err}", path.display()))?;
+        file.sync_all()
+            .await
+            .map_err(|err| format!("verifier ledger sync failed ({}): {err}", path.display()))?;
+        Ok(())
+    }
+
     /// #979 / M15-C2 — after a goal-driven turn finishes, re-queue
     /// another continuation only if the runtime is idle AND the
     /// per-goal policy still allows another fire. This is the
@@ -15712,11 +16280,38 @@ fn detect_goal_complete_sentinel(content: &str) -> bool {
 /// `charge_goal_verifier_usage`; since codex round 5 nothing rides
 /// `ToolResult.tokens_used` for this call. On a provider error the usage
 /// is zero.
+/// Result of ONE verifier provider call — the single-attempt seam.
+///
+/// v4 layering: this free function performs EXACTLY ONE `provider.chat`
+/// and returns its structured classification. The bounded retry loop,
+/// per-attempt charge and budget gate live in the orchestrator wrapper
+/// (`InProcessAgentOrchestrator::verify_goal_completion_bounded`) — the
+/// free function has no orchestrator state, so it structurally cannot
+/// charge or gate (and nesting another loop here would double the
+/// wrapper's attempts to 4).
+pub(crate) struct SingleVerifierCall {
+    pub verdict: GoalCompletionVerdict,
+    pub kind: Option<crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind>,
+    pub missing_evidence: Option<String>,
+    /// `true` only for CallFailed whose underlying error is retryable
+    /// (`LlmError::is_retryable` — rate limit, server error, network,
+    /// timeout, stream error). Authentication/quota/invalid-request
+    /// failures are NOT retryable and must not trigger the second call.
+    pub call_error_retryable: bool,
+    /// Truncated provider error text (CallFailed only), for the ledger and
+    /// call-site rendering. The original error is preserved, never dropped.
+    pub call_error: Option<String>,
+    pub usage: octos_llm::TokenUsage,
+}
+
+/// Max chars of a provider error kept in the structured result / ledger.
+pub(crate) const VERIFIER_CALL_ERROR_CHARS: usize = 400;
+
 pub(crate) async fn run_goal_completion_verifier_with_usage(
     provider: Arc<dyn LlmProvider>,
     objective: &str,
     evidence: &str,
-) -> (GoalCompletionVerdict, octos_llm::TokenUsage) {
+) -> SingleVerifierCall {
     let prompt = format!(
         "You are an INDEPENDENT completion verifier. Do not assume the work is \
 done just because the agent said so.\n\nGOAL OBJECTIVE:\n{objective}\n\nThe \
@@ -15750,57 +16345,438 @@ objective is fully met, or `NOT_DONE: <short reason>` otherwise."
         prompt_cache_context: None,
     };
     let messages = vec![octos_core::Message::user(prompt)];
-    let (verdict_text, usage) = match provider.chat(&messages, &[], &config).await {
-        Ok(response) => (response.content.unwrap_or_default(), response.usage),
+    match provider.chat(&messages, &[], &config).await {
+        Ok(response) => {
+            let reasoning_present = response
+                .reasoning_content
+                .as_deref()
+                .is_some_and(|r| !r.trim().is_empty());
+            let parsed = crate::autonomy::goal_loop_runtime::classify_verifier_reply(
+                response.content.as_deref(),
+                reasoning_present,
+            );
+            if matches!(
+                parsed.kind,
+                Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::EmptyResponse)
+            ) {
+                tracing::warn!(
+                    provider = %provider.provider_name(),
+                    model = %provider.model_id(),
+                    usage_in = response.usage.input_tokens,
+                    usage_out = response.usage.output_tokens,
+                    stop_reason = ?response.stop_reason,
+                    "goal completion verifier returned EMPTY content (Ok but no text)"
+                );
+            }
+            SingleVerifierCall {
+                verdict: parsed.verdict,
+                kind: parsed.kind,
+                missing_evidence: parsed.missing_evidence,
+                call_error_retryable: false,
+                call_error: None,
+                usage: response.usage,
+            }
+        }
         Err(error) => {
-            // #24 — log the failing provider + error so an empty verdict can be
-            // attributed to a layer (call failure vs empty content) instead of
-            // surfacing as a bare "verifier returned: " with no reason.
+            // #24 — attribute the failing provider + error so an empty verdict
+            // can be traced to a layer. Preserve the error (truncated) and its
+            // retryability instead of dropping it: the wrapper needs
+            // `is_retryable` to decide the ONE bounded retry, and the ledger
+            // needs the error text.
             tracing::warn!(
                 provider = %provider.provider_name(),
                 model = %provider.model_id(),
                 error = %error,
                 "goal completion verifier call failed"
             );
-            return (
-                GoalCompletionVerdict::NotDone {
-                    reason: format!("verifier call failed: {error}"),
+            // `chat` returns `eyre::Result`; the typed `LlmError` (when
+            // present) carries the retryability policy. Non-typed errors
+            // default to non-retryable (conservative — no second call).
+            let retryable = error
+                .chain()
+                .filter_map(|cause| cause.downcast_ref::<octos_llm::LlmError>())
+                .next()
+                .is_some_and(|llm| llm.is_retryable());
+            let text = error.to_string();
+            SingleVerifierCall {
+                verdict: GoalCompletionVerdict::NotDone {
+                    reason: format!("verifier call failed: {text}"),
                 },
-                octos_llm::TokenUsage::default(),
-            );
+                kind: Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::CallFailed),
+                missing_evidence: None,
+                call_error_retryable: retryable,
+                call_error: Some(text.chars().take(VERIFIER_CALL_ERROR_CHARS).collect()),
+                usage: octos_llm::TokenUsage::default(),
+            }
         }
-    };
-    // "Done" only on an explicit affirmative that is NOT negated. Checking the
-    // trimmed first token keeps `NOT_DONE` from matching the `DONE` substring.
-    // Strip backticks first: the prompt says "`DONE`" (with backticks), so a
-    // literally-compliant model returns `DONE` → we must accept that.
-    let trimmed = verdict_text.trim().trim_matches('`');
-    // #24 — log the raw verdict so an EMPTY reason (the #23 symptom) is
-    // attributable: a healthy model returns non-empty text; an empty trimmed
-    // verdict here means the provider returned Ok with empty/whitespace
-    // content, which is a different layer than a call error.
-    if trimmed.is_empty() {
-        tracing::warn!(
-            provider = %provider.provider_name(),
-            model = %provider.model_id(),
-            usage_in = usage.input_tokens,
-            usage_out = usage.output_tokens,
-            "goal completion verifier returned EMPTY content (Ok but no text)"
-        );
     }
-    let first_token = trimmed
-        .split(|c: char| c.is_whitespace() || c == ':')
-        .next()
-        .unwrap_or("")
-        .to_ascii_uppercase();
-    let verdict = if first_token == "DONE" {
-        GoalCompletionVerdict::Done
-    } else {
-        GoalCompletionVerdict::NotDone {
-            reason: trimmed.chars().take(200).collect(),
+}
+
+/// Per-field saturating sum of two token usages (spec Decision 4).
+/// `semantic_checkpoint` is NOT summed — it is
+/// `Option<SemanticCheckpointReport>` (a report, not a counter); the later
+/// writer's value wins.
+pub(crate) fn sum_token_usage(
+    a: &octos_llm::TokenUsage,
+    b: &octos_llm::TokenUsage,
+) -> octos_llm::TokenUsage {
+    octos_llm::TokenUsage {
+        input_tokens: a.input_tokens.saturating_add(b.input_tokens),
+        output_tokens: a.output_tokens.saturating_add(b.output_tokens),
+        reasoning_tokens: a.reasoning_tokens.saturating_add(b.reasoning_tokens),
+        cache_read_tokens: a.cache_read_tokens.saturating_add(b.cache_read_tokens),
+        cache_write_tokens: a.cache_write_tokens.saturating_add(b.cache_write_tokens),
+        semantic_checkpoint: b.semantic_checkpoint.clone(),
+    }
+}
+
+// ── evo-goal-verifier: ledger, digest, gate types (spec v4 Decision 5) ──
+
+/// Cooldown for replaying infra-class (call_failed / empty_response)
+/// verdicts on the SAME evidence: within the window the gate replays the
+/// stale transient verdict; after it a fresh call is allowed so a recovered
+/// provider cannot stay wedged. Semantic outcomes (done /
+/// insufficient_evidence / invalid_response) replay permanently.
+pub(crate) const VERIFIER_INFRA_COOLDOWN_MS: u64 = 10 * 60 * 1000;
+
+/// Domain separation label for the evidence digest (spec v4: labelled and
+/// length-bounded, never a bare concatenation).
+const VERIFIER_DIGEST_DOMAIN: &str = "octos-goal-verifier-evidence-v1";
+
+/// Stable SHA-256 fingerprint of (objective, evidence, revision). The
+/// revision disambiguates `set_goal`'s same-id replace (#1935 ABA): two
+/// incarnations of one goal_id with identical objective text hash
+/// differently. Length-prefixing the fields prevents `"ab"+"c"` vs
+/// `"a"+"bc"` concatenation ambiguity.
+pub(crate) fn verifier_evidence_digest(objective: &str, evidence: &str, revision: u64) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(VERIFIER_DIGEST_DOMAIN.as_bytes());
+    hasher.update(format!("\0obj:{}\0", objective.len()).as_bytes());
+    hasher.update(objective.as_bytes());
+    hasher.update(format!("\0ev:{}\0", evidence.len()).as_bytes());
+    hasher.update(evidence.as_bytes());
+    hasher.update(format!("\0rev:{revision}\0").as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// One line of the per-scope verifier ledger
+/// (`<data_dir>/goal-verifier-ledgers/<scope-fingerprint>.jsonl`).
+/// Append-only; `outcome` is five-valued (done / call_failed /
+/// empty_response / invalid_response / insufficient_evidence) so a Done
+/// verdict IS representable (replay after restart needs it).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct VerifierLedgerRecord {
+    /// Ledger schema version. The reader fail-closes on any line whose
+    /// version is not exactly this value (outer defect ③): an unknown
+    /// future format must not be silently interpreted with today's rules,
+    /// and a missing version (pre-versioning line) must not fall back to
+    /// an old Done.
+    pub version: u32,
+    /// Full-scope fingerprint (VG-SCOPE): sha256 over the domain label and
+    /// the length-prefixed (data_dir storage identity, cwd-scoped session,
+    /// profile, goal_id) tuple — the same fingerprint that names the ledger
+    /// file. The reader fail-closes when it does not match the expected
+    /// scope: a record carried across sessions / profiles / storage roots is
+    /// foreign even when its goal_id text matches (no sanitize / separator /
+    /// path-alias misrecognition, because the identity is a hash of the
+    /// length-prefixed fields, not a concatenation). No `serde(default)`:
+    /// a pre-scope (v2) line fails deserialization and fail-closes.
+    pub scope: String,
+    pub goal_id: String,
+    pub ts_ms: u64,
+    pub outcome: String,
+    pub attempts: u32,
+    /// Audit mirror of the summed usage; the AUTHORITATIVE counter is the
+    /// goals row's tokens_used (charged per attempt). Do not aggregate
+    /// this field for accounting.
+    pub usage: octos_llm::TokenUsage,
+    #[serde(default)]
+    pub missing_evidence: Option<String>,
+    /// Truncated provider error (call_failed only).
+    #[serde(default)]
+    pub error: Option<String>,
+    pub evidence_digest: String,
+    #[serde(default)]
+    pub replayed: bool,
+}
+
+/// Result of the gate's ledger lookup.
+pub(crate) enum VerifierGateLookup {
+    /// No replayable record — proceed with a live call.
+    Miss,
+    /// A replayable verdict exists (within cooldown for infra classes).
+    Replay(ReplayedVerdict),
+    /// The ledger is unreadable/corrupt/unknown-version — fail closed.
+    FailClosed(String),
+}
+
+pub(crate) struct ReplayedVerdict {
+    verdict: GoalCompletionVerdict,
+    kind: Option<crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind>,
+    missing_evidence: Option<String>,
+    ts_ms: u64,
+}
+
+/// Verifier ledger schema version (outer defect ③ / VG-SCOPE). Lines
+/// without this field (v1) or with an older/newer version are fail-closed
+/// on read — the gate must not interpret a record whose format it cannot
+/// verify. v3 adds the mandatory `scope` fingerprint; v2 records (no
+/// scope) fail the version check and are never replayed.
+pub(crate) const VERIFIER_LEDGER_VERSION: u32 = 3;
+
+/// Domain separation label for the scope fingerprint (VG-SCOPE): the
+/// persistent ledger path AND the record's `scope` field are this hash, so
+/// a Done minted by one (data_dir, session, profile, goal) scope can never
+/// be mistaken for another scope's — regardless of sanitize collisions,
+/// separator injection or path aliasing.
+const VERIFIER_SCOPE_DOMAIN: &str = "octos-goal-verifier-scope-v1";
+
+/// The full real scope of one verification (VG-SCOPE): the data_dir
+/// storage identity, the cwd-scoped session key, the profile and the
+/// goal_id — every isolation axis the brief requires. Two verifications
+/// share a ledger file / single-flight mutex / memory-cache entry only
+/// when ALL four match; everything else is isolated by construction. The
+/// components are folded into `fingerprint` at construction (the data_dir
+/// identity is canonicalized — symlink aliases like /var ↔ /private/var
+/// resolve, and the identity is stable across the preflight creating a
+/// missing directory; the session identity is `scoped_goal_key`, so the
+/// same wire session under two cwd scopes is two scopes).
+struct VerifierScope {
+    goal_id: String,
+    /// sha256 hex over VERIFIER_SCOPE_DOMAIN + the length-prefixed
+    /// (storage identity, session scope, profile, goal_id) tuple. Used as
+    /// the ledger filename, the record's `scope` value, the single-flight
+    /// registry key and the memory-cache key.
+    fingerprint: String,
+}
+
+/// Length-prefixed, domain-labelled fingerprint of the full scope tuple.
+/// Same discipline as `verifier_evidence_digest`: hashing length-prefixed
+/// fields makes `"ab"+"c"` vs `"a"+"bc"` collisions impossible.
+fn verifier_scope_fingerprint(
+    storage_identity: &str,
+    session_scope: &str,
+    profile_id: &str,
+    goal_id: &str,
+) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(VERIFIER_SCOPE_DOMAIN.as_bytes());
+    for field in [storage_identity, session_scope, profile_id, goal_id] {
+        hasher.update(format!("\0f:{}\0", field.len()).as_bytes());
+        hasher.update(field.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Stable storage identity for a data_dir: canonicalize the deepest
+/// existing ancestor and re-append the missing tail, so the identity (a)
+/// resolves path aliases (symlinks) and (b) does not change when the
+/// preflight later creates a not-yet-existing directory. Falls back to the
+/// lossy path text when nothing canonicalizes (e.g. a relative path whose
+/// anchor is unreadable) — fail-safe: two texts that differ simply never
+/// share a ledger.
+fn verifier_storage_identity(data_dir: &std::path::Path) -> String {
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut cursor = data_dir.to_path_buf();
+    loop {
+        match cursor.canonicalize() {
+            Ok(mut canon) => {
+                for part in tail.iter().rev() {
+                    canon.push(part);
+                }
+                return canon.to_string_lossy().into_owned();
+            }
+            Err(_) => {
+                let Some(file_name) = cursor.file_name().map(|n| n.to_os_string()) else {
+                    return data_dir.to_string_lossy().into_owned();
+                };
+                tail.push(file_name);
+                if !cursor.pop() {
+                    return data_dir.to_string_lossy().into_owned();
+                }
+            }
         }
+    }
+}
+
+/// REAL per-scope single-flight (outer defect ①): a process-wide registry
+/// of async mutexes. The std map lock is held ONLY for the get-or-insert
+/// clone (never across an await); the returned OWNED guard is held across
+/// the whole gate-read → attempts → append section. A second concurrent
+/// caller for the same scope parks on `lock_owned().await`, then re-reads
+/// the gate INSIDE the lock and replays the first caller's fresh record
+/// instead of issuing a second provider chat. No raw pointers, no no-op
+/// RAII counter guard. Registry entries are never removed while held;
+/// idle entries are cheap (an unlocked `Arc<Mutex<()>>`) and bounded by
+/// the number of distinct scopes ever verified in-process.
+async fn verifier_scope_guard(scope: &str) -> tokio::sync::OwnedMutexGuard<()> {
+    let mutex = {
+        static REGISTRY: OnceLock<StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> =
+            OnceLock::new();
+        let registry = REGISTRY.get_or_init(|| StdMutex::new(HashMap::new()));
+        let mut map = registry.lock().expect("verifier scope registry poisoned");
+        map.entry(scope.to_owned())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     };
-    (verdict, usage)
+    mutex.lock_owned().await
+}
+
+/// In-memory verdict cache for no-data_dir (legacy ephemeral) sessions —
+/// outer defect ②. Scope → digest → verdict, so different sessions /
+/// profiles / goals never share entries. Process-local by construction:
+/// NOT restart-durable, and never reported as persistent.
+fn verifier_memory_cache() -> &'static StdMutex<HashMap<String, HashMap<String, CachedVerdict>>> {
+    static CACHE: OnceLock<StdMutex<HashMap<String, HashMap<String, CachedVerdict>>>> =
+        OnceLock::new();
+    CACHE.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+#[derive(Debug, Clone)]
+struct CachedVerdict {
+    verdict: GoalCompletionVerdict,
+    kind: Option<crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind>,
+    missing_evidence: Option<String>,
+    /// Wall-clock ms of the ORIGINAL verdict (the attempt's finish time for a
+    /// live call; the source ts carried over on replay). Drives the infra
+    /// cooldown on the memory-cache path (outer fix ②). Not part of the
+    /// identity — poisoning it with `u64::MAX` must never change a verdict,
+    /// only its replayability.
+    ts_ms: u64,
+}
+
+/// Shared memory-cache read (VG-SCOPE scope key = the full-scope
+/// fingerprint): primary store for data_dir=None sessions, and the
+/// append-failure overlay for the persistent path (a scope whose last
+/// append failed must not re-spend against the same bad storage inside the
+/// infra cooldown). Infra kinds replay only inside
+/// VERIFIER_INFRA_COOLDOWN_MS; semantic verdicts replay permanently.
+fn verifier_memory_cache_lookup(scope_key: &str, digest: &str) -> VerifierGateLookup {
+    let cache = verifier_memory_cache();
+    let cache = cache.lock().expect("verifier memory cache poisoned");
+    match cache.get(scope_key).and_then(|m| m.get(digest)) {
+        None => VerifierGateLookup::Miss,
+        Some(record) => {
+            let is_infra = matches!(
+                record.kind,
+                Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::CallFailed)
+                    | Some(
+                        crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::EmptyResponse
+                    )
+            );
+            if is_infra
+                && current_epoch_ms().saturating_sub(record.ts_ms) > VERIFIER_INFRA_COOLDOWN_MS
+            {
+                VerifierGateLookup::Miss
+            } else {
+                VerifierGateLookup::Replay(ReplayedVerdict {
+                    verdict: record.verdict.clone(),
+                    kind: record.kind,
+                    missing_evidence: record.missing_evidence.clone(),
+                    ts_ms: record.ts_ms,
+                })
+            }
+        }
+    }
+}
+
+/// Insert (or overwrite) a memory-cache verdict for (scope, digest).
+fn verifier_memory_cache_insert(scope_key: &str, digest: &str, cached: CachedVerdict) {
+    let cache = verifier_memory_cache();
+    let mut cache = cache.lock().expect("verifier memory cache poisoned");
+    cache
+        .entry(scope_key.to_owned())
+        .or_default()
+        .insert(digest.to_owned(), cached);
+}
+
+/// Test-only helper: age (or freshen) a cached memory-gate verdict in place.
+/// Separate from the struct so no production tuple-construction site is
+/// tempted to populate it with `cached.ts_ms` — that self-overwrite would
+/// silently re-poison the value on every replay (outer fix ②, k3 review).
+#[cfg(test)]
+fn verifier_memory_cache_set_ts_ms(scope: &str, digest: &str, ts_ms: u64) {
+    let cache = verifier_memory_cache();
+    let mut cache = cache.lock().expect("verifier memory cache poisoned");
+    if let Some(entry) = cache.get_mut(scope).and_then(|m| m.get_mut(digest)) {
+        entry.ts_ms = ts_ms;
+    }
+}
+
+/// The persistent gate lives one file per FULL SCOPE (VG-SCOPE): the
+/// filename is the scope fingerprint (hex), so two sessions / profiles /
+/// storage roots with the same goal_id text never share a ledger, and the
+/// goal_id text needs no lossy sanitization at all.
+fn verifier_ledger_path(data_dir: &std::path::Path, scope_fingerprint: &str) -> std::path::PathBuf {
+    data_dir
+        .join("goal-verifier-ledgers")
+        .join(format!("{scope_fingerprint}.jsonl"))
+}
+
+/// VG-PREFLIGHT: prove the persistent ledger is usable BEFORE any provider
+/// chat (called with the scope's single-flight guard held). Creates the
+/// data_dir / ledger dir when missing, rejects a non-directory data_dir,
+/// then opens the ledger with create+append — the exact operation the
+/// post-call append will need — and syncs. Any failure is returned as a
+/// diagnostic; the caller fail-closes with 0 chats / 0 attempts / 0
+/// charge, so unusable storage can never be paid for with provider calls.
+async fn verifier_ledger_preflight(
+    data_dir: &std::path::Path,
+    ledger_path: &std::path::Path,
+) -> Result<(), String> {
+    tokio::fs::create_dir_all(data_dir).await.map_err(|err| {
+        format!(
+            "verifier data dir create failed ({}): {err}",
+            data_dir.display()
+        )
+    })?;
+    let dir_meta = tokio::fs::metadata(data_dir).await.map_err(|err| {
+        format!(
+            "verifier data dir unreadable ({}): {err}",
+            data_dir.display()
+        )
+    })?;
+    if !dir_meta.is_dir() {
+        return Err(format!(
+            "verifier data dir is not a directory ({})",
+            data_dir.display()
+        ));
+    }
+    if let Some(parent) = ledger_path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|err| {
+            format!(
+                "verifier ledger dir create failed ({}): {err}",
+                parent.display()
+            )
+        })?;
+    }
+    let file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(ledger_path)
+        .await
+        .map_err(|err| {
+            format!(
+                "verifier ledger not appendable before any provider call ({}): {err} — refusing to spend",
+                ledger_path.display()
+            )
+        })?;
+    file.sync_all().await.map_err(|err| {
+        format!(
+            "verifier ledger sync failed before any provider call ({}): {err} — refusing to spend",
+            ledger_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn current_epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 /// A failed first write leaves no payload for /stop's Completed tombstone.
@@ -20270,9 +21246,10 @@ mod tests {
         let provider = std::sync::Arc::new(MaxTokensCapturingProvider {
             seen_max_tokens: std::sync::Mutex::new(None),
         });
-        let (verdict, _usage) =
+        let call =
             run_goal_completion_verifier_with_usage(provider.clone(), "objective", "evidence")
                 .await;
+        let verdict = call.verdict;
         assert!(verdict.is_done(), "mock returns DONE");
         let seen = *provider.seen_max_tokens.lock().unwrap();
         assert_eq!(
@@ -37853,17 +38830,1652 @@ mod tests {
             }
         }
 
-        let (verdict, _usage) = run_goal_completion_verifier_with_usage(
+        let call = run_goal_completion_verifier_with_usage(
             Arc::new(BacktickProvider),
             "test objective",
             "test evidence",
         )
         .await;
+        let verdict = call.verdict;
         assert_eq!(
             verdict,
             GoalCompletionVerdict::Done,
             "parser must accept `DONE` (with backticks)"
         );
+    }
+
+    // ── evo-goal-verifier v4: wrapper-level tests (gate / single-flight /
+    // ledger / budget / retry) ────────────────────────────────────────────
+
+    /// Scripted verifier provider: serves a queue of replies, counts chats.
+    struct ScriptedVerifierProvider {
+        replies: StdMutex<Vec<ScriptedReply>>,
+        chats: std::sync::atomic::AtomicU32,
+    }
+
+    enum ScriptedReply {
+        Ok {
+            content: &'static str,
+            usage: octos_llm::TokenUsage,
+        },
+        ErrRetryable(&'static str),
+        ErrAuth(&'static str),
+    }
+
+    impl ScriptedVerifierProvider {
+        fn done() -> Arc<Self> {
+            Arc::new(Self {
+                replies: StdMutex::new(vec![ScriptedReply::Ok {
+                    content: "DONE",
+                    usage: usage_of(5, 2, 0, 0, 0),
+                }]),
+                chats: std::sync::atomic::AtomicU32::new(0),
+            })
+        }
+        fn chats(&self) -> u32 {
+            self.chats.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for ScriptedVerifierProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            use std::sync::atomic::Ordering;
+            self.chats.fetch_add(1, Ordering::SeqCst);
+            // FIFO: replies are served in the order the test queued them.
+            // (The original `Vec::pop` was LIFO — a retry script written as
+            // [error, DONE] served DONE first and made the wrapper retry a
+            // success; see outer fix ④.)
+            let next = {
+                let mut replies = self.replies.lock().expect("scripted replies");
+                if replies.is_empty() {
+                    None
+                } else {
+                    Some(replies.remove(0))
+                }
+            };
+            match next {
+                Some(ScriptedReply::Ok { content, usage }) => Ok(octos_llm::ChatResponse {
+                    content: Some(content.to_owned()),
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                    stop_reason: octos_llm::StopReason::EndTurn,
+                    usage,
+                    provider_index: None,
+                }),
+                Some(ScriptedReply::ErrRetryable(msg)) => {
+                    Err(eyre::eyre!(octos_llm::LlmError::new(
+                        octos_llm::LlmErrorKind::ServerError { status: 503 },
+                        msg,
+                    )))
+                }
+                Some(ScriptedReply::ErrAuth(msg)) => {
+                    Err(eyre::eyre!(octos_llm::LlmError::auth(msg)))
+                }
+                None => Ok(octos_llm::ChatResponse {
+                    // Exhausted script: a benign non-verdict so the wrapper
+                    // classifies InvalidResponse instead of panicking.
+                    content: Some("SCRIPT-EXHAUSTED".to_owned()),
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                    stop_reason: octos_llm::StopReason::EndTurn,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: None,
+                }),
+            }
+        }
+        fn model_id(&self) -> &str {
+            "scripted-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "test"
+        }
+    }
+
+    fn usage_of(
+        input: u32,
+        output: u32,
+        reasoning: u32,
+        cache_read: u32,
+        cache_write: u32,
+    ) -> octos_llm::TokenUsage {
+        octos_llm::TokenUsage {
+            input_tokens: input,
+            output_tokens: output,
+            reasoning_tokens: reasoning,
+            cache_read_tokens: cache_read,
+            cache_write_tokens: cache_write,
+            semantic_checkpoint: None,
+        }
+    }
+
+    /// Slow scripted provider for the single-flight barrier test: every
+    /// chat announces itself, then parks until the test hands it a permit.
+    /// Permits travel over an unbounded mpsc channel: sends are STORED, so a
+    /// permit issued before the chat parks is never lost (a bare
+    /// `Notify::notify_waiters` would lose it), and no synchronization
+    /// depends on the join order of the test body (outer fix ③ — the first
+    /// version released only AFTER `tokio::join!` returned, a guaranteed
+    /// deadlock).
+    struct BarrierVerifierProvider {
+        chats: std::sync::atomic::AtomicU32,
+        release: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<u32>>,
+        permits: tokio::sync::mpsc::UnboundedSender<u32>,
+    }
+
+    impl BarrierVerifierProvider {
+        fn chats(&self) -> u32 {
+            self.chats.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for BarrierVerifierProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            use std::sync::atomic::Ordering;
+            self.chats.fetch_add(1, Ordering::SeqCst);
+            // Park until the test hands this chat a permit. The receiver
+            // sits behind a tokio mutex so `chat(&self)` can drive it; the
+            // guard never crosses the provider boundary.
+            let _permit = self.release.lock().await.recv().await;
+            Ok(octos_llm::ChatResponse {
+                content: Some("DONE".to_owned()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: usage_of(1, 1, 0, 0, 0),
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "barrier-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "test"
+        }
+    }
+
+    /// Two concurrent verify calls for the SAME goal + SAME evidence must
+    /// produce exactly ONE provider chat: the per-scope async mutex
+    /// serializes them and the second re-reads the gate INSIDE the lock,
+    /// finds the first caller's appended record, and replays it (real RED
+    /// for defect ①: the old no-op counter guard let both through, so a
+    /// slow provider showed chats==2).
+    #[tokio::test]
+    async fn goal_verifier_single_flight_on_concurrent_gate_miss() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "sf-barrier");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "single flight".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let (permit_tx, permit_rx) = tokio::sync::mpsc::unbounded_channel::<u32>();
+        let provider = Arc::new(BarrierVerifierProvider {
+            chats: std::sync::atomic::AtomicU32::new(0),
+            release: tokio::sync::Mutex::new(permit_rx),
+            permits: permit_tx,
+        });
+
+        // Release driver, spawned BEFORE the joined verifications so it is
+        // live on the runtime while they run: stage ONE permit immediately
+        // (enough for the single legitimate chat), then drip extras —
+        // a wrongly-started second chat would also consume a permit and be
+        // COUNTED, never deadlocked; a leftover permit is harmless.
+        let driver = {
+            let permits = provider.permits.clone();
+            tokio::spawn(async move {
+                let _ = permits.send(1);
+                // Extra permits: one per wrongly-started chat, so a buggy
+                // double-chat finishes (and gets caught by the assert)
+                // instead of hanging the test.
+                for n in 2..=8 {
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    let _ = permits.send(n);
+                }
+            })
+        };
+
+        // Two concurrent verifications of the SAME goal + SAME evidence,
+        // under a BOUNDED timeout (outer fix ③): if the single-flight guard
+        // ever regresses into a hang (e.g. permit loss, join-order
+        // inversion), the test FAILS fast with the chats observed so far
+        // instead of hanging the suite.
+        let joined = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            tokio::join!(
+                orchestrator.verify_goal_completion_bounded(
+                    &session_id,
+                    "tenant-a",
+                    &snapshot,
+                    provider.clone(),
+                    "same evidence",
+                    Some(temp.path()),
+                ),
+                orchestrator.verify_goal_completion_bounded(
+                    &session_id,
+                    "tenant-a",
+                    &snapshot,
+                    provider.clone(),
+                    "same evidence",
+                    Some(temp.path()),
+                ),
+            )
+        })
+        .await;
+        driver.abort();
+        let (a, b) = match joined {
+            Ok(pair) => pair,
+            Err(_elapsed) => panic!(
+                "single-flight verification deadlocked: no join within 30s (chats observed: {})",
+                provider.chats()
+            ),
+        };
+
+        assert_eq!(
+            provider.chats(),
+            1,
+            "concurrent same-evidence verification must single-flight to exactly ONE provider chat"
+        );
+        // The first caller gets the live Done; the second replays it.
+        assert!(a.is_done() || b.is_done());
+        let (first, second) = if a.replayed { (b, a) } else { (a, b) };
+        assert!(!first.replayed, "one outcome must be the live call");
+        assert_eq!(first.attempts, 1);
+        assert!(
+            second.replayed,
+            "the concurrent caller must replay the first caller's fresh verdict, not re-chat"
+        );
+        assert_eq!(second.attempts, 0);
+        assert_eq!(second.usage.input_tokens, 0);
+    }
+
+    /// data_dir=None must be a REAL in-memory cache (defect ②): the second
+    /// identical call makes zero provider chats and replays attempts=0 /
+    /// usage=0.
+    #[tokio::test]
+    async fn goal_verifier_no_data_dir_uses_memory_gate() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "mem-gate");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "memory gate".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let provider = ScriptedVerifierProvider::done();
+
+        let first = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(first.is_done(), "first (live) call is Done");
+        assert_eq!(first.attempts, 1);
+        assert_eq!(first.usage.input_tokens, 5);
+        assert_eq!(provider.chats(), 1);
+
+        // Different goal_id → different scope → different memory entry:
+        // craft a second snapshot for a second session's goal.
+        let session_b = SessionKey::with_profile("tenant-a", "api", "mem-gate-b");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_b.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "memory gate".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set goal b");
+        let snapshot_b = orchestrator
+            .goal_verification_snapshot(&session_b, "tenant-a")
+            .expect("snapshot b");
+        let other = orchestrator
+            .verify_goal_completion_bounded(
+                &session_b,
+                "tenant-a",
+                &snapshot_b,
+                provider.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(
+            !other.replayed,
+            "different goal must not share the memory entry"
+        );
+        assert_eq!(provider.chats(), 2);
+
+        // Same scope + same evidence again → replay, ZERO new chats.
+        let provider2 = ScriptedVerifierProvider::done();
+        let second = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider2.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(second.is_done(), "replay reconstructs the Done verdict");
+        assert!(second.replayed, "second same-evidence call must replay");
+        assert_eq!(second.attempts, 0, "replay makes no attempts");
+        assert_eq!(second.usage.input_tokens, 0, "replay reports zero usage");
+        assert_eq!(
+            provider2.chats(),
+            0,
+            "memory cache must suppress the second provider chat entirely"
+        );
+    }
+
+    /// New orchestrator instance + same data_dir → the ledger replays
+    /// (restart durability of the persistent gate).
+    #[tokio::test]
+    async fn goal_verifier_dedupes_same_evidence_recheck() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let objective = "persist gate";
+        let evidence = "the evidence text";
+
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "persist-gate");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: objective.into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let provider = ScriptedVerifierProvider::done();
+        let first = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                evidence,
+                Some(temp.path()),
+            )
+            .await;
+        assert!(first.is_done());
+        assert!(!first.replayed);
+        assert_eq!(provider.chats(), 1);
+
+        // NEW instance (process restart), same ledger dir, same goal text
+        // → the ledger replays the stored Done with zero chats.
+        let restarted = InProcessAgentOrchestrator::default();
+        restarted
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: objective.into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set goal on restarted instance");
+        let snapshot2 = restarted
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot on restarted instance");
+        assert_eq!(
+            snapshot2.goal_id, snapshot.goal_id,
+            "same session+objective mints the same monotonic goal id"
+        );
+        let provider2 = ScriptedVerifierProvider::done();
+        let second = restarted
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot2,
+                provider2.clone(),
+                evidence,
+                Some(temp.path()),
+            )
+            .await;
+        assert!(second.is_done(), "replayed verdict is Done");
+        assert!(
+            second.replayed,
+            "ledger must replay the same-evidence verdict"
+        );
+        assert_eq!(second.attempts, 0);
+        assert_eq!(
+            provider2.chats(),
+            0,
+            "persistent ledger must suppress the recheck chat"
+        );
+        assert!(
+            second.replayed_of_ts_ms.is_some(),
+            "replay surfaces the source ts"
+        );
+    }
+
+    /// Corrupt ledger tail → fail closed: no chat, no Done, diagnostic set.
+    #[tokio::test]
+    async fn goal_verifier_ledger_read_failure_fails_closed() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "failclosed");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "fail closed".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        // Seed a TRUNCATED tail line into this scope's ledger (the first
+        // line is a VALID v3 record for another digest, so the fail-closed
+        // is provably caused by the corrupt tail, not the seed).
+        let scope = orchestrator.verifier_scope(
+            Some(temp.path()),
+            &session_id,
+            "tenant-a",
+            &snapshot.goal_id,
+        );
+        let dir = temp.path().join("goal-verifier-ledgers");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join(format!("{}.jsonl", scope.fingerprint)),
+            format!(
+                concat!(
+                    "{{\"version\":3,\"scope\":\"{sc}\",\"goal_id\":\"{gid}\",\"ts_ms\":1,\"outcome\":\"done\",",
+                    "\"attempts\":1,\"usage\":{{\"input_tokens\":1,\"output_tokens\":1}},",
+                    "\"evidence_digest\":\"deadbeef\",\"replayed\":false}}\n",
+                    "{{\"version\":3,\"scope\":\"{sc}\",\"goal_id\":\"placehol" // truncated mid-JSON
+                ),
+                sc = scope.fingerprint,
+                gid = snapshot.goal_id,
+            ),
+        )
+        .expect("seed truncated ledger");
+
+        let provider = ScriptedVerifierProvider::done();
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(
+            !outcome.is_done(),
+            "unreadable ledger must not produce Done"
+        );
+        assert_eq!(
+            provider.chats(),
+            0,
+            "unreadable ledger must not trigger a provider chat"
+        );
+        assert!(
+            outcome.diagnostic.is_some(),
+            "fail-closed outcome carries a diagnostic"
+        );
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("active")
+        );
+    }
+
+    /// Unknown `version` in an otherwise-valid line → fail closed.
+    #[tokio::test]
+    async fn goal_verifier_ledger_unknown_version_fails_closed() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "ver-unknown");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "unknown version".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        let scope = orchestrator.verifier_scope(
+            Some(temp.path()),
+            &session_id,
+            "tenant-a",
+            &snapshot.goal_id,
+        );
+        let dir = temp.path().join("goal-verifier-ledgers");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join(format!("{}.jsonl", scope.fingerprint)),
+            format!(
+                concat!(
+                    "{{\"version\":99,\"scope\":\"{sc}\",\"goal_id\":\"{gid}\",\"ts_ms\":1,",
+                    "\"outcome\":\"done\",\"attempts\":1,",
+                    "\"usage\":{{\"input_tokens\":1,\"output_tokens\":1}},",
+                    "\"evidence_digest\":\"deadbeef\",\"replayed\":false}}\n"
+                ),
+                sc = scope.fingerprint,
+                gid = snapshot.goal_id,
+            ),
+        )
+        .expect("seed future-version ledger");
+
+        let provider = ScriptedVerifierProvider::done();
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(!outcome.is_done(), "future version must not replay a Done");
+        assert_eq!(provider.chats(), 0);
+        assert!(outcome.diagnostic.is_some());
+    }
+
+    /// A record whose goal_id does not belong to this ledger's goal →
+    /// fail closed (never accept a foreign goal's Done).
+    #[tokio::test]
+    async fn goal_verifier_ledger_foreign_goal_fails_closed() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "foreign-goal");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "foreign goal".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        let scope = orchestrator.verifier_scope(
+            Some(temp.path()),
+            &session_id,
+            "tenant-a",
+            &snapshot.goal_id,
+        );
+        let dir = temp.path().join("goal-verifier-ledgers");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        // Line 1: this scope's fingerprint but a FOREIGN goal_id. Line 2
+        // (in a second scenario below): the correct goal_id but a FOREIGN
+        // scope fingerprint. Both are fail-closed.
+        std::fs::write(
+            dir.join(format!("{}.jsonl", scope.fingerprint)),
+            format!(
+                concat!(
+                    "{{\"version\":3,\"scope\":\"{sc}\",\"goal_id\":\"goal_99\",\"ts_ms\":1,\"outcome\":\"done\",",
+                    "\"attempts\":1,\"usage\":{{\"input_tokens\":1,\"output_tokens\":1}},",
+                    "\"evidence_digest\":\"deadbeef\",\"replayed\":false}}\n"
+                ),
+                sc = scope.fingerprint,
+            ),
+        )
+        .expect("seed foreign-goal ledger");
+
+        let provider = ScriptedVerifierProvider::done();
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(!outcome.is_done(), "a foreign goal's Done must not replay");
+        assert_eq!(provider.chats(), 0);
+        assert!(outcome.diagnostic.is_some());
+
+        // Correct goal_id but a FOREIGN scope fingerprint (e.g. another
+        // session's ledger file hard-linked / renamed into place): also
+        // fail-closed, still zero chats.
+        std::fs::write(
+            dir.join(format!("{}.jsonl", scope.fingerprint)),
+            format!(
+                concat!(
+                    "{{\"version\":3,\"scope\":\"{bad}\",\"goal_id\":\"{gid}\",\"ts_ms\":1,\"outcome\":\"done\",",
+                    "\"attempts\":1,\"usage\":{{\"input_tokens\":1,\"output_tokens\":1}},",
+                    "\"evidence_digest\":\"deadbeef\",\"replayed\":false}}\n"
+                ),
+                bad = verifier_scope_fingerprint(&verifier_storage_identity(temp.path()), "other-session", "tenant-a", &snapshot.goal_id),
+                gid = snapshot.goal_id,
+            ),
+        )
+        .expect("seed foreign-scope ledger");
+        let provider2 = ScriptedVerifierProvider::done();
+        let outcome2 = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider2.clone(),
+                "e",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(
+            !outcome2.is_done(),
+            "a foreign scope's Done must not replay"
+        );
+        assert_eq!(provider2.chats(), 0);
+        assert!(outcome2.diagnostic.is_some());
+    }
+
+    /// Write-unusable ledger (file is read-only) → fail closed with ZERO
+    /// provider spend (VG-PREFLIGHT): the read-side gate still parses the
+    /// seeded line cleanly and Misses (read succeeds), but the pre-chat
+    /// preflight's append-open fails with EACCES — so no chat, no attempt,
+    /// no charge, on BOTH calls. The post-chat write/flush/sync failure
+    /// path (usage of the real attempt preserved in the diagnostic
+    /// outcome) remains in the wrapper; it needs a filesystem that passes
+    /// open+append but fails write, which no portable fault injection
+    /// covers (no lint/unsafe; /dev/full is not portable).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn goal_verifier_ledger_write_failure_fails_closed() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "write-fail");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "write fail".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        // Seed a VALID v3 line for a DIFFERENT digest so the read-side gate
+        // parses cleanly and Misses (read succeeds), then chmod the file
+        // to read-only so the preflight append-open fails.
+        let scope = orchestrator.verifier_scope(
+            Some(temp.path()),
+            &session_id,
+            "tenant-a",
+            &snapshot.goal_id,
+        );
+        let dir = temp.path().join("goal-verifier-ledgers");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let ledger = dir.join(format!("{}.jsonl", scope.fingerprint));
+        std::fs::write(
+            &ledger,
+            format!(
+                concat!(
+                    "{{\"version\":3,\"scope\":\"{sc}\",\"goal_id\":\"{gid}\",\"ts_ms\":1,",
+                    "\"outcome\":\"insufficient_evidence\",\"attempts\":1,",
+                    "\"usage\":{{\"input_tokens\":1,\"output_tokens\":1}},",
+                    "\"missing_evidence\":\"stale\",\"evidence_digest\":\"other\",\"replayed\":false}}\n"
+                ),
+                sc = scope.fingerprint,
+                gid = snapshot.goal_id,
+            ),
+        )
+        .expect("seed valid ledger");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&ledger, std::fs::Permissions::from_mode(0o444))
+            .expect("chmod read-only");
+
+        let provider = ScriptedVerifierProvider::done();
+        let first = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                Some(temp.path()),
+            )
+            .await;
+        let second = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                Some(temp.path()),
+            )
+            .await;
+        // Restore permissions so TempDir cleanup can remove the file.
+        let _ = std::fs::set_permissions(&ledger, std::fs::Permissions::from_mode(0o644));
+        assert!(
+            !first.is_done() && !second.is_done(),
+            "an unpersistable Done is not a success"
+        );
+        assert_eq!(
+            provider.chats(),
+            0,
+            "unusable storage is detected by the pre-chat preflight — no provider spend on either call"
+        );
+        assert_eq!(first.attempts + second.attempts, 0);
+        assert_eq!(first.usage.input_tokens + second.usage.input_tokens, 0);
+        assert!(first.diagnostic.is_some() && second.diagnostic.is_some());
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("active")
+        );
+    }
+
+    /// Different sessions with the same goal_id numbering must be isolated
+    /// (scope includes the session), AND the wrapper must charge each
+    /// attempt and sum non-zero usages per field.
+    #[tokio::test]
+    async fn goal_verifier_gate_scoped_to_session_and_charges_per_attempt() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let orchestrator = InProcessAgentOrchestrator::default();
+
+        let session_a = SessionKey::with_profile("tenant-a", "api", "scope-a");
+        let session_b = SessionKey::with_profile("tenant-a", "api", "scope-b");
+        for sid in [&session_a, &session_b] {
+            orchestrator
+                .set_goal(GoalSetRequest {
+                    session_id: sid.clone(),
+                    profile_id: "tenant-a".into(),
+                    objective: "same objective".into(),
+                    status: Some("active".into()),
+                    token_budget: None,
+                    transition_actor: None,
+                })
+                .expect("set goal");
+        }
+        // Both sessions mint sequential goal ids (the seq is process-wide),
+        // so the SAME goal_id text cannot be assumed — what matters for
+        // isolation here is that each session's verification is gated and
+        // charged independently.
+        let snap_a = orchestrator
+            .goal_verification_snapshot(&session_a, "tenant-a")
+            .expect("snap a");
+        let snap_b = orchestrator
+            .goal_verification_snapshot(&session_b, "tenant-a")
+            .expect("snap b");
+
+        let provider = ScriptedVerifierProvider::done();
+        let a = orchestrator
+            .verify_goal_completion_bounded(
+                &session_a,
+                "tenant-a",
+                &snap_a,
+                provider.clone(),
+                "shared evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(a.is_done());
+        assert!(!a.replayed);
+
+        // Same objective + SAME evidence + same revision → same digest —
+        // but a DIFFERENT session (VG-SCOPE): the persistent gate is bound
+        // to the full scope (session/profile/goal_id/storage identity), so
+        // b must NOT inherit a's durable Done even with identical evidence.
+        // (The previous "DESIGNED cross-session dedupe" comment described
+        // the VG-SCOPE defect as a feature; it was never authorized.)
+        let provider_b = ScriptedVerifierProvider::done();
+        // Same profile as the set_goal above ("tenant-a") — the retry gate
+        // is profile-bound, so a mismatched profile would suppress the
+        // second attempt and its charge.
+        let b = orchestrator
+            .verify_goal_completion_bounded(
+                &session_b,
+                "tenant-a",
+                &snap_b,
+                provider_b.clone(),
+                "shared evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(
+            !b.replayed,
+            "a different session must not replay the first session's durable Done"
+        );
+        assert_eq!(
+            provider_b.chats(),
+            1,
+            "the second session needs its own verification"
+        );
+
+        // Per-attempt charge landed on each goal row (input+output only).
+        let state = orchestrator.state();
+        let used_a = state
+            .goals
+            .get(&session_a)
+            .map(|g| g.tokens_used)
+            .unwrap_or(0);
+        let used_b = state
+            .goals
+            .get(&session_b)
+            .map(|g| g.tokens_used)
+            .unwrap_or(0);
+        drop(state);
+        assert_eq!(used_a, 7, "attempt usage (in 5 + out 2) charged to goal a");
+        assert_eq!(used_b, 7, "attempt usage charged to goal b");
+    }
+
+    /// Two non-zero usages sum per field (saturating), including the
+    /// reasoning/cache mirror fields (defect ⑤).
+    #[tokio::test]
+    async fn goal_verifier_sums_billed_second_empty_attempt() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "sum-usage");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "sum usage".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        // Two EMPTY replies (both counted, both billed) with distinct
+        // non-zero usages on every field. Empty is transient → retry once.
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![
+                ScriptedReply::Ok {
+                    content: "",
+                    usage: usage_of(10, 2, 3, 4, 5),
+                },
+                ScriptedReply::Ok {
+                    content: "",
+                    usage: usage_of(8, 1, 30, 40, 50),
+                },
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert_eq!(
+            outcome.kind.map(|k| k.as_str()),
+            Some("empty_response"),
+            "both-empty run classifies EmptyResponse"
+        );
+        assert_eq!(outcome.attempts, 2);
+        assert_eq!(provider.chats(), 2);
+        assert_eq!(outcome.usage.input_tokens, 18, "10 + 8");
+        assert_eq!(outcome.usage.output_tokens, 3, "2 + 1");
+        assert_eq!(outcome.usage.reasoning_tokens, 33, "3 + 30");
+        assert_eq!(outcome.usage.cache_read_tokens, 44, "4 + 40");
+        assert_eq!(outcome.usage.cache_write_tokens, 55, "5 + 50");
+    }
+
+    /// Budget exhausted by the FIRST attempt's charge must prevent the
+    /// second chat (status-based gate; defect ⑤'s charge-then-check order).
+    #[tokio::test]
+    async fn goal_verifier_budget_exhaustion_prevents_second_call() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "budget-cap");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "budget cap".into(),
+                status: Some("active".into()),
+                // Budget exactly one attempt's input+output (5+2=7).
+                token_budget: Some(7),
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        // First reply: EMPTY (transient → would retry) with usage 5/2 —
+        // the per-attempt charge flips the goal to budget_limited, so the
+        // wrapper must NOT start the second chat.
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "",
+                usage: usage_of(5, 2, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert_eq!(
+            outcome.attempts, 1,
+            "first charge exhausted the budget → no second attempt"
+        );
+        assert_eq!(
+            provider.chats(),
+            1,
+            "no second provider.chat after budget exhaustion"
+        );
+        assert_eq!(outcome.kind.map(|k| k.as_str()), Some("empty_response"));
+    }
+
+    /// A retryable server error retried once → success (spec: transient
+    /// retry), and a NON-retryable auth error must NOT retry (defect ⑤).
+    #[tokio::test]
+    async fn goal_verifier_retries_transient_and_skips_auth_error() {
+        // Part 1: retryable ServerError then DONE → Done, attempts 2.
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "retry-transient");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "retry transient".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let provider = Arc::new(ScriptedVerifierProvider {
+            // FIFO: the 503 first, then DONE.
+            replies: StdMutex::new(vec![
+                ScriptedReply::ErrRetryable("upstream 503"),
+                ScriptedReply::Ok {
+                    content: "DONE",
+                    usage: usage_of(4, 1, 0, 0, 0),
+                },
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(outcome.is_done(), "retryable failure then DONE → Done");
+        assert_eq!(outcome.attempts, 2);
+        assert_eq!(provider.chats(), 2);
+        assert_eq!(
+            outcome.usage.input_tokens, 4,
+            "Err attempt contributes zero usage"
+        );
+
+        // Part 2: authentication error is NOT retryable → attempts 1.
+        let session_id2 = SessionKey::with_profile("tenant-a", "api", "auth-noretry");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id2.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "auth no retry".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot2 = orchestrator
+            .goal_verification_snapshot(&session_id2, "tenant-a")
+            .expect("snapshot");
+        let provider2 = Arc::new(ScriptedVerifierProvider {
+            // FIFO: the auth error FIRST, then (never reached) DONE.
+            replies: StdMutex::new(vec![
+                ScriptedReply::ErrAuth("invalid api key"),
+                ScriptedReply::Ok {
+                    content: "DONE",
+                    usage: usage_of(4, 1, 0, 0, 0),
+                },
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome2 = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id2,
+                "tenant-a",
+                &snapshot2,
+                provider2.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(!outcome2.is_done());
+        assert_eq!(
+            outcome2.kind.map(|k| k.as_str()),
+            Some("call_failed"),
+            "auth error classifies CallFailed"
+        );
+        assert_eq!(outcome2.attempts, 1, "auth errors are not retried");
+        assert_eq!(provider2.chats(), 1, "exactly one chat for auth failure");
+    }
+
+    /// Changed evidence (new digest) releases a new verification round; the
+    /// historical ledger line is preserved (append-only).
+    #[tokio::test]
+    async fn goal_verifier_changed_evidence_releases_recheck() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "changed-ev");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "changed evidence".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        // First round: NOT_DONE (semantic, permanent for this digest).
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "NOT_DONE: missing X",
+                usage: usage_of(2, 1, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let first = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "old evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(
+            first.kind.map(|k| k.as_str()),
+            Some("insufficient_evidence")
+        );
+        assert!(!first.replayed);
+
+        // Same digest again → replay, zero chats.
+        let provider_same = ScriptedVerifierProvider::done();
+        let replay = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider_same.clone(),
+                "old evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(replay.replayed, "same digest semantic verdict replays");
+        assert_eq!(provider_same.chats(), 0);
+
+        // NEW evidence (new digest) → fresh chat allowed; history kept.
+        let provider_new = ScriptedVerifierProvider::done();
+        let second = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider_new.clone(),
+                "new evidence with more proof",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(!second.replayed, "changed digest must release a new call");
+        assert!(second.is_done());
+        assert_eq!(provider_new.chats(), 1);
+
+        let scope = orchestrator.verifier_scope(
+            Some(temp.path()),
+            &session_id,
+            "tenant-a",
+            &snapshot.goal_id,
+        );
+        let dir = temp.path().join("goal-verifier-ledgers");
+        let content = std::fs::read_to_string(dir.join(format!("{}.jsonl", scope.fingerprint)))
+            .expect("ledger readable");
+        let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "append-only: both rounds coexist, got {lines:?}"
+        );
+        assert!(lines[0].contains("insufficient_evidence"));
+        assert!(lines[1].contains("\"outcome\":\"done\""));
+        assert!(
+            lines[1].contains("\"version\":3"),
+            "records carry the version field"
+        );
+        assert!(
+            lines[1].contains(&format!("\"scope\":\"{}\"", scope.fingerprint)),
+            "records carry the full-scope fingerprint"
+        );
+    }
+
+    /// Infra-class cooldown: a call_failed record younger than TTL replays;
+    /// older than TTL releases a new call.
+    #[tokio::test]
+    async fn goal_verifier_infra_cooldown_replay_and_release() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "cooldown");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "cooldown".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let digest =
+            verifier_evidence_digest(&snapshot.objective, "cooldown evidence", snapshot.revision);
+
+        let scope = orchestrator.verifier_scope(
+            Some(temp.path()),
+            &session_id,
+            "tenant-a",
+            &snapshot.goal_id,
+        );
+        let dir = temp.path().join("goal-verifier-ledgers");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let now = current_epoch_ms();
+        // A FRESH call_failed record (inside the 10-minute window) and an
+        // OLD one for a different digest (beyond it).
+        let fresh = format!(
+            concat!(
+                "{{\"version\":3,\"scope\":\"{sc}\",\"goal_id\":\"{gid}\",\"ts_ms\":{ts},",
+                "\"outcome\":\"call_failed\",\"attempts\":2,",
+                "\"usage\":{{\"input_tokens\":0,\"output_tokens\":0}},",
+                "\"error\":\"upstream 503\",\"evidence_digest\":\"{dg}\",\"replayed\":false}}\n"
+            ),
+            sc = scope.fingerprint,
+            gid = snapshot.goal_id,
+            ts = now,
+            dg = digest,
+        );
+        let old_digest =
+            verifier_evidence_digest(&snapshot.objective, "old evidence", snapshot.revision);
+        let old = format!(
+            concat!(
+                "{{\"version\":3,\"scope\":\"{sc}\",\"goal_id\":\"{gid}\",\"ts_ms\":{ts},",
+                "\"outcome\":\"call_failed\",\"attempts\":2,",
+                "\"usage\":{{\"input_tokens\":0,\"output_tokens\":0}},",
+                "\"error\":\"upstream 503\",\"evidence_digest\":\"{dg}\",\"replayed\":false}}\n"
+            ),
+            sc = scope.fingerprint,
+            gid = snapshot.goal_id,
+            ts = now.saturating_sub(VERIFIER_INFRA_COOLDOWN_MS + 60_000),
+            dg = old_digest,
+        );
+        std::fs::write(
+            dir.join(format!("{}.jsonl", scope.fingerprint)),
+            format!("{old}{fresh}"),
+        )
+        .expect("seed cooldown ledger");
+
+        // Inside cooldown: replay, zero chats.
+        let provider_fresh = ScriptedVerifierProvider::done();
+        let within = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider_fresh.clone(),
+                "cooldown evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(
+            within.replayed,
+            "fresh infra record replays within cooldown"
+        );
+        assert_eq!(provider_fresh.chats(), 0);
+
+        // Beyond cooldown: a new call is allowed.
+        let provider_old = ScriptedVerifierProvider::done();
+        let beyond = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider_old.clone(),
+                "old evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(!beyond.replayed, "expired infra record releases a new call");
+        assert_eq!(provider_old.chats(), 1);
+    }
+
+    /// Outer fix ① — a REAL cwd-scoped session (not just an unscoped
+    /// fixture): the retry gate must resolve the goal through
+    /// `scoped_goal_key` and match the FULL snapshot identity. Two halves:
+    /// (a) goal untouched → the transient failure IS retried (proves the
+    ///     scoped lookup finds the goal — the old bare `state.goals.get(
+    ///     session_id)` found nothing for a scoped session and would have
+    ///     suppressed the retry);
+    /// (b) goal objective changed between attempts (revision bumped) → the
+    ///     retry is suppressed even though goal_id and status still match
+    ///     (the old id/status-only check would have retried against the NEW
+    ///     objective while grading evidence against the snapshot's OLD one).
+    #[tokio::test]
+    async fn goal_verifier_retry_gate_matches_scoped_goal_identity() {
+        // ── (a) unchanged scoped goal → retried ──────────────────────────
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "scoped-retry");
+        orchestrator.set_goal_scope(&session_id, Some("/tmp/proj-a".to_owned()));
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "scoped retry".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal under a cwd-scoped key");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot resolves through the scoped key");
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![
+                ScriptedReply::ErrRetryable("upstream 503"),
+                ScriptedReply::Ok {
+                    content: "DONE",
+                    usage: usage_of(4, 1, 0, 0, 0),
+                },
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(
+            outcome.is_done(),
+            "unchanged scoped goal: transient failure retried to Done"
+        );
+        assert_eq!(outcome.attempts, 2);
+        assert_eq!(
+            provider.chats(),
+            2,
+            "scoped lookup must find the goal — a bare-wire lookup would suppress the retry"
+        );
+
+        // ── (b) objective changed (revision bumped) → NOT retried ────────
+        let session_id2 = SessionKey::with_profile("tenant-a", "api", "scoped-stale");
+        orchestrator.set_goal_scope(&session_id2, Some("/tmp/proj-b".to_owned()));
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id2.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "original objective".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot2 = orchestrator
+            .goal_verification_snapshot(&session_id2, "tenant-a")
+            .expect("snapshot");
+        // User edits the objective between the snapshot and the retry
+        // decision: same goal_id, same "active" status, NEW objective and a
+        // bumped revision — a different incarnation.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id2.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "edited objective".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("edit objective");
+        let stale = GoalVerificationSnapshot {
+            goal_id: snapshot2.goal_id.clone(),
+            objective: "original objective".to_owned(),
+            revision: snapshot2.revision,
+        };
+        let provider2 = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![
+                ScriptedReply::ErrRetryable("upstream 503"),
+                ScriptedReply::Ok {
+                    content: "DONE",
+                    usage: usage_of(4, 1, 0, 0, 0),
+                },
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let outcome2 = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id2,
+                "tenant-a",
+                &stale,
+                provider2.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(
+            !outcome2.is_done(),
+            "stale-incarnation retry must not reach DONE"
+        );
+        assert_eq!(
+            outcome2.attempts, 1,
+            "objective/revision mismatch suppresses the second chat"
+        );
+        assert_eq!(provider2.chats(), 1);
+    }
+
+    /// Outer fix ② — the memory gate (data_dir=None) applies the SAME infra
+    /// cooldown as the JSONL ledger: an expired CallFailed/EmptyResponse
+    /// verdict is a Miss (new provider call allowed), a fresh one replays.
+    #[tokio::test]
+    async fn goal_verifier_memory_cache_infra_cooldown_releases_recall() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "mem-cooldown");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "memory cooldown".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        // A transient failure (both attempts, FIFO) caches an infra verdict
+        // in the memory gate.
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![
+                ScriptedReply::ErrRetryable("upstream 503"),
+                ScriptedReply::ErrRetryable("upstream 503 again"),
+            ]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let first = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert_eq!(first.kind.map(|k| k.as_str()), Some("call_failed"));
+        assert_eq!(
+            provider.chats(),
+            2,
+            "transient failure retried once, then cached"
+        );
+
+        // Within the cooldown: replay, zero new chats.
+        let provider_fresh = ScriptedVerifierProvider::done();
+        let within = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider_fresh.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(
+            within.replayed,
+            "fresh infra verdict replays from the memory gate"
+        );
+        assert_eq!(provider_fresh.chats(), 0);
+
+        // Age the cached verdict beyond the cooldown via the test-only
+        // setter (no production write path to ts_ms exists).
+        let scope = orchestrator.verifier_scope(None, &session_id, "tenant-a", &snapshot.goal_id);
+        let digest = verifier_evidence_digest(&snapshot.objective, "e", snapshot.revision);
+        verifier_memory_cache_set_ts_ms(
+            &scope.fingerprint,
+            &digest,
+            current_epoch_ms().saturating_sub(VERIFIER_INFRA_COOLDOWN_MS + 60_000),
+        );
+
+        // Beyond the cooldown: Miss → a new provider call is allowed.
+        let provider_old = ScriptedVerifierProvider::done();
+        let beyond = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider_old.clone(),
+                "e",
+                None,
+            )
+            .await;
+        assert!(
+            !beyond.replayed,
+            "expired infra verdict must release a new call"
+        );
+        assert_eq!(provider_old.chats(), 1);
+        assert!(
+            beyond.is_done(),
+            "the released call runs live and can reach Done"
+        );
+    }
+
+    /// Outer runtime probe (VG-SCOPE), ported verbatim from
+    /// ../outer-verifier-runtime-probes.rs: two natural fresh orchestrators,
+    /// sessions A and B, both minting goal_01 with the same objective /
+    /// revision / evidence against the SAME provided ledger dir. Session B
+    /// must NOT replay session A's durable Done — the persistent gate binds
+    /// the full real scope (cwd-scoped session, profile, goal_id, data_dir
+    /// identity), not just the goal_id text.
+    #[tokio::test]
+    async fn outer_verifier_runtime_durable_done_cannot_cross_session_after_restart() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_a = SessionKey::with_profile("tenant-a", "api", "outer-scope-a");
+        let session_b = SessionKey::with_profile("tenant-a", "api", "outer-scope-b");
+        let first = InProcessAgentOrchestrator::default();
+        let restarted = InProcessAgentOrchestrator::default();
+        for (orchestrator, session) in [(&first, &session_a), (&restarted, &session_b)] {
+            orchestrator
+                .set_goal(GoalSetRequest {
+                    session_id: session.clone(),
+                    profile_id: "tenant-a".into(),
+                    objective: "same objective, distinct session".into(),
+                    status: Some("active".into()),
+                    token_budget: None,
+                    transition_actor: None,
+                })
+                .unwrap();
+        }
+        let a = first
+            .goal_verification_snapshot(&session_a, "tenant-a")
+            .unwrap();
+        let b = restarted
+            .goal_verification_snapshot(&session_b, "tenant-a")
+            .unwrap();
+        assert_eq!(
+            a.goal_id, b.goal_id,
+            "natural fresh orchestrators both begin at goal_01"
+        );
+        assert_eq!(a.revision, b.revision);
+        let provider_a = ScriptedVerifierProvider::done();
+        let provider_b = ScriptedVerifierProvider::done();
+        let result_a = first
+            .verify_goal_completion_bounded(
+                &session_a,
+                "tenant-a",
+                &a,
+                provider_a.clone(),
+                "same evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(result_a.is_done());
+        assert_eq!(provider_a.chats(), 1);
+        let result_b = restarted
+            .verify_goal_completion_bounded(
+                &session_b,
+                "tenant-a",
+                &b,
+                provider_b.clone(),
+                "same evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(
+            !result_b.replayed,
+            "a different session must not inherit the first session's durable Done"
+        );
+        assert_eq!(
+            provider_b.chats(),
+            1,
+            "the second session needs its own verification"
+        );
+    }
+
+    /// Outer runtime probe (VG-PREFLIGHT), ported verbatim from
+    /// ../outer-verifier-runtime-probes.rs: a provided ledger dir that
+    /// exists and is readable but NOT writable (mode 0555), with no ledger
+    /// file yet. The wrapper must detect the unusable storage BEFORE any
+    /// provider chat: both calls spend zero chats / zero attempts / zero
+    /// charged usage and stay NotDone.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn outer_verifier_runtime_unwritable_new_ledger_spends_zero_calls() {
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempfile::tempdir().unwrap();
+        let data = temp.path().join("readonly");
+        std::fs::create_dir(&data).unwrap();
+        std::fs::set_permissions(&data, std::fs::Permissions::from_mode(0o555)).unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session = SessionKey::with_profile("tenant-a", "api", "outer-io-preflight");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "check storage before spending".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .unwrap();
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session, "tenant-a")
+            .unwrap();
+        let provider = ScriptedVerifierProvider::done();
+        let first = orchestrator
+            .verify_goal_completion_bounded(
+                &session,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence",
+                Some(&data),
+            )
+            .await;
+        let second = orchestrator
+            .verify_goal_completion_bounded(
+                &session,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence",
+                Some(&data),
+            )
+            .await;
+        std::fs::set_permissions(&data, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(!first.is_done() && !second.is_done());
+        assert_eq!(
+            provider.chats(),
+            0,
+            "an unusable provided ledger must be detected before either call"
+        );
+        assert_eq!(first.attempts + second.attempts, 0);
+        assert_eq!(first.usage.input_tokens + second.usage.input_tokens, 0);
     }
 
     /// `detect_goal_complete_sentinel` covers all canonical sentinels

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -4963,7 +4963,7 @@ impl InProcessAgentOrchestrator {
         // still active after the previous per-attempt charge.
         let mut attempts: u32 = 0;
         let mut usage = octos_llm::TokenUsage::default();
-        let (verdict, outcome_kind, missing_evidence, call_error);
+        let (verdict, outcome_kind, missing_evidence, call_error, record_reason);
         loop {
             attempts += 1;
             let call = run_goal_completion_verifier_with_usage(
@@ -4992,10 +4992,24 @@ impl InProcessAgentOrchestrator {
             if retry {
                 continue;
             }
+            // PR-2273 P2-③: an InvalidResponse verdict carries its bounded
+            // raw-quote reason ONLY in `NotDone.reason`. Persist it into
+            // the NEW `reason` column (ROOT #1: NOT `missing_evidence` —
+            // that field keeps its parser semantics and stuffing a
+            // protocol error there would disguise it as missing evidence).
+            // The reader prefers `reason`, then falls back to the v3
+            // legacy columns (missing_evidence → error → outcome).
+            record_reason = match (&call.verdict, call.kind) {
+                (
+                    GoalCompletionVerdict::NotDone { reason },
+                    Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::InvalidResponse),
+                ) => Some(reason.clone()),
+                _ => None,
+            };
+            call_error = call.call_error;
             verdict = call.verdict;
             outcome_kind = call.kind;
             missing_evidence = call.missing_evidence;
-            call_error = call.call_error;
             break;
         }
 
@@ -5021,6 +5035,7 @@ impl InProcessAgentOrchestrator {
                     attempts,
                     usage: usage.clone(),
                     missing_evidence: missing_evidence.clone(),
+                    reason: record_reason.clone(),
                     error: call_error.clone(),
                     evidence_digest: digest.clone(),
                     replayed: false,
@@ -5289,10 +5304,16 @@ impl InProcessAgentOrchestrator {
                 let verdict = if kind.is_none() {
                     GoalCompletionVerdict::Done
                 } else {
+                    // PR-2273 P2-③ reader: prefer the persisted bounded
+                    // `reason` (new rows), then the v3 legacy fallbacks —
+                    // missing_evidence (insufficient_evidence rows),
+                    // error (call_failed rows), bare outcome (old
+                    // invalid_response rows carry no detail).
                     GoalCompletionVerdict::NotDone {
                         reason: record
-                            .missing_evidence
+                            .reason
                             .clone()
+                            .or_else(|| record.missing_evidence.clone())
                             .or_else(|| record.error.clone())
                             .unwrap_or_else(|| record.outcome.clone()),
                     }
@@ -16401,7 +16422,16 @@ objective is fully met, or `NOT_DONE: <short reason>` otherwise."
                 .filter_map(|cause| cause.downcast_ref::<octos_llm::LlmError>())
                 .next()
                 .is_some_and(|llm| llm.is_retryable());
-            let text = error.to_string();
+            // PR-2273 P2-②: ONE bounded, Unicode-safe error string feeds
+            // BOTH the NotDone reason and `call_error` — the pre-fix path
+            // pushed the UNTRUNCATED `error.to_string()` into the reason
+            // (only call_error was truncated), leaking an unbounded
+            // multi-byte error into UI/tool/persisted surfaces.
+            let text: String = error
+                .to_string()
+                .chars()
+                .take(VERIFIER_CALL_ERROR_CHARS)
+                .collect();
             SingleVerifierCall {
                 verdict: GoalCompletionVerdict::NotDone {
                     reason: format!("verifier call failed: {text}"),
@@ -16409,7 +16439,7 @@ objective is fully met, or `NOT_DONE: <short reason>` otherwise."
                 kind: Some(crate::autonomy::goal_loop_runtime::GoalVerifierFailureKind::CallFailed),
                 missing_evidence: None,
                 call_error_retryable: retryable,
-                call_error: Some(text.chars().take(VERIFIER_CALL_ERROR_CHARS).collect()),
+                call_error: Some(text),
                 usage: octos_llm::TokenUsage::default(),
             }
         }
@@ -16497,6 +16527,13 @@ pub(crate) struct VerifierLedgerRecord {
     pub usage: octos_llm::TokenUsage,
     #[serde(default)]
     pub missing_evidence: Option<String>,
+    /// PR-2273 P2-③: bounded NotDone reason (currently written for
+    /// InvalidResponse so a restart replays the raw-quote detail instead
+    /// of the bare enum string). `serde(default)` keeps pre-existing v3
+    /// rows deserializable; the reader prefers this over the legacy
+    /// missing_evidence/error/outcome fallbacks.
+    #[serde(default)]
+    pub reason: Option<String>,
     /// Truncated provider error (call_failed only).
     #[serde(default)]
     pub error: Option<String>,
@@ -16582,27 +16619,74 @@ fn verifier_scope_fingerprint(
 /// anchor is unreadable) — fail-safe: two texts that differ simply never
 /// share a ledger.
 fn verifier_storage_identity(data_dir: &std::path::Path) -> String {
+    // Storage identity for the verifier ledger scope: the SAME directory
+    // must yield the SAME identity across every spelling, before AND after
+    // the preflight creates missing components:
+    //   plain `a/b`, `./a/b`, missing-tail `a/new/../b`, tails climbing
+    //   above the missing pieces, and symlinked components (which must
+    // keep OS resolution — a `..` that lands back on an EXISTING dir
+    // resumes canonicalization from there).
+    //
+    // Algorithm: anchor, walk up to the deepest EXISTING ancestor via
+    // `canonicalize`, then replay the collected missing components
+    // outermost-first onto the canonical anchor — pushing each `Normal`
+    // and IMMEDIATELY canonicalizing the candidate (so a component that
+    // already exists — e.g. a symlink created between calls, or a `..`
+    // that returns to existing territory — resolves through the OS),
+    // popping the candidate on `ParentDir`, and skipping `CurDir`.
+    // `PathBuf::pop` on an absolute candidate stops at the root, so a
+    // `..` past the anchor can never climb above it.
+    let anchored = if data_dir.is_absolute() {
+        data_dir.to_path_buf()
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => cwd.join(data_dir),
+            // No cwd (extreme sandbox): identical fallback on every call,
+            // so the identity is still stable.
+            Err(_) => data_dir.to_path_buf(),
+        }
+    };
+    // Collected innermost-first while walking up to the existing anchor.
     let mut tail: Vec<std::ffi::OsString> = Vec::new();
-    let mut cursor = data_dir.to_path_buf();
-    loop {
-        match cursor.canonicalize() {
-            Ok(mut canon) => {
-                for part in tail.iter().rev() {
-                    canon.push(part);
-                }
-                return canon.to_string_lossy().into_owned();
-            }
-            Err(_) => {
-                let Some(file_name) = cursor.file_name().map(|n| n.to_os_string()) else {
-                    return data_dir.to_string_lossy().into_owned();
-                };
-                tail.push(file_name);
-                if !cursor.pop() {
-                    return data_dir.to_string_lossy().into_owned();
-                }
-            }
+    let mut cursor = anchored.clone();
+    let mut canon: std::path::PathBuf = loop {
+        if let Ok(c) = cursor.canonicalize() {
+            break c;
+        }
+        let Some(back) = cursor.components().next_back() else {
+            // Nothing left to walk: keep the anchored text (stable).
+            return anchored.to_string_lossy().into_owned();
+        };
+        use std::path::Component;
+        match back {
+            Component::Normal(name) => tail.push(name.to_os_string()),
+            Component::CurDir => tail.push(".".to_owned().into()),
+            Component::ParentDir => tail.push("..".to_owned().into()),
+            // Root/Prefix terminate the walk at the filesystem root.
+            _ => break cursor.clone(),
+        }
+        if !cursor.pop() {
+            return anchored.to_string_lossy().into_owned();
+        }
+    };
+    // Replay outermost-first (tail was collected innermost-first).
+    for part in tail.iter().rev() {
+        if part == "." {
+            continue;
+        }
+        if part == ".." {
+            canon.pop();
+            continue;
+        }
+        canon.push(part);
+        // A component that exists NOW (symlink or real dir created since
+        // the walk, or a `..` that returned to existing territory) must
+        // resolve through the OS, not stay lexical.
+        if let Ok(resolved) = canon.canonicalize() {
+            canon = resolved;
         }
     }
+    canon.to_string_lossy().into_owned()
 }
 
 /// REAL per-scope single-flight (outer defect ①): a process-wide registry
@@ -39772,6 +39856,547 @@ mod tests {
         assert_eq!(outcome.usage.reasoning_tokens, 33, "3 + 30");
         assert_eq!(outcome.usage.cache_read_tokens, 44, "4 + 40");
         assert_eq!(outcome.usage.cache_write_tokens, 55, "5 + 50");
+    }
+
+    /// PR-2273 P2-③ (ROOT #1 compat): a v3 ledger row written BEFORE the
+    /// `reason` column existed (invalid_response, no reason field) must
+    /// still deserialize and replay via the legacy outcome fallback — the
+    /// new reader prefers `reason` but never breaks old rows.
+    #[tokio::test]
+    async fn goal_verifier_old_v3_row_without_reason_still_replays() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: SessionKey::with_profile("tenant-a", "api", "iv-old-v3-anchor"),
+                profile_id: "tenant-a".into(),
+                objective: "throwaway id anchor".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("throwaway goal (id anchor)");
+        let session_id = SessionKey::with_profile("tenant-a", "api", "iv-old-v3");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "old v3 row".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let temp = tempfile::TempDir::new().expect("temp dir");
+
+        // Run ONE live call so the ledger file + scope fingerprint exist,
+        // then hand-rewrite the row into the PRE-reason v3 shape.
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "DONE: but never actually finished",
+                usage: usage_of(4, 2, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let _ = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider,
+                "evidence-old",
+                Some(temp.path()),
+            )
+            .await;
+        let rows = read_scope_ledger_rows(&temp, &session_id, "tenant-a", &snapshot);
+        assert_eq!(rows.len(), 1);
+        let mut row: serde_json::Value = serde_json::from_str(&rows[0]).expect("row");
+        // Strip the new column AND the detail columns — a true old-v3 row.
+        row.as_object_mut().expect("obj").remove("reason");
+        row.as_object_mut().expect("obj").remove("missing_evidence");
+        row.as_object_mut().expect("obj").remove("error");
+        let scope_fp = row["scope"].as_str().expect("scope").to_owned();
+        let ledger_path = verifier_ledger_path(temp.path(), &scope_fp);
+        std::fs::write(&ledger_path, format!("{row}\n")).expect("rewrite old-v3 row");
+
+        // Fresh orchestrator (restart) with id parity reads the old row:
+        // deserializes (serde default), replays invalid_response with the
+        // legacy bare-outcome fallback text.
+        let restarted = InProcessAgentOrchestrator::default();
+        restarted
+            .set_goal(GoalSetRequest {
+                session_id: SessionKey::with_profile("tenant-a", "api", "iv-old-v3-anchor"),
+                profile_id: "tenant-a".into(),
+                objective: "throwaway id anchor".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("throwaway goal (id anchor)");
+        restarted
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "old v3 row".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot2 = restarted
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot2");
+        assert_eq!(snapshot2.goal_id, snapshot.goal_id, "id parity");
+        let provider2 = ScriptedVerifierProvider::done();
+        let outcome = restarted
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot2,
+                provider2,
+                "evidence-old",
+                Some(temp.path()),
+            )
+            .await;
+        assert!(outcome.replayed, "old v3 row replays");
+        assert_eq!(outcome.kind.map(|k| k.as_str()), Some("invalid_response"));
+        assert_eq!(
+            outcome.not_done_reason(),
+            Some("invalid_response"),
+            "legacy fallback text for a detail-less old row"
+        );
+    }
+
+    /// PR-2273 P2-①: storage identity must be STABLE across the
+    /// preflight-creates-the-directory transition. A NONEXISTING RELATIVE
+    /// data_dir under a real cwd previously resolved to the raw relative
+    /// string on first use, then to an ABSOLUTE canonical path after
+    /// preflight created it — two identities, so scope/mutex/cache/ledger
+    /// all split and the same evidence paid a fresh provider call.
+    #[tokio::test]
+    async fn goal_verifier_storage_identity_stable_across_relative_dir_creation() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "rel-dir");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "relative dir stability".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+
+        // A nonexistent RELATIVE path under the CURRENT cwd — WITHOUT
+        // touching the process cwd (ROOT: set_current_dir pollutes the
+        // parallel whole-repo test run). Reserve a unique basename by
+        // creating the guard directory IN the cwd (so its Drop actually
+        // cleans the re-created path), remember the basename, remove the
+        // empty guard dir we just made, then use `<basename>/nested` as
+        // the relative data_dir. No cwd garbage survives panic or success.
+        let cwd = std::env::current_dir().expect("cwd");
+        let guard = tempfile::Builder::new()
+            .prefix(".verifier-relative-")
+            .tempdir_in(&cwd)
+            .expect("guard dir in cwd");
+        let basename = guard
+            .path()
+            .file_name()
+            .expect("guard basename")
+            .to_os_string();
+        std::fs::remove_dir(guard.path()).expect("remove empty guard dir");
+        let relative = std::path::PathBuf::from(&basename).join("nested");
+        assert!(
+            !relative.exists(),
+            "precondition: relative path does not exist yet"
+        );
+
+        // First identity BEFORE creation, second AFTER preflight created it.
+        let identity_before = verifier_storage_identity(&relative);
+        let provider = ScriptedVerifierProvider::done();
+        let _first = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence-rel",
+                Some(&relative),
+            )
+            .await;
+        assert!(
+            relative.exists(),
+            "preflight created the missing relative directory"
+        );
+        let identity_after = verifier_storage_identity(&relative);
+        assert_eq!(
+            identity_before, identity_after,
+            "storage identity must not change when preflight creates the dir"
+        );
+
+        // PR-2273 follow-up (ROOT probe `new/../other`): a missing tail
+        // containing `..` must collapse to the SAME identity before and
+        // after creation — first call creates `<cwd>/other-tail`, and the
+        // `..`-spelled path agrees on every call thereafter.
+        let guard2 = tempfile::Builder::new()
+            .prefix(".verifier-relative-")
+            .tempdir_in(&cwd)
+            .expect("guard dir 2");
+        let base2 = guard2
+            .path()
+            .file_name()
+            .expect("basename 2")
+            .to_os_string();
+        std::fs::remove_dir(guard2.path()).expect("remove empty guard 2");
+        let dotted = std::path::PathBuf::from(&base2).join("new/../other");
+        let identity_dotted_before = verifier_storage_identity(&dotted);
+        let plain = std::path::PathBuf::from(&base2).join("other");
+        std::fs::create_dir_all(&plain).expect("create plain target");
+        let identity_plain = verifier_storage_identity(&plain);
+        assert_eq!(
+            identity_dotted_before, identity_plain,
+            "`..` over missing pieces collapses to the plain identity"
+        );
+        // After the dotted path exists (via the plain target), the dotted
+        // spelling still agrees — no drift post-creation.
+        let identity_dotted_after = verifier_storage_identity(&dotted);
+        assert_eq!(identity_dotted_after, identity_plain);
+
+        // Positive: an EXISTING symlinked ancestor keeps OS resolution —
+        // two spellings of the same real dir share one identity.
+        // (Unix-only: std::os::unix::fs::symlink.)
+        #[cfg(unix)]
+        {
+            let guard3 = tempfile::Builder::new()
+                .prefix(".verifier-relative-")
+                .tempdir_in(&cwd)
+                .expect("guard dir 3");
+            let real = guard3.path().join("real-dir");
+            std::fs::create_dir_all(&real).expect("real dir");
+            let link = guard3.path().join("link-dir");
+            std::os::unix::fs::symlink(&real, &link).expect("symlink");
+            let via_real = verifier_storage_identity(&real);
+            let via_link = verifier_storage_identity(&link);
+            assert_eq!(
+                via_real, via_link,
+                "existing symlinked ancestors resolve to one identity"
+            );
+            // existing-symlink + `..`: per POSIX path resolution, `..` binds
+            // to the path-lexical parent (link/sub/.. == link), and the FINAL
+            // component then resolves through the symlink — so
+            // link/sub/../leaf ≡ link/leaf ≡ real-dir/leaf.
+            let via_link_dotdot = verifier_storage_identity(&link.join("sub/../leaf"));
+            let via_link_leaf = verifier_storage_identity(&link.join("leaf"));
+            let via_real_leaf = verifier_storage_identity(&real.join("leaf"));
+            assert_eq!(
+                via_link_dotdot, via_link_leaf,
+                "`..` binds to the path-lexical parent (link/sub/.. == link)"
+            );
+            assert_eq!(
+                via_link_leaf, via_real_leaf,
+                "the leaf resolves through the symlink to the real dir"
+            );
+
+            // ── ROOT probe matrix: every spelling stable pre/post creation ──
+            let guard4 = tempfile::Builder::new()
+                .prefix(".verifier-relative-")
+                .tempdir_in(&cwd)
+                .expect("guard dir 4");
+            let base4 = guard4
+                .path()
+                .file_name()
+                .expect("basename 4")
+                .to_os_string();
+            std::fs::remove_dir(guard4.path()).expect("remove empty guard 4");
+            let mk = |spelling: &str| std::path::PathBuf::from(&base4).join(spelling);
+            // (spelling, equivalent plain form) pairs.
+            let cases: Vec<(&str, String)> = vec![
+                ("plain/x/y", "plain/x/y".to_owned()),
+                ("./cur/x", "cur/x".to_owned()),
+                ("dd/new/../other", "dd/other".to_owned()),
+                ("deep/a/b/../../../shallow", "shallow".to_owned()),
+            ];
+            for (spelling, plain_eq) in &cases {
+                let dotted = mk(spelling);
+                let before = verifier_storage_identity(&dotted);
+                // Create through the DOTTED spelling itself — a real
+                // creation the preflight would perform — then compare BOTH
+                // spellings' identities against it.
+                std::fs::create_dir_all(&dotted).expect("create via dotted spelling");
+                assert!(dotted.exists(), "dotted path really exists now");
+                let after_dotted = verifier_storage_identity(&dotted);
+                assert_eq!(
+                    before, after_dotted,
+                    "spelling {spelling:?} stable across creation via itself"
+                );
+                let plain_path = mk(plain_eq);
+                assert!(plain_path.exists(), "plain equivalent reached");
+                let plain_identity = verifier_storage_identity(&plain_path);
+                assert_eq!(
+                    after_dotted, plain_identity,
+                    "spelling {spelling:?} and plain {plain_eq:?} share one identity"
+                );
+                // Clean the case dir so later cases start fresh under base4.
+                let _ = std::fs::remove_dir_all(mk(spelling.split('/').next().unwrap_or("")));
+                let _ = std::fs::remove_dir_all(&plain_path);
+            }
+            std::fs::create_dir_all(mk("shallow")).expect("recreate for cleanup guard");
+        }
+
+        // ── v2 probe regression (ROOT 2273-tail-v2-path-probes.json case 7):
+        // `new/../link/fresh` where `link` is an EXISTING symlink to a
+        // real dir. The `..` collapses over the MISSING `new`, landing on
+        // the guard base — an EXISTING dir — after which the symlink MUST
+        // resolve through the OS: identity == target/inner/fresh, and it
+        // must be STABLE across creation of `fresh` in the target.
+        #[cfg(unix)]
+        {
+            let guard5 = tempfile::Builder::new()
+                .prefix(".verifier-relative-")
+                .tempdir_in(&cwd)
+                .expect("guard dir 5");
+            let real5 = guard5.path().join("target/inner");
+            std::fs::create_dir_all(&real5).expect("real target dir");
+            let link5 = guard5.path().join("link");
+            std::os::unix::fs::symlink(&real5, &link5).expect("symlink 5");
+            let dotted5 = guard5.path().join("new/../link/fresh");
+            let before5 = verifier_storage_identity(&dotted5);
+            let direct5 = real5.join("fresh");
+            std::fs::create_dir_all(&direct5).expect("create fresh in target");
+            let after5 = verifier_storage_identity(&dotted5);
+            let direct_identity5 = verifier_storage_identity(&direct5);
+            assert_eq!(
+                before5, direct_identity5,
+                "`..` back onto an existing dir must resume OS resolution through the symlink"
+            );
+            assert_eq!(after5, direct_identity5, "stable after creation");
+            // And a FURTHER `..` after the symlink-resolved component climbs
+            // the RESOLVED target (`target/inner`), not the symlink's parent.
+            let dotted6 = guard5.path().join("new/../link/fresh/../top");
+            let via_target = verifier_storage_identity(&real5.join("top"));
+            let dotted6_identity = verifier_storage_identity(&dotted6);
+            assert_eq!(
+                dotted6_identity, via_target,
+                "`..` after a resolved symlink climbs the resolved parent"
+            );
+        }
+
+        // Second identical call with the SAME relative path must REPLAY the
+        // first verdict (durable replay, zero provider chats).
+        let second = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence-rel",
+                Some(&relative),
+            )
+            .await;
+        assert_eq!(provider.chats(), 1, "no second provider call");
+        assert!(second.replayed, "same identity ⇒ durable replay");
+        // The guard's Drop removes whatever preflight re-created under the
+        // basename; nothing here mutates the process cwd.
+        let _ = guard;
+    }
+
+    /// PR-2273 P2-②: the CallFailed NotDone reason itself must be the
+    /// bounded, Unicode-safe error string — the pre-fix path pushed the
+    /// UNTRUNCATED `error.to_string()` into `NotDone.reason` (only
+    /// `call_error` was truncated), so a multi-byte provider error longer
+    /// than the cap leaked an unbounded reason into UI/tool/persisted
+    /// surfaces.
+    #[tokio::test]
+    async fn goal_verifier_call_failed_reason_is_bounded_unicode_safe() {
+        struct LongMultibyteErrorProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for LongMultibyteErrorProvider {
+            async fn chat(
+                &self,
+                _m: &[octos_core::Message],
+                _t: &[octos_llm::ToolSpec],
+                _c: &octos_llm::ChatConfig,
+            ) -> eyre::Result<octos_llm::ChatResponse> {
+                // 600 emoji, each 4 bytes — far past VERIFIER_CALL_ERROR_CHARS.
+                Err(eyre::eyre!("{}", "💡".repeat(600)))
+            }
+            fn model_id(&self) -> &str {
+                "long-error"
+            }
+            fn provider_name(&self) -> &str {
+                "long-error"
+            }
+        }
+
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "bounded-reason");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "bounded reason".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let outcome = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                std::sync::Arc::new(LongMultibyteErrorProvider),
+                "evidence",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(outcome.kind.map(|k| k.as_str()), Some("call_failed"));
+        let reason = outcome.not_done_reason().expect("reason present");
+        let reason_chars = reason.chars().count();
+        // The reason may carry a short prefix ("verifier call failed: ")
+        // around the bounded error, but the WHOLE line stays bounded and
+        // every char is a valid char boundary (no panic, no mojibake).
+        assert!(
+            reason_chars <= VERIFIER_CALL_ERROR_CHARS + 64,
+            "reason must be bounded, got {reason_chars} chars"
+        );
+        assert!(
+            reason.chars().all(|c| c == '💡' || !c.is_control()),
+            "no mangled multi-byte artifacts"
+        );
+    }
+
+    /// PR-2273 P2-③: an InvalidResponse verdict must persist its bounded
+    /// raw-quote reason and REPLAY it after a restart — the pre-fix ledger
+    /// row stored only `outcome=invalid_response` with no reason, so a
+    /// read-back produced the bare enum string instead of the diagnostic
+    /// detail. v3 old rows (no reason field) must stay readable via the
+    /// existing fallback.
+    #[tokio::test]
+    async fn goal_verifier_invalid_response_reason_persists_and_replays() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        // Deterministic goal-id alignment for restart parity: ids are
+        // minted sequentially per orchestrator (goal_01, goal_02, …), so a
+        // throwaway goal occupies goal_01 on BOTH orchestrators and the
+        // session under test lands on goal_02 with an identical id — the
+        // scope fingerprint (which includes goal_id) then matches across
+        // the restart.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: SessionKey::with_profile("tenant-a", "api", "iv-throwaway"),
+                profile_id: "tenant-a".into(),
+                objective: "throwaway id anchor".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set throwaway goal (id anchor)");
+        let session_id = SessionKey::with_profile("tenant-a", "api", "iv-reason");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "persist invalid reason".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let snapshot = orchestrator
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot");
+        let temp = tempfile::TempDir::new().expect("temp dir");
+
+        let provider = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "DONE: but the tests were never green",
+                usage: usage_of(4, 2, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let first = orchestrator
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot,
+                provider.clone(),
+                "evidence-iv",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(first.kind.map(|k| k.as_str()), Some("invalid_response"));
+        assert!(!first.replayed);
+
+        // Durability: a FRESH orchestrator over the same data dir (restart
+        // semantics) replays the SAME verdict — with the bounded raw-quote
+        // reason intact, and NO new provider call.
+        let restarted = InProcessAgentOrchestrator::default();
+        restarted
+            .set_goal(GoalSetRequest {
+                session_id: SessionKey::with_profile("tenant-a", "api", "iv-throwaway"),
+                profile_id: "tenant-a".into(),
+                objective: "throwaway id anchor".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set throwaway goal (id anchor)");
+        restarted
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "persist invalid reason".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal (same id semantics under fresh state)");
+        let snapshot2 = restarted
+            .goal_verification_snapshot(&session_id, "tenant-a")
+            .expect("snapshot after restart");
+        assert_eq!(
+            snapshot2.goal_id, snapshot.goal_id,
+            "restart parity: same goal id ⇒ same scope fingerprint"
+        );
+        let provider2 = Arc::new(ScriptedVerifierProvider {
+            replies: StdMutex::new(vec![ScriptedReply::Ok {
+                content: "DONE",
+                usage: usage_of(1, 1, 0, 0, 0),
+            }]),
+            chats: std::sync::atomic::AtomicU32::new(0),
+        });
+        let replayed = restarted
+            .verify_goal_completion_bounded(
+                &session_id,
+                "tenant-a",
+                &snapshot2,
+                provider2.clone(),
+                "evidence-iv",
+                Some(temp.path()),
+            )
+            .await;
+        assert_eq!(
+            provider2.chats(),
+            0,
+            "durable replay after restart must not call the provider"
+        );
+        assert!(replayed.replayed, "durable replay after restart");
+        assert_eq!(replayed.kind.map(|k| k.as_str()), Some("invalid_response"));
+        let reason = replayed.not_done_reason().expect("reason replayed");
+        assert!(
+            reason.contains("DONE: but the tests were never green"),
+            "the bounded raw quote must survive the restart, got: {reason}"
+        );
     }
 
     /// Test util: read the EXACT ledger file for a session's verifier

--- a/crates/octos-cli/src/autonomy/goal_loop_runtime.rs
+++ b/crates/octos-cli/src/autonomy/goal_loop_runtime.rs
@@ -294,6 +294,231 @@ impl GoalCompletionVerdict {
     }
 }
 
+/// Structured classification of why a goal-completion verifier outcome was
+/// not a clean `Done` — the orthogonal axis to [`GoalCompletionVerdict`].
+///
+/// The verdict answers "is the objective met?"; this kind answers "how
+/// healthy was the verification call itself?". Mixing the two (the
+/// pre-evo-verifier `NotDone { reason }`) made infrastructure failures
+/// indistinguishable from semantic evidence gaps, so callers could neither
+/// retry sensibly nor report what was missing.
+///
+/// `None` on the outcome ⟺ `Done` (a successful verification has no failure
+/// kind — the illegal `Done + CallFailed` state is unrepresentable).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GoalVerifierFailureKind {
+    /// The provider call itself failed (`chat` returned `Err`). Transient —
+    /// retried at most once when the underlying error is retryable.
+    CallFailed,
+    /// Provider returned `Ok` with empty/whitespace content (including the
+    /// reasoning-only case: `reasoning_content` non-empty, `content` empty —
+    /// thinking burned the budget, #23 family). Transient — retried once.
+    EmptyResponse,
+    /// Non-empty reply that violates the verdict protocol: `DONE` with
+    /// trailing text, multi-line residue, unpaired backticks, prose
+    /// negation, `Done.` — anything that is not an exact verdict. NOT
+    /// retried (same prompt ⇒ same malformed answer; blind retry just burns
+    /// 2× tokens). The reason embeds a truncated quote of the raw reply so
+    /// the agent can self-correct next turn.
+    InvalidResponse,
+    /// The verifier answered `NOT_DONE: <reason>` — a *semantic* verdict
+    /// that the objective is not yet met. Never retried; `missing_evidence`
+    /// carries what the verifier found lacking.
+    InsufficientEvidence,
+}
+
+impl GoalVerifierFailureKind {
+    /// Whether this kind is eligible for the single bounded retry (transient
+    /// infrastructure classes only — see spec Decision 3).
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::CallFailed | Self::EmptyResponse)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::CallFailed => "call_failed",
+            Self::EmptyResponse => "empty_response",
+            Self::InvalidResponse => "invalid_response",
+            Self::InsufficientEvidence => "insufficient_evidence",
+        }
+    }
+}
+
+impl fmt::Display for GoalVerifierFailureKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Ledger `outcome` value: the failure kinds plus the success value, so a
+/// `Done` verdict is representable in the persistent verifier ledger.
+pub const GOAL_VERIFIER_OUTCOME_DONE: &str = "done";
+
+/// Structured result of one bounded goal-completion verification run.
+///
+/// Wraps the (unchanged) [`GoalCompletionVerdict`] with the orthogonal
+/// failure classification, attempt count, semantic gap, replay provenance
+/// and the usage summed across *all* attempts (failures included).
+// `TokenUsage` (octos-llm) implements neither PartialEq nor Eq, so the
+// outcome derives only Debug/Clone; structural comparison in tests asserts
+// the individual fields (verdict/kind/attempts) instead.
+#[derive(Debug, Clone)]
+pub struct GoalVerifierOutcome {
+    /// The semantic verdict — unchanged type, so `maybe_complete_goal_from_model`
+    /// and its guards see exactly what they saw before.
+    pub verdict: GoalCompletionVerdict,
+    /// `None` ⟺ `verdict` is `Done`.
+    pub kind: Option<GoalVerifierFailureKind>,
+    /// Number of provider calls made in this run (≤2; 0 on a gate replay).
+    pub attempts: u32,
+    /// What the verifier said is missing (InsufficientEvidence) or a
+    /// truncated quote of a protocol-violating reply (InvalidResponse).
+    pub missing_evidence: Option<String>,
+    /// True when no new call was made — the persistent same-evidence gate
+    /// replayed a ledger verdict (`replayed_of_ts` is that record's ts).
+    pub replayed: bool,
+    pub replayed_of_ts_ms: Option<u64>,
+    /// Composite diagnostic (k3 round-3 B): set when the verification could
+    /// not complete its bookkeeping — e.g. a Done verdict whose ledger write
+    /// failed (fail-closed), or an unreadable gate ledger. The goal stays
+    /// open; the message names the remediation path.
+    pub diagnostic: Option<String>,
+    /// Usage summed per-field across every attempt, billed or not.
+    pub usage: octos_llm::TokenUsage,
+}
+
+impl GoalVerifierOutcome {
+    pub fn is_done(&self) -> bool {
+        self.verdict.is_done()
+    }
+
+    /// NotDone reason for call sites: classification + attempts, never the
+    /// bare `verifier returned: ` of the pre-evo-verifier era.
+    pub fn not_done_reason(&self) -> Option<&str> {
+        match &self.verdict {
+            GoalCompletionVerdict::Done => None,
+            GoalCompletionVerdict::NotDone { reason } => Some(reason),
+        }
+    }
+}
+
+/// Parsed verdict of a raw verifier reply — the pure, sync, provider-free
+/// core of the strict DONE protocol (spec Decision 2, final rule).
+///
+/// Deterministic ladder (no heuristics):
+/// 1. `None`/whitespace-only content → `EmptyResponse` (reasoning-only
+///    replies land here too — thinking burned the budget).
+/// 2. Strip at most one layer of a *paired* markdown fence.
+/// 3. Strip *paired* backticks (repeatable; unpaired are left alone).
+/// 4. Let L = the non-blank lines.
+/// 5. `|L| == 1` and `L[0]` case-insensitively `DONE` → `Done`.
+/// 6. Else `L[0]` (after paired-backtick strip) case-insensitively starts
+///    with `NOT_DONE` → `InsufficientEvidence`, missing = text after the
+///    colon (capped at 200 chars).
+/// 7. Else (trailing text, multi-line residue, `Done.`, prose) →
+///    `InvalidResponse` with a truncated quote of the raw reply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedVerifierReply {
+    pub verdict: GoalCompletionVerdict,
+    pub kind: Option<GoalVerifierFailureKind>,
+    pub missing_evidence: Option<String>,
+}
+
+/// Max chars of the raw reply quoted into an InvalidResponse reason —
+/// enough for the agent to see and fix its format next turn (spec Decision 2).
+pub const VERIFIER_INVALID_QUOTE_CHARS: usize = 120;
+/// Max chars of the NOT_DONE tail kept as missing evidence (pre-existing
+/// `take(200)` cap, preserved).
+pub const VERIFIER_MISSING_EVIDENCE_CHARS: usize = 200;
+
+fn strip_paired_backticks(mut text: &str) -> &str {
+    loop {
+        let bytes = text.as_bytes();
+        if bytes.len() >= 2 && bytes.first() == Some(&b'`') && bytes.last() == Some(&b'`') {
+            text = &text[1..text.len() - 1];
+        } else {
+            return text;
+        }
+    }
+}
+
+/// The strict verdict protocol parser (pure; see [`ParsedVerifierReply`]).
+pub fn classify_verifier_reply(
+    content: Option<&str>,
+    _reasoning_present: bool,
+) -> ParsedVerifierReply {
+    let raw = content.unwrap_or("");
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return ParsedVerifierReply {
+            verdict: GoalCompletionVerdict::NotDone {
+                reason: "verifier returned EMPTY content (Ok but no text)".to_owned(),
+            },
+            kind: Some(GoalVerifierFailureKind::EmptyResponse),
+            missing_evidence: None,
+        };
+    }
+    // At most one layer of a paired ``` fence.
+    let mut t = trimmed;
+    if let Some(inner) = t.strip_prefix("```") {
+        if let Some(body) = inner.strip_suffix("```") {
+            t = body.trim();
+        }
+    }
+    t = strip_paired_backticks(t);
+    let lines: Vec<&str> = t.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.len() == 1 && lines[0].eq_ignore_ascii_case("done") {
+        return ParsedVerifierReply {
+            verdict: GoalCompletionVerdict::Done,
+            kind: None,
+            missing_evidence: None,
+        };
+    }
+    let first = strip_paired_backticks(lines.first().copied().unwrap_or(""));
+    // Safe prefix match: NO arbitrary byte slicing (a multi-byte reply like
+    // 💡💡💡 has no char boundary at any fixed byte index — the previous
+    // `first[..9]` sliced into a code point and panicked). Also NOT_DONE is
+    // 8 bytes, not 9: match the exact prefix case-INSENSITIVELY over ASCII
+    // (spec Decision 2 keeps `done`/`Done` Done — the same leniency applies
+    // to `not_done`/`nOt_DoNe`; outer defect ⑥), and require the next char
+    // to be a delimiter (`:`/space/end) so fused tokens like NOT_DONEgarbage
+    // stay protocol violations (InvalidResponse), not semantic NOT_DONEs.
+    let bytes = first.as_bytes();
+    let prefix_matches = bytes.len() >= 8
+        && bytes[..8]
+            .iter()
+            .zip(b"NOT_DONE")
+            .all(|(b, p)| b.eq_ignore_ascii_case(p));
+    let not_done_tail = if prefix_matches {
+        Some(&first[8..])
+    } else {
+        None
+    }
+    .filter(|tail| tail.is_empty() || tail.starts_with(':') || tail.starts_with(' '));
+    if let Some(tail) = not_done_tail {
+        let missing = tail.trim_start_matches([':', ' ']).trim();
+        let missing: String = missing
+            .chars()
+            .take(VERIFIER_MISSING_EVIDENCE_CHARS)
+            .collect();
+        return ParsedVerifierReply {
+            verdict: GoalCompletionVerdict::NotDone {
+                reason: format!("insufficient evidence: {missing}"),
+            },
+            kind: Some(GoalVerifierFailureKind::InsufficientEvidence),
+            missing_evidence: Some(missing),
+        };
+    }
+    let quote: String = trimmed.chars().take(VERIFIER_INVALID_QUOTE_CHARS).collect();
+    ParsedVerifierReply {
+        verdict: GoalCompletionVerdict::NotDone {
+            reason: format!("verifier reply violated the verdict protocol: {quote}"),
+        },
+        kind: Some(GoalVerifierFailureKind::InvalidResponse),
+        missing_evidence: None,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GoalBudgetResolution {
     pub goal_id: GoalId,
@@ -1117,6 +1342,189 @@ mod tests {
 
     fn at(seconds: u64) -> SystemTime {
         UNIX_EPOCH + Duration::from_secs(seconds)
+    }
+
+    // ── classify_verifier_reply: strict verdict protocol (spec Decision 2) ──
+    // NOTE (process honesty, outer round 3): the production parser was written
+    // FIRST and these tests were added after — including two RED reproductions
+    // of defects the outer loop found by probing the extracted functions:
+    // (1) NOT_DONE is 8 bytes, the old `first[..9]` slice never matched, so
+    //     `NOT_DONE: missing X` was misclassified InvalidResponse;
+    // (2) byte-9 slicing panicked on multi-byte UTF-8 (💡💡💡 has no char
+    //     boundary at byte 9). Both must FAIL against the old code and PASS
+    //     after the fix (safe prefix matching, no arbitrary byte slicing).
+
+    #[test]
+    fn classify_not_done_prefix_is_recognized() {
+        // RED reproduction (outer defect 1): the 8-vs-9 byte bug.
+        let parsed = classify_verifier_reply(Some("NOT_DONE: missing X"), false);
+        assert_eq!(
+            parsed.kind,
+            Some(GoalVerifierFailureKind::InsufficientEvidence)
+        );
+        assert!(!parsed.verdict.is_done());
+        let missing = parsed.missing_evidence.expect("missing evidence recorded");
+        assert!(missing.contains("missing X"), "got {missing:?}");
+    }
+
+    #[test]
+    fn classify_multibyte_reply_does_not_panic() {
+        // RED reproduction (outer defect 2): byte slicing on UTF-8 must not
+        // panic; the emoji reply is prose → InvalidResponse, not a crash.
+        let parsed = classify_verifier_reply(Some("💡💡💡"), false);
+        assert_eq!(parsed.kind, Some(GoalVerifierFailureKind::InvalidResponse));
+        assert!(!parsed.verdict.is_done());
+    }
+
+    #[test]
+    fn classify_rejects_not_done_garbage_fusion() {
+        // Boundary from outer round 3: NOT_DONEgarbage is a protocol
+        // violation (InvalidResponse), NOT insufficient evidence — the
+        // prefix rule must not swallow fused tokens.
+        let parsed = classify_verifier_reply(Some("NOT_DONEgarbage"), false);
+        assert_eq!(parsed.kind, Some(GoalVerifierFailureKind::InvalidResponse));
+    }
+
+    #[test]
+    fn classify_accepts_exact_done_variants() {
+        for text in [
+            "DONE", "done", "Done", "`DONE`", "``DONE``", "DONE\n", "  DONE  ",
+        ] {
+            let parsed = classify_verifier_reply(Some(text), false);
+            assert!(parsed.verdict.is_done(), "{text:?} must be Done");
+            assert_eq!(parsed.kind, None, "{text:?} must have no failure kind");
+        }
+    }
+
+    #[test]
+    fn classify_accepts_mixed_case_done_and_not_done() {
+        // Outer defect ⑥: the final rule (spec Decision 2) makes the
+        // verdict protocol case-insensitive over ASCII — `dOnE` is Done
+        // and `nOt_DoNe: X` is InsufficientEvidence, exactly like the
+        // lower/capital forms the first version enumerated.
+        for text in ["dOnE", "DoNe", "dONE"] {
+            let parsed = classify_verifier_reply(Some(text), false);
+            assert!(parsed.verdict.is_done(), "{text:?} must be Done");
+            assert_eq!(parsed.kind, None, "{text:?} must have no failure kind");
+        }
+        for text in [
+            "nOt_DoNe: missing X",
+            "NOT_done: missing X",
+            "not_DONE missing X",
+        ] {
+            let parsed = classify_verifier_reply(Some(text), false);
+            assert_eq!(
+                parsed.kind,
+                Some(GoalVerifierFailureKind::InsufficientEvidence),
+                "{text:?} must be InsufficientEvidence"
+            );
+            assert!(
+                parsed
+                    .missing_evidence
+                    .as_deref()
+                    .is_some_and(|m| m.contains("missing X")),
+                "{text:?} must carry the tail"
+            );
+        }
+        // The fused-token boundary survives case-insensitivity:
+        // NOT_DONEgarbage stays a protocol violation in ANY casing.
+        for text in ["nOt_DoNegarbage", "not_DONEgarbage"] {
+            let parsed = classify_verifier_reply(Some(text), false);
+            assert_eq!(
+                parsed.kind,
+                Some(GoalVerifierFailureKind::InvalidResponse),
+                "{text:?} must be InvalidResponse"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_accepts_single_paired_fence() {
+        let parsed = classify_verifier_reply(Some("```\nDONE\n```"), false);
+        assert!(parsed.verdict.is_done());
+    }
+
+    #[test]
+    fn classify_rejects_done_with_trailing_text() {
+        for text in [
+            "DONE: but the build log was never checked",
+            "DONE\nNOT_DONE: tests failing",
+            "DONEgarbage",
+            "Done.",
+        ] {
+            let parsed = classify_verifier_reply(Some(text), false);
+            assert!(!parsed.verdict.is_done(), "{text:?} must not be Done");
+            assert_eq!(
+                parsed.kind,
+                Some(GoalVerifierFailureKind::InvalidResponse),
+                "{text:?} must be InvalidResponse"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_rejects_unpaired_backticks() {
+        for text in ["`DONE", "DONE`"] {
+            let parsed = classify_verifier_reply(Some(text), false);
+            assert!(!parsed.verdict.is_done(), "{text:?} must not be Done");
+            assert_eq!(parsed.kind, Some(GoalVerifierFailureKind::InvalidResponse));
+        }
+    }
+
+    #[test]
+    fn classify_empty_and_reasoning_only_is_empty_response() {
+        for content in [None, Some(""), Some("   ")] {
+            let parsed = classify_verifier_reply(content, true);
+            assert_eq!(parsed.kind, Some(GoalVerifierFailureKind::EmptyResponse));
+            assert!(!parsed.verdict.is_done());
+        }
+    }
+
+    #[test]
+    fn classify_prose_negation_is_invalid_response_with_quote() {
+        let parsed =
+            classify_verifier_reply(Some("The build is still failing, tests not run"), false);
+        assert_eq!(parsed.kind, Some(GoalVerifierFailureKind::InvalidResponse));
+        let GoalCompletionVerdict::NotDone { reason } = parsed.verdict else {
+            panic!("prose must be NotDone");
+        };
+        assert!(
+            reason.contains("The build is still failing"),
+            "reason must quote the raw reply: {reason}"
+        );
+    }
+
+    #[test]
+    fn classify_not_done_with_multibyte_reason_does_not_panic() {
+        // Regression companion of the emoji-panic fix: a real NOT_DONE whose
+        // reason contains multi-byte chars must parse safely and keep the
+        // tail (no byte-slice anywhere in the path).
+        let parsed = classify_verifier_reply(Some("NOT_DONE: 💡缺测试"), false);
+        assert_eq!(
+            parsed.kind,
+            Some(GoalVerifierFailureKind::InsufficientEvidence)
+        );
+        assert!(parsed.missing_evidence.unwrap().contains("💡缺测试"));
+    }
+
+    #[test]
+    fn classify_missing_evidence_capped_at_200_chars() {
+        let long = "x".repeat(500);
+        let parsed = classify_verifier_reply(Some(&format!("NOT_DONE: {long}")), false);
+        let missing = parsed.missing_evidence.expect("missing");
+        assert_eq!(missing.chars().count(), VERIFIER_MISSING_EVIDENCE_CHARS);
+    }
+
+    #[test]
+    fn classify_not_done_without_colon_still_insufficient() {
+        // NOT_DONE followed directly by the reason (no colon) is still a
+        // semantic NOT_DONE verdict; the tail is the missing evidence.
+        let parsed = classify_verifier_reply(Some("NOT_DONE tests not run"), false);
+        assert_eq!(
+            parsed.kind,
+            Some(GoalVerifierFailureKind::InsufficientEvidence)
+        );
+        assert!(parsed.missing_evidence.unwrap().contains("tests not run"));
     }
 
     #[test]

--- a/crates/octos-cli/src/autonomy/goal_loop_runtime.rs
+++ b/crates/octos-cli/src/autonomy/goal_loop_runtime.rs
@@ -402,6 +402,37 @@ impl GoalVerifierOutcome {
     }
 }
 
+/// evo-goal-verifier (spec Decision 1/6, M5): ONE canonical human-readable
+/// NotDone line shared by every call site — goal_tool's ToolResult output
+/// and the three sentinel stations' failure notes — so the structured
+/// `{kind} (attempt n/2): reason [replayed…][diagnostic]` format cannot
+/// drift between the four entry points. Done renders as `done`.
+impl fmt::Display for GoalVerifierOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_done() {
+            return f.write_str("done");
+        }
+        let kind = self.kind.map(|k| k.as_str()).unwrap_or("unknown");
+        write!(
+            f,
+            "verifier {kind} (attempt {}/{}): {}",
+            self.attempts,
+            crate::autonomy::agent_orchestrator::VERIFIER_MAX_ATTEMPTS,
+            self.not_done_reason().unwrap_or("unknown")
+        )?;
+        if self.replayed {
+            match self.replayed_of_ts_ms {
+                Some(ts) => write!(f, " [replayed verdict from {ts}]")?,
+                None => f.write_str(" [replayed verdict from history]")?,
+            }
+        }
+        if let Some(d) = &self.diagnostic {
+            write!(f, " [diagnostic: {d}]")?;
+        }
+        Ok(())
+    }
+}
+
 /// Parsed verdict of a raw verifier reply — the pure, sync, provider-free
 /// core of the strict DONE protocol (spec Decision 2, final rule).
 ///

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -2689,7 +2689,7 @@ mod tests {
     /// when a goal-scoped peer parks (`model_goal_record_peer_escalation`) but
     /// until this fold no production read existed, so the master model could
     /// never see them. Same data_dir gate as `ledger_findings`.
-
+    //
     /// evo-goal-verifier M4 (spec Filter: goal_update_reports_structured_
     /// verifier_failure, CallFailed variant): two transient call failures
     /// cap at attempt 2/2 and the refusal output names call_failed.

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -1436,31 +1436,11 @@ impl Tool for GoalUpdateTool {
                 )
                 .await;
             if !outcome.is_done() {
-                let attempt_note = if outcome.replayed {
-                    format!(
-                        " [replayed verdict from {}]",
-                        outcome
-                            .replayed_of_ts_ms
-                            .map(|ts| ts.to_string())
-                            .unwrap_or_else(|| "history".to_owned())
-                    )
-                } else {
-                    format!(" (attempt {}/{})", outcome.attempts, 2)
-                };
-                let kind_note = outcome
-                    .kind
-                    .map(|k| k.as_str().to_owned())
-                    .unwrap_or_default();
-                let diagnostic_note = outcome
-                    .diagnostic
-                    .as_ref()
-                    .map(|d| format!(" [diagnostic: {d}]"))
-                    .unwrap_or_default();
+                // M5: single canonical formatting source — the Display impl
+                // on GoalVerifierOutcome. All four call sites render the
+                // same `verifier {kind} (attempt n/2): reason` line.
                 return Ok(ToolResult {
-                    output: format!(
-                        "goal_update: completion NOT verified — verifier {kind_note}{attempt_note}: {}{diagnostic_note}",
-                        outcome.not_done_reason().unwrap_or("unknown"),
-                    ),
+                    output: format!("goal_update: completion NOT verified — {outcome}"),
                     success: false,
                     ..Default::default()
                 });
@@ -2142,6 +2122,43 @@ mod tests {
         }
     }
 
+    /// evo-goal-verifier M4: always fails with a RETRYABLE server error so
+    /// the bounded wrapper burns both attempts (attempt 2/2) before
+    /// refusing with kind=call_failed.
+    struct FailingVerifierProvider {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl Default for FailingVerifierProvider {
+        fn default() -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl octos_llm::LlmProvider for FailingVerifierProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<octos_llm::ChatResponse> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(eyre::eyre!(octos_llm::LlmError::new(
+                octos_llm::LlmErrorKind::ServerError { status: 503 },
+                "always failing",
+            )))
+        }
+        fn model_id(&self) -> &str {
+            "failing-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "failing-verifier"
+        }
+    }
+
     /// Captures the Debug of the messages the verifier is called with, so a
     /// test can assert exactly what evidence reached the independent verifier.
     struct CapturingVerifierProvider {
@@ -2592,6 +2609,19 @@ mod tests {
             .expect("goal_update runs");
         assert!(!result.success, "NotDone verdict refuses the transition");
         assert!(result.tokens_used.is_none(), "no stamp on refusal either");
+        // M4 (cross/GAP hardening): the refusal output must carry the
+        // STRUCTURED kind + attempt + reason via the canonical Display line.
+        assert!(
+            result
+                .output
+                .contains("verifier insufficient_evidence (attempt 1/2)"),
+            "structured kind+attempts in refusal output, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("evidence missing"),
+            "missing-evidence reason surfaced"
+        );
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
         let (tokens_used, _, _) = orchestrator
             .goal_counters_for_test(&session)
@@ -2659,6 +2689,43 @@ mod tests {
     /// when a goal-scoped peer parks (`model_goal_record_peer_escalation`) but
     /// until this fold no production read existed, so the master model could
     /// never see them. Same data_dir gate as `ledger_findings`.
+
+    /// evo-goal-verifier M4 (spec Filter: goal_update_reports_structured_
+    /// verifier_failure, CallFailed variant): two transient call failures
+    /// cap at attempt 2/2 and the refusal output names call_failed.
+    #[tokio::test]
+    async fn goal_update_reports_call_failed_verifier_failure() {
+        use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+        let orchestrator = default_agent_orchestrator();
+        let session = SessionKey("verifier-callfailed-prof:api:goal-update-callfailed".to_owned());
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session.clone(),
+                profile_id: "verifier-callfailed-prof".to_owned(),
+                objective: "surface call failure".to_owned(),
+                status: Some("active".to_owned()),
+                token_budget: Some(10_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+
+        let verifier = std::sync::Arc::new(FailingVerifierProvider::default());
+        let tool = GoalUpdateTool::new("verifier-callfailed-prof").with_verifier_provider(verifier);
+        let mut ctx = ToolContext::zero();
+        ctx.parent_session_key = Some(session.0.clone());
+
+        let result = tool
+            .execute_with_context(&ctx, &json!({"status": "complete", "reason": "attempt"}))
+            .await
+            .expect("goal_update runs");
+        assert!(!result.success, "call failure refuses the transition");
+        assert!(
+            result.output.contains("verifier call_failed (attempt 2/2)"),
+            "call_failed kind + capped attempts in output, got: {}",
+            result.output
+        );
+    }
+
     #[tokio::test]
     async fn goal_get_includes_open_escalations_when_data_dir_set() {
         use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -1421,32 +1421,45 @@ impl Tool for GoalUpdateTool {
                 .map(|dd| orchestrator.model_goal_ledger_findings(dd, &snapshot.goal_id))
                 .unwrap_or_default();
             let evidence = completion_evidence_with_ledger(reason, &ledger_findings);
-            let (verdict, usage) =
-                crate::autonomy::agent_orchestrator::run_goal_completion_verifier_with_usage(
+            // evo-goal-verifier — the SINGLE shared recovery entry: digest
+            // gate → single call → per-attempt charge → budget gate →
+            // bounded retry (≤2 calls) → ledger append. The wrapper owns
+            // the charge; this call site no longer charges directly.
+            let outcome = orchestrator
+                .verify_goal_completion_bounded(
+                    &session_id,
+                    &self.profile_id,
+                    &snapshot,
                     verifier_provider,
-                    &snapshot.objective,
                     &evidence,
+                    self.data_dir.as_deref(),
                 )
                 .await;
-            // #1935 round 5 — exactly-once direct charge, while the goal is
-            // still active/budget_limited (a `complete` goal cannot be
-            // charged). Covers Done AND NotDone outcomes.
-            let _ = orchestrator.charge_goal_verifier_usage(
-                &session_id,
-                &self.profile_id,
-                Some(&snapshot.goal_id),
-                &usage,
-            );
-            if !verdict.is_done() {
+            if !outcome.is_done() {
+                let attempt_note = if outcome.replayed {
+                    format!(
+                        " [replayed verdict from {}]",
+                        outcome
+                            .replayed_of_ts_ms
+                            .map(|ts| ts.to_string())
+                            .unwrap_or_else(|| "history".to_owned())
+                    )
+                } else {
+                    format!(" (attempt {}/{})", outcome.attempts, 2)
+                };
+                let kind_note = outcome
+                    .kind
+                    .map(|k| k.as_str().to_owned())
+                    .unwrap_or_default();
+                let diagnostic_note = outcome
+                    .diagnostic
+                    .as_ref()
+                    .map(|d| format!(" [diagnostic: {d}]"))
+                    .unwrap_or_default();
                 return Ok(ToolResult {
                     output: format!(
-                        "goal_update: completion NOT verified — independent verifier returned: {}",
-                        match verdict {
-                            crate::autonomy::goal_loop_runtime::GoalCompletionVerdict::NotDone {
-                                reason,
-                            } => reason,
-                            _ => "unknown".to_string(),
-                        }
+                        "goal_update: completion NOT verified — verifier {kind_note}{attempt_note}: {}{diagnostic_note}",
+                        outcome.not_done_reason().unwrap_or("unknown"),
                     ),
                     success: false,
                     ..Default::default()
@@ -2012,13 +2025,14 @@ mod tests {
         )
         .expect("build live k3 provider");
 
-        let (verdict, usage) =
-            crate::autonomy::agent_orchestrator::run_goal_completion_verifier_with_usage(
-                provider,
-                "Write the number 42 to a file.",
-                "I wrote 42 to /tmp/answer.txt and verified it with cat.",
-            )
-            .await;
+        let call = crate::autonomy::agent_orchestrator::run_goal_completion_verifier_with_usage(
+            provider,
+            "Write the number 42 to a file.",
+            "I wrote 42 to /tmp/answer.txt and verified it with cat.",
+        )
+        .await;
+        let verdict = call.verdict;
+        let usage = call.usage;
         let is_done = verdict.is_done();
         let reason = match &verdict {
             crate::autonomy::goal_loop_runtime::GoalCompletionVerdict::NotDone { reason } => {
@@ -2070,13 +2084,14 @@ mod tests {
             "四切片实证齐全。".repeat(40),
             "1. [peer:s2] (finding) zai lane done\n2. [peer:s4] (finding) docs done\n".repeat(20)
         );
-        let (verdict, usage) =
-            crate::autonomy::agent_orchestrator::run_goal_completion_verifier_with_usage(
-                provider,
-                "#19 goal peer 多模型能力 + zai GLM 5.2 接入。切片 S1-S4。",
-                &long_evidence,
-            )
-            .await;
+        let call = crate::autonomy::agent_orchestrator::run_goal_completion_verifier_with_usage(
+            provider,
+            "#19 goal peer 多模型能力 + zai GLM 5.2 接入。切片 S1-S4。",
+            &long_evidence,
+        )
+        .await;
+        let verdict = call.verdict;
+        let usage = call.usage;
         let reason = match &verdict {
             crate::autonomy::goal_loop_runtime::GoalCompletionVerdict::NotDone { reason } => {
                 reason.clone()

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -10273,6 +10273,7 @@ mod tests;
 /// lane, data_dir) so the REAL `maybe_advance_goal_runtime_after_turn` can
 /// be driven end-to-end without a full registry bootstrap.
 #[cfg(test)]
+#[allow(clippy::too_many_arguments, private_interfaces)]
 pub(crate) fn session_actor_for_goal_test(
     session_key: SessionKey,
     agent: Arc<Agent>,
@@ -10287,7 +10288,6 @@ pub(crate) fn session_actor_for_goal_test(
         mpsc::Sender<ActorMessage>,
         mpsc::Receiver<ActorMessage>,
     ) = mpsc::channel(1);
-    let data_dir = data_dir;
     let actor = SessionActor {
         session_key,
         channel: "api".to_owned(),

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -51,9 +51,7 @@ use tokio::sync::{Mutex, RwLock, Semaphore, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use crate::autonomy::agent_orchestrator::{
-    InProcessAgentOrchestrator, default_agent_orchestrator, run_goal_completion_verifier_with_usage,
-};
+use crate::autonomy::agent_orchestrator::{InProcessAgentOrchestrator, default_agent_orchestrator};
 use crate::autonomy::master_continuation_scheduler::{
     MasterContinuationReason, MasterContinuationRuntimeState, QueuedMasterContinuation,
 };
@@ -5428,33 +5426,29 @@ impl SessionActor {
             // the sentinel verifier (it runs outside the turn's routing scopes),
             // so a failover attributes to this session instead of publishing
             // unattributed. Autonomous turns are Normal policy → router only.
-            let (verdict, verifier_usage) = octos_llm::with_router_context(
+            // evo-goal-verifier: the wrapper owns gate/charge/retry/ledger;
+            // per-attempt usage is charged inside it, so nothing is charged
+            // here anymore.
+            let outcome = octos_llm::with_router_context(
                 octos_llm::RouterContext {
                     session_id: Some(self.session_key.to_string()),
                     ..Default::default()
                 },
-                run_goal_completion_verifier_with_usage(
+                orchestrator.verify_goal_completion_bounded(
+                    &self.session_key,
+                    profile_id,
+                    &snapshot,
                     verifier_provider,
-                    &snapshot.objective,
                     &assistant_tail,
+                    Some(self.data_dir.as_path()),
                 ),
             )
             .await;
-            // #1958 — the verifier call is real goal spend: fold it into the
-            // goal's tokens_used BEFORE `maybe_complete_goal_from_model` can
-            // flip the goal (a `complete` goal can no longer be charged).
-            // `record_goal_turn` above only charged the turn's own tokens.
-            let _ = orchestrator.charge_goal_verifier_usage(
-                &self.session_key,
-                profile_id,
-                Some(&snapshot.goal_id),
-                &verifier_usage,
-            );
             if orchestrator.maybe_complete_goal_from_model(
                 &self.session_key,
                 profile_id,
                 &assistant_tail,
-                &verdict,
+                &outcome.verdict,
                 &snapshot,
                 // #1957 (codex #1) — this interactive-chat goal path carries the
                 // profile data dir, so a sentinel completion syncs to the ledger.

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -5456,6 +5456,31 @@ impl SessionActor {
             ) {
                 return;
             }
+            // evo-goal-verifier M1 (cross A1): a claimed-but-UNVERIFIED
+            // completion must surface the structured failure kind on the
+            // sentinel path too — session_actor previously dropped
+            // `outcome.kind` entirely. The canonical Display line keeps the
+            // format identical to goal_update's ToolResult output.
+            if !outcome.is_done() {
+                tracing::warn!(
+                    session_id = %self.session_key,
+                    goal_id = %snapshot.goal_id,
+                    "sentinel goal completion not verified: {outcome}"
+                );
+                let note = format!("goal completion not verified — {outcome}");
+                {
+                    let mut handle = self.session_handle.lock().await;
+                    handle.push_message_in_memory(octos_core::Message::system(note.clone()));
+                }
+                // Canonical durable append (per-key lock → fresh open →
+                // seq'd write), mirroring `persist_assistant_message`.
+                let _ = octos_bus::session::persist_message_through_canonical_path(
+                    &self.data_dir,
+                    &self.session_key,
+                    octos_core::Message::system(note),
+                )
+                .await;
+            }
         }
         // Re-queue another continuation only if we are still idle AND
         // policy allows. The idle gate matches `drain_master_continuations`'s
@@ -10242,3 +10267,79 @@ fn format_thinking_prefix(reasoning: Option<&str>) -> String {
 #[cfg(test)]
 #[path = "session_actor_tests.rs"]
 mod tests;
+
+/// evo-goal-verifier GAP-6/7 test hook: construct a SessionActor directly
+/// with the pieces the goal-accountant path reads (session_handle, verifier
+/// lane, data_dir) so the REAL `maybe_advance_goal_runtime_after_turn` can
+/// be driven end-to-end without a full registry bootstrap.
+#[cfg(test)]
+pub(crate) fn session_actor_for_goal_test(
+    session_key: SessionKey,
+    agent: Arc<Agent>,
+    session_handle: Arc<Mutex<SessionHandle>>,
+    out_tx: mpsc::Sender<OutboundMessage>,
+    inbox: mpsc::Receiver<ActorMessage>,
+    self_tx: mpsc::Sender<ActorMessage>,
+    data_dir: std::path::PathBuf,
+    goal_verifier_llm: Option<Arc<dyn LlmProvider>>,
+) -> SessionActor {
+    let (dummy_spawn_tx, _dummy_spawn_rx): (
+        mpsc::Sender<ActorMessage>,
+        mpsc::Receiver<ActorMessage>,
+    ) = mpsc::channel(1);
+    let data_dir = data_dir;
+    let actor = SessionActor {
+        session_key,
+        channel: "api".to_owned(),
+        chat_id: String::new(),
+        tenant_id: None,
+        inbox,
+        agent,
+        hooks: None,
+        hook_context: None,
+        session_handle,
+        out_tx,
+        status_indicator: None,
+        sender_user_id: None,
+        user_status_config: UserStatusConfig::default(),
+        data_dir: data_dir.clone(),
+        usage_ledger: None,
+        session_usage: octos_agent::SharedSessionUsage::default(),
+        max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
+        idle_timeout: Duration::from_secs(60),
+        session_timeout: Duration::from_secs(120),
+        semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        global_shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        queue_mode: QueueMode::Followup,
+        responsiveness: ResponsivenessObserver::new(),
+        adaptive_router: None,
+        lane_routing: None,
+        memory_store: None,
+        usage_profile_id: "gap67-prof".to_owned(),
+        active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        overflow_cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        active_sessions: Arc::new(RwLock::new(
+            ActiveSessionStore::open(std::path::Path::new("/tmp/octos-gap67-active-sessions"))
+                .expect("active session store"),
+        )),
+        user_workspace: data_dir.clone(),
+        cron_tool: None,
+        self_tx,
+        pending_approvals: HumanPendingApprovalStore::default(),
+        approvals_audit: Arc::new(crate::approvals_audit::ApprovalsAuditLog::new(
+            &data_dir,
+            crate::approvals_audit::ApprovalsAuditConfig::from_env(),
+        )),
+        persistent_retry_state: Arc::new(std::sync::Mutex::new(LoopRetryState::default())),
+        context_manager: Arc::new(std::sync::Mutex::new(ContextManager::new("gap67", None))),
+        retry_state_path: Some(data_dir.clone().join("retry_state.json")),
+        recovered_tasks: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        consecutive_recovery_turns: Arc::new(std::sync::Mutex::new(0)),
+        current_command_cmid: None,
+        last_turn_total_tokens: 0,
+        goal_verifier_llm,
+    };
+    let _ = dummy_spawn_tx;
+    actor
+}

--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -10674,3 +10674,131 @@ async fn gateway_terminal_dual_sink_installer_ignores_sessionless_reentry() {
     );
     assert_eq!(runtime.pending_continuation_count_for_test(), 0);
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// evo-goal-verifier GAP-6/7 (spec Filters: sentinel_paths_keep_goal_active_
+// on_empty_response / session_actor_sentinel_reports_verifier_failure_kind)
+// — REAL session_actor path: factory-wired goal_verifier_llm whose replies
+// are empty, a claimed completion, and the post-turn goal accountant
+// (`maybe_advance_goal_runtime_after_turn`) must (a) keep the goal ACTIVE
+// and (b) surface the structured kind in a durable system note.
+// ─────────────────────────────────────────────────────────────────────────
+struct EmptyReplyVerifier;
+
+#[async_trait::async_trait]
+impl LlmProvider for EmptyReplyVerifier {
+    async fn chat(
+        &self,
+        _m: &[octos_core::Message],
+        _t: &[octos_llm::ToolSpec],
+        _c: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        Ok(octos_llm::ChatResponse {
+            content: None,
+            reasoning_content: Some("thinking…".to_owned()),
+            tool_calls: Vec::new(),
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage {
+                input_tokens: 3,
+                output_tokens: 1,
+                ..Default::default()
+            },
+            provider_index: None,
+        })
+    }
+    fn model_id(&self) -> &str {
+        "empty-verifier"
+    }
+    fn provider_name(&self) -> &str {
+        "empty-verifier"
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_actor_sentinel_reports_verifier_failure_kind() {
+    use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let task_store = SessionTaskQueryStore::default();
+    let (mut factory, _out_tx, _out_rx) =
+        build_minimal_actor_factory(&dir, task_store, Some("gap67-prof".to_owned())).await;
+    // Wire the empty-reply verifier into the REAL factory field the
+    // session_actor reads at :5422 — no wrapper shortcut.
+    factory.goal_verifier_llm = Some(Arc::new(EmptyReplyVerifier));
+
+    // Set an active goal for the session the actor will own.
+    let orchestrator = crate::autonomy::agent_orchestrator::default_agent_orchestrator();
+    let key = octos_core::SessionKey("gap67-prof:api:gap67-actor".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: key.clone(),
+            profile_id: "gap67-prof".to_owned(),
+            objective: "surface failure kind".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal");
+    let snapshot_before = orchestrator
+        .goal_verification_snapshot(&key, "gap67-prof")
+        .expect("snapshot before");
+
+    // Drive the actor's real post-turn goal accountant with a CLAIMED
+    // completion in the session history: `maybe_advance_goal_runtime_after_
+    // turn` reads the assistant tail, detects the claim, runs the wired
+    // verifier (empty replies → empty_response, 2/2 attempts), refuses the
+    // completion, and appends the structured system note.
+    let mut session_handle = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    session_handle
+        .session_mut()
+        .messages
+        .push(octos_core::Message::assistant(
+            "All tasks complete. <goal:complete>",
+        ));
+    let handle = Arc::new(tokio::sync::Mutex::new(session_handle));
+
+    // Build the actor via the registry spawn path.
+    let (proxy_tx, _proxy_rx) = mpsc::channel(64);
+    let (_inbox_tx, inbox_rx) = mpsc::channel(8);
+    let (self_tx, _self_rx) = mpsc::channel(8);
+    let tools = octos_agent::ToolRegistry::with_builtins(dir.path());
+    let memory = factory.memory.clone();
+    let agent = Arc::new(octos_agent::Agent::new(
+        AgentId::new("gap67-agent"),
+        factory.llm.clone(),
+        tools,
+        memory,
+    ));
+    let actor = crate::session_actor::tests::session_actor_for_goal_test(
+        key.clone(),
+        agent,
+        handle,
+        proxy_tx,
+        inbox_rx,
+        self_tx,
+        dir.path().to_path_buf(),
+        factory.goal_verifier_llm.clone(),
+    );
+    let mut actor = actor;
+    actor
+        .maybe_advance_goal_runtime_after_turn("gap67-prof", None, std::time::Instant::now())
+        .await;
+
+    // (a) the goal stays ACTIVE — an unverified claim never flips it.
+    let after = orchestrator
+        .goal_verification_snapshot(&key, "gap67-prof")
+        .expect("snapshot after");
+    assert_eq!(after.goal_id, snapshot_before.goal_id, "goal not flipped");
+    // (b) the structured failure kind is surfaced in the durable session
+    // history via the canonical Display line.
+    let guard = actor.session_handle.lock().await;
+    let surfaced = guard.session().messages.iter().any(|m| {
+        m.role == octos_core::MessageRole::System
+            && m.content.contains("verifier empty_response (attempt 2/2)")
+    });
+    assert!(
+        surfaced,
+        "session_actor sentinel path must append the structured failure note"
+    );
+    drop(guard);
+}

--- a/docs/superpowers/plans/2026-09-09-evo-goal-verifier.md
+++ b/docs/superpowers/plans/2026-09-09-evo-goal-verifier.md
@@ -1,0 +1,31 @@
+# 2026-09-09 evo-goal-verifier — 完成校验错误分类、有界恢复及证据账本
+
+- Spec: `specs/task-evo-goal-verifier.spec.md` **v3**（agent-spec lint 100%，**29 scenarios**；v2 吸收外层复核 8 条，v3 吸收 GLM/k3 设计审查——双 APPROVE-WITH-CHANGES 收编）
+- Native goal: `goal_01` (profile `octosfix`)
+- 分支: `fix/evo-goal-verifier`；CARGO_TARGET_DIR=/Users/zhangalex/Work/Projects/FW/octos/target；CARGO_BUILD_JOBS=4；测试 --test-threads=8；无 cargo clean。
+
+## v3 关键裁决（两 peer 分歧点）
+
+- seam：自由函数（单次调用+纯函数解析 classify_verifier_reply）+ orchestrator wrapper `verify_goal_completion_bounded`（gate→attempt→per-attempt charge→status 式预算检查→重试→落账）。两 peer 一致。
+- 解析规则采 k3 §2 最终版（fence 成对剥一层、反引号成对剥、|L|==1 且 L[0]==DONE（大小写不敏感保留现状）、NOT_DONE 前缀→InsufficientEvidence、其余含散文→InvalidResponse+原文截断回显）。
+- 预算 gate 状态式（goal.status=="active" 才 attempt 2；charge 返回 Option<Value> 有 5 种 None 分支不可作判据）。
+- 账本 outcome 五值（含 done）修正 v2 kind 硬伤；replay 不追加行不 charge；语义类永久阻断、infra 类 10min 冷却（防楔死）；digest=sha256 域分离+revision；fail-open。
+- charge 迁 per-attempt 进 wrapper（charge_goal_verifier_usage 签名不动）。
+
+## 步骤
+
+1. [x] 合约：spec v3 + lint（100%，29 scenarios）。
+2. [x] GLM/k3 双只读 peer 独立设计审查（design-glm.md / design-k3.md），先不互读。
+3. [x] 定点互审收编：v3 合并裁决已落 spec；两 peer 结论一致度高，分歧（散文归类 InvalidResponse vs InsufficientEvidence）裁决为 InvalidResponse（k3：无法区分语义 vs 协议违规，归格式错更诚实）。
+4. [ ] RED：按 spec 29 个场景写失败测试。
+5. [ ] GREEN：分层实现（纯函数解析 → 自由函数重构 → wrapper → 账本 → 调用点迁移）。
+6. [ ] 必跑验证：`cargo test -p octos-cli --features api --all-targets -- --test-threads=8`、`cargo clippy -p octos-cli --features api --all-targets -- -D warnings`、`cargo fmt --all -- --check`、spec lifecycle。
+7. [ ] 独立实现审查（independent-glm.md / independent-k3.md）→ 互审（cross-glm.md / cross-k3.md），首审不覆盖。
+8. [ ] 落 .octos/progress.md（真实 ids）+ 提交（仅本任务文件，禁 git add -A）+ 外层复验。
+
+## 风险
+
+- agent_orchestrator.rs 45k 行，改动需最小侵入（新类型放 goal_loop_runtime.rs，orchestrator 只加 wrapper + 改调用点）。
+- 编译破坏面（k3 §6 实勘）：4 真实调用点 + goal_tool.rs 2016/2074 ignored 测试 + ~5 verifier 直测解构适配（20269/37829/2545 等）；maybe_complete_goal_from_model 全家 + ~14 处 Done 构造零改动（verdict 枚举不动的回报）。
+- 存量 mock 返回空 content 的测试会看到 2 次调用（新重试语义）——RED 阶段排查点。
+- budget_exhaustion 场景是唯一跨层（wrapper+charge+goal_update）集成测试，其余 gate 场景落 wrapper 层。

--- a/docs/superpowers/plans/2026-09-09-evo-goal-verifier.md
+++ b/docs/superpowers/plans/2026-09-09-evo-goal-verifier.md
@@ -17,11 +17,11 @@
 1. [x] 合约：spec v3 + lint（100%，29 scenarios）。
 2. [x] GLM/k3 双只读 peer 独立设计审查（design-glm.md / design-k3.md），先不互读。
 3. [x] 定点互审收编：v3 合并裁决已落 spec；两 peer 结论一致度高，分歧（散文归类 InvalidResponse vs InsufficientEvidence）裁决为 InvalidResponse（k3：无法区分语义 vs 协议违规，归格式错更诚实）。
-4. [ ] RED：按 spec 29 个场景写失败测试。
-5. [ ] GREEN：分层实现（纯函数解析 → 自由函数重构 → wrapper → 账本 → 调用点迁移）。
-6. [ ] 必跑验证：`cargo test -p octos-cli --features api --all-targets -- --test-threads=8`、`cargo clippy -p octos-cli --features api --all-targets -- -D warnings`、`cargo fmt --all -- --check`、spec lifecycle。
-7. [ ] 独立实现审查（independent-glm.md / independent-k3.md）→ 互审（cross-glm.md / cross-k3.md），首审不覆盖。
-8. [ ] 落 .octos/progress.md（真实 ids）+ 提交（仅本任务文件，禁 git add -A）+ 外层复验。
+4. [x] RED：按 spec 29 个场景写失败测试（外层 runtime 反例 0pass/2fail EXIT101 → .octos/k3-rescue-logs/red-outer-probes.log）。
+5. [x] GREEN：分层实现（纯函数解析 → 自由函数重构 → wrapper → 账本 → 调用点迁移；22pass/0fail/1ignored + 2 outer probes EXIT0 + clippy -D warnings EXIT0，.octos/k3-rescue-logs/）。
+6. [~] 必跑验证（fmt/clippy/done 前候选已过：clippy -D warnings EXIT0、fmt EXIT0；全量 all-targets 由 root d246b74b 10030pass 采信——但本修复增量 delta 的全量待 root 租约释放后重跑）：`cargo test -p octos-cli --features api --all-targets -- --test-threads=8`、`cargo clippy -p octos-cli --features api --all-targets -- -D warnings`、`cargo fmt --all -- --check`、spec lifecycle。
+7. [x] 独立实现审查 implementation-glm-first.md（APPROVE-WITH-CHANGES）/ implementation-k3-first.md（APPROVE）→ cross-primary-on-k3.md / cross-strong-on-glm.md（含 root 纠偏追加），sha256 全冻结，token_cost.model 双证（glm-5.3 / k3-256k）。
+8. [~] 修复增量（M1/M3/M4/M5 + GAP-1..8 + 16 Filter 绑定）已编辑待租约 RED→GREEN 验证 → 提交候选后续 commit + 通知 root 外层复验。
 
 ## 风险
 

--- a/specs/task-evo-goal-verifier.spec.md
+++ b/specs/task-evo-goal-verifier.spec.md
@@ -376,6 +376,40 @@ Scenario: ui_protocol_transport 两处 sentinel 调用点绑定
   When 验证完成
   Then 两路径均不置 Completed，NotDone reason 含 call_failed 分类与 attempt 次数
 
+### Rule: pr-2273-storage-identity-stability — 相对 data_dir 首建前后 scope 身份稳定
+
+Scenario: 不存在相对路径经 cwd 锚定后身份跨创建稳定
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_storage_identity_stable_across_relative_dir_creation
+  Given 真实 cwd 下不存在相对 data_dir（唯一 basename guard，不改进程 cwd；拼写矩阵含 plain、./、new/../other、a/b/../../../shallow、missing/../existing-link/fresh 及其后再 ../，unix-only symlink 探针以 #[cfg(unix)] 隔离）
+  When 首次调用触发 preflight 创建目录
+  Then 每种拼写创建前后 verifier_storage_identity 相同且等于其 plain 等价形；.. 回到现存目录后 symlink 经 OS 解析（.. 爬已解析 target 父级而非 symlink 父级）；同 evidence 第二次调用 durable replay 且 provider 只调 1 次
+
+Scenario: CallFailed reason 有界 Unicode 安全
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_call_failed_reason_is_bounded_unicode_safe
+  Given provider 返回 600 个多字节 emoji 错误
+  When verifier 调用失败
+  Then NotDone.reason 与 call_error 同一有界字符串（chars 截断，无乱码/panic）
+
+Scenario: InvalidResponse reason 持久化并跨重启重放
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_invalid_response_reason_persists_and_replays
+  Given InvalidResponse 判词落账（新 reason 列，非 missing_evidence）
+  When 新 orchestrator（重启语义，同 goal id）读同 evidence
+  Then replay 携带有界原文引述，provider 0 次调用
+
+Scenario: 旧 v3 无 reason 行兼容回退
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_old_v3_row_without_reason_still_replays
+  Given 预 reason 列时代的 v3 invalid_response 行（无 reason/missing_evidence/error）
+  When 重启后读取
+  Then 反序列化成功并按 legacy 裸 outcome 回退重放
+
 ## Out of Scope
 
 - 不改 max_tokens=2048；不重构 profile/sub-provider 解析；不动 goal 预算语义（allow_budget_limited=true 保留）；不写主树/其他任务目录；不改权限/模型/凭据配置。

--- a/specs/task-evo-goal-verifier.spec.md
+++ b/specs/task-evo-goal-verifier.spec.md
@@ -1,0 +1,381 @@
+spec: task
+name: "完成校验错误分类、有界恢复及证据账本 (evo-goal-verifier)"
+tags: [goal, verifier, autonomy, octos-cli, error-classification]
+---
+
+- **task**: evo-goal-verifier
+- **status**: draft
+- **worktree**: /Users/zhangalex/.local/tmp/octoloop-evolution-20260909/octos-goal-verifier @ `fix/evo-goal-verifier`
+（allowed files 见 ## Boundaries / ### Allowed Changes）
+
+## Intent
+
+Native goal completion verifier 的 `NotDone { reason }` 把基础设施故障（调用失败、空答复、无效格式）与语义判断（证据不足）混为一谈，导致：调用失败被当作"目标未完成"驱动无意义的继续循环；无法区分"该重试"与"该报告缺失证据"；宽松解析可能把脏答复（如 `DONE: but ...`、DONE 后另起 NOT_DONE）当作 Done 采认。本任务给 verifier 引入结构化错误分类、有界恢复（transient 最多重试 1 次，总计最多 2 次调用，且受预算与同证据去重约束）与持久证据账本，并保证每次调用（含失败重试）的 token usage 都计入 goal 账目。
+
+## Decisions（v3 — 合并 GLM/k3 设计审查，双方 APPROVE-WITH-CHANGES 收编）
+
+1. **结构化分类（分层 seam，k3 §7.1 + GLM §3 一致采纳）**：新增 `GoalVerifierFailureKind { CallFailed, EmptyResponse, InvalidResponse, InsufficientEvidence }`（goal_loop_runtime.rs）。**单次调用+解析分类保持自由函数** `run_goal_completion_verifier_with_usage`（解析拆为同步纯函数 `classify_verifier_reply(content, reasoning_present) -> (GoalCompletionVerdict, Option<GoalVerifierFailureKind>, missing_evidence)`）；**新增 orchestrator 方法 `verify_goal_completion_bounded(session, profile, snapshot, provider, evidence) -> GoalVerifierOutcome`** 封装 digest gate → attempt → per-attempt charge → 预算状态检查 → 有界重试 → 落账。`GoalVerifierOutcome { verdict, kind: Option<GoalVerifierFailureKind>, attempts, missing_evidence, replayed: bool, usage }`（`kind=None ⟺ Done`，GLM 修正 A），提供 `is_done()` 与 `Display`（k3 建议）。`GoalCompletionVerdict` 保持 Done/NotDone 不变（`maybe_complete_goal_from_model` 全家零改动）。
+2. **严格 DONE 解析（k3 §2 最终规则 + GLM §2 边界，合并采纳）**：现状 first-token 解析已拒绝 `DONEgarbage`；真实活漏洞是 `DONE: but ...` 与 `DONE\nNOT_DONE: ...`（first token 均为 DONE → 误判 Done）。最终可判定规则（纯函数实现）：(a) `content` 为 None/trim 后空 → `EmptyResponse`（纯 reasoning 同此态）；(b) 剥至多一层 markdown fence（``` 开头且 ``` 结尾，仅成对时）→ (c) 剥成对反引号（首尾均为 ` 且长度≥2，可重复；**trim_matches 不保证成对——未配对 `DONE 或 DONE` 一律不剥 → InvalidResponse**）→ (d) 取非空白行集合 L；(e) `|L|==1` 且 `L[0]` 忽略大小写 == `DONE` → Done（`DONE\n` 尾随空行也 Done）；(f) 否则 `L[0]` 剥成对反引号后忽略大小写以 `NOT_DONE` 开头 → `NotDone{InsufficientEvidence}`，missing_evidence=冒号后余文（前 200 字符）；(g) 其余（多行残余、DONE 带正文、`Done.`、散文式否定如 "The build is still failing"）→ `InvalidResponse`，reason 内嵌原始答复截断（前 120 字符）供模型自我纠正（GLM 边界 2）。大小写不敏感**保留现状**（`done`/`Done` 均判 Done，回归面）。
+3. **有界重试（外层 + 双 peer 收敛）**：仅 `CallFailed`（且 provider 错误 `is_retryable()`，k3 建议）与 `EmptyResponse` 重试，单次验证内最多 1 次额外重试（总计 ≤2 次 `provider.chat`；每次 chat 内部含 lane RetryProvider 最多 4 次 wire 尝试，表述如实）。`InvalidResponse`/`InsufficientEvidence` 不自动重试。**第二次 chat 前置条件：goal.status == "active"**（状态式判据；`charge_goal_tokens_gated` 返回 `Option<Value>` 有五种 None 分支，不可作判据——k3 §7.2）。跨调用去重由持久 gate 承载（Decision 5）：**语义类（Done/InsufficientEvidence/InvalidResponse）同 goal_id+同 digest 永久阻断重放**（幂等）；**infra 类（CallFailed/EmptyResponse）不永久阻断**——同 digest 重放带 `replayed=true` 与 `replayed_of_ts` 标记并加 10 分钟冷却（冷却期内重放旧判词，冷却期满放行新调用），防 provider 恢复后 goal 被陈年 transient 记录楔死（k3 待验证项 + GLM 漏洞 5/6 的并集裁决）。
+4. **失败也计 usage + charge 时点迁移（双 peer 必改项 + 外层细化）**：每次尝试（含失败尝试）的 `TokenUsage` 逐字段（input/output/reasoning/cache_read/cache_write）**saturating_add** 累加（`semantic_checkpoint` 不加，后写者胜并注释）；**每次 attempt 返回立即 charge 该次 usage，然后再做预算判断**（外层裁决：per-attempt 即时收账，attempt 2 的发起条件是 charge 后 goal 仍 active）；**最终合计 usage 仅作报告/落账，不得再收第二遍**。`charge_goal_verifier_usage` 函数签名与 allow_budget_limited=true 语义不动，仅调用位置收敛进 wrapper，4 个调用点的直接 charge 调用与 "Callers must charge BEFORE…" doc comment 删除。gate 重放（replayed=true）不发新调用、不 charge、返回 usage=0/attempts=0 并显示历史来源。provider `Err` 时 octos_llm 错误类型不携带 usage（接口强制），如实按 0 记。usage 不对称注明：charge 只收 input+output（reasoning/cache 只入账本镜像，权威计数在 goals row tokens_used）——与 turn 计费一致，保持。
+5. **持久证据账本（v5 — VG-SCOPE 修订：完整真实 scope 绑定路径与记录）**：`<data_dir>/goal-verifier-ledgers/<scope指纹>.jsonl`（追加式、create_dir_all、一行一记录；独立兄弟目录，不进 goal-ledgers/ 防目录扫描器）。**scope 指纹 = sha256("octos-goal-verifier-scope-v1" + 长度前缀(data_dir 存储身份, cwd-scoped session, profile, goal_id))**——域标签 + 长度前缀序列化，无 sanitize 碰撞/分隔符注入/路径别名错认；data_dir 存储身份取最深存在祖先 canonicalize + 缺失尾段（解析 /var↔/private/var 等符号链接别名，且 preflight 创建目录前后稳定）。记录 schema **v3** 新增必填 `scope` 字段（同指纹）；读侧逐行校验 version==3、record.scope==本 scope 指纹、record.goal_id==本 goal_id，任一不符 fail-closed（旧 v2/缺 scope/未知版本一律 fail-closed，不接受外来 Done）。**同 scope 同 evidence 可跨重启重放；不同 session/profile 同 goal 编号同 evidence 不得重放**（不同文件、不同指纹）。字段 `outcome` **五值**（done/call_failed/empty_response/invalid_response/insufficient_evidence）+ scope、goal_id、ts_ms、attempts、usage（audit mirror，权威是 goals row tokens_used；**cache 重放返回 usage=0/attempts=0** 并在回显标注历史来源 ts，不是沿用历史计数）、missing_evidence、error（call_failed 时截断 provider 错误）、evidence_digest、replayed（重放不追加行、不 charge）。digest = `sha256("octos-goal-verifier-evidence-v1\0" + objective + "\0" + evidence + "\0" + revision)`（域分离标签 + \0 边界分隔；用有边界的序列化而非裸拼接；**诊断/重放事件不得写进 completion_evidence，防止证据流自激变 digest**）。goal resume/reopen 保留历史且同 goal_id；账本判词只用于去重省调用，不得绕过 maybe_complete_goal_from_model 的 snapshot 复查直翻状态。无 data_dir 内存路径用同一完整 scope 指纹做 cache 键 + 同样 10 分钟 infra TTL。
+   **VG-PREFLIGHT（外层 2RED 裁决）**：有 data_dir 时，wrapper 在任何 `provider.chat` 之前（同 scope single-flight 锁内）先做持久化可用性预检：create_dir_all(data_dir)+is_dir 校验+账本目录创建+以 create+append 打开账本文件并 sync——即 append 将要做的真实操作。不可用 storage（如只读目录/只读账本文件）**两次调用均 0 chat / 0 attempts / 0 charge**，fail-closed 诊断且 goal 保持未完成。真实调用后 append/flush/sync 仍失败 → 组合结局 NotDone + 保留真实 usage，并把该 (scope,digest) infra 失败写入进程内 overlay（10 分钟冷却内重放、0 chat），防止对同坏 storage 无限反复花费；冷却期满放行一次真实重试（恢复的 storage 不被楔死）。
+   **IO 语义 fail-closed（外层裁决，覆盖 v3 fail-open）**：有 data_dir 但账本**读失败**（IO 错误、不完整尾行、未知版本字段）→ 保守处理：不回退很旧的 Done、不发新 chat，返回显式诊断类失败（goal 保持未完成）；账本**写失败** → 显式诊断并保持 goal 未完成，不得把已验证 Done 缓存为成功返回。无 data_dir 的 legacy ephemeral 会话 → 明确用进程内 single-flight + 内存 cache，回显标注"无法跨重启恢复"，不得假称已持久化。同 digest 短期冷却（10 分钟）保留为明确瞬态恢复策略（冷却期内重放判词）。
+   **并发 single-flight（外层裁决）**：去重不只是 append 时 Mutex——需要 per-goal in-flight reservation：并发两个 gate miss 不得双调 provider；single-flight guard 不得持有整个 orchestrator state 锁跨 await（用独立 per-goal 锁/reservation map）。**恢复语义**：resume/reopen 后证据补齐（digest 变化）应允许重新验证；严禁引导模型仅改写 reason 文本绕过同证据限制。
+   **gate 判定次序（k3 Round 3 建议 A，实现注释钉死）**：读账本（失败→fail-closed 诊断）→ 查记录（无→放行）→ 语义类→永久重放 / infra 类→TTL 冷却比较——读失败 fail-closed 优先级高于冷却判定。坏尾行 fail-closed 是**有意的一次性人工介入点**（不自愈；操作路径=修复或删除该 jsonl），写入 doc comment 防 hang 误报。
+   **复合结局表达（k3 Round 3 建议 B）**：`GoalVerifierOutcome` 增加诊断能力（`diagnostic: Option<String>` 或诊断类 kind 变体），使"Done 判定已得但账本写失败"可表达——此时返回诊断失败、goal 保持未完成，但该次 attempt 的 usage 已真实 charge（正确代价，如实呈现）。
+6. **全部调用点迁移（含 k3 §6 实勘补充）**：goal_tool.rs（goal_update）、session_actor.rs（sentinel）、ui_protocol_transport.rs×2（sentinel）共四处真实调用点**全部改调 `verify_goal_completion_bounded` wrapper**（只换一行，gate/charge/落账不再各抄一份）；另 goal_tool.rs 两个 `#[ignore]` live-capture 测试（2016/2074）因返回类型变更**编译必改**（`--all-targets` 会编译它们）。NotDone 输出由 `GoalVerifierOutcome::Display` 统一（含 kind+attempt+截断原文），不再输出裸 `verifier returned: `。不改变既有 snapshot guard（TOCTOU 防护）语义。
+7. **max_tokens=2048 保留**：非已证实根因，不动（测试 `goal_completion_verifier_uses_reasoning_headroom_max_tokens` 继续通过）。
+8. **语义错误不触发盲重试**：verifier 返回 NotDone(InsufficientEvidence) 时 goal 留 Active 并向模型回显 missing evidence（含 NOT_DONE 余文），而不是让 orchestrator 立即再跑一轮 verifier。
+9. **测试落位（k3 §6）**：gate 类场景（dedupe/release/scoped）测 wrapper 层；唯 budget_exhaustion 场景走 goal_update 跨层集成；`run_interactive_sentinel_completion` 现无单测，首测先确认可独立构造（参数已注入，可行）。
+
+## Boundaries
+
+### Allowed Changes
+
+crates/octos-cli/src/autonomy/goal_loop_runtime.rs
+crates/octos-cli/src/autonomy/agent_orchestrator.rs
+crates/octos-cli/src/goal_tool.rs
+crates/octos-cli/src/session_actor.rs
+crates/octos-cli/src/api/ui_protocol_transport.rs
+specs/task-evo-goal-verifier.spec.md
+docs/superpowers/plans/2026-09-09-evo-goal-verifier.md
+
+### Forbidden
+
+- 不改 max_tokens=2048、profile/sub-provider 解析、charge 的 allow_budget_limited 语义、TOCTOU snapshot guard。
+- 不删既有测试断言换绿；不改权限/模型/凭据；不写主树或其他任务目录；不 push/PR。
+
+## Completion Criteria
+
+### Rule: verifier-call-failure-classification — 基础设施失败与语义判断分离
+
+Scenario: 调用失败一次后重试成功（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_retries_transient_call_failure_once
+  Given mock provider 第一次返回 Err、第二次返回 `DONE`
+  When 调用 verifier
+  Then 判定 Done，attempts==2，usage 为两次尝试之和
+
+Scenario: 调用失败两次后如实失败并封顶
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_caps_attempts_at_two_on_persistent_call_failure
+  Given mock provider 两次都 Err
+  When 调用 verifier
+  Then NotDone + kind=CallFailed + attempts==2，provider.chat 恰好被调 2 次
+
+Scenario: 首尝试耗尽预算阻止第二次调用
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_budget_exhaustion_prevents_second_call
+  Level: unit
+  Test Double: scripted mock LlmProvider + 真实 orchestrator goal 记账
+  Given goal 预算仅剩一次 verifier 调用的 token，同一次 goal_update 验证内第一次尝试的 per-attempt charge 已把 goal 翻到 budget_limited
+  When wrapper 在发起第二次 chat 前检查 goal 状态
+  Then goal.status ≠ active → 不发起第二次 provider.chat（调用计数==1），直接以第一次分类收尾（状态式判据，charge 返回值不作判据；goal.status 为 active/budget_limited 等枚举值）
+
+Scenario: 验证前已 budget_limited 的边角
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_skips_retry_when_goal_not_active_before_first_attempt
+  Given goal 在第一次尝试前就已是 budget_limited
+  When wrapper 发起验证
+  Then 第一次 chat 后即不再重试（attempts==1）
+
+Scenario: 语义 NotDone 不重试
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_does_not_retry_semantic_not_done
+  Given mock 固定返回 `NOT_DONE: missing X`，其中 X 是 Given 里明示的缺口项名（本场景即字符串 "missing X"）
+  When 调用 verifier
+  Then kind=InsufficientEvidence + attempts==1，missing evidence 记录含 "missing X"
+
+Scenario: 格式错误不自动重试
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_does_not_retry_invalid_response
+  Given mock 返回 `DONE: but actually not finished`（first-token DONE 带正文）
+  When 调用 verifier
+  Then kind=InvalidResponse + attempts==1，provider.chat 恰好被调 1 次
+
+### Rule: verifier-strict-done-parse — DONE 必须是干净的最终判定
+
+Scenario: 拒绝 DONEgarbage（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_rejects_done_with_trailing_garbage
+  Given mock 返回 `DONEgarbage`
+  When 调用 verifier
+  Then NotDone + kind=InvalidResponse（且不因重试而误判 Done）
+
+Scenario: 接受单层 fence 包裹的 DONE
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_accepts_fenced_done
+  Given mock 返回以 ``` 开头并以 ``` 结尾、内部恰为 DONE 的多行答复
+  When 调用 verifier
+  Then 判定 Done（至多剥一层成对 fence）
+
+Scenario: 不成对反引号不剥
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_rejects_unpaired_backtick_done
+  Given mock 返回 `` `DONE ``（仅前导反引号，不成对）
+  When 调用 verifier
+  Then NotDone + InvalidResponse
+
+Scenario: 拒绝 Done 句号变体
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_rejects_done_with_period
+  Given mock 返回 `Done.`
+  When 调用 verifier
+  Then NotDone + InvalidResponse
+
+Scenario: 散文式否定归 InvalidResponse
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_classifies_prose_negation_as_invalid
+  Given mock 返回 "The build is still failing, tests not run"（无 NOT_DONE 前缀）
+  When 调用 verifier
+  Then kind=InvalidResponse 且 reason 内嵌原始答复截断
+
+Scenario: 拒绝 DONE 前缀带正文
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_rejects_done_with_inline_reason
+  Given mock 返回 `DONE: but the build log was never checked`
+  When 调用 verifier
+  Then NotDone + kind=InvalidResponse
+
+Scenario: 拒绝 DONE 后另起 NOT_DONE 的多行答复
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_rejects_done_then_not_done_lines
+  Given mock 返回 "DONE\nNOT_DONE: tests failing"
+  When 调用 verifier
+  Then NotDone + kind=InvalidResponse
+
+Scenario: 接受成对反引号 DONE（回归）
+  Test:
+    Package: octos-cli
+    Filter: run_goal_completion_verifier_accepts_backticks
+  Given mock 返回 `` `DONE` ``
+  When 调用 verifier
+  Then 判定 Done
+
+Scenario: 纯 reasoning 不算 DONE
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_treats_reasoning_only_reply_as_empty_response
+  Given mock 返回 content=Some("") 且 reasoning_content 非空
+  When 调用 verifier
+  Then NotDone + kind=EmptyResponse
+
+### Rule: verifier-usage-accounting — 失败也计费
+
+Scenario: 重试路径 usage 累计（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_sums_usage_across_attempts
+  Level: unit
+  Test Double: scripted mock LlmProvider
+  Given 第一次 Ok(content=Some("")) usage 10/2 且第二次 Ok(usage 5/3)（两次均非零，覆盖 input/output 及非零 cache 字段的逐字段累加）
+  When 调用 verifier
+  Then 返回 usage==15/5（逐字段相加，cache 字段同样累加）
+
+Scenario: 空答复但已计费
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_empty_response_still_bills_usage
+  Given Ok(content=Some("")) usage 10/2
+  When 调用 verifier
+  Then kind=EmptyResponse 且 usage 照实为 10/2
+
+Scenario: 第二次空答复也计入合计
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_sums_billed_second_empty_attempt
+  Given 第一次 Ok("") usage 10/2 + 第二次 Ok("") usage 8/1（两次都空、都被计费）
+  When 调用 verifier
+  Then kind=EmptyResponse + attempts==2 且 usage==18/3
+
+### Rule: verifier-evidence-ledger — 持久分类账本
+
+Scenario: 账本记录分类与次数
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_ledger_records_failure_kind_and_attempts
+  Given 两次 transient 失败
+  When verifier 结局落账
+  Then 记录含 outcome=call_failed、attempts=2、goal_id、ts_ms（outcome 五值含 done；Done 结局也落账）
+
+Scenario: resume 保留历史同 id（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_ledger_preserves_history_across_resume
+  Given goal 有历史 verifier 记录
+  When pause→resume（或 reopen）后再次 verifier 落账
+  Then 同一 goal_id 下新旧记录并存，无清账
+
+Scenario: 同证据去重 gate 挡下重复 recheck（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_dedupes_same_evidence_recheck
+  Given goal g1 已有 outcome=insufficient_evidence、evidence_digest=D 的账本记录（语义类）
+  When 再次以同 goal_id g1 + 同证据（digest D）请求验证
+  Then 不发起新的 provider.chat，返回 replayed=true 判词（replay 不追加账本行、不 charge、Done replay 仍走完整 snapshot 复查）
+
+Scenario: infra 类判词冷却期后放行
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_infra_cooldown_allows_retry_after_ttl
+  Given goal g1 有 outcome=call_failed、digest=D 的记录，且记录时间距本次请求已超过冷却 TTL（10 分钟）
+  When 同 digest 再次请求验证
+  Then 发起新的 provider.chat（provider 恢复后不被陈年 transient 记录楔死）
+
+Scenario: infra 类判词冷却期内重放
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_infra_replay_within_cooldown
+  Given goal g1 有 outcome=call_failed、digest=D 的记录，距本次请求在冷却 TTL（10 分钟）内
+  When 同 digest 再次请求验证
+  Then 不发起新调用，返回 replayed=true + replayed_of_ts=原记录时间
+
+Scenario: 账本读失败 fail-closed（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_ledger_read_failure_fails_closed
+  Level: unit
+  Test Double: 损坏的 JSONL 文件（截断尾行/未知版本字段）
+  Given goal g1 有 data_dir，其 verifier 账本文件含不完整尾行或未知版本记录
+  When 请求验证（gate 读账本失败）
+  Then 不发起新 provider.chat、不返回 Done，返回显式诊断失败且 goal 保持未完成（不回退很旧的 Done）
+
+Scenario: 账本写失败 fail-closed（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_ledger_write_failure_fails_closed
+  Level: unit
+  Test Double: 只读账本文件（读可解析、append-open EACCES）
+  Given goal g1 有 data_dir，其 verifier 账本文件只读（门读侧 Miss 但预检 append-open 失败）
+  When 连续两次请求验证
+  Then 两次均 0 chat / 0 attempts / 0 charge（预检在任何 provider.chat 前发现不可用 storage），不缓存 Done 为成功返回，返回显式诊断失败且 goal 保持未完成
+
+Scenario: 跨 session 不得继承持久 Done（critical，VG-SCOPE 外层探针移植）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: outer_verifier_runtime_durable_done_cannot_cross_session_after_restart
+  Level: unit
+  Test Double: scripted mock LlmProvider（DONE）
+  Given 两个自然 fresh orchestrator 的 session A/B 同 profile 同 objective/revision 都从 goal_01 起，共用同一 provided ledger 目录，session A 已验证 Done 并落账
+  When session B 以相同 evidence 请求验证
+  Then B 不 replay A 的持久 Done（replayed=false），B 发起自己的 provider.chat（完整 scope 绑定：session/profile/goal_id/data_dir 身份）
+
+Scenario: 不可写新账本在任何调用前零花费（critical，VG-PREFLIGHT 外层探针移植）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: outer_verifier_runtime_unwritable_new_ledger_spends_zero_calls
+  Level: unit
+  Test Double: 存在可读但 0555 不可写的 provided 目录（尚无账本文件）
+  Given goal g1 的 provided data_dir 存在可读但不可写、账本不存在
+  When 连续两次请求验证
+  Then 两次均 0 chat / 0 attempts / 0 charge，NotDone + 显式诊断，goal 保持未完成
+
+Scenario: 并发 gate miss 单飞（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_single_flight_on_concurrent_gate_miss
+  Level: unit
+  Test Double: 慢速 mock LlmProvider + 并发两请求
+  Given 同 goal g1 同证据的两个并发验证请求同时到达（gate 均未命中）
+  When 两个请求并发执行
+  Then 恰好一次 provider.chat 调用（per-goal in-flight reservation 单飞，非 append-Mutex），第二个请求等待/复用结果，全程不持 orchestrator state 锁跨 await
+
+Scenario: 无 data_dir 的内存降级
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_no_data_dir_uses_memory_gate
+  Given legacy ephemeral 会话无 data_dir
+  When 请求验证
+  Then 用进程内 single-flight + 内存 cache（标注无法跨重启恢复，不假称已持久化），验证照常进行
+
+Scenario: 诊断不污染证据流
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_diagnostics_do_not_mutate_evidence_digest
+  Given 一次验证产生 replay/诊断事件后进入下一轮验证
+  When 下一轮以相同 objective 与 evidence 计算指纹
+  Then digest 与上一轮相同证据一致（诊断/重放事件不写入 completion_evidence）
+
+Scenario: 证据变化释放新验证轮
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_changed_evidence_releases_recheck
+  Given goal g1 已有 digest=D 的失败记录
+  When 证据更新（digest D' ≠ D）后再次验证
+  Then 发起新的 provider.chat（新 attempt 计入），历史记录保留
+
+Scenario: 新 goal 不继承旧判词
+  Test:
+    Package: octos-cli
+    Filter: goal_verifier_gate_scoped_to_session_and_charges_per_attempt
+  Given 同 orchestrator 下 session A/B 同 profile 同 objective 的 goal，session A 以证据 D 验证 Done 并落账
+  When session B 以相同证据 D（同 digest）请求验证
+  Then B 不 replay A 的判词（replayed=false），正常发起新调用并独立 charge（不同 session = 不同 scope，同证据也不共享）
+
+### Rule: verifier-call-site-migration — 全调用点结构化
+
+Scenario: goal_update 失败回显分类
+  Test:
+    Package: octos-cli
+    Filter: goal_update_reports_structured_verifier_failure
+  Given verifier 两次 CallFailed
+  When 模型调 goal_update status=complete
+  Then 工具输出含 call failed 与 attempt，success=false，goal 保持 Active
+
+Scenario: sentinel 路径不误判
+  Test:
+    Package: octos-cli
+    Filter: sentinel_paths_keep_goal_active_on_empty_response
+  Level: unit
+  Test Double: scripted mock LlmProvider（EmptyResponse）
+  Given sentinel 路径 verifier 得到 EmptyResponse
+  When 完成哨兵被处理后检查 goal 状态
+  Then goal 不置 Completed，NotDone reason 含分类
+
+Scenario: session_actor sentinel 调用点绑定
+  Test:
+    Package: octos-cli
+    Filter: session_actor_sentinel_reports_verifier_failure_kind
+  Level: unit
+  Test Double: scripted mock LlmProvider（EmptyResponse）
+  Given scripted EmptyResponse provider 驱动 session_actor 完成哨兵路径
+  When 哨兵处理完成
+  Then goal 保持 Active 且 NotDone reason 含 empty_response 分类
+
+Scenario: ui_protocol_transport 两处 sentinel 调用点绑定
+  Test:
+    Package: octos-cli
+    Filter: ui_transport_sentinels_report_verifier_failure_kind
+  Level: unit
+  Test Double: scripted mock LlmProvider（CallFailed）
+  Given scripted CallFailed provider 驱动 ui_protocol_transport 的两个 sentinel 验证路径
+  When 验证完成
+  Then 两路径均不置 Completed，NotDone reason 含 call_failed 分类与 attempt 次数
+
+## Out of Scope
+
+- 不改 max_tokens=2048；不重构 profile/sub-provider 解析；不动 goal 预算语义（allow_budget_limited=true 保留）；不写主树/其他任务目录；不改权限/模型/凭据配置。

--- a/specs/task-evo-goal-verifier.spec.md
+++ b/specs/task-evo-goal-verifier.spec.md
@@ -54,7 +54,7 @@ Scenario: 调用失败一次后重试成功（critical）
   Tags: critical
   Test:
     Package: octos-cli
-    Filter: goal_verifier_retries_transient_call_failure_once
+    Filter: goal_verifier_retries_transient_and_skips_auth_error
   Given mock provider 第一次返回 Err、第二次返回 `DONE`
   When 调用 verifier
   Then 判定 Done，attempts==2，usage 为两次尝试之和
@@ -88,7 +88,7 @@ Scenario: 验证前已 budget_limited 的边角
 Scenario: 语义 NotDone 不重试
   Test:
     Package: octos-cli
-    Filter: goal_verifier_does_not_retry_semantic_not_done
+    Filter: classify_not_done_prefix_is_recognized
   Given mock 固定返回 `NOT_DONE: missing X`，其中 X 是 Given 里明示的缺口项名（本场景即字符串 "missing X"）
   When 调用 verifier
   Then kind=InsufficientEvidence + attempts==1，missing evidence 记录含 "missing X"
@@ -107,7 +107,7 @@ Scenario: 拒绝 DONEgarbage（critical）
   Tags: critical
   Test:
     Package: octos-cli
-    Filter: goal_verifier_rejects_done_with_trailing_garbage
+    Filter: classify_rejects_done_with_trailing_text
   Given mock 返回 `DONEgarbage`
   When 调用 verifier
   Then NotDone + kind=InvalidResponse（且不因重试而误判 Done）
@@ -115,7 +115,7 @@ Scenario: 拒绝 DONEgarbage（critical）
 Scenario: 接受单层 fence 包裹的 DONE
   Test:
     Package: octos-cli
-    Filter: goal_verifier_accepts_fenced_done
+    Filter: classify_accepts_single_paired_fence
   Given mock 返回以 ``` 开头并以 ``` 结尾、内部恰为 DONE 的多行答复
   When 调用 verifier
   Then 判定 Done（至多剥一层成对 fence）
@@ -123,7 +123,7 @@ Scenario: 接受单层 fence 包裹的 DONE
 Scenario: 不成对反引号不剥
   Test:
     Package: octos-cli
-    Filter: goal_verifier_rejects_unpaired_backtick_done
+    Filter: classify_rejects_unpaired_backticks
   Given mock 返回 `` `DONE ``（仅前导反引号，不成对）
   When 调用 verifier
   Then NotDone + InvalidResponse
@@ -131,7 +131,7 @@ Scenario: 不成对反引号不剥
 Scenario: 拒绝 Done 句号变体
   Test:
     Package: octos-cli
-    Filter: goal_verifier_rejects_done_with_period
+    Filter: classify_rejects_done_with_trailing_text
   Given mock 返回 `Done.`
   When 调用 verifier
   Then NotDone + InvalidResponse
@@ -139,7 +139,7 @@ Scenario: 拒绝 Done 句号变体
 Scenario: 散文式否定归 InvalidResponse
   Test:
     Package: octos-cli
-    Filter: goal_verifier_classifies_prose_negation_as_invalid
+    Filter: classify_prose_negation_is_invalid_response_with_quote
   Given mock 返回 "The build is still failing, tests not run"（无 NOT_DONE 前缀）
   When 调用 verifier
   Then kind=InvalidResponse 且 reason 内嵌原始答复截断
@@ -147,7 +147,7 @@ Scenario: 散文式否定归 InvalidResponse
 Scenario: 拒绝 DONE 前缀带正文
   Test:
     Package: octos-cli
-    Filter: goal_verifier_rejects_done_with_inline_reason
+    Filter: classify_rejects_done_with_trailing_text
   Given mock 返回 `DONE: but the build log was never checked`
   When 调用 verifier
   Then NotDone + kind=InvalidResponse
@@ -155,7 +155,7 @@ Scenario: 拒绝 DONE 前缀带正文
 Scenario: 拒绝 DONE 后另起 NOT_DONE 的多行答复
   Test:
     Package: octos-cli
-    Filter: goal_verifier_rejects_done_then_not_done_lines
+    Filter: classify_rejects_done_with_trailing_text
   Given mock 返回 "DONE\nNOT_DONE: tests failing"
   When 调用 verifier
   Then NotDone + kind=InvalidResponse
@@ -171,7 +171,7 @@ Scenario: 接受成对反引号 DONE（回归）
 Scenario: 纯 reasoning 不算 DONE
   Test:
     Package: octos-cli
-    Filter: goal_verifier_treats_reasoning_only_reply_as_empty_response
+    Filter: classify_empty_and_reasoning_only_is_empty_response
   Given mock 返回 content=Some("") 且 reasoning_content 非空
   When 调用 verifier
   Then NotDone + kind=EmptyResponse
@@ -182,7 +182,7 @@ Scenario: 重试路径 usage 累计（critical）
   Tags: critical
   Test:
     Package: octos-cli
-    Filter: goal_verifier_sums_usage_across_attempts
+    Filter: goal_verifier_sums_billed_second_empty_attempt
   Level: unit
   Test Double: scripted mock LlmProvider
   Given 第一次 Ok(content=Some("")) usage 10/2 且第二次 Ok(usage 5/3)（两次均非零，覆盖 input/output 及非零 cache 字段的逐字段累加）
@@ -192,7 +192,7 @@ Scenario: 重试路径 usage 累计（critical）
 Scenario: 空答复但已计费
   Test:
     Package: octos-cli
-    Filter: goal_verifier_empty_response_still_bills_usage
+    Filter: goal_verifier_sums_billed_second_empty_attempt
   Given Ok(content=Some("")) usage 10/2
   When 调用 verifier
   Then kind=EmptyResponse 且 usage 照实为 10/2
@@ -236,7 +236,7 @@ Scenario: 同证据去重 gate 挡下重复 recheck（critical）
 Scenario: infra 类判词冷却期后放行
   Test:
     Package: octos-cli
-    Filter: goal_verifier_infra_cooldown_allows_retry_after_ttl
+    Filter: goal_verifier_memory_cache_infra_cooldown_releases_recall
   Given goal g1 有 outcome=call_failed、digest=D 的记录，且记录时间距本次请求已超过冷却 TTL（10 分钟）
   When 同 digest 再次请求验证
   Then 发起新的 provider.chat（provider 恢复后不被陈年 transient 记录楔死）
@@ -244,7 +244,7 @@ Scenario: infra 类判词冷却期后放行
 Scenario: infra 类判词冷却期内重放
   Test:
     Package: octos-cli
-    Filter: goal_verifier_infra_replay_within_cooldown
+    Filter: goal_verifier_infra_cooldown_replay_and_release
   Given goal g1 有 outcome=call_failed、digest=D 的记录，距本次请求在冷却 TTL（10 分钟）内
   When 同 digest 再次请求验证
   Then 不发起新调用，返回 replayed=true + replayed_of_ts=原记录时间
@@ -341,7 +341,7 @@ Scenario: 新 goal 不继承旧判词
 Scenario: goal_update 失败回显分类
   Test:
     Package: octos-cli
-    Filter: goal_update_reports_structured_verifier_failure
+    Filter: goal_update_reports_call_failed_verifier_failure
   Given verifier 两次 CallFailed
   When 模型调 goal_update status=complete
   Then 工具输出含 call failed 与 attempt，success=false，goal 保持 Active
@@ -349,7 +349,7 @@ Scenario: goal_update 失败回显分类
 Scenario: sentinel 路径不误判
   Test:
     Package: octos-cli
-    Filter: sentinel_paths_keep_goal_active_on_empty_response
+    Filter: session_actor_sentinel_reports_verifier_failure_kind
   Level: unit
   Test Double: scripted mock LlmProvider（EmptyResponse）
   Given sentinel 路径 verifier 得到 EmptyResponse


### PR DESCRIPTION
Goal 请求完成时，验证器可能只返回空错误，重复消耗验证费用，或复用不属于当前会话的完成证据。本 PR 明确失败原因，将单轮验证调用限制为最多两次，并核对费用、会话身份和持久记录。

- 严格解析 DONE，区分四类失败，仅对暂时性故障重试；调用费用先入账，再检查预算。
- 完整快照身份、按存储目录/session 隔离的 v3 账本及并发合并共同阻止旧证据串用；存储不可用时在调用模型前拒绝。
- 不存在的相对目录在创建前后保持相同身份，覆盖 `.`、`..` 和软链接组合，避免同一证据重复调用模型。
- 对用户可见的调用错误按 Unicode 字符限制长度；持久化无效答复的有界原因，重启重放保留诊断细节，兼容缺少新字段的旧 v3 记录。
- 将结构化原因传到 goal 工具、session actor 和 UI 通知；规格解析器识别 40 个验收场景，均绑定真实测试。

当前补丁 `38130f80` 已通过 GLM-5.3 / K3-256K 增量互审及 Codex 独立检查。三个审查问题均有真实 RED→GREEN 回归；相关回归 65 通过、0 失败、1 忽略，最后的测试矩阵调整后 32 项 verifier 回归通过。八种路径的独立实际目录创建探针全部通过。格式检查、`cargo clippy -p octos-cli --features api --all-targets -- -D warnings`、规格 parse/lint 均通过。

与 #2272 `e8f77422` 组合后的提交 `142ca5a2` 已在普通干净检出中完成下面的全量检查，源码前后未变：fmt 和 clippy 均成功；172 套件共 10,047 通过、1 失败、100 忽略，all-targets 退出码 101。唯一失败是未改动的 `stdio_connection_stops_dispatch_after_writer_failure`：同一编译产物单独运行连续三次通过，与 `embedded_client_uses_real_oup_negotiation_and_rpc_errors` 两测试并行时重现全局计数器串扰（实际计数 3，断言期望 1）。两个测试及 transport 实现相对原已验证组合 `8b4da851` 均无改动。此项作为已有测试隔离缺陷保留，不将本轮全量记为通过；修复提交 `38130f80` 的 GitHub CI 已全部通过，外环增量复审也已重新 APPROVED。

```sh
cargo fmt --all -- --check
cargo clippy --all-targets --features api -- -D warnings
cargo test --all-targets --features api --no-fail-fast -- --test-threads=8
```

覆盖边界：自动运行入口测试验证实际的有界验证包装器、警告构造及线路发送，属于组件测试；整个 autonomous turn 的端到端覆盖仍在范围外。


最新状态：远端合入 main（已合并的 #2272）后，当前 HEAD 为 `240f7114`，Git tree 与上述独立验证的 `142ca5a2` 完全相同，APPROVED 保留。[该 HEAD 的 CI](https://github.com/octos-org/octos/actions/runs/34392402288) 现已全部通过（attempt 2），包括 CLI、API、进程级、工具端到端和安全检查。

首轮 CI 曾在未改动的 build-cache 测试 `inherited_flock_live_holder_and_wrong_token_remain_excluded` 的 180ms 耗时断言失败（3,679 通过、1 失败、10 忽略）。随后只定点重跑该 CLI 任务及其依赖任务，没有修改代码或放宽断言；完整 CLI 任务通过，原失败用例在日志中两次执行均通过。首轮失败和本次成功日志均保留，不据此声称已修复该时序断言的稳定性问题。
