### PR TITLE
test: gate Unix-only tests to fix the check-windows build break on main

### DIFF
--- a/crates/octos-agent/src/sandbox/docker.rs
+++ b/crates/octos-agent/src/sandbox/docker.rs
@@ -171,7 +171,11 @@ fn cache_mount_refusal() -> Command {
 mod tests {
     use super::*;
 
+    // Unix-only: on Windows `std::fs::canonicalize` returns a `\\?\C:`
+    // verbatim path whose drive colon trips the `-v` injection guard, and
+    // the Docker backend refuses drive-letter cwd mounts there anyway.
     #[test]
+    #[cfg(unix)]
     fn build_cache_target_is_mounted_and_env_reaches_container() {
         let sb = DockerSandbox {
             config: DockerConfig::default(),

--- a/crates/octos-cli/src/build_cache/pool.rs
+++ b/crates/octos-cli/src/build_cache/pool.rs
@@ -1972,7 +1972,10 @@ mod tests {
         assert_eq!(pid_alive(i32::MAX as u32 + 1), Some(false));
     }
 
+    // Dead-holder reclamation hinges on `pid_alive`'s kill(pid, 0)
+    // semantics, which only exist on Unix; `spawn_dead_pid` is cfg(unix).
     #[test]
+    #[cfg(unix)]
     fn report_only_preserves_dead_holder_and_all_slot_files() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().join("pool");
@@ -2165,6 +2168,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn dead_holder_slot_is_reclaimable() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().join("pool");
@@ -2605,7 +2609,9 @@ mod tests {
         assert!(dir.join(TARGET_LEAF).is_dir(), "no_lock never deletes");
     }
 
+    // chmod-based EACCES plus the dead-pid seam are both Unix-only.
     #[test]
+    #[cfg(unix)]
     fn unreadable_holder_json_is_skipped_not_stale() {
         // D4: an EACCES on holder.json means the slot is probably someone
         // else's — conservative skip, not "stale holder".

--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -6193,7 +6193,9 @@ mod peer_task_registry_tests {
     /// (never collapsing to None like `to_str()`), and two different roots
     /// encode to two different scopes so one root's `/stop` purge can never
     /// match the other's stamped items.
+    // Constructing a non-UTF-8 OsStr uses `OsStrExt::from_bytes` (Unix-only).
     #[test]
+    #[cfg(unix)]
     fn workspace_scope_encoding_is_lossless_and_distinct() {
         use std::os::unix::ffi::OsStrExt;
 
@@ -6517,7 +6519,9 @@ mod peer_turn_status_tests {
         assert_eq!(f.rounds_delivered, 1, "#2024 floor: bare result.md");
     }
 
+    // `std::os::unix::fs::symlink` is Unix-only.
     #[test]
+    #[cfg(unix)]
     fn peer_list_symlinked_turns_index_is_ignored() {
         let temp = tempfile::tempdir().unwrap();
         let dir = staged(temp.path(), "sl", None);


### PR DESCRIPTION
## Problem

`check-windows` is red on main (run 34397691827 on 946b4e49, also failing since 09-06). Two distinct breaks, all in test code:

1. **octos-cli test targets fail to compile on Windows** —
   - `peers/mod.rs`: `workspace_scope_encoding_is_lossless_and_distinct` uses `std::os::unix::ffi::OsStrExt` / `OsStr::from_bytes` (E0433/E0599); `peer_list_symlinked_turns_index_is_ignored` uses `std::os::unix::fs::symlink` (E0433).
   - `build_cache/pool.rs`: `report_only_preserves_dead_holder_and_all_slot_files`, `dead_holder_slot_is_reclaimable`, `unreadable_holder_json_is_skipped_not_stale` call `spawn_dead_pid()`, which is itself `#[cfg(unix)]` (E0425 ×3).
2. **octos-agent Windows runtime failure** — `sandbox::docker::tests::build_cache_target_is_mounted_and_env_reaches_container` panics at docker.rs:192: on Windows `std::fs::canonicalize` returns a `\\?\C:` verbatim path whose drive colon trips the `-v` mount-injection guard in `wrap_with_slot`, so the command comes back as the refusal stub without the asserted `--env` args.

## Root cause

- The pool tests exercise dead-holder reclamation, which hinges on `pid_alive`'s `kill(pid, 0)` semantics. On non-Unix hosts `pid_alive` is a conservative always-alive stub (pool.rs:506-511), so the behavior under test does not exist on Windows by design — these tests can never be meaningful there, only fail to compile.
- The peers tests construct non-UTF-8 `OsStr`s and symlinks via Unix-only extension traits.
- The docker test asserts Unix path semantics; the Docker backend is structurally Unix-shaped in this code path (the workspace cwd mount guard also refuses drive-letter paths), so the mount command it expects cannot be produced on Windows. Making the mount work on Windows (dunce + drive-letter-aware parsing) would be a feature, not a build-break fix; ci.yml's own note on this job says to prefer "fixing it or narrowing the failing test to `#[cfg(unix)]`".

## Fix

Add `#[cfg(unix)]` (plus a one-line rationale comment, matching the file's existing gated tests such as `pid_alive_distinguishes_eperm_from_esrch`) to the five test functions. No production code touched; 14 insertions across 3 files.

## Test evidence

- **Windows compile (the broken path)**: `cargo check --workspace --all-targets --target x86_64-pc-windows-gnu` on this branch — zero errors (covers every lib-test and integration-test target of octos-cli/octos-agent under `cfg(windows)`; `windows-gnu` resolves E0433/E0599/E0425 name-resolution identically to CI's `windows-msvc`). Also clean with octos-cli's full CI feature set (`api,telegram,discord,dingtalk,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3`).
- **Unix regression**: the five gated tests still exist and pass on Unix (5/5), plus `sandbox::docker` tests 15/15.
- **fmt/clippy**: `cargo fmt --all -- --check` clean; `cargo clippy -p octos-cli -p octos-agent --all-targets -- -D warnings` clean.
- Three local `peers::build_cache_peer_tests` failures observed during the run are environmental (the machine had 40 GB free, below the 50 GB space gate added in #2268) and unrelated to this diff.
- Independent review pass confirmed each CI error maps to exactly one gate, that the remaining `spawn_dead_pid` call sites were already gated on main, and that no other ungated Unix-only API use exists in these crates' test code.

## End-to-end note

The failing environment is Windows CI itself; `check-windows` runs its test steps only on main/manual, so the post-merge main run is the final confirmation. The pre-merge evidence above reproduces the exact failing compile surface (`cfg(windows)` test targets, all targets) locally and shows it clean.

Refs #2267
