### PR TITLE
test: name serve_broken_pipe e2e module after its target so the CI skip works

### DIFF
--- a/crates/octos-cli/tests/serve_broken_pipe.rs
+++ b/crates/octos-cli/tests/serve_broken_pipe.rs
@@ -15,14 +15,20 @@
 //! `cargo test -p octos-cli --features api --test serve_broken_pipe -- --test-threads=1`
 
 // Process-control tests require libc pipe/kill/setsid — unsafe is inherent.
-// #39 — the whole `imp` module is unix-only BY ORIGINAL DESIGN (libc pipes,
+// #39 — the test module is unix-only BY ORIGINAL DESIGN (libc pipes,
 // raw-fd Stdio, SIGINT/SIGKILL): the #37 hardening broke the cfg structure
 // by leaving the imports and several `libc::` call sites outside any gate
 // (E0432/E0433 on Windows). Gate the entire module so the file compiles on
-// Windows with the SAME existence shape as before #37: no tests, no imp.
+// Windows with the SAME existence shape as before #37: no tests, no module.
+// The module is named `serve_broken_pipe` so every test name carries the
+// target name: the broad CI integration step excludes these
+// process-spawning e2e with `--skip serve_broken_pipe` (they run in the
+// dedicated serial step below it), and --skip matches test names, not
+// target names — under the old `imp` name the filter silently matched
+// nothing and the e2e leaked into the parallel step, flaking under load.
 #[cfg(unix)]
 #[allow(unsafe_code)]
-mod imp {
+mod serve_broken_pipe {
     use std::os::fd::FromRawFd;
     use std::process::{Command, Stdio};
     use std::sync::Mutex;


### PR DESCRIPTION
## Problem

The `test-octos-cli` job has a broad integration step named "Test octos-cli (integration, excluding serve process e2e)" that runs `cargo test -p octos-cli --tests -- --skip serve_broken_pipe`, with a dedicated serial step right below for the process-spawning BrokenPipe e2e. The exclusion is silently broken: the four process e2e run in the fully-parallel broad step anyway and flake there — the 60s cleanup-marker poll in `imp::serve_shutdown_broken_pipe_cleanup_marker_observed` timed out on two unrelated PR CI runs ([33997597638](https://github.com/octos-org/octos/actions/runs/33997597638) on Sep 5, [34415043855](https://github.com/octos-org/octos/actions/runs/34415043855) on Sep 9), failing both PRs' required checks.

## Root cause

`--skip` matches **test names**, not the target name. The tests live in `mod imp` (added in cd65eb68 / #2154), so their names — `imp::serve_shutdown_broken_pipe_cleanup_marker_observed`, `imp::serve_shutdown_order_preserved`, `imp::serve_startup_broken_pipe_no_panic`, `imp::subprocess_panic_stderr_broken_pipe_no_abort` — have never contained the substring `serve_broken_pipe`. The filter has matched nothing since introduction: `cargo test -p octos-cli --tests -- --skip serve_broken_pipe --list` still lists 3843 of 3843 tests.

## Fix

Rename the module `imp` → `serve_broken_pipe`. Every test name now carries the target name, so the existing CI filter excludes exactly these 4 tests — and any future test added to the file. One-word change plus an explanatory comment; no workflow edit. The `#[cfg(unix)]` gating, the SERIAL mutex, and every test body are untouched.

## Test evidence

- Broad step filter behavior, before → after (same binary, `--list`): 3843 → 3839 tests; the only four excluded are the renamed e2e, zero leakage. The two unrelated lib unit tests with `broken_pipe` in their names (`serve_console_write_line_broken_pipe_returns_ok`, `write_panic_report_broken_pipe_no_panic`) still run.
- Dedicated serial step unchanged and green for real: `cargo test -p octos-cli --features api --test serve_broken_pipe -- --test-threads=1` → 4 passed, 0 failed (64.97s).
- The spec selectors in `specs/task-s-broken-pipe-shutdown.spec.md` use bare names, which remain substring-matched under the new module prefix.
- End-to-end note: this is a CI/test-selection change, so the "product" is the test list itself — the before/after `--list` diff above is the end-to-end demonstration. The full parallel integration suite itself is unchanged in content (only these four tests move out of it, back to their intended lane).

## Review

Two-round review: self-review of the full diff, then an independent adversarial review (twice — once for an earlier ci.yml four-substring variant, which it approved with wording notes I adopted, and once for this final module-rename variant). The reviewer verified repo-wide that nothing references the old `imp::…` names, that no tooling parses these test names, that Windows compilation shape is unchanged, and that the rename closes the future-addition leak. Verdict: approve.

No tracking issue — filed directly as a CI build-break-class fix after the flake failed required checks on two unrelated PRs.