### PR TITLE
fix(agent): classify before_llm_call hook denies as policy/expected, not internal/bug (#2249)

### DIFF
--- a/crates/octos-agent/src/agent/llm_call.rs
+++ b/crates/octos-agent/src/agent/llm_call.rs
@@ -125,7 +125,11 @@ impl Agent {
                 ctx.as_ref(),
             );
             if let HookResult::Deny(reason) = hooks.run(HookEvent::BeforeLlmCall, &payload).await {
-                eyre::bail!("LLM call denied by hook: {reason}");
+                // #2249: a typed error (not a bare `eyre::bail!`) so the loop
+                // boundary classifies the deny as policy/expected instead of
+                // internal/bug. `HookDeniedError`'s Display keeps the exact
+                // user-facing wording this bail used to produce.
+                return Err(crate::hooks::HookDeniedError { reason }.into());
             }
         }
 

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -6949,6 +6949,57 @@ async fn should_not_emit_turn_failure_when_hook_denies_llm_call_under_failfast()
     );
 }
 
+/// #2249 — a `before_llm_call` deny is expected policy behaviour, not a
+/// harness bug: the classified error event must carry `variant="policy"
+/// recovery="expected"` so operator dashboards stop paging on it.
+#[tokio::test]
+#[cfg(unix)]
+async fn should_classify_hook_deny_as_policy_not_internal_bug() {
+    use crate::hooks::{HookConfig, HookEvent, HookExecutor};
+
+    let dir = tempfile::tempdir().unwrap();
+    let chat_calls = Arc::new(AtomicUsize::new(0));
+    let provider: Arc<dyn LlmProvider> = Arc::new(AlwaysErrorProvider {
+        chat_calls: chat_calls.clone(),
+    });
+    let tools = ToolRegistry::with_builtins(dir.path());
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let hooks = Arc::new(HookExecutor::new(vec![HookConfig {
+        event: HookEvent::BeforeLlmCall,
+        command: vec!["false".into()],
+        timeout_ms: 5000,
+        tool_filter: vec![],
+        path_filter: vec![],
+        requires_bin: None,
+    }]));
+    let sink_path = dir.path().join("harness-events.jsonl");
+    let agent = Agent::new(AgentId::new("hookdeny-policy"), provider, tools, memory)
+        .with_hooks(hooks)
+        .with_harness_event_sink(sink_path.to_string_lossy().into_owned());
+
+    let result = agent.run_task(&task_for("hi", dir.path())).await;
+
+    assert!(result.is_err(), "hook-deny must still bail with Err");
+    assert_eq!(
+        chat_calls.load(AtomicOrdering::SeqCst),
+        0,
+        "hook denied the call before the provider was reached"
+    );
+    let sink = std::fs::read_to_string(&sink_path).expect("error event written to sink");
+    let error_events: Vec<_> = sink
+        .lines()
+        .filter_map(|line| crate::harness_events::HarnessEvent::from_json_line(line).ok())
+        .filter_map(|event| match event.payload {
+            crate::harness_events::HarnessEventPayload::Error { data } => Some(data),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(error_events.len(), 1, "exactly one classified error event");
+    assert_eq!(error_events[0].variant, "policy");
+    assert_eq!(error_events[0].recovery, "expected");
+    assert!(error_events[0].message.contains("denied by hook"));
+}
+
 /// Records the message contents of every LLM call and returns EndTurn
 /// immediately. Used to assert what the model actually saw and that it was
 /// (or was not) called at all.

--- a/crates/octos-agent/src/agent/loop_state.rs
+++ b/crates/octos-agent/src/agent/loop_state.rs
@@ -73,7 +73,17 @@ const DEFAULT_PLUGIN_TIMEOUT_LIMIT: u32 = 3;
 const DEFAULT_PLUGIN_PROTOCOL_LIMIT: u32 = 2;
 const DEFAULT_DELEGATE_DEPTH_LIMIT: u32 = 1;
 const DEFAULT_INTERNAL_LIMIT: u32 = 1;
+/// Hook-deny (policy) errors escalate immediately — retrying a policy
+/// decision can never succeed (#2249).
+const DEFAULT_POLICY_LIMIT: u32 = 1;
 const DEFAULT_SHELL_SPIRAL_LIMIT: u32 = 1;
+
+/// `#[serde(default = "...")]` helper for `LoopRetryLimits::policy`. Lets
+/// legacy retry-state JSON (pre-policy field) deserialize cleanly with the
+/// canonical default instead of `0`, which would disable the bucket.
+fn default_policy_limit() -> u32 {
+    DEFAULT_POLICY_LIMIT
+}
 
 /// Per-bucket hard limits. Tuned for M6.2 defaults, exposed so integration
 /// tests and operators can override them if needed.
@@ -97,6 +107,10 @@ pub struct LoopRetryLimits {
     pub plugin_protocol: u32,
     pub delegate_depth_exceeded: u32,
     pub internal: u32,
+    /// Added with the PolicyDeny variant (#2249). `serde(default)` keeps
+    /// legacy retry-state sidecar JSON (pre-policy) deserializable.
+    #[serde(default = "default_policy_limit")]
+    pub policy: u32,
     pub shell_spiral: u32,
 }
 
@@ -118,6 +132,7 @@ impl Default for LoopRetryLimits {
             plugin_protocol: DEFAULT_PLUGIN_PROTOCOL_LIMIT,
             delegate_depth_exceeded: DEFAULT_DELEGATE_DEPTH_LIMIT,
             internal: DEFAULT_INTERNAL_LIMIT,
+            policy: DEFAULT_POLICY_LIMIT,
             shell_spiral: DEFAULT_SHELL_SPIRAL_LIMIT,
         }
     }
@@ -208,6 +223,11 @@ pub struct LoopRetryCounters {
     pub plugin_protocol: u32,
     pub delegate_depth_exceeded: u32,
     pub internal: u32,
+    /// Added with the PolicyDeny variant (#2249). `serde(default)` keeps
+    /// legacy retry-state sidecar JSON (pre-policy) deserializable; a
+    /// missing field deserializes to `0`.
+    #[serde(default)]
+    pub policy: u32,
     pub shell_spiral: u32,
 }
 
@@ -270,6 +290,9 @@ impl LoopRetryCounters {
         self.internal = self
             .internal
             .saturating_add(turn.internal.saturating_sub(base.internal));
+        self.policy = self
+            .policy
+            .saturating_add(turn.policy.saturating_sub(base.policy));
         self.shell_spiral = self
             .shell_spiral
             .saturating_add(turn.shell_spiral.saturating_sub(base.shell_spiral));
@@ -508,6 +531,7 @@ impl LoopRetryState {
                 self.limits.delegate_depth_exceeded,
             ),
             HarnessError::Internal { .. } => (&mut self.counters.internal, self.limits.internal),
+            HarnessError::PolicyDeny { .. } => (&mut self.counters.policy, self.limits.policy),
         };
         *counter_ref = counter_ref.saturating_add(1);
         (*counter_ref, limit)
@@ -536,6 +560,9 @@ fn decide_for_variant(error: &HarnessError) -> LoopDecision {
         RecoveryHint::CompactContext => LoopDecision::CompactAndRetry,
         // Non-retryable, surface to operator.
         RecoveryHint::FailFast => LoopDecision::Escalate,
+        // Expected policy behaviour (hook deny) — not a fault; surface for
+        // audit, never retry (#2249).
+        RecoveryHint::Expected => LoopDecision::Escalate,
         // Internal invariant violation — bug, not recoverable.
         RecoveryHint::Bug => LoopDecision::Escalate,
     }
@@ -719,6 +746,7 @@ mod tests {
             plugin_protocol: v,
             delegate_depth_exceeded: v,
             internal: v,
+            policy: v,
             shell_spiral: v,
         };
         let offset_counters = |v: u32| LoopRetryCounters {
@@ -737,7 +765,8 @@ mod tests {
             plugin_protocol: v + 12,
             delegate_depth_exceeded: v + 13,
             internal: v + 14,
-            shell_spiral: v + 15,
+            policy: v + 15,
+            shell_spiral: v + 16,
         };
         let uniform_limits = |v: u32| LoopRetryLimits {
             rate_limited: v,
@@ -755,6 +784,7 @@ mod tests {
             plugin_protocol: v,
             delegate_depth_exceeded: v,
             internal: v,
+            policy: v,
             shell_spiral: v,
         };
 

--- a/crates/octos-agent/src/harness_errors.rs
+++ b/crates/octos-agent/src/harness_errors.rs
@@ -58,6 +58,9 @@ pub enum RecoveryHint {
     /// requests, content filtered responses, and structural budget violations
     /// like delegation depth exceeded.
     FailFast,
+    /// Expected policy behaviour, not a fault — e.g. a lifecycle hook denied
+    /// the call (#2249). Surface for audit, never page, never retry.
+    Expected,
     /// Internal invariant violation — log and bail out; operators must
     /// investigate. Not retryable.
     Bug,
@@ -72,6 +75,7 @@ impl RecoveryHint {
             RecoveryHint::SwitchProvider => "switch_provider",
             RecoveryHint::CompactContext => "compact_context",
             RecoveryHint::FailFast => "fail_fast",
+            RecoveryHint::Expected => "expected",
             RecoveryHint::Bug => "bug",
         }
     }
@@ -155,6 +159,11 @@ pub enum HarnessError {
         limit: u32,
         message: String,
     },
+    /// A lifecycle hook denied the operation (#2249). Expected policy
+    /// behaviour, not a harness fault — classified apart from `Internal` so
+    /// operator dashboards and alerting do not treat a policy decision as a
+    /// bug.
+    PolicyDeny { message: String },
     /// Catch-all for agent-internal bugs (poisoned locks, unexpected state,
     /// etc.). Treat as `RecoveryHint::Bug`.
     Internal { message: String },
@@ -211,6 +220,7 @@ impl HarnessError {
             HarnessError::PluginTimeout { .. } => "plugin_timeout",
             HarnessError::PluginProtocol { .. } => "plugin_protocol",
             HarnessError::DelegateDepthExceeded { .. } => "delegate_depth_exceeded",
+            HarnessError::PolicyDeny { .. } => "policy",
             HarnessError::Internal { .. } => "internal",
         }
     }
@@ -277,6 +287,10 @@ impl HarnessError {
             | HarnessError::PluginSpawn { .. }
             | HarnessError::PluginProtocol { .. } => RecoveryHint::FailFast,
 
+            // Non-retryable, but NOT a fault: a lifecycle hook denied the
+            // call (#2249). Surface for audit; never page, never retry.
+            HarnessError::PolicyDeny { .. } => RecoveryHint::Expected,
+
             // Internal invariant broken — bug, not recoverable.
             HarnessError::Internal { .. } => RecoveryHint::Bug,
         }
@@ -300,6 +314,7 @@ impl HarnessError {
             | HarnessError::PluginTimeout { message, .. }
             | HarnessError::PluginProtocol { message, .. }
             | HarnessError::DelegateDepthExceeded { message, .. }
+            | HarnessError::PolicyDeny { message }
             | HarnessError::Internal { message } => message,
         }
     }
@@ -325,8 +340,10 @@ impl HarnessError {
     }
 
     /// Classify a raw `eyre::Report` at an agent-loop boundary. Downcasts to
-    /// `LlmError` first; falls back to `ToolExecution` with the provided
-    /// `tool_name`, or `Internal` when no tool context is available.
+    /// `LlmError` first, then to [`crate::hooks::HookDeniedError`] (#2249 — a
+    /// hook deny is policy, not a bug); falls back to `ToolExecution` with
+    /// the provided `tool_name`, or `Internal` when no tool context is
+    /// available.
     ///
     /// This is the canonical entry point that enforces invariant #1 ("no raw
     /// `eyre::Report` escapes the agent loop without classification"): every
@@ -334,6 +351,16 @@ impl HarnessError {
     pub fn classify_report(report: &eyre::Report, tool_name: Option<&str>) -> Self {
         if let Some(llm) = report.downcast_ref::<LlmError>() {
             return Self::from_llm_error(llm);
+        }
+        // #2249 — a before-hook deny is expected policy behaviour: classify it
+        // `policy`/`expected` so dashboards stop paging on it as `internal`/`bug`.
+        if report
+            .downcast_ref::<crate::hooks::HookDeniedError>()
+            .is_some()
+        {
+            return HarnessError::PolicyDeny {
+                message: truncate(&report.to_string(), MAX_HARNESS_ERROR_MESSAGE_BYTES),
+            };
         }
         let message = truncate(&report.to_string(), MAX_HARNESS_ERROR_MESSAGE_BYTES);
         match tool_name {
@@ -498,6 +525,7 @@ impl HarnessError {
             | HarnessError::ContentFiltered { .. }
             | HarnessError::Network { .. }
             | HarnessError::Timeout { .. }
+            | HarnessError::PolicyDeny { .. }
             | HarnessError::Internal { .. } => {}
         }
         out
@@ -702,6 +730,21 @@ mod tests {
         assert_eq!(err.recovery_hint(), RecoveryHint::SwitchProvider);
         assert!(err.message().contains("MiniMax-M2.5-highspeed"));
         assert!(err.message().contains("top up or switch provider"));
+    }
+
+    #[test]
+    fn classify_report_downcasts_hook_deny_through_eyre() {
+        // #2249 — a `before_llm_call` deny bails with a typed HookDeniedError;
+        // the loop boundary must classify it `policy`/`expected`, never
+        // `internal`/`bug` (a policy deny pages nobody).
+        let report: eyre::Report = crate::hooks::HookDeniedError {
+            reason: "no network calls today".into(),
+        }
+        .into();
+        let classified = HarnessError::classify_report(&report, None);
+        assert_eq!(classified.variant_name(), "policy");
+        assert_eq!(classified.recovery_hint(), RecoveryHint::Expected);
+        assert!(classified.message().contains("no network calls today"));
     }
 
     #[test]

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -674,6 +674,29 @@ pub trait HookPayloadEnricher: Send + Sync {
     fn enrich(&self, event: &HookEvent, payload: &mut HookPayload);
 }
 
+/// Typed error for a before-hook policy deny that escapes as an
+/// `eyre::Report` (#2249). A deny is expected policy behaviour, not a
+/// harness fault — carrying a type (instead of a bare `eyre::bail!` string)
+/// lets `HarnessError::classify_report` downcast it into the `policy` /
+/// `expected` classification instead of `internal` / `bug`.
+///
+/// The `Display` wording is load-bearing: it surfaces verbatim to users as
+/// the permission-denial message, and the FailFast hook-deny exclusion in
+/// `loop_runner.rs` prefix-matches it.
+#[derive(Debug)]
+pub struct HookDeniedError {
+    /// Deny reason reported by the hook (empty when the hook gave none).
+    pub reason: String,
+}
+
+impl std::fmt::Display for HookDeniedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LLM call denied by hook: {}", self.reason)
+    }
+}
+
+impl std::error::Error for HookDeniedError {}
+
 /// Result of running hooks for an event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HookResult {

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -144,7 +144,8 @@ pub use harness_events::{
     emit_registered_credential_rotation_event,
 };
 pub use hooks::{
-    HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookPayloadEnricher, HookResult,
+    HookConfig, HookContext, HookDeniedError, HookEvent, HookExecutor, HookPayload,
+    HookPayloadEnricher, HookResult,
 };
 pub use mcp::{McpClient, McpServerConfig};
 pub use memory_segment::{

--- a/crates/octos-agent/tests/harness_errors.rs
+++ b/crates/octos-agent/tests/harness_errors.rs
@@ -230,6 +230,7 @@ fn should_count_errors_per_variant_in_metrics() {
         "plugin_timeout",
         "plugin_protocol",
         "delegate_depth_exceeded",
+        "policy",
         "internal",
     ] {
         assert!(
@@ -265,6 +266,38 @@ fn should_classify_403_quota_as_quota_with_provider_label() {
     // failing the turn (pre-27b this asserted FailFast).
     assert_eq!(classified.recovery_hint(), RecoveryHint::SwitchProvider);
     assert!(classified.message().contains("MiniMax-M2.5-highspeed"));
+}
+
+#[test]
+fn should_classify_hook_deny_as_policy_not_bug() {
+    // #2249 — a `before_llm_call` hook deny escapes the LLM call as a typed
+    // `HookDeniedError` report. It is expected policy behaviour, not a
+    // harness fault: it must classify `variant=policy recovery=expected`
+    // instead of `variant=internal recovery=bug`, so operator dashboards
+    // stop paging on policy decisions.
+    let report: eyre::Report = octos_agent::hooks::HookDeniedError {
+        reason: "no network calls today".into(),
+    }
+    .into();
+    let classified = HarnessError::classify_report(&report, None);
+    assert!(
+        matches!(classified, HarnessError::PolicyDeny { .. }),
+        "expected PolicyDeny, got {classified:?}"
+    );
+    assert_eq!(classified.variant_name(), "policy");
+    assert_eq!(classified.recovery_hint(), RecoveryHint::Expected);
+    assert!(classified.message().contains("no network calls today"));
+
+    // The emitted event stays schema-conformant and round-trips.
+    let event = classified.to_event("s", "t", None, None);
+    let json = serde_json::to_string(&event).expect("serialize");
+    let restored = HarnessEvent::from_json_line(&json).expect("round-trip");
+    let HarnessEventPayload::Error { data } = restored.payload else {
+        panic!("expected Error payload");
+    };
+    assert_eq!(data.variant, "policy");
+    assert_eq!(data.recovery, "expected");
+    assert_eq!(data.schema_version, HARNESS_ERROR_SCHEMA_VERSION);
 }
 
 #[test]

--- a/crates/octos-agent/tests/loop_retry_state.rs
+++ b/crates/octos-agent/tests/loop_retry_state.rs
@@ -19,6 +19,35 @@ use octos_agent::{LoopDecision, LoopRetryLimits, LoopRetryState};
 // ─────────────────────────────────────────────────────────────────────────
 
 #[test]
+fn should_escalate_hook_deny_immediately_and_exhaust_bucket() {
+    // #2249 — a hook deny is expected policy behaviour: never retried
+    // (Escalate on the first observation), bucket capped at 1 like the
+    // other non-retryable variants.
+    let mut state = LoopRetryState::new();
+    let err = HarnessError::PolicyDeny {
+        message: "LLM call denied by hook: policy".into(),
+    };
+    assert_eq!(state.observe(&err), LoopDecision::Escalate);
+    assert_eq!(state.observe(&err), LoopDecision::Exhausted);
+}
+
+#[test]
+fn should_deserialize_legacy_retry_state_without_policy_bucket() {
+    // #2249 — retry-state sidecars written before the PolicyDeny variant
+    // have no `policy` field: limits must fall back to the canonical
+    // default (1), counters to 0 — not fail deserialization.
+    let state = LoopRetryState::new();
+    let mut json: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&state).expect("serialize")).expect("value");
+    json["limits"].as_object_mut().unwrap().remove("policy");
+    json["counters"].as_object_mut().unwrap().remove("policy");
+    let restored: LoopRetryState =
+        serde_json::from_value(json).expect("legacy JSON without policy bucket deserializes");
+    assert_eq!(restored.limits.policy, 1);
+    assert_eq!(restored.counters.policy, 0);
+}
+
+#[test]
 fn should_escalate_after_invalid_tool_call_limit() {
     let mut state = LoopRetryState::with_limits(LoopRetryLimits {
         invalid_request: 2,


### PR DESCRIPTION
## Problem

A `before_llm_call` hook deny is expected policy behaviour, but it surfaced in telemetry as a harness bug:

```
harness error classified variant="internal" recovery=bug error=LLM call denied by hook: …
```

Operator dashboards and alerting page on `recovery=bug`, so every policy deny looked like a harness fault (#2249).

## Root cause

`llm_call.rs` bailed with a bare `eyre::bail!("LLM call denied by hook: …")`. At the loop boundary, `HarnessError::classify_report` could not downcast the report to `LlmError`, had no tool context, and fell through to the `Internal` catch-all (`variant=internal recovery=bug`).

## Fix

- `llm_call.rs` now returns a typed `hooks::HookDeniedError` whose `Display` keeps the exact user-facing wording the bare bail produced (the FailFast hook-deny exclusion in `loop_runner.rs` prefix-matches that wording, so it keeps working; pinned by the existing `should_not_emit_turn_failure_when_hook_denies_llm_call_under_failfast`).
- `classify_report` downcasts `HookDeniedError` into a new `HarnessError::PolicyDeny` variant (`variant=policy`) carrying a new `RecoveryHint::Expected` (`recovery=expected`).
- `LoopRetryState` gains a `policy` bucket (limit 1, serde-defaulted exactly like the `quota` bucket was, so legacy retry-state sidecar JSON still deserializes). `Expected` maps to `Escalate`: the deny still bails the turn with no retry, byte-for-byte the same control flow as before.

One observer-side change to call out: `task_supervisor` only early-paints a task as observed-failed for `recovery in {fail_fast, bug}`, so a policy deny no longer triggers that early paint. The owner join path still reports the true terminal state when the bailed turn propagates, so no task-state regression — the early paint was exactly the dashboard pollution the issue reports.

## Test evidence

Red→green: the new end-to-end test fails on main (`variant` was `"internal"`) and passes with the fix.

- New e2e (`loop_runner_tests.rs`): live agent + real `false`-command `before_llm_call` hook + harness event sink — asserts the turn bails, the provider is never called, and exactly one error event lands with `variant=policy recovery=expected`.
- New unit (`harness_errors.rs`): `classify_report` downcasts `HookDeniedError` through `eyre::Report` to `policy`/`expected`.
- New acceptance (`tests/harness_errors.rs`): variant/recovery contract + event schema round-trip.
- New (`tests/loop_retry_state.rs`): `PolicyDeny` escalates immediately and exhausts its bucket on the second observation; legacy retry-state JSON without the `policy` field deserializes with limit=1/counter=0.

Full verification on this branch: `cargo fmt --all -- --check` clean; `cargo clippy -p octos-agent --all-targets -- -D warnings` clean; `cargo test -p octos-agent --lib` 2889 passed / 0 failed; `--test harness_errors` 19 passed; `--test loop_retry_state` 10 passed; `cargo check -p octos-cli --all-targets` clean.

## Review

Independently reviewed with a fresh-eyes maintainer pass over the full diff (deny-path coverage, control-flow preservation, serde compatibility, exhaustive-match audit, test quality): verdict APPROVE. Its findings were nits, each either addressed or noted above.

Closes #2249