### PR TITLE
fix(cli): relocate the goal operator-control socket when the data dir exceeds sun_path (#2248)

### DIFF
--- a/crates/octos-cli/src/commands/goal.rs
+++ b/crates/octos-cli/src/commands/goal.rs
@@ -18,7 +18,9 @@
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
-use eyre::{Result, WrapErr, bail, eyre};
+#[cfg(all(unix, feature = "api"))]
+use eyre::WrapErr;
+use eyre::{Result, bail, eyre};
 
 use super::Executable;
 use crate::autonomy::supervisor_store::{
@@ -107,10 +109,14 @@ const GOAL_OPERATOR_TRANSITION_METHOD: &str = "session/goal/operator_transition"
 /// `sun_path` capacity for a bound unix socket. The terminating NUL is not
 /// representable in the path, so the limit is exclusive — a path of exactly
 /// this many bytes still fails to bind.
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(all(feature = "api", any(target_os = "linux", target_os = "android")))]
 const SUN_PATH_CAPACITY: usize = 108;
 /// Conservative value for every other unix target (macOS/BSD).
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+#[cfg(all(
+    feature = "api",
+    unix,
+    not(any(target_os = "linux", target_os = "android"))
+))]
 const SUN_PATH_CAPACITY: usize = 104;
 
 /// Marker file a relocated serve publishes inside the data dir, carrying the
@@ -119,7 +125,11 @@ const SUN_PATH_CAPACITY: usize = 104;
 const GOAL_OPERATOR_CONTROL_SOCKET_POINTER: &str = ".octos-goal-control.sock.path";
 
 /// Bind-side resolution of the goal operator-control socket (#2248).
-#[cfg(unix)]
+///
+/// The bind side only exists under the `api` feature (serve), so these
+/// helpers are gated to match — the minimal production library build
+/// (`--no-default-features`) would otherwise see them as dead code.
+#[cfg(all(unix, feature = "api"))]
 struct GoalControlSocketPath {
     path: PathBuf,
     /// True when the canonical in-data-dir path did not fit `sun_path` and
@@ -135,7 +145,7 @@ struct GoalControlSocketPath {
 /// the real path is published in a pointer file inside the data dir for the
 /// connect side. The length decision runs on the canonicalized path so a
 /// short symlink spelling cannot split the two sides' choices.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "api"))]
 fn goal_control_bind_path(data_dir: &Path) -> Result<GoalControlSocketPath> {
     let resolved = std::fs::canonicalize(data_dir).unwrap_or_else(|error| {
         tracing::debug!(%error, data_dir = %data_dir.display(), "canonicalize failed; using the spelled data dir");
@@ -179,7 +189,7 @@ fn goal_control_connect_path(data_dir: &Path) -> PathBuf {
 /// where the socket actually lives: write it when relocated, remove a stale
 /// one when canonical. A missing pointer while the serve lock is held means
 /// an old serve, which the connect side already fails closed against.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "api"))]
 fn publish_goal_control_socket(data_dir: &Path, socket: &GoalControlSocketPath) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
@@ -228,7 +238,7 @@ fn publish_goal_control_socket(data_dir: &Path, socket: &GoalControlSocketPath) 
 ///
 /// The returned bool marks a subdir the caller must create and chmod 0700.
 /// Pure: environment and mode bits come in as parameters for testability.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "api"))]
 fn fallback_base_dir(
     xdg_runtime_dir: Option<PathBuf>,
     temp_dir: PathBuf,
@@ -244,7 +254,7 @@ fn fallback_base_dir(
     (temp_dir, false)
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "api"))]
 fn fallback_socket_base_dir() -> Result<PathBuf> {
     use std::os::unix::fs::PermissionsExt;
 
@@ -280,7 +290,7 @@ fn fallback_socket_base_dir() -> Result<PathBuf> {
 
 /// Deterministic relocated socket name under `base`, keyed by a stable hash
 /// of the canonical data dir.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "api"))]
 fn hashed_fallback_socket(base: &Path, canonical_data_dir: &Path) -> Result<PathBuf> {
     let path = base.join(format!(
         ".octos-goal-control-{:016x}.sock",
@@ -298,7 +308,7 @@ fn hashed_fallback_socket(base: &Path, canonical_data_dir: &Path) -> Result<Path
 /// Cheap 64-bit FNV-1a hash of a path (same idiom as octos-agent's
 /// file_state_cache) — stable across processes and releases, which is what
 /// the connect side needs.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "api"))]
 fn fnv1a64(path: &Path) -> u64 {
     const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
     const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
@@ -1334,7 +1344,7 @@ mod tests_2116_readonly {
 /// #2248 — long data dirs must not kill `octos serve`: the goal
 /// operator-control socket relocates, publishing its real path in a pointer
 /// file inside the data dir.
-#[cfg(all(test, unix))]
+#[cfg(all(test, unix, feature = "api"))]
 mod tests_2248_sun_len {
     use super::*;
 

--- a/crates/octos-cli/src/commands/goal.rs
+++ b/crates/octos-cli/src/commands/goal.rs
@@ -18,7 +18,7 @@
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
-use eyre::{Result, bail, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 
 use super::Executable;
 use crate::autonomy::supervisor_store::{
@@ -104,6 +104,212 @@ struct GoalOperatorControlResponse {
 const GOAL_OPERATOR_CONTROL_SOCKET: &str = ".octos-goal-control.sock";
 const GOAL_OPERATOR_TRANSITION_METHOD: &str = "session/goal/operator_transition";
 
+/// `sun_path` capacity for a bound unix socket. The terminating NUL is not
+/// representable in the path, so the limit is exclusive — a path of exactly
+/// this many bytes still fails to bind.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const SUN_PATH_CAPACITY: usize = 108;
+/// Conservative value for every other unix target (macOS/BSD).
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+const SUN_PATH_CAPACITY: usize = 104;
+
+/// Marker file a relocated serve publishes inside the data dir, carrying the
+/// real socket path so the connect side needs no environment knowledge.
+#[cfg(unix)]
+const GOAL_OPERATOR_CONTROL_SOCKET_POINTER: &str = ".octos-goal-control.sock.path";
+
+/// Bind-side resolution of the goal operator-control socket (#2248).
+#[cfg(unix)]
+struct GoalControlSocketPath {
+    path: PathBuf,
+    /// True when the canonical in-data-dir path did not fit `sun_path` and
+    /// the socket was relocated outside the data dir.
+    relocated: bool,
+}
+
+/// #2248 — the canonical location is `<data_dir>/.octos-goal-control.sock`,
+/// but `sun_path` is a fixed-size array, so a long data dir made
+/// `UnixListener::bind` fail with `path must be shorter than SUN_LEN` and
+/// took down all of `octos serve`. When the canonical path does not fit, the
+/// socket relocates to a deterministic hashed name outside the data dir and
+/// the real path is published in a pointer file inside the data dir for the
+/// connect side. The length decision runs on the canonicalized path so a
+/// short symlink spelling cannot split the two sides' choices.
+#[cfg(unix)]
+fn goal_control_bind_path(data_dir: &Path) -> Result<GoalControlSocketPath> {
+    let resolved = std::fs::canonicalize(data_dir).unwrap_or_else(|error| {
+        tracing::debug!(%error, data_dir = %data_dir.display(), "canonicalize failed; using the spelled data dir");
+        data_dir.to_path_buf()
+    });
+    let canonical = resolved.join(GOAL_OPERATOR_CONTROL_SOCKET);
+    if canonical.as_os_str().len() < SUN_PATH_CAPACITY {
+        return Ok(GoalControlSocketPath {
+            path: canonical,
+            relocated: false,
+        });
+    }
+    let fallback = hashed_fallback_socket(&fallback_socket_base_dir()?, &resolved)?;
+    tracing::info!(
+        socket_path = %fallback.display(),
+        "data dir too long for a unix socket sun_path; goal operator-control RPC          relocated outside the data dir (#2248)"
+    );
+    Ok(GoalControlSocketPath {
+        path: fallback,
+        relocated: true,
+    })
+}
+
+/// Connect-side resolution: the pointer file a relocated serve publishes, or
+/// the canonical in-data-dir path otherwise.
+#[cfg(unix)]
+fn goal_control_connect_path(data_dir: &Path) -> PathBuf {
+    let resolved = std::fs::canonicalize(data_dir).unwrap_or_else(|_| data_dir.to_path_buf());
+    if let Ok(contents) =
+        std::fs::read_to_string(resolved.join(GOAL_OPERATOR_CONTROL_SOCKET_POINTER))
+    {
+        let path = contents.trim();
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    resolved.join(GOAL_OPERATOR_CONTROL_SOCKET)
+}
+
+/// After a successful bind, keep the data dir's pointer file in sync with
+/// where the socket actually lives: write it when relocated, remove a stale
+/// one when canonical. A missing pointer while the serve lock is held means
+/// an old serve, which the connect side already fails closed against.
+#[cfg(unix)]
+fn publish_goal_control_socket(data_dir: &Path, socket: &GoalControlSocketPath) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let resolved = std::fs::canonicalize(data_dir).unwrap_or_else(|_| data_dir.to_path_buf());
+    let pointer = resolved.join(GOAL_OPERATOR_CONTROL_SOCKET_POINTER);
+    if !socket.relocated {
+        match std::fs::remove_file(&pointer) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        return Ok(());
+    }
+    let stage = resolved.join(".octos-goal-control.sock.path.tmp");
+    std::fs::write(
+        &stage,
+        format!(
+            "{}
+",
+            socket.path.display()
+        ),
+    )
+    .wrap_err_with(|| {
+        format!(
+            "failed to stage goal-control socket pointer at {}",
+            stage.display()
+        )
+    })?;
+    std::fs::set_permissions(&stage, std::fs::Permissions::from_mode(0o600))?;
+    std::fs::rename(&stage, &pointer).wrap_err_with(|| {
+        format!(
+            "failed to publish goal-control socket pointer at {}",
+            pointer.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Base directory for a relocated goal-control socket: `$XDG_RUNTIME_DIR`
+/// when set and absolute (per-user, 0700, exempt from tmpfiles aging); else
+/// the temp dir — nested under a per-user 0700 subdir when the temp dir is
+/// shared (sticky world-writable, e.g. Linux `/tmp`), so no other local user
+/// can pre-create the predictable socket name and block serve startup. A
+/// per-user temp dir (macOS `/var/folders/.../T`, 0700) is used directly: it
+/// needs no subdir, and its length leaves no room for one under `sun_path`.
+///
+/// The returned bool marks a subdir the caller must create and chmod 0700.
+/// Pure: environment and mode bits come in as parameters for testability.
+#[cfg(unix)]
+fn fallback_base_dir(
+    xdg_runtime_dir: Option<PathBuf>,
+    temp_dir: PathBuf,
+    temp_mode: u32,
+) -> (PathBuf, bool) {
+    if let Some(dir) = xdg_runtime_dir.filter(|d| d.is_absolute()) {
+        return (dir, false);
+    }
+    if temp_mode & 0o7777 == 0o1777 {
+        let uid = rustix::process::geteuid().as_raw();
+        return (temp_dir.join(format!("octos-goal-control-{uid}")), true);
+    }
+    (temp_dir, false)
+}
+
+#[cfg(unix)]
+fn fallback_socket_base_dir() -> Result<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let xdg = std::env::var_os("XDG_RUNTIME_DIR")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from);
+    let temp = std::env::temp_dir();
+    let mode = std::fs::metadata(&temp)
+        .map(|m| m.permissions().mode())
+        .unwrap_or(0);
+    let (base, ours) = fallback_base_dir(xdg, temp, mode);
+    if ours {
+        std::fs::create_dir_all(&base).wrap_err_with(|| {
+            format!(
+                "failed to create goal-control fallback dir {}",
+                base.display()
+            )
+        })?;
+        // Refuse (EPERM, named) if another local user pre-created the
+        // directory; heal our own to 0700 so the socket stays owner-only
+        // even on a shared /tmp.
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700)).wrap_err_with(
+            || {
+                format!(
+                    "failed to restrict goal-control fallback dir {}",
+                    base.display()
+                )
+            },
+        )?;
+    }
+    Ok(base)
+}
+
+/// Deterministic relocated socket name under `base`, keyed by a stable hash
+/// of the canonical data dir.
+#[cfg(unix)]
+fn hashed_fallback_socket(base: &Path, canonical_data_dir: &Path) -> Result<PathBuf> {
+    let path = base.join(format!(
+        ".octos-goal-control-{:016x}.sock",
+        fnv1a64(canonical_data_dir)
+    ));
+    if path.as_os_str().len() >= SUN_PATH_CAPACITY {
+        bail!(
+            "goal operator-control socket path {} is still too long for a unix socket              (sun_path limit {SUN_PATH_CAPACITY} bytes); set XDG_RUNTIME_DIR or TMPDIR to a              shorter path",
+            path.display()
+        );
+    }
+    Ok(path)
+}
+
+/// Cheap 64-bit FNV-1a hash of a path (same idiom as octos-agent's
+/// file_state_cache) — stable across processes and releases, which is what
+/// the connect side needs.
+#[cfg(unix)]
+fn fnv1a64(path: &Path) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET;
+    for &byte in path.as_os_str().as_encoded_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
 #[cfg(all(unix, feature = "api"))]
 pub(crate) fn spawn_goal_operator_control(
     data_dir: &Path,
@@ -111,14 +317,24 @@ pub(crate) fn spawn_goal_operator_control(
 ) -> Result<tokio::task::JoinHandle<()>> {
     use std::os::unix::fs::PermissionsExt;
 
-    let socket_path = data_dir.join(GOAL_OPERATOR_CONTROL_SOCKET);
-    match std::fs::remove_file(&socket_path) {
+    let socket = goal_control_bind_path(data_dir)?;
+    match std::fs::remove_file(&socket.path) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error.into()),
     }
-    let listener = tokio::net::UnixListener::bind(&socket_path)?;
-    std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))?;
+    let listener = tokio::net::UnixListener::bind(&socket.path).map_err(|error| {
+        eyre!(
+            "failed to bind goal operator-control socket at {}: {error}",
+            socket.path.display()
+        )
+    })?;
+    std::fs::set_permissions(&socket.path, std::fs::Permissions::from_mode(0o600))?;
+    // A relocated socket is undiscoverable by environment-independent
+    // recomputation alone; publish its real path inside the data dir. If we
+    // cannot, the endpoint is unreachable while the serve lock is held —
+    // fail startup rather than strand `octos goal reopen/archive`.
+    publish_goal_control_socket(data_dir, &socket)?;
     let runtime_data_dir = data_dir.to_path_buf();
     Ok(tokio::spawn(async move {
         loop {
@@ -276,7 +492,7 @@ fn online_transition(
 ) -> Result<()> {
     use std::io::{BufRead, Write};
 
-    let socket_path = data_dir.join(GOAL_OPERATOR_CONTROL_SOCKET);
+    let socket_path = goal_control_connect_path(data_dir);
     let mut stream = std::os::unix::net::UnixStream::connect(&socket_path).map_err(|error| {
         eyre!(
             "octos serve is live for this data directory, but its online goal-control RPC is \
@@ -1112,5 +1328,174 @@ mod tests_2116_readonly {
         let folded = store.load_goal_groups_by_id().expect("folded state");
         let goal = folded.values().next().expect("goal remains");
         assert_eq!(metadata_str(goal, "status"), Some("archived"));
+    }
+}
+
+/// #2248 — long data dirs must not kill `octos serve`: the goal
+/// operator-control socket relocates, publishing its real path in a pointer
+/// file inside the data dir.
+#[cfg(all(test, unix))]
+mod tests_2248_sun_len {
+    use super::*;
+
+    fn long_data_dir(base: &Path) -> PathBuf {
+        let dir = base.join("x".repeat(120));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn short_data_dir_uses_canonical_location() {
+        // Guaranteed-short base even under a long TMPDIR.
+        let temp = tempfile::tempdir_in("/tmp").unwrap();
+        let socket = goal_control_bind_path(temp.path()).unwrap();
+        let canonical = std::fs::canonicalize(temp.path()).unwrap();
+        assert!(!socket.relocated);
+        assert_eq!(socket.path, canonical.join(GOAL_OPERATOR_CONTROL_SOCKET));
+    }
+
+    #[test]
+    fn long_data_dir_relocates_to_hashed_socket() {
+        let temp = tempfile::tempdir().unwrap();
+        let long = long_data_dir(temp.path());
+        let canonical_long = std::fs::canonicalize(&long).unwrap();
+        assert!(
+            canonical_long
+                .join(GOAL_OPERATOR_CONTROL_SOCKET)
+                .as_os_str()
+                .len()
+                >= SUN_PATH_CAPACITY
+        );
+
+        let socket = goal_control_bind_path(&long).unwrap();
+        assert!(socket.relocated);
+        let name = socket.path.file_name().unwrap().to_str().unwrap();
+        assert!(name.starts_with(".octos-goal-control-"));
+        assert!(name.ends_with(".sock"));
+        assert!(socket.path.as_os_str().len() < SUN_PATH_CAPACITY);
+        // Deterministic: same data dir, same endpoint.
+        assert_eq!(socket.path, goal_control_bind_path(&long).unwrap().path);
+        // A different data dir hashes to a different fallback.
+        let other = long_data_dir(temp.path().join("other").as_path());
+        assert_ne!(socket.path, goal_control_bind_path(&other).unwrap().path);
+    }
+
+    /// The decision must be spelling-independent across the sun_path
+    /// threshold: a short symlink to an over-long real dir relocates to the
+    /// same endpoint as the real path.
+    #[test]
+    fn short_symlink_spelling_shares_the_long_paths_endpoint() {
+        let temp = tempfile::tempdir_in("/tmp").unwrap();
+        let long = long_data_dir(temp.path());
+        let link = temp.path().join("lnk");
+        std::os::unix::fs::symlink(&long, &link).unwrap();
+        assert!(link.join(GOAL_OPERATOR_CONTROL_SOCKET).as_os_str().len() < SUN_PATH_CAPACITY);
+
+        let via_link = goal_control_bind_path(&link).unwrap();
+        let via_real = goal_control_bind_path(&long).unwrap();
+        assert!(via_link.relocated);
+        assert_eq!(via_link.path, via_real.path);
+    }
+
+    #[test]
+    fn relocated_socket_roundtrip_via_pointer_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let long = long_data_dir(temp.path());
+
+        // The premise: the canonical path is beyond this platform's sun_path.
+        let canonical = std::fs::canonicalize(&long)
+            .unwrap()
+            .join(GOAL_OPERATOR_CONTROL_SOCKET);
+        let err = std::os::unix::net::UnixListener::bind(&canonical).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+        // The fix: bind the relocated socket, publish the pointer, and the
+        // connect side finds it with no environment knowledge.
+        let socket = goal_control_bind_path(&long).unwrap();
+        let listener = std::os::unix::net::UnixListener::bind(&socket.path).unwrap();
+        publish_goal_control_socket(&long, &socket).unwrap();
+        let connect_path = goal_control_connect_path(&long);
+        assert_eq!(connect_path, socket.path);
+        std::os::unix::net::UnixStream::connect(&connect_path).unwrap();
+        listener.accept().unwrap();
+        std::fs::remove_file(&socket.path).unwrap();
+    }
+
+    #[test]
+    fn connect_path_defaults_to_canonical_without_pointer() {
+        let temp = tempfile::tempdir_in("/tmp").unwrap();
+        let canonical = std::fs::canonicalize(temp.path()).unwrap();
+        assert_eq!(
+            goal_control_connect_path(temp.path()),
+            canonical.join(GOAL_OPERATOR_CONTROL_SOCKET)
+        );
+    }
+
+    #[test]
+    fn canonical_publish_removes_stale_pointer() {
+        let temp = tempfile::tempdir_in("/tmp").unwrap();
+        let canonical = std::fs::canonicalize(temp.path()).unwrap();
+        let pointer = canonical.join(GOAL_OPERATOR_CONTROL_SOCKET_POINTER);
+        std::fs::write(&pointer, "/tmp/stale.sock\n").unwrap();
+
+        let socket = goal_control_bind_path(temp.path()).unwrap();
+        assert!(!socket.relocated);
+        publish_goal_control_socket(temp.path(), &socket).unwrap();
+        assert!(!pointer.exists());
+    }
+
+    #[test]
+    fn fallback_base_prefers_absolute_xdg_runtime_dir() {
+        let (base, ours) = fallback_base_dir(
+            Some(PathBuf::from("/run/user/1000")),
+            PathBuf::from("/tmp"),
+            0o1777,
+        );
+        assert_eq!((base, ours), (PathBuf::from("/run/user/1000"), false));
+    }
+
+    #[test]
+    fn fallback_base_rejects_relative_xdg_runtime_dir() {
+        let (base, ours) = fallback_base_dir(
+            Some(PathBuf::from("relative")),
+            PathBuf::from("/tmp"),
+            0o1777,
+        );
+        // Falls through to the shared-temp subdir branch.
+        assert!(ours);
+        assert_ne!(base, PathBuf::from("relative"));
+    }
+
+    #[test]
+    fn fallback_base_nests_under_shared_temp_only() {
+        let uid = rustix::process::geteuid().as_raw();
+        let (base, ours) = fallback_base_dir(None, PathBuf::from("/tmp"), 0o1777);
+        assert_eq!(
+            (base, ours),
+            (
+                PathBuf::from(format!("/tmp/octos-goal-control-{uid}")),
+                true
+            )
+        );
+        // A per-user (0700) temp dir is used directly.
+        let (base, ours) = fallback_base_dir(None, PathBuf::from("/var/folders/xx/T"), 0o700);
+        assert_eq!((base, ours), (PathBuf::from("/var/folders/xx/T"), false));
+    }
+
+    #[test]
+    fn overlong_fallback_base_is_a_named_error() {
+        let base = PathBuf::from(format!("/{}", "y".repeat(200)));
+        let err = hashed_fallback_socket(&base, Path::new("/some/data/dir")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("sun_path"));
+        assert!(msg.contains("XDG_RUNTIME_DIR"));
+        assert!(msg.contains("yyyy")); // names the offending path
+    }
+
+    /// The hash is the cross-release contract between bind and connect side;
+    /// pin one golden vector so a refactor cannot silently split them.
+    #[test]
+    fn fnv1a64_golden_vector() {
+        assert_eq!(fnv1a64(Path::new("/some/data/dir")), 0x4e35_adf4_9b95_7813);
     }
 }


### PR DESCRIPTION
## Problem

`octos serve` binds its goal operator-control RPC at `<data_dir>/.octos-goal-control.sock`. Unix socket paths are bounded by the fixed-size `sun_path` array (104 bytes on macOS/BSD, 108 on Linux), so a data-dir path of ~80+ bytes made the bind fail with `path must be shorter than SUN_LEN` — and since `spawn_goal_operator_control` is fatal to startup (serve.rs), the entire serve refused to start. The error named neither the path nor a remedy.

## Root cause

The socket path is `data_dir.join(".octos-goal-control.sock")` with no length handling; `sockaddr_un.sun_path` cannot hold the result, so Rust's std returns `InvalidInput` before the syscall.

## Fix

- New `goal_control_bind_path`: canonicalize the data dir (so a short-symlink spelling cannot split the two sides' decisions), use the canonical in-data-dir socket when it fits, else relocate to a deterministic FNV-1a-hashed name under `` — falling back to the temp dir, nested in a per-user 0700 subdir when the temp dir is shared (1777), so no other local user can pre-create the predictable name and block startup. A relocated path that still exceeds `sun_path` (pathological `TMPDIR`) is a hard error naming the path and the fix.
- The serve side publishes the real socket path in a `.octos-goal-control.sock.path` pointer file inside the data dir (atomic write+rename, 0600; stale pointer removed when canonical). The connect side (`octos goal reopen/archive`) reads the pointer and otherwise uses the canonical path — it needs no environment knowledge, so a systemd-launched serve and an interactive shell resolve the same endpoint even with different `XDG_RUNTIME_DIR`/`TMPDIR`. Pointer absent + serve lock held = old serve, which the connect side already fails closed against.
- Bind failure now names the socket path; relocation is logged at info.

## Test evidence

- 10 new tests in `tests_2248_sun_len` (all `#[cfg(unix)]`): canonical location for short dirs, relocation determinism and per-dir uniqueness, threshold-straddling symlink spelling resolving to the same endpoint, a bind→publish→connect round trip through the pointer file, connect defaulting to canonical without a pointer, stale-pointer removal on canonical publish, fallback-base selection table (absolute/relative XDG, shared vs per-user temp), the overlong-fallback named error, and a golden FNV vector pinning the cross-release hash contract.
- `cargo test -p octos-cli --features api --lib commands::goal` — 22/22 pass. Full `--lib` suite: 3683 pass; the only 3 failures (`peers::build_cache_peer_tests` flock slot tests) reproduce identically on unmodified origin/main (c8e6ba15) on this machine and are green in CI — pre-existing local-environment issue, not this diff.
- `cargo clippy -p octos-cli --features api --lib --tests` clean; `cargo fmt --check` clean.

## End-to-end

Built `octos` from origin/main and from this branch (`--features api`), ran `serve --data-dir <120-byte path> --port 0`:

- **Before**: startup aborts with `failed to start local goal operator-control RPC: path must be shorter than SUN_LEN` (goal.rs:120) — the exact issue report.
- **After**: serve starts, `/health` returns `{"status":"healthy"}`; the socket lives at the hashed per-user-temp path (mode 0600) and the pointer file inside the data dir names it. Short data dir regression-checked: canonical socket, no pointer file.
- The CLI connect path itself is covered by the pointer round-trip test (real bind + real connect); a full `octos goal reopen` against a live serve needs a seeded goal in the supervisor store, which the unit-level round trip exercises identically at the socket layer.

## Review

Three rounds: self-review of the full diff, then two independent adversarial reviews. The first found the spelled-vs-canonical decision split and the shared-/tmp pre-creation DoS (both fixed). The second found the environment-dependent fallback breaking bind/connect agreement — motivating the pointer-file design — plus the fixed-name subdir DoS (now per-uid via `rustix::process::geteuid`), unvalidated relative `XDG_RUNTIME_DIR` (now rejected), and a silent canonicalize failure (now debug-logged). All adopted findings re-verified by the full test battery and the end-to-end runs above.

Closes #2248