### PR TITLE
fix(cli): populate hook payload session_id/profile_id on chat and serve --stdio (#2246)

### DIFF
--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -1200,6 +1200,13 @@ impl Agent {
         self.hooks.clone()
     }
 
+    /// Returns the session-level context injected into hook payloads, if
+    /// any. Counterpart to [`Self::hooks`] — the runtime layer uses it to
+    /// assert the context survives session construction (#2246).
+    pub fn hook_context(&self) -> Option<HookContext> {
+        self.hook_ctx()
+    }
+
     /// Set session-level context for hook payloads.
     pub fn with_hook_context(self, ctx: HookContext) -> Self {
         *self.hook_context.lock().unwrap_or_else(|e| e.into_inner()) = Some(ctx);

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -43268,3 +43268,29 @@ async fn ui_transport_autonomous_consumer_emits_verifier_warning_wire_shape() {
         "an unverified claim never completes the goal"
     );
 }
+
+/// #2246 — structural guard: `run_standalone_turn` rebuilds the turn agent
+/// from `Agent::new_shared`, so the bootstrap agent's hook context does not
+/// carry over; the re-application must stay wired (this is the path
+/// `octos chat` / `serve --stdio` actually serve turns on, and the one the
+/// issue reporter observed empty `session_id`/`profile_id` through).
+#[test]
+fn standalone_turn_reapplies_hook_context() {
+    let path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/api/ui_protocol_transport.rs");
+    let text = std::fs::read_to_string(&path).expect("read ui_protocol_transport.rs");
+    let start = text
+        .find("async fn run_standalone_turn")
+        .expect("run_standalone_turn exists");
+    let body = &text[start..];
+    let hooks_at = body
+        .find("request_agent = request_agent.with_hooks(hooks);")
+        .expect("run_standalone_turn attaches the profile hook executor");
+    let ctx_at = body.find("request_agent.with_hook_context(").expect(
+        "run_standalone_turn must re-apply the hook context onto the per-turn agent (#2246)",
+    );
+    assert!(
+        ctx_at > hooks_at,
+        "hook context must be re-applied alongside the hook executor wiring"
+    );
+}

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -34706,6 +34706,13 @@ async fn run_standalone_turn(
     if let Some(hooks) = session_runtime.profile.hook_executor.clone() {
         request_agent = request_agent.with_hooks(hooks);
     }
+    // #2246 — the per-turn rebuild starts from `Agent::new_shared`, so the
+    // bootstrap agent's hook context does not carry over; re-apply it here
+    // (same ids the session's spawn tool receives above).
+    request_agent = request_agent.with_hook_context(octos_agent::HookContext {
+        session_id: Some(session_id.to_string()),
+        profile_id: Some(session_runtime.profile.profile_id.clone()),
+    });
     // Phase 3-A plumbing follow-up (Phase 1 gap): propagate the
     // `SessionScope` the cached `SessionRuntime` constructed at
     // `runtime/session.rs::bootstrap` onto this per-turn rebuilt agent.

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -674,6 +674,16 @@ impl SessionRuntime {
             agent = agent.with_hooks(hooks);
         }
 
+        // #2246 — populate the hook payload context at session construction,
+        // where both ids are known; before this, chat/serve-stdio turns fired
+        // `before_llm_call` / `after_llm_call` / `after_tool_call` payloads
+        // with no `session_id` / `profile_id` (gateway sessions were already
+        // covered via `ActorFactory::hook_context_template`).
+        agent = agent.with_hook_context(octos_agent::HookContext {
+            session_id: Some(session_key.to_string()),
+            profile_id: Some(profile.profile_id.clone()),
+        });
+
         // RFC-1 (issue #1290): same pattern for the `mofa_make`
         // dispatcher. The loader registered it but its `Weak<ToolRegistry>`
         // back-reference needs the Arc-wrapped registry; we plant it here.
@@ -2199,6 +2209,39 @@ tools = ["read_file"]
             Arc::ptr_eq(&agent_hooks, &executor),
             "agent.hooks() must be the same Arc as profile.hook_executor",
         );
+    }
+
+    /// #2246 — the session agent's hook context must carry both ids at
+    /// session construction: before this, `octos chat` / `serve --stdio`
+    /// fired `before_llm_call` / `after_llm_call` / `after_tool_call`
+    /// payloads with no `session_id` / `profile_id`, leaving per-session
+    /// hook policy (budget, rate limit, audit) stateless-blind.
+    #[tokio::test]
+    async fn session_runtime_agent_carries_hook_context_ids() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let hook = octos_agent::HookConfig {
+            event: octos_agent::HookEvent::BeforeLlmCall,
+            command: vec!["/bin/true".to_string()],
+            timeout_ms: 1000,
+            tool_filter: Vec::new(),
+            path_filter: Vec::new(),
+            requires_bin: None,
+        };
+        let executor = Arc::new(octos_agent::HookExecutor::new(vec![hook]));
+        let profile = make_profile_with_hooks(data_dir, executor).await;
+
+        let key = SessionKey::new("api", "hook-probe");
+        let rt = SessionRuntime::bootstrap(&profile, key.clone(), None)
+            .await
+            .expect("bootstrap");
+
+        let ctx = rt
+            .agent
+            .hook_context()
+            .expect("session agent must carry a hook context (#2246)");
+        assert_eq!(ctx.session_id.as_deref(), Some(key.to_string().as_str()));
+        assert_eq!(ctx.profile_id.as_deref(), Some("_main"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

On `octos chat` and `octos serve --stdio --solo`, `before_llm_call` / `after_llm_call` / `after_tool_call` hook payloads carry no `session_id` / `profile_id`, so per-session hook policy (budget, rate limit, audit) is stateless-blind on exactly the two transports where operators run hooks. The gateway path already populates them via `ActorFactory::hook_context_template`; the OUP transport never did.

## Root cause

Both OUP agent construction sites attach the hook executor without a context:

- `SessionRuntime::bootstrap` (runtime/session.rs) chains `.with_hooks()` but never `.with_hook_context()`;
- `run_standalone_turn` (api/ui_protocol_transport.rs) rebuilds the turn agent from a fresh `Agent::new_shared` every turn, so even a bootstrap-time context could not carry over — and it only re-applied `.with_hooks()`.

## Fix

Per the maintainer's triage guidance (populate at session construction, not per-emission-site):

- `SessionRuntime::bootstrap` now sets `HookContext { session_id: session_key.to_string(), profile_id: profile.profile_id }` on the session agent — the same string forms the gateway template produces.
- `run_standalone_turn` re-applies the same context onto the per-turn rebuilt agent, mirroring the spawn-tool wiring already present in the same function.
- `Agent` gains a `hook_context()` accessor (mirroring the existing `hooks()` accessor, which exists for exactly this kind of runtime-layer assertion) so the regression test can observe the wiring.

Side effect, verified and intended: harness error events on these transports now carry the real session id instead of `"unknown"` (`loop_runner::harness_error_context` falls back to `hook_ctx().session_id`). The context is populated whether or not hooks are configured; with no hooks configured nothing reads it except that fallback.

Known follow-up, deliberately out of scope: gateway sessions without a named profile emit `profile_id: null` while chat/serve now emit `"_main"` for the same ambient profile; unifying that is a gateway-template change.

## Tests

- New `runtime::session::tests::session_runtime_agent_carries_hook_context_ids`: fails before the fix (`hook_context()` is `None` — verified by reverting the wiring), passes after.
- New structural guard `standalone_turn_reapplies_hook_context` (same source-scan idiom as `turn_loop.rs::standalone_turn_loop_breaks_on_interrupt_step`) pins the per-turn re-application in `run_standalone_turn`, the path the reporter actually observed; verified to fail when the wiring is removed.
- `cargo test -p octos-cli --lib`: 3674 passed, 3 failed — the 3 are `peers::build_cache_peer_tests` failing on this machine's real free disk (<50 GB) via #2268's production space gate, unrelated to this diff (no shared code; deterministic 0.07 s failures with an explicit free-space error; filed as #2279).
- `cargo test -p octos-agent --lib hooks`: 65 passed.
- `cargo fmt --check`, `cargo clippy -p octos-cli --all-targets -- -D warnings`, the CI minimal (`--lib --no-default-features`) and matrix-feature clippy variants, and `cargo clippy -p octos-agent --all-targets -- -D warnings` all pass.

## End-to-end evidence

Real binary, real hook, on the reported path (`octos chat --message hi` with a `before_llm_call` dump hook appending stdin to a file; provider pointed at a dead port so the hook payload is the observation):

- Before: `{"event": "before_llm_call"}` — no ids, reproducing the issue.
- After: `{"event": "before_llm_call", "session_id": "_main:cli:01a0899f-…", "profile_id": "_main"}`.

## Review

One round of independent adversarial review (given only the issue, the diff, and file paths): approve, no blockers. Its one actionable finding — the per-turn site was guarded only by the bootstrap test — is addressed by the structural guard above. Two observations recorded for the record: the unconditional (not hook-gated) population is intentional and noted above; the gateway "_main" vs null divergence is the follow-up noted above.

Closes #2246
