### PR TITLE
test(peers): neutralize the 50 GB free-space gate in three build_cache_peer_tests (#2279)

### DIFF
--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -2060,10 +2060,14 @@ mod build_cache_peer_tests {
         let data = tempfile::tempdir().unwrap();
         let peers_root = data.path().join("peers");
         std::fs::create_dir_all(&peers_root).unwrap();
-        set_build_cache_config(
-            &peers_root,
-            Some(crate::build_cache::BuildCacheConfig::default()),
-        );
+        // Slot namespaces / release semantics are under test here, not the
+        // free-space gate (covered by the pool's own tests) — disable it so
+        // the result does not depend on the host's disk.
+        let config = BuildCacheConfig {
+            min_free_gb: 0,
+            ..Default::default()
+        };
+        set_build_cache_config(&peers_root, Some(config.clone()));
         // Two DIFFERENT repo keys so each pool has capacity; the assertion is
         // per-pool namespace semantics + distinct paths for distinct peers.
         let repo_a = data.path().join("repo-a");
@@ -2076,7 +2080,7 @@ mod build_cache_peer_tests {
             "slug-a",
             Some("goal-1"),
             Some("t1"),
-            &crate::build_cache::BuildCacheConfig::default(),
+            &config,
         )
         .expect("peer A acquires");
         let slot_b = build_cache_peer::acquire_for_staging(
@@ -2085,7 +2089,7 @@ mod build_cache_peer_tests {
             "slug-b",
             Some("goal-1"),
             Some("t2"),
-            &crate::build_cache::BuildCacheConfig::default(),
+            &config,
         )
         .expect("peer B acquires");
         assert_ne!(
@@ -2107,7 +2111,7 @@ mod build_cache_peer_tests {
             "slug-a",
             Some("goal-1"),
             Some("t3"),
-            &crate::build_cache::BuildCacheConfig::default(),
+            &config,
         )
         .expect("freed slot reusable by next turn");
         drop(slot_c);
@@ -2118,10 +2122,13 @@ mod build_cache_peer_tests {
         let data = tempfile::tempdir().unwrap();
         let peers_root = data.path().join("peers");
         std::fs::create_dir_all(&peers_root).unwrap();
-        set_build_cache_config(
-            &peers_root,
-            Some(crate::build_cache::BuildCacheConfig::default()),
-        );
+        // See two_staged_peers_… above: the free-space gate is not what this
+        // test pins, so keep it off the host's real disk.
+        let config = BuildCacheConfig {
+            min_free_gb: 0,
+            ..Default::default()
+        };
+        set_build_cache_config(&peers_root, Some(config.clone()));
         let repo = data.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         // Staging acquired slot-1 (peer_slots default 2 → slot-2 free). The
@@ -2136,7 +2143,7 @@ mod build_cache_peer_tests {
             "slug-x",
             Some("g"),
             Some("t1"),
-            &crate::build_cache::BuildCacheConfig::default(),
+            &config,
         )
         .unwrap();
         std::fs::create_dir_all(peers_root.join("slug-x")).unwrap();
@@ -2147,7 +2154,7 @@ mod build_cache_peer_tests {
             "slug-x",
             Some("g"),
             Some("t2"),
-            &crate::build_cache::BuildCacheConfig::default(),
+            &config,
         )
         .unwrap();
         assert_ne!(
@@ -2176,10 +2183,13 @@ mod build_cache_peer_tests {
         let data = tempfile::tempdir().unwrap();
         let peers_root = data.path().join("peers");
         std::fs::create_dir_all(&peers_root).unwrap();
-        set_build_cache_config(
-            &peers_root,
-            Some(crate::build_cache::BuildCacheConfig::default()),
-        );
+        // See two_staged_peers_… above: the free-space gate is not what this
+        // test pins, so keep it off the host's real disk.
+        let config = BuildCacheConfig {
+            min_free_gb: 0,
+            ..Default::default()
+        };
+        set_build_cache_config(&peers_root, Some(config.clone()));
         let repo = data.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let slot = build_cache_peer::acquire_for_staging(
@@ -2188,7 +2198,7 @@ mod build_cache_peer_tests {
             "slug-i",
             Some("g"),
             Some("t1"),
-            &crate::build_cache::BuildCacheConfig::default(),
+            &config,
         )
         .unwrap();
         let key = build_cache_slot_registry_key(&peers_root, "slug-i");


### PR DESCRIPTION
## Problem

On any machine with less than 50 GB of free disk, `cargo test -p octos-cli --lib` fails three tests deterministically (0.07 s, 3/3 in isolation — not a timing flake):

- `two_staged_peers_acquire_distinct_slots_and_release_on_terminal`
- `adopt_rule_first_boot_does_not_double_acquire`
- `registry_release_is_idempotent_across_terminal_and_close`

CI stays green only because the runners have >50 GB free, so every disk-constrained dev machine hits this.

## Root cause

#2268 added the real free-space gate to the build-cache slot pool (`fs2::available_space`, default `min_free_gb: 50`). These three tests call the production acquire path with `BuildCacheConfig::default()` — the real 50 GB gate against the real disk — while asserting things that have nothing to do with free space (slot namespaces, distinct paths per peer, idempotent release). The file's other tests already neutralize the gate with `min_free_gb: 0` (peers/mod.rs:1984, :2022, :4754, :5160); these three were missed.

## Fix

Set `min_free_gb: 0` in the three tests' `BuildCacheConfig` (one `config` binding per test, shared by `set_build_cache_config` and every `acquire_for_staging` call), matching the file's own convention. Gate behavior itself remains covered by the pool's own deterministic tests (`space_gate_low_space_is_typed_error_not_panic`, `space_gate_zero_disables_the_gate`, `space_gate_unknown_fails_closed`), so no coverage is lost. Test-only change; no production code touched.

## Test evidence

On a machine with 32.85 GB free (below the gate):

- Before: the 3 tests fail with `free space 32.85 GB ... is below the 50 GB gate` (3 passed / 3 failed in the module).
- After: `cargo test -p octos-cli --lib` — **3677 passed, 0 failed** (full suite, first run).
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p octos-cli --lib --no-default-features -- -D warnings` — clean.
- `cargo clippy -p octos-cli --all-targets --no-default-features --features api,telegram,discord,dingtalk,slack,whatsapp,feishu,email,matrix,audio_mp3 -- -D warnings` — clean.

## End-to-end evidence

The issue scenario *is* the test suite on a disk-constrained machine, so the before/after above is the real-path demonstration: same host, same disk (32.85 GB free), the exact command from the issue goes from 3 deterministic failures to fully green.

## Review

Independent adversarial review (given only the issue text, the diff, and the file paths) found no blockers: verified `min_free_gb: 0` disables the gate on every path these tests exercise, confirmed the bare `BuildCacheConfig` is the same single type (no divergent defaults), confirmed gate coverage is genuinely held by the pool's tests, confirmed no test-isolation hazard from the tempdir-keyed global config map, and swept the whole repo for other gated-config acquire call sites — none remain (pool.rs:2437/2454 only test `validate()`/serde; commands/cache.rs:787 only reads directories; all other `acquire_for_staging` test callers already set `min_free_gb: 0`). Its one nit (missing explanatory comment on the third test) is applied.

Closes #2279