### PR TITLE
fix(peers): retain validated identity for closed peers

### DIFF
--- a/crates/octos-cli/src/commands/peer.rs
+++ b/crates/octos-cli/src/commands/peer.rs
@@ -69,9 +69,10 @@ pub(crate) struct PeerListRow {
     pub name: Option<String>,
     pub model_lane: Option<String>,
     /// Trusted-lifetime identity (anti cross-runtime/same-slug fencing);
-    /// null when the projection is untrusted — and also for the `closed`
-    /// branch, which intentionally reports identity-free (the closed marker
-    /// takes precedence over the projection; conservative contract).
+    /// null when the projection is untrusted. The `closed` branch runs the
+    /// SAME full trust check (not bypassed by the marker): a trusted
+    /// lifetime keeps its identity for terminal-event correlation; a
+    /// missing/forged/foreign/corrupt one stays null.
     pub master_session_id: Option<String>,
     pub task_id: Option<String>,
     pub generation: Option<u64>,

--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -4324,15 +4324,33 @@ pub(crate) fn derive_peer_execution_facet(
     let terminal = read_last_terminal_evidence(peer_dir, slug);
     let last_outcome = terminal.as_ref().map(|(_, outcome)| outcome.clone());
     if closed {
+        // The closed marker wins the EXECUTION label (lifecycle terminal),
+        // but it does NOT bypass the trust check: identity is retained only
+        // when the SAME full projection validation as the open branch passes
+        // (registry_key, writer shape, non-empty identity, Idle digest
+        // re-bind). Missing/forged/foreign/corrupt ⇒ all-null, exactly like
+        // an untrusted open peer (merged-review audit 2026-09-10, PR #2272).
+        // Destructure ONCE (ROOT review 2: successive `identity.map` calls
+        // move the Option after the first consumption — compile error).
+        let (master, task_id, generation, turn_id) =
+            match trusted_lifetime_projection(peer_dir, profile_id, slug) {
+                Some(p) => (
+                    Some(p.master),
+                    Some(p.task_id),
+                    Some(p.generation),
+                    p.turn_id,
+                ),
+                None => (None, None, None, None),
+            };
         return PeerExecutionFacet {
             execution: "closed",
             last_outcome,
             round: rounds_delivered,
             rounds_delivered,
-            master_session_id: None,
-            task_id: None,
-            generation: None,
-            turn_id: None,
+            master_session_id: master,
+            task_id,
+            generation,
+            turn_id,
         };
     }
     match trusted_lifetime_projection(peer_dir, profile_id, slug) {
@@ -6541,10 +6559,115 @@ mod peer_turn_status_tests {
         let temp = tempfile::tempdir().unwrap();
         let dir = staged(temp.path(), "cl", None);
         terminal(&dir, "cl", 1, "errored");
+        lifetime(&dir, "octos", "cl", "failed", 1, Some("t1"), None);
         peer_io::write_peer_file_atomic(&dir, "closed", "closer\n1\n").unwrap();
         let f = facet(temp.path(), "cl");
         assert_eq!(f.execution, "closed");
         assert_eq!(f.last_outcome.as_deref(), Some("errored"));
+        // merged-review fix: a TRUSTED lifetime under a closed marker keeps
+        // its identity for terminal-event correlation.
+        assert_eq!(f.master_session_id.as_deref(), Some("master-cl"));
+        assert_eq!(f.task_id.as_deref(), Some("task-cl"));
+        assert_eq!(f.generation, Some(1));
+        assert_eq!(f.turn_id.as_deref(), Some("t1"));
+    }
+
+    #[test]
+    fn peer_list_closed_with_foreign_lifetime_keeps_null_identity() {
+        // The closed marker must NOT bypass validation: a lifetime minted
+        // for a DIFFERENT profile (foreign registry_key) stays untrusted.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "fc", None);
+        terminal(&dir, "fc", 1, "errored");
+        lifetime(&dir, "octosfix", "fc", "failed", 1, Some("t1"), None);
+        peer_io::write_peer_file_atomic(&dir, "closed", "x").unwrap();
+        let f = facet(temp.path(), "fc"); // facet() reads with profile "octos"
+        assert_eq!(f.execution, "closed");
+        assert!(f.master_session_id.is_none());
+        assert!(f.task_id.is_none());
+        assert!(f.generation.is_none());
+        assert!(f.turn_id.is_none());
+    }
+
+    #[test]
+    fn peer_list_closed_with_missing_lifetime_keeps_null_identity() {
+        // Legacy closed peer (no lifetime.json): identity stays null — the
+        // pre-fix conservative shape, now an explicit regression pin.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "mc", None);
+        terminal(&dir, "mc", 1, "completed");
+        peer_io::write_peer_file_atomic(&dir, "closed", "x").unwrap();
+        let f = facet(temp.path(), "mc");
+        assert_eq!(f.execution, "closed");
+        assert_eq!(f.last_outcome.as_deref(), Some("completed"));
+        assert!(f.master_session_id.is_none());
+        assert!(f.task_id.is_none());
+        assert!(f.generation.is_none());
+        assert!(f.turn_id.is_none());
+    }
+
+    #[test]
+    fn peer_list_closed_with_malformed_lifetime_keeps_null_identity() {
+        // ROOT review 1 (Peer): malformed lifetime under a closed marker must
+        // degrade to null identity — the marker never repairs a torn record.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "ml", None);
+        terminal(&dir, "ml", 1, "errored");
+        peer_io::write_peer_file_atomic(&dir, "lifetime.json", "{\"version\": 1, \"phase\":")
+            .unwrap();
+        peer_io::write_peer_file_atomic(&dir, "originator", "m").unwrap();
+        peer_io::write_peer_file_atomic(&dir, "closed", "x").unwrap();
+        let f = facet(temp.path(), "ml");
+        assert_eq!(f.execution, "closed");
+        assert_eq!(f.last_outcome.as_deref(), Some("errored"));
+        assert!(f.master_session_id.is_none());
+        assert!(f.task_id.is_none());
+        assert!(f.generation.is_none());
+        assert!(f.turn_id.is_none());
+    }
+
+    #[test]
+    fn peer_list_closed_with_corrupt_idle_digest_keeps_null_identity() {
+        // ROOT review 1 (Peer): a closed peer whose lifetime is Idle with a
+        // NON-MATCHING result digest stays identity-free — the digest re-bind
+        // is part of the same full trust check, closed or not.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "cd", None);
+        terminal(&dir, "cd", 1, "completed");
+        // Idle REQUIRES a digest; write one that does NOT match result.md.
+        lifetime(&dir, "octos", "cd", "idle", 1, Some("t1"), Some("deadbeef"));
+        peer_io::write_peer_file_atomic(&dir, "closed", "x").unwrap();
+        let f = facet(temp.path(), "cd");
+        assert_eq!(f.execution, "closed");
+        assert!(
+            f.master_session_id.is_none(),
+            "digest corruption must not certify identity"
+        );
+        assert!(f.task_id.is_none());
+        assert!(f.generation.is_none());
+        assert!(f.turn_id.is_none());
+        // The strict terminal evidence still carries the real history.
+        assert_eq!(f.last_outcome.as_deref(), Some("completed"));
+    }
+
+    #[test]
+    fn peer_list_closed_after_failed_round_keeps_outcome() {
+        // Orthogonal to identity retention: the REAL history (an errored
+        // round) stays visible on a closed row with a trusted lifetime.
+        let temp = tempfile::tempdir().unwrap();
+        let dir = staged(temp.path(), "of", None);
+        // Write rounds in ORDER (round1 first): `terminal` rewrites result.md
+        // each call, so a reverse order would leave result.md bound to the
+        // LOWER round and break the highest-version cross-check.
+        terminal(&dir, "of", 1, "completed");
+        terminal(&dir, "of", 2, "interrupted");
+        lifetime(&dir, "octos", "of", "failed", 2, Some("t2"), None);
+        peer_io::write_peer_file_atomic(&dir, "closed", "x").unwrap();
+        let f = facet(temp.path(), "of");
+        assert_eq!(f.execution, "closed");
+        assert_eq!(f.last_outcome.as_deref(), Some("interrupted"));
+        assert_eq!(f.rounds_delivered, 2);
+        assert_eq!(f.generation, Some(2));
     }
 
     #[test]

--- a/docs/peer-status-interface.json
+++ b/docs/peer-status-interface.json
@@ -4,7 +4,7 @@
   "spec": "specs/task-evo-peer-turn-status.spec.md",
   "change_note": "v2 依外层复核：删除并行 turn-state.json 设计，current 执行/身份改为 lifetime.json 只读安全投影；outcome 恒取 turns.txt 终止证据；closed 表现为 execution=closed 而非 idle；身份含 task/generation/turn_id；契约文件移入 tracked docs/。",
   "producer": {
-    "cli_command": "octos peer list [--json] [--data-dir DIR]",
+    "cli_command": "octos peer list [--json] [--data-dir DIR] [--profile ID]",
     "tool": "peer_list (serve)",
     "assembly": "crates/octos-cli/src/commands/peer.rs::list_peers（CLI JSON/表格共用）；crates/octos-cli/src/peers/mod.rs（投影 + blackboard + compose_peer_list_text）"
   },
@@ -13,7 +13,7 @@
     "authority_outcome": "peers/<slug>/turns.txt 最后一条 '<round> <outcome> <ts>'（与最高编号 result-<n>.md 互为印证）；result.md 正文不作成功证据",
     "lifecycle": "peers/<slug>/closed — 终态标记，status=closed 且 execution=closed（不代表上一执行成功，last_outcome 保留）"
   },
-  "identity_fields_note": "master_session_id/task_id/generation/turn_id 来自可信 lifetime 投影（master_session_id=lifetime.master）。消费端以 runtime/master_session_id/slug/task_id/generation/turn_id 关联，防跨 runtime/同 slug 串线。不可信或缺失时为 null；closed 分支同样全部 null（closed 标记优先于投影，身份不随 closed 保留——保守契约）。",
+  "identity_fields_note": "master_session_id/task_id/generation/turn_id 来自可信 lifetime 投影（master_session_id=lifetime.master）。消费端以 runtime/master_session_id/slug/task_id/generation/turn_id 关联，防跨 runtime/同 slug 串线。不可信或缺失时为 null；closed 分支同样走同一完整信任校验（registry_key/writer 形状/非空身份/Idle digest 重算）——通过则保留身份供终止事件关联，未通过则 null，closed 标记不绕过校验。",
   "output_fields": {
     "slug": "String",
     "status": "running | done | closed — 不变：目录交付语义（done=result 文件存在）",
@@ -47,7 +47,7 @@
   "known_limitations": {
     "gateway_inbox_path": "session_actor.rs 的 gateway in-process inbox 直投路径无 begin_peer_lifetime_turn（代码事实核实 2026-09-09）：该路径 round2 从 queued 直达 terminal，无 running 中间态。呈现按投影如实输出。",
     "crash_window": "真实写序（ui_protocol_transport.rs）：result.md → lifetime(finish_peer_lifetime_turn) → result-<n>.md → turns.txt。各点崩溃呈现：finish 前崩溃 → 投影仍 Running（孤儿 Running 语义见 begin_crash_orphan_running）；finish 后、turns append 前崩溃 → phase 已 Idle/Pending/Failed，呈现 idle/queued/failed，last_outcome 取决于 turns 尾行与最高 result-<n>.md 互证结果——尾行尚未更新时可能为旧 outcome 或 null（双侧不一致即 null），不绝对保留旧值。不用时间戳裁决。",
-    "idle_no_turns": "lifetime=Idle 且 turns.txt 空（测试工厂可构造）→ execution=idle, last_outcome=null, round=0。合法组合。",
+    "idle_no_turns": "lifetime=Idle 且 turns.txt 空（测试工厂可构造）→ execution=idle、last_outcome=null。round 取 rounds_delivered：可信 Idle 必有 result.md（digest 绑定），故裸 result 下限使 round>=1，历史示例 round=0 不可达。",
     "digest_mismatch_test": "反例测试必须包含 nonempty 但不匹配的 digest（peer_list_idle_digest_mismatch_degrades_to_unknown）。",
     "begin_crash_orphan_running": "begin_peer_lifetime_turn 后、terminal 前崩溃 → 盘上残留 phase=Running。跨重启恢复扫描不处理 Running（仅 closed 退休与 Idle 摘要重绑）；孤儿 Running 保持 running 呈现直到真实生命周期更新，无自动降级，可能长期呈 running。"
   },
@@ -56,5 +56,8 @@
   "clarifications": {
     "round_on_terminal_phases": "idle/failed 时若有严格终止证据（turns 尾行 × 最高 result-<n>.md 互证）则取该证据的轮号，否则 rounds_delivered；正常连续编号盘面两者恒等。（GLM 首审 LOW#3 裁决采纳：保留实现的更大信息量，契约措辞对齐）",
     "legacy_bare_only_outcome": "last_outcome 需要 result-<n>.md 印证（Side B）；bare-only（仅 result.md+turns.txt）legacy 盘面为 null——保守方向，不 assert 无印证的 outcome。（GLM 首审 LOW#4 裁决采纳）"
-  }
+  },
+  "spec_revision": "v3.1（冻结合约代次；与 schema version 不同维度）",
+  "versioning_note": "schema \"version\" 是输出字段集版本（新增/变更字段才 bump，当前 2）；\"spec_revision\" 是冻结合约代次（当前 v3.1）。两者独立演进：行为语义澄清（如 closed 身份保留）不改字段集，故不 bump version。",
+  "serve_text_note": "serve 的 peer_list 索引文本（compose_peer_list_text）实际对全部列表行（done/awaiting_input/running 等）附 `exec=<execution|?>` 与 `outcome=<last_outcome>` 后缀（closed 且无 outcome 的行除外）——是 spec 94 行'done 行追加'描述的实际超集；行形状对既有读者稳定。"
 }

--- a/docs/superpowers/plans/2026-09-10-merged-peer-review.md
+++ b/docs/superpowers/plans/2026-09-10-merged-peer-review.md
@@ -3,7 +3,7 @@
 审计源：merged-review-audit-20260910/REVIEW-AUDIT.md（#2272）。基线 329566d3。
 
 ## 步骤
-1. 设计+测试计划 → /Users/zhangalex/.local/tmp/octoloop-review-repair-20260910/peer-design.md ✅
+1. 设计+测试计划 → 修复工作目录下 peer-design.md（会话 scratch 交接件，不入库） ✅
 2. 行为修复（实际历史：实现与测试同 turn 连续完成，非测试先行；RED 为步骤 4a 的事后补做可执行验证）：closed 分支改走 trusted_lifetime_projection 同一校验，通过保留身份、否则 null ✅（5 新测试 + 1 既有测试修改）
 3. 文档同步：interface（identity note/idle_no_turns round≥1/cli --profile/spec_revision+versioning_note/serve 超集说明）、spec（generation 1 对齐/closed 条款/serve 超集）、peer.rs 注释 ✅
 4. Cargo 窗口授予后的真实 RED/GREEN 顺序（ROOT review 2 修正）：

--- a/docs/superpowers/plans/2026-09-10-merged-peer-review.md
+++ b/docs/superpowers/plans/2026-09-10-merged-peer-review.md
@@ -1,0 +1,26 @@
+# merged-peer-review 修复计划（2026-09-10，TASK=peer）
+
+审计源：merged-review-audit-20260910/REVIEW-AUDIT.md（#2272）。基线 329566d3。
+
+## 步骤
+1. 设计+测试计划 → /Users/zhangalex/.local/tmp/octoloop-review-repair-20260910/peer-design.md ✅
+2. 行为修复（实际历史：实现与测试同 turn 连续完成，非测试先行；RED 为步骤 4a 的事后补做可执行验证）：closed 分支改走 trusted_lifetime_projection 同一校验，通过保留身份、否则 null ✅（5 新测试 + 1 既有测试修改）
+3. 文档同步：interface（identity note/idle_no_turns round≥1/cli --profile/spec_revision+versioning_note/serve 超集说明）、spec（generation 1 对齐/closed 条款/serve 超集）、peer.rs 注释 ✅
+4. Cargo 窗口授予后的真实 RED/GREEN 顺序（ROOT review 2 修正）：
+   a. RED（基线文件替换法——GLM 审查指出：生产与测试同在 mod.rs，stash 整文件会连测试一起撤走）：**先 `cp` 保存当前候选 mod.rs 到修复工作目录下 mod.rs.candidate**，再从 `git show 329566d3:crates/octos-cli/src/peers/mod.rs` 取基线文件，把本分支的 closed 测试段（5 新 + 1 修改）（含 helper 不变）拼入基线文件的测试模块 → 编译运行 → identity Some 断言真实执行并红；negative 用例在基线即绿，如实记录其性质为回归钉而非 RED 项
+   b. GREEN：从 4a 保存的候选文件 `cp` 恢复 mod.rs（不使用 git stash）→ 同一测试集真实执行全绿
+   c. fmt --check + clippy -D warnings（获租约后）
+   d. 如实记录：本任务实际历史是先写实现（同 turn 连续完成），RED 步骤为事后补做的可执行验证，不以 git show 静态推断替代测试
+5. GLM-5.3 + K3-256K 只读独立 diff 审查 → 互读 → disposition → 最终报告 peer-result.md
+
+## Dispositions
+- 性能重复读消除：wontdo（无测量基线；禁缓存/过期语义）
+- 孤儿 Running 恢复写入者：wontdo（破坏 begin/finish 单写者；维持已知限制）
+- schema version bump：不做（行为语义澄清不改输出字段集）
+
+## 实际验证结果（2026-09-10，Cargo 窗口期）
+- RED（基线生产 + 候选测试，真实执行）：closed 6 测试 → 2 failed / 4 passed，EXIT=101——identity Some 断言在基线恒 null 行为上真实红；4 个负例在基线即绿（回归钉性质，如实记录）。日志 red-run.log
+- GREEN（候选恢复后）：closed 6/6 passed，EXIT=0（green-run.log）；peer_list_ 全套 35/35 passed，EXIT=0（green-peerlist.log）
+- fmt --check：首次 EXIT=1（一处 assert 换行），`cargo fmt -p octos-cli` 后已修复（纯格式，语义零变化）
+- clippy -p octos-cli --features api --all-targets -- -D warnings：EXIT=0（clippy.log）
+- fixture 顺序修正（ROOT 确认）：closed_after_failed_round 改为先 round1 completed 后 round2 interrupted（terminal helper 重写 result.md，倒序会破坏最高轮绑定）

--- a/specs/task-evo-peer-turn-status.spec.md
+++ b/specs/task-evo-peer-turn-status.spec.md
@@ -64,8 +64,10 @@ numbered results 终止证据。
   unknown，turns.txt 只产出 last_outcome，不推导 execution）：
   1. `closed` 标记存在 → status=closed（不变），execution=`closed`（不是
      idle——closed 是生命周期终态，不代表上一执行成功），last_outcome 保留
-     turns.txt 证据值；closed 分支身份四元组为 null（closed 标记优先于
-     投影，保守契约）。
+     turns.txt 证据值；closed 分支身份走与开放分支完全相同的完整信任
+     校验（registry_key/writer 形状/非空身份/Idle digest 重算）：通过则
+     保留四元组供终止事件关联，缺失/伪造/foreign/corrupt 则 null，
+     closed 标记不绕过校验（merged-review 2026-09-10 行为修复）。
   2. lifetime 投影可信 → Pending→`queued`、Running→`running`、
      Failed→`failed`、Idle→`idle`。
   3. lifetime 缺失或不可信（含 legacy）→ execution=`unknown`（turns.txt
@@ -92,8 +94,10 @@ numbered results 终止证据。
   契约落在 tracked 文件 docs/peer-status-interface.json（CI 可依赖），
   .octos/ 下仅为交接草稿。
 - serve `peer_list` 索引文本（compose_peer_list_text）同步：done 行追加
-  `outcome=<last_outcome>` 与 `exec=<execution>`；awaiting_input 优先级
-  不变；进程内 wire 活性只在 serve 回调叠加、只收紧不放宽。
+  `outcome=<last_outcome>` 与 `exec=<execution>`（实现实际对全部列表行
+  附此后缀、closed 无 outcome 行除外——spec 描述为最小集，实现为审定的
+  实际超集）；awaiting_input 优先级不变；进程内 wire 活性只在 serve
+  回调叠加、只收紧不放宽。
 
 ## Boundaries
 
@@ -134,7 +138,7 @@ Scenario: round1 completed 后 round2 queued 不显示旧完成
   Test:
     Package: octos-cli
     Filter: peer_list_round2_queued_shows_queued_not_stale_done
-  Given turns.txt 记录 `1 completed <ts1>` 且 lifetime.json 为 phase=pending generation=2（可信投影）
+  Given turns.txt 记录 `1 completed <ts1>` 且 lifetime.json 为 phase=pending generation=1（可信投影）
   When 调用 `list_peers`
   Then status=="done" 且 execution=="queued" 且 round==2 且 last_outcome=="completed"
 
@@ -218,10 +222,26 @@ Scenario: closed peer 保持 closed 优先
   Test:
     Package: octos-cli
     Filter: peer_list_closed_peer_reports_closed_execution_with_outcome
-  Given 一个 closed peer（closed 标记 + result.md + turns.txt `1 errored`）
+  Given 一个 closed peer（closed 标记 + result.md + turns.txt `1 errored` + 可信 Failed lifetime）
   When 调用 `list_peers`
-  Then status=="closed" 且 execution=="closed" 且 last_outcome=="errored"
+  Then status=="closed" 且 execution=="closed" 且 last_outcome=="errored" 且身份四元组保留（master/task/generation/turn_id 为真实值）
 
+
+Scenario: closed + 损坏 lifetime 身份仍 null
+  Test:
+    Package: octos-cli
+    Filter: peer_list_closed_with_malformed_lifetime_keeps_null_identity
+  Given closed 标记 + turns `1 errored` + lifetime.json 为截断 JSON（malformed）
+  When 调用 `list_peers`
+  Then execution=="closed" 且 last_outcome=="errored" 且身份四元组全 null（closed 标记不修复撕裂记录）
+
+Scenario: closed + Idle digest 损坏身份仍 null
+  Test:
+    Package: octos-cli
+    Filter: peer_list_closed_with_corrupt_idle_digest_keeps_null_identity
+  Given closed 标记 + turns `1 completed` + lifetime.json 为 phase=idle 且 result_digest 与 result.md 实际 SHA256 不匹配
+  When 调用 `list_peers`
+  Then execution=="closed" 且身份四元组全 null（digest 重算绑定属于同一完整校验）且 last_outcome=="completed"
 ### Rule: derivation-precedence — execution 派生优先级
 Scenario: 派生优先级 closed > 可信 lifetime > unknown
   Test:


### PR DESCRIPTION
Closing a peer used to discard its identity even when its lifetime record was valid, preventing correlation with terminal events. Retain the identity only after the same full trust validation used for open peers; missing, foreign, malformed, and digest-mismatched records keep null identity. Closed status and the last execution outcome remain independent.

Follow-up to #2272. Align the interface and spec for closed identity, generation, idle rounds, profile selection, schema/spec versioning, and serve text. Orphan-running recovery and unmeasured read-performance changes remain deferred.

Validation: closed cases 6/6 and peer-list cases 35/35; GLM-5.3 and K3-256k independent reviews plus mutual review passed. On updated main e0af1634, the combined repair tree passes cargo fmt, cargo clippy --all-targets -- -D warnings, and 12 selected regression tests run through cargo test --all-targets (including both upstream hook-context tests).

The earlier unfiltered workspace run completed 172 suites: 10,061 passed, 2 failed, 100 existing ignored. The fixed-port test failure (3103 instead of 3101) reproduces on unmodified upstream main because another local service owns port 3101. The scheduler test passes in isolation on both upstream and the repair binary. No tests were weakened or newly ignored; the full local run is not reported as green. GitHub CI is still running.
