### PR TITLE
fix(goals): route verifier warnings and deduplicate replay notes

### DIFF
--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -2436,6 +2436,150 @@ pub async fn persist_message_through_canonical_path(
     handle.add_message_with_seq_unlocked(message).await
 }
 
+/// Idempotently persist ONE system note to a session through the canonical
+/// per-key persist path, returning the durable message.
+///
+/// Semantics (PR #2283 follow-up): the existence check and the append run
+/// inside the SAME `persist_lock_for` critical section as every other
+/// canonical write, so two concurrent callers for the same `note_id` commit
+/// exactly one row and both receive that row.
+///
+/// STRICT canonical read (this helper does NOT relax the legacy loader):
+/// - the file's size is bounded by `MAX_SESSION_FILE_SIZE`;
+/// - the first line must be a valid `SessionMeta` with a supported schema;
+/// - every non-empty subsequent line must parse as a `Message` OR a
+///   `SessionControlRecord` — an unparsable line, a missing trailing
+///   newline on a non-empty final line, or an unreadable-but-existing file
+///   are `Err` (fail-closed: never treated as "absent", never appended past
+///   a corrupt tail);
+/// - visibility follows rollback semantics: the note is "present" only if
+///   `assemble_session_messages` (the same fold every reload uses) still
+///   shows it — a rolled-back note is legitimately absent and is re-added.
+///
+/// On success returns the durable `Message` — the row this call appended,
+/// or the pre-existing row with its ORIGINAL timestamp and content (the
+/// note is never re-stamped with a fresh timestamp).
+///
+/// The id rides `client_message_id`; `role` is forced to `System` and
+/// `thread_id` to `None` (no thread semantics implied).
+pub async fn persist_system_note_once_through_canonical_path(
+    data_dir: &Path,
+    key: &SessionKey,
+    note: Message,
+    note_id: &str,
+) -> Result<Message> {
+    let lock = persist_lock_for(key);
+    let _guard = lock.lock().await;
+    let mut handle = SessionHandle::open(data_dir, key);
+
+    let canonical = handle.session_path();
+    let file_meta = match std::fs::metadata(&canonical) {
+        // Genuinely absent: a new session — the append below writes the
+        // meta line itself. Only NotFound counts as absent; permission or
+        // any other stat error is fail-closed (never "treated as absent").
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(eyre::eyre!(
+                "session transcript stat failed ({}): {error}",
+                canonical.display()
+            ));
+        }
+        Ok(meta) => Some(meta),
+    };
+    // A zero-byte regular file can remain after creation but before the
+    // metadata write; the canonical append initializes it on retry.
+    if let Some(meta) = file_meta.filter(|meta| !meta.is_file() || meta.len() != 0) {
+        if meta.len() > MAX_SESSION_FILE_SIZE {
+            return Err(eyre::eyre!(
+                "session transcript exceeds size limit ({}: {} > {})",
+                canonical.display(),
+                meta.len(),
+                MAX_SESSION_FILE_SIZE
+            ));
+        }
+        let bytes = std::fs::read(&canonical).map_err(|error| {
+            eyre::eyre!(
+                "session transcript exists but cannot be read ({}): {error}",
+                canonical.display()
+            )
+        })?;
+        let text = String::from_utf8(bytes.clone()).map_err(|error| {
+            eyre::eyre!(
+                "session transcript is not valid UTF-8 ({}): {error}",
+                canonical.display()
+            )
+        })?;
+        let mut lines = text.lines();
+        let header = lines.next().ok_or_else(|| {
+            eyre::eyre!(
+                "session transcript is empty (no meta line): {}",
+                canonical.display()
+            )
+        })?;
+        let session_meta: SessionMeta = serde_json::from_str(header).map_err(|error| {
+            eyre::eyre!(
+                "session transcript meta line is invalid ({}): {error}",
+                canonical.display()
+            )
+        })?;
+        if session_meta.schema_version > CURRENT_SESSION_SCHEMA {
+            return Err(eyre::eyre!(
+                "session transcript schema {} is newer than supported {} ({}): refusing",
+                session_meta.schema_version,
+                CURRENT_SESSION_SCHEMA,
+                canonical.display()
+            ));
+        }
+        let body = lines.collect::<Vec<_>>();
+        // Trailing newline: ANY non-empty file must end with one — a bare
+        // meta line (or any final line) without it would make the append
+        // concatenate the note JSON onto the last row. Only a genuinely
+        // EMPTY (0-byte) file counts as new and is safe to append into.
+        if !bytes.is_empty() && bytes.last() != Some(&b'\n') {
+            return Err(eyre::eyre!(
+                "session transcript does not end with a newline ({}): refusing to append",
+                canonical.display()
+            ));
+        }
+        // Every non-empty post-meta line must parse as Message or control
+        // record (strict — no skip-past-corruption). Errors carry the LINE
+        // NUMBER, never the line content.
+        let mut line_no = 1usize; // meta line is line 1
+        for line in body.iter().filter(|l| !l.trim().is_empty()) {
+            let parses = serde_json::from_str::<SessionControlRecord>(line).is_ok()
+                || serde_json::from_str::<Message>(line).is_ok();
+            if !parses {
+                line_no += 1;
+                return Err(eyre::eyre!(
+                    "session transcript line {} is neither a Message nor a control record ({}): refusing",
+                    line_no,
+                    canonical.display()
+                ));
+            }
+            line_no += 1;
+        }
+        // Visibility follows the same rollback-aware fold as every reload.
+        for message in assemble_session_messages(body.iter().copied()) {
+            if message.role == MessageRole::System
+                && message.client_message_id.as_deref() == Some(note_id)
+            {
+                return Ok(message);
+            }
+        }
+    }
+
+    // Absent (or no file yet): append through the same locked canonical
+    // path, then return the durable row.
+    let mut message = note;
+    message.role = MessageRole::System;
+    message.client_message_id = Some(note_id.to_owned());
+    message.thread_id = None;
+    handle
+        .add_message_with_seq_unlocked(message.clone())
+        .await
+        .map(|_| message)
+}
+
 /// Upsert a durable child-session contract through the canonical locked
 /// path: per-key persist lock → FRESH open (latest disk state) → mutate →
 /// rewrite, all inside one critical section.

--- a/crates/octos-bus/src/session_tests.rs
+++ b/crates/octos-bus/src/session_tests.rs
@@ -3220,3 +3220,356 @@ async fn should_not_migrate_legacy_file_when_exporting_transcript() {
         "export must not create the per-user tree"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// evening 2026-09-10: persist_system_note_once_through_canonical_path —
+// idempotency, concurrency, strict-read fail-closed, and durable-row
+// identity (original timestamp/content preserved).
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Same id twice → exactly one durable row; the second call returns the
+/// ORIGINAL row (same timestamp and content).
+#[tokio::test]
+async fn system_note_once_same_id_returns_original_row_without_duplicate() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:same-id".to_owned());
+
+    let first = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("note A"),
+        "goal-verifier-note:v1:g1:d1",
+    )
+    .await
+    .expect("first append");
+    let first_ts = first.timestamp;
+
+    // Different content, SAME id → the durable original wins.
+    let second = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("note A-prime"),
+        "goal-verifier-note:v1:g1:d1",
+    )
+    .await
+    .expect("second call resolves");
+    assert_eq!(second.content, "note A", "first-writer-wins content");
+    assert_eq!(second.timestamp, first_ts, "original timestamp preserved");
+
+    let durable = SessionHandle::open(dir.path(), &key);
+    let count = durable
+        .session()
+        .messages
+        .iter()
+        .filter(|m| {
+            m.role == octos_core::MessageRole::System
+                && m.client_message_id.as_deref() == Some("goal-verifier-note:v1:g1:d1")
+        })
+        .count();
+    assert_eq!(count, 1, "exactly one durable row for the id");
+}
+
+/// Different ids → independent rows.
+#[tokio::test]
+async fn system_note_once_distinct_ids_append_independently() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:distinct-ids".to_owned());
+    for id in ["g1:d1", "g1:d2", "g2:d1"] {
+        let note_id = format!("goal-verifier-note:v1:{id}");
+        persist_system_note_once_through_canonical_path(
+            dir.path(),
+            &key,
+            octos_core::Message::system(format!("note {id}")),
+            &note_id,
+        )
+        .await
+        .expect("append");
+    }
+    let durable = SessionHandle::open(dir.path(), &key);
+    assert_eq!(
+        durable.session().messages.len(),
+        3,
+        "three independent notes"
+    );
+}
+
+/// Concurrent same-id calls → exactly one durable row (the shared per-key
+/// persist lock serializes check+append).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn system_note_once_concurrent_same_id_single_durable_row() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:concurrent".to_owned());
+    let data_dir = dir.path().to_path_buf();
+    let mut joins = Vec::new();
+    for i in 0..8 {
+        let data_dir = data_dir.clone();
+        let key = key.clone();
+        joins.push(tokio::spawn(async move {
+            persist_system_note_once_through_canonical_path(
+                &data_dir,
+                &key,
+                octos_core::Message::system(format!("concurrent {i}")),
+                "goal-verifier-note:v1:g1:d1",
+            )
+            .await
+        }));
+    }
+    for j in joins {
+        j.await.expect("join").expect("call ok");
+    }
+    let durable = SessionHandle::open(dir.path(), &key);
+    let count = durable
+        .session()
+        .messages
+        .iter()
+        .filter(|m| {
+            m.role == octos_core::MessageRole::System
+                && m.client_message_id.as_deref() == Some("goal-verifier-note:v1:g1:d1")
+        })
+        .count();
+    assert_eq!(count, 1, "concurrency commits exactly one row");
+}
+
+/// Strict read: a corrupt meta header means Err and the file is left
+/// byte-identical (no append past a broken head).
+#[tokio::test]
+async fn system_note_once_bad_header_fails_closed_file_untouched() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:bad-header".to_owned());
+    // Seed a valid session, then corrupt the meta line.
+    persist_message_through_canonical_path(dir.path(), &key, octos_core::Message::user("seed"))
+        .await
+        .expect("seed");
+    let users_dir = dir.path().join("users");
+    let canonical = find_first_jsonl(&users_dir).expect("canonical file");
+    let original = std::fs::read(&canonical).expect("read");
+    let body_start = original
+        .iter()
+        .position(|b| *b == b'\n')
+        .expect("meta newline")
+        + 1;
+    let mut corrupted = b"{not json\n".to_vec();
+    corrupted.extend_from_slice(&original[body_start..]);
+    assert_eq!(corrupted.last(), Some(&b'\n'), "isolate header corruption");
+    std::fs::write(&canonical, &corrupted).expect("corrupt");
+
+    let result = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("note"),
+        "goal-verifier-note:v1:g1:d1",
+    )
+    .await;
+    assert!(result.is_err(), "bad header must fail closed");
+    let after = std::fs::read(&canonical).expect("read after");
+    assert_eq!(after, corrupted, "failed call must preserve every byte");
+}
+
+/// Strict read: a body line that parses as neither Message nor control
+/// record means Err (never treat a corrupt tail as absence).
+#[tokio::test]
+async fn system_note_once_bad_body_line_fails_closed() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:bad-body".to_owned());
+    persist_message_through_canonical_path(dir.path(), &key, octos_core::Message::user("seed"))
+        .await
+        .expect("seed");
+    let users_dir = dir.path().join("users");
+    let canonical = find_first_jsonl(&users_dir).expect("canonical file");
+    let text = std::fs::read_to_string(&canonical).expect("read");
+    let mut lines: Vec<&str> = text.lines().collect();
+    lines.push("!!!not a message or control record!!!");
+    std::fs::write(&canonical, lines.join("\n") + "\n").expect("append bad line");
+
+    let result = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("note"),
+        "goal-verifier-note:v1:g1:d1",
+    )
+    .await;
+    assert!(result.is_err(), "bad body line must fail closed");
+}
+
+/// Strict read: a non-empty final line WITHOUT a trailing newline means Err
+/// (an append would concatenate onto it).
+#[tokio::test]
+async fn system_note_once_missing_trailing_newline_fails_closed() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:no-newline".to_owned());
+    persist_message_through_canonical_path(dir.path(), &key, octos_core::Message::user("seed"))
+        .await
+        .expect("seed");
+    let users_dir = dir.path().join("users");
+    let canonical = find_first_jsonl(&users_dir).expect("canonical file");
+    let text = std::fs::read_to_string(&canonical).expect("read");
+    std::fs::write(&canonical, text.trim_end()).expect("strip trailing newline");
+
+    let result = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("note"),
+        "goal-verifier-note:v1:g1:d1",
+    )
+    .await;
+    assert!(result.is_err(), "missing trailing newline must fail closed");
+}
+
+/// Test util: first .jsonl under the users/ tree (single-session tempdir).
+fn find_first_jsonl(users_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    fn visit(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+        let entries = std::fs::read_dir(dir).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(found) = visit(&path) {
+                    return Some(found);
+                }
+            } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                return Some(path);
+            }
+        }
+        None
+    }
+    visit(users_dir)
+}
+
+/// Meta-only file WITHOUT a trailing newline: fail closed; the file bytes
+/// are unchanged (an append would glue the note JSON onto the meta line).
+#[tokio::test]
+async fn system_note_once_meta_only_no_newline_fails_closed_bytes_unchanged() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:meta-nonl".to_owned());
+    persist_message_through_canonical_path(dir.path(), &key, octos_core::Message::user("seed"))
+        .await
+        .expect("seed");
+    let users_dir = dir.path().join("users");
+    let canonical = find_first_jsonl(&users_dir).expect("canonical file");
+    // Keep ONLY the meta line, no trailing newline.
+    let text = std::fs::read_to_string(&canonical).expect("read");
+    let meta_only = text.lines().next().expect("meta line").to_owned();
+    std::fs::write(&canonical, &meta_only).expect("meta-only, no newline");
+    let before = std::fs::read(&canonical).expect("bytes before");
+
+    let result = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("note"),
+        "goal-verifier-note:v1:g1:d1",
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "meta-only file without newline must fail closed"
+    );
+    let after = std::fs::read(&canonical).expect("bytes after");
+    assert_eq!(before, after, "file bytes unchanged by the failed call");
+}
+
+/// Invalid UTF-8 in the transcript: fail closed; bytes unchanged.
+#[tokio::test]
+async fn system_note_once_invalid_utf8_fails_closed_bytes_unchanged() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:bad-utf8".to_owned());
+    persist_message_through_canonical_path(dir.path(), &key, octos_core::Message::user("seed"))
+        .await
+        .expect("seed");
+    let users_dir = dir.path().join("users");
+    let canonical = find_first_jsonl(&users_dir).expect("canonical file");
+    let mut bytes = std::fs::read(&canonical).expect("read");
+    // Corrupt INSIDE a valid JSON string: lossy UTF-8 decoding would still
+    // produce a valid Message, so only strict decoding rejects this case.
+    let offset = bytes
+        .windows(4)
+        .rposition(|part| part == b"seed")
+        .expect("seed content");
+    bytes[offset] = 0xFF;
+    let lossy = String::from_utf8_lossy(&bytes);
+    let body = lossy.lines().nth(1).expect("message line");
+    assert!(serde_json::from_str::<octos_core::Message>(body).is_ok());
+    std::fs::write(&canonical, &bytes).expect("invalid utf8 body");
+    let before = std::fs::read(&canonical).expect("bytes before");
+
+    let result = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("note"),
+        "goal-verifier-note:v1:g1:d1",
+    )
+    .await;
+    assert!(result.is_err(), "invalid UTF-8 must fail closed");
+    let after = std::fs::read(&canonical).expect("bytes after");
+    assert_eq!(before, after, "file bytes unchanged by the failed call");
+}
+
+/// The canonical path is a DIRECTORY: fail closed; the directory's bytes
+/// (its listing) are unchanged — nothing is written through it.
+#[tokio::test]
+async fn system_note_once_target_is_directory_fails_closed() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:target-dir".to_owned());
+    persist_message_through_canonical_path(dir.path(), &key, octos_core::Message::user("seed"))
+        .await
+        .expect("seed");
+    let users_dir = dir.path().join("users");
+    let canonical = find_first_jsonl(&users_dir).expect("canonical file");
+    let backup = canonical.with_extension("jsonl.backup");
+    std::fs::rename(&canonical, &backup).expect("rename aside");
+    std::fs::create_dir(&canonical).expect("dir at target");
+
+    let result = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("note"),
+        "goal-verifier-note:v1:g1:d1",
+    )
+    .await;
+    assert!(result.is_err(), "a directory target must fail closed");
+    assert!(
+        canonical.is_dir(),
+        "the directory is untouched (still a directory, empty)"
+    );
+    let entries: Vec<_> = std::fs::read_dir(&canonical).expect("read dir").collect();
+    assert!(entries.is_empty(), "nothing written through the directory");
+
+    // Restore for cleanup.
+    std::fs::remove_dir(&canonical).expect("remove dir");
+    std::fs::rename(&backup, &canonical).expect("restore");
+}
+
+/// Recovery after file creation succeeds but the initial metadata write fails.
+#[tokio::test]
+async fn system_note_once_zero_byte_file_recovers_and_stays_idempotent() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let key = octos_core::SessionKey("noteonce-prof:api:empty-file".to_owned());
+    let canonical = SessionHandle::open(dir.path(), &key).session_path();
+    std::fs::create_dir_all(canonical.parent().unwrap()).expect("parent");
+    std::fs::write(&canonical, []).expect("real empty canonical file");
+    assert_eq!(std::fs::metadata(&canonical).unwrap().len(), 0);
+    let id = "goal-verifier-note:v1:g1:d1";
+    let first = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("recovered note"),
+        id,
+    )
+    .await
+    .expect("recover empty file");
+    let second = persist_system_note_once_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::system("must not replace"),
+        id,
+    )
+    .await
+    .expect("idempotent replay");
+    assert_eq!(second.content, first.content);
+    assert_eq!(second.timestamp, first.timestamp);
+    let reopened = SessionHandle::open(dir.path(), &key);
+    assert_eq!(reopened.session().messages.len(), 1);
+    assert_eq!(
+        reopened.session().messages[0].client_message_id.as_deref(),
+        Some(id)
+    );
+    assert_eq!(reopened.session().messages[0].content, "recovered note");
+}

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -43294,3 +43294,147 @@ fn standalone_turn_reapplies_hook_context() {
         "hook context must be re-applied alongside the hook executor wiring"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// merged-review 2026-09-10 Fix 1: the interactive sentinel failure warning
+// must carry the WIRE session id (no NUL, no `~cwd-` scope suffix) while the
+// goal lookup still uses the scoped key. Driven at the REAL send site with a
+// real WsConnection channel — not a helper-only call.
+// ─────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn interactive_sentinel_failure_warning_carries_wire_session_id() {
+    use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+
+    let orchestrator = crate::autonomy::agent_orchestrator::InProcessAgentOrchestrator::default();
+    // A SCOPED goal key in the real internal form: wire session id, then
+    // the NUL byte and cwd-scope suffix (as a unicode escape in the literal).
+    let scoped_key = octos_core::SessionKey(
+        "wirefix-prof:api:wirefix-session\u{0}~cwd-76ac4758abceb96a".to_owned(),
+    );
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: scoped_key.clone(),
+            profile_id: "wirefix-prof".to_owned(),
+            objective: "wire key on warning".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal under the scoped key");
+    let snapshot = orchestrator
+        .goal_verification_snapshot(&scoped_key, "wirefix-prof")
+        .expect("snapshot resolves through the scoped key");
+
+    struct EmptyReplyVerifier;
+    #[async_trait::async_trait]
+    impl octos_llm::LlmProvider for EmptyReplyVerifier {
+        async fn chat(
+            &self,
+            _m: &[octos_core::Message],
+            _t: &[octos_llm::ToolSpec],
+            _c: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            Ok(octos_llm::ChatResponse {
+                content: None,
+                reasoning_content: Some("thinking…".to_owned()),
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "empty-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "empty-verifier"
+        }
+    }
+
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let sentinel_outcome = run_interactive_sentinel_completion(
+        &orchestrator,
+        std::sync::Arc::new(EmptyReplyVerifier),
+        &scoped_key,
+        "wirefix-prof",
+        &snapshot.goal_id,
+        "All tasks are complete. <goal:complete>",
+        Some(temp.path()),
+    )
+    .await;
+    let (kind, line) = sentinel_outcome
+        .failure
+        .expect("structured failure produced");
+
+    // THE shared production boundary: the same constructor the
+    // interactive callsite uses (single normalization route), exercised
+    // through a real WsConnection + send_notification_ephemeral.
+    let notification = goal_verifier_failure_warning(&scoped_key, kind, &line);
+    let (ws_tx, mut ws_rx) = tokio::sync::mpsc::channel(8);
+    let ws = WsConnection::new(ws_tx);
+    let ledger = UiProtocolLedger::new(16);
+    send_notification_ephemeral(&ws, &ledger, notification).expect("send");
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(2), ws_rx.recv())
+        .await
+        .expect("frame")
+        .expect("open");
+    let WsMessage::Text(text) = frame else {
+        panic!("text frame")
+    };
+    let json: serde_json::Value = serde_json::from_str(text.as_str()).expect("parse");
+    let sid = json["params"]["session_id"].as_str().expect("session_id");
+    assert!(
+        !sid.contains('\u{0}'),
+        "wire session id must not carry the NUL scope separator, got: {sid:?}"
+    );
+    assert!(
+        !sid.contains("~cwd-"),
+        "wire session id must not leak the cwd scope suffix, got: {sid:?}"
+    );
+    assert_eq!(
+        sid, "wirefix-prof:api:wirefix-session",
+        "the warning session id is the WIRE form of the scoped goal key"
+    );
+    // And the goal lookup DID use the scoped key (goal stays active).
+    let still = orchestrator
+        .goal_verification_snapshot(&scoped_key, "wirefix-prof")
+        .expect("scoped lookup still works");
+    assert_eq!(still.goal_id, snapshot.goal_id);
+}
+
+#[tokio::test]
+async fn interactive_sentinel_failure_warning_plain_session_unchanged() {
+    use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+
+    let orchestrator = crate::autonomy::agent_orchestrator::InProcessAgentOrchestrator::default();
+    let plain = octos_core::SessionKey("plainfix-prof:api:plainfix-session".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: plain.clone(),
+            profile_id: "plainfix-prof".to_owned(),
+            objective: "plain key".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set goal");
+    orchestrator
+        .goal_verification_snapshot(&plain, "plainfix-prof")
+        .expect("snapshot");
+
+    // Plain keys pass through wire_key_from_goal_key unchanged — assert the
+    // constructor keeps the exact session id.
+    let notification = goal_verifier_failure_warning(
+        &plain,
+        "empty_response",
+        "verifier empty_response (attempt 2/2): no verdict text",
+    );
+    let UiNotification::Warning(event) = notification else {
+        panic!("warning")
+    };
+    assert_eq!(event.session_id, plain, "plain session id unchanged");
+}

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -32305,8 +32305,9 @@ fn goal_verifier_failure_warning(
     // merged-review 2026-09-10 Fix 1: the WarningEvent carries the WIRE
     // session id. Goal lookups keep the scoped key; this shared
     // constructor is the single production boundary that strips the
-    // `\0~cwd-…` scope suffix, so every caller (interactive :36723 and
-    // tests) routes through the SAME normalization.
+    // `\0~cwd-…` scope suffix, so every caller (the interactive sentinel
+    // consumer in `run_standalone_turn` and the tests) routes through the
+    // SAME normalization.
     UiNotification::Warning(octos_core::ui_protocol::WarningEvent {
         session_id: crate::autonomy::agent_orchestrator::wire_key_from_goal_key(session_id),
         turn_id: None,

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -32272,10 +32272,14 @@ struct InteractiveSentinelOutcome {
     failure: Option<(&'static str, String)>,
 }
 
-/// evo-goal-verifier M1: the canonical verifier-failure notification the
-/// sentinel stations emit on a claimed-but-unverified completion. ONE
-/// constructor shared by the interactive (:36659) and autonomous (:37553)
-/// consumers so the wire shape cannot drift between them.
+/// evo-goal-verifier M1: the verifier-failure notification the AUTONOMOUS
+/// station emits. Its `session_id` argument is the turn's plain WIRE
+/// session id (`params.session_id`) — the goal record is addressed
+/// separately through the scoped `goal_ctx.goal_session_key` (see the
+/// accountant block) — so no scope stripping is needed here. The
+/// INTERACTIVE station uses `goal_verifier_failure_warning`, which DOES
+/// strip the cwd-scope suffix because its caller holds the turn-pinned
+/// scoped goal key.
 fn goal_verifier_warning_event(
     session_id: &SessionKey,
     outcome: &crate::autonomy::goal_loop_runtime::GoalVerifierOutcome,
@@ -32298,8 +32302,13 @@ fn goal_verifier_failure_warning(
     kind: &str,
     line: &str,
 ) -> UiNotification {
+    // merged-review 2026-09-10 Fix 1: the WarningEvent carries the WIRE
+    // session id. Goal lookups keep the scoped key; this shared
+    // constructor is the single production boundary that strips the
+    // `\0~cwd-…` scope suffix, so every caller (interactive :36723 and
+    // tests) routes through the SAME normalization.
     UiNotification::Warning(octos_core::ui_protocol::WarningEvent {
-        session_id: session_id.clone(),
+        session_id: crate::autonomy::agent_orchestrator::wire_key_from_goal_key(session_id),
         turn_id: None,
         code: format!("goal_verifier_{kind}"),
         message: format!("goal completion not verified — {line}"),

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -5467,28 +5467,60 @@ impl SessionActor {
                     goal_id = %snapshot.goal_id,
                     "sentinel goal completion not verified: {outcome}"
                 );
-                // merged-review 2026-09-10 Fix 2: a REPLAYED failure is the
-                // same failure event re-surfaced, not a new one — the
-                // durable/in-memory note is appended only on a FRESH
-                // verdict. The warn above still fires every time, and the
-                // replay semantics (attempts==0) remain the caller's
-                // feedback; goal status/charging/TTL live in the wrapper
-                // and are untouched. Changed evidence produces a fresh
-                // digest → a new non-replayed verdict → a new note.
-                if !outcome.replayed {
-                    let note = format!("goal completion not verified — {outcome}");
-                    {
+                // evening 2026-09-10 (PR #2283 follow-up): the note is
+                // persisted IDEMPOTENTLY under a stable per-verdict identity
+                // — goal id + the same evidence digest the wrapper gates on
+                // (objective ‖ evidence ‖ revision). The `!replayed` gate is
+                // GONE: a replay whose note never landed (crash window or a
+                // previous persist failure) now recovers it, while an
+                // already-persisted note is returned as-is (original
+                // timestamp/content) and never duplicated. RAM mirrors ONLY
+                // the durable row the helper returns — a failed append
+                // leaves no phantom. Goal status, charging and TTL live in
+                // the wrapper and are untouched.
+                let digest = crate::autonomy::agent_orchestrator::verifier_evidence_digest(
+                    &snapshot.objective,
+                    &assistant_tail,
+                    snapshot.revision,
+                );
+                let note_id = format!("goal-verifier-note:v1:{}:{digest}", snapshot.goal_id);
+                match octos_bus::session::persist_system_note_once_through_canonical_path(
+                    &self.data_dir,
+                    &self.session_key,
+                    octos_core::Message::system(format!(
+                        "goal completion not verified — {outcome}"
+                    )),
+                    &note_id,
+                )
+                .await
+                {
+                    Ok(durable_row) => {
+                        // Mirror the durable row into RAM only when this
+                        // actor's mirror lacks a System row with the same
+                        // note id (covers: fresh append, disk-had-it-but-
+                        // RAM-didn't repair, and the no-duplicate case).
                         let mut handle = self.session_handle.lock().await;
-                        handle.push_message_in_memory(octos_core::Message::system(note.clone()));
+                        let mirrored = handle.session().messages.iter().any(|m| {
+                            m.role == octos_core::MessageRole::System
+                                && m.client_message_id.as_deref() == Some(note_id.as_str())
+                        });
+                        if !mirrored {
+                            handle.push_message_in_memory(durable_row);
+                        }
                     }
-                    // Canonical durable append (per-key lock → fresh open →
-                    // seq'd write), mirroring `persist_assistant_message`.
-                    let _ = octos_bus::session::persist_message_through_canonical_path(
-                        &self.data_dir,
-                        &self.session_key,
-                        octos_core::Message::system(note),
-                    )
-                    .await;
+                    Err(error) => {
+                        // Fail-closed: record and leave RAM untouched. The
+                        // next same-evidence verification (replay) retries
+                        // the same note id naturally — no background loop,
+                        // no charging/TTL changes.
+                        tracing::error!(
+                            session_id = %self.session_key,
+                            goal_id = %snapshot.goal_id,
+                            note_id = %note_id,
+                            error = %error,
+                            "goal verifier failure note persist failed; will retry on next verification"
+                        );
+                    }
                 }
             }
         }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -5467,19 +5467,29 @@ impl SessionActor {
                     goal_id = %snapshot.goal_id,
                     "sentinel goal completion not verified: {outcome}"
                 );
-                let note = format!("goal completion not verified — {outcome}");
-                {
-                    let mut handle = self.session_handle.lock().await;
-                    handle.push_message_in_memory(octos_core::Message::system(note.clone()));
+                // merged-review 2026-09-10 Fix 2: a REPLAYED failure is the
+                // same failure event re-surfaced, not a new one — the
+                // durable/in-memory note is appended only on a FRESH
+                // verdict. The warn above still fires every time, and the
+                // replay semantics (attempts==0) remain the caller's
+                // feedback; goal status/charging/TTL live in the wrapper
+                // and are untouched. Changed evidence produces a fresh
+                // digest → a new non-replayed verdict → a new note.
+                if !outcome.replayed {
+                    let note = format!("goal completion not verified — {outcome}");
+                    {
+                        let mut handle = self.session_handle.lock().await;
+                        handle.push_message_in_memory(octos_core::Message::system(note.clone()));
+                    }
+                    // Canonical durable append (per-key lock → fresh open →
+                    // seq'd write), mirroring `persist_assistant_message`.
+                    let _ = octos_bus::session::persist_message_through_canonical_path(
+                        &self.data_dir,
+                        &self.session_key,
+                        octos_core::Message::system(note),
+                    )
+                    .await;
                 }
-                // Canonical durable append (per-key lock → fresh open →
-                // seq'd write), mirroring `persist_assistant_message`.
-                let _ = octos_bus::session::persist_message_through_canonical_path(
-                    &self.data_dir,
-                    &self.session_key,
-                    octos_core::Message::system(note),
-                )
-                .await;
             }
         }
         // Re-queue another continuation only if we are still idle AND

--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -11070,3 +11070,569 @@ async fn session_actor_new_evidence_failure_appends_fresh_note() {
         "new evidence failure appends a fresh note"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// evening 2026-09-10 recovery regressions (PR #2283 follow-up review):
+// the durable session note must be recoverable across a restart and must
+// not leave a phantom in-memory note when its own persist fails. These run
+// against the CURRENT actor behavior first — both MUST fail (RED) before
+// any behavior change.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// T1 (crash-gap recovery): the verifier ledger already holds the verdict
+/// (written by a direct wrapper call) while the session file does NOT yet
+/// hold the note (the crash window between the ledger append and the note
+/// persist). A NEWLY-BUILT actor over the same session/goal/evidence — with
+/// a REAL completion-claim sentinel — surfaces the durable note without a
+/// second provider call (the idempotent note path recovers the missing
+/// row).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_actor_restart_with_ledger_verdict_but_missing_note_appends_it() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSetRequest, default_agent_orchestrator,
+    };
+
+    struct CountingEmptyVerifier {
+        calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+    #[async_trait::async_trait]
+    impl LlmProvider for CountingEmptyVerifier {
+        async fn chat(
+            &self,
+            _m: &[octos_core::Message],
+            _t: &[octos_llm::ToolSpec],
+            _c: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(octos_llm::ChatResponse {
+                content: None,
+                reasoning_content: Some("thinking…".to_owned()),
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "empty-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "empty-verifier"
+        }
+    }
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let orchestrator = default_agent_orchestrator();
+    let key = octos_core::SessionKey("restart-note-prof:api:restart-note-actor".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: key.clone(),
+            profile_id: "restart-note-prof".to_owned(),
+            objective: "restart note recovery".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal");
+
+    // The REAL completion-claim sentinel (the known-green tests use this
+    // exact shape) — both the pre-crash evidence AND the actor's tail.
+    let claim = "All tasks are complete. <goal:complete>";
+
+    // Phase 1 (pre-crash): ONE direct wrapper call so the verifier ledger
+    // holds the EmptyResponse verdict durably for this evidence. The
+    // session NOTE never lands (we do not run the actor here) — that is
+    // the crash window under test.
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let snapshot = orchestrator
+        .goal_verification_snapshot(&key, "restart-note-prof")
+        .expect("snapshot");
+    let first = orchestrator
+        .verify_goal_completion_bounded(
+            &key,
+            "restart-note-prof",
+            &snapshot,
+            std::sync::Arc::new(CountingEmptyVerifier {
+                calls: calls.clone(),
+            }),
+            claim,
+            Some(dir.path()),
+        )
+        .await;
+    assert!(
+        !first.replayed,
+        "precondition: the phase-1 wrapper call is a FRESH verdict"
+    );
+    let provider_calls_phase1 = calls.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        provider_calls_phase1 >= 1,
+        "phase 1 actually called the provider"
+    );
+
+    // Phase 2 (crash-gap): seed the durable claim row FIRST, then build
+    // the actor's handle from a FRESH SessionHandle::open — the claim loads
+    // from the real disk state (no manual RAM fabrication), while the NOTE
+    // row is absent (the crash lost it). The wrapper replays the ledger
+    // verdict (same goal + same evidence digest); the note must still be
+    // appended.
+    let cmid = octos_core::ClientMessageId::new("restart-seed-cmid");
+    octos_bus::session::persist_message_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::assistant_with_thread(claim, octos_core::ThreadId::rooted_at(&cmid)),
+    )
+    .await
+    .expect("seed durable claim row");
+    let loaded = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    assert!(
+        loaded
+            .session()
+            .messages
+            .iter()
+            .any(|m| m.role == octos_core::MessageRole::Assistant && m.content == claim),
+        "fresh reader loaded the durable claim row"
+    );
+    let handle = Arc::new(tokio::sync::Mutex::new(loaded));
+
+    let (factory, _out_tx, _out_rx) = build_minimal_actor_factory(
+        &dir,
+        SessionTaskQueryStore::default(),
+        Some("restart-note-prof".to_owned()),
+    )
+    .await;
+
+    let tools = octos_agent::ToolRegistry::with_builtins(dir.path());
+    let memory = factory.memory.clone();
+    let agent = Arc::new(octos_agent::Agent::new(
+        AgentId::new("restart-note-agent"),
+        factory.llm.clone(),
+        tools,
+        memory,
+    ));
+    let (proxy_tx, _proxy_rx) = mpsc::channel(64);
+    let (_inbox_tx, inbox_rx) = mpsc::channel(8);
+    let (self_tx, _self_rx) = mpsc::channel(8);
+    let mut actor = crate::session_actor::tests::session_actor_for_goal_test(
+        key.clone(),
+        agent,
+        handle,
+        proxy_tx,
+        inbox_rx,
+        self_tx,
+        dir.path().to_path_buf(),
+        Some(std::sync::Arc::new(CountingEmptyVerifier {
+            calls: calls.clone(),
+        })),
+    );
+
+    actor
+        .maybe_advance_goal_runtime_after_turn("restart-note-prof", None, std::time::Instant::now())
+        .await;
+
+    // No additional provider call: the ledger verdict replayed, not a new
+    // verification.
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::SeqCst),
+        provider_calls_phase1,
+        "the replay must not add provider calls"
+    );
+
+    // The durable session file must now carry the structured failure note.
+    let durable = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    let notes = durable
+        .session()
+        .messages
+        .iter()
+        .filter(|m| {
+            m.role == octos_core::MessageRole::System
+                && m.content.contains("goal completion not verified")
+        })
+        .count();
+    assert_eq!(
+        notes, 1,
+        "the crash window between the ledger append and the note persist must not lose the note"
+    );
+}
+
+/// T2 (persist failure): the note's own durable append FAILS through a real
+/// I/O error — the canonical JSONL path is replaced by a DIRECTORY (appends
+/// to a directory fail on every platform; the verifier ledger lives in a
+/// SIBLING directory and is untouched). No phantom in-memory note remains;
+/// after restoring the file, the same-evidence retry persists exactly ONE
+/// note without extra provider calls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_actor_note_persist_failure_no_phantom_and_retry_recovers() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSetRequest, default_agent_orchestrator,
+    };
+
+    struct CountingEmptyVerifier {
+        calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+    #[async_trait::async_trait]
+    impl LlmProvider for CountingEmptyVerifier {
+        async fn chat(
+            &self,
+            _m: &[octos_core::Message],
+            _t: &[octos_llm::ToolSpec],
+            _c: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(octos_llm::ChatResponse {
+                content: None,
+                reasoning_content: Some("thinking…".to_owned()),
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "empty-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "empty-verifier"
+        }
+    }
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let orchestrator = default_agent_orchestrator();
+    let key = octos_core::SessionKey("phantom-note-prof:api:phantom-note-actor".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: key.clone(),
+            profile_id: "phantom-note-prof".to_owned(),
+            objective: "no phantom notes".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal");
+
+    let claim = "All tasks are complete. <goal:complete>";
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    // Create the canonical JSONL on disk with the durable claim row, then
+    // locate it (the tempdir hosts exactly one session).
+    let cmid = octos_core::ClientMessageId::new("seed-claim-cmid");
+    octos_bus::session::persist_message_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::assistant_with_thread(claim, octos_core::ThreadId::rooted_at(&cmid)),
+    )
+    .await
+    .expect("seed durable claim row");
+    let users_dir = dir.path().join("users");
+    let canonical = walkdir_find_session_jsonl(&users_dir).expect("canonical session file on disk");
+
+    let (factory, _out_tx, _out_rx) = build_minimal_actor_factory(
+        &dir,
+        SessionTaskQueryStore::default(),
+        Some("phantom-note-prof".to_owned()),
+    )
+    .await;
+    let session_handle = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    let handle = Arc::new(tokio::sync::Mutex::new(session_handle));
+    let tools = octos_agent::ToolRegistry::with_builtins(dir.path());
+    let memory = factory.memory.clone();
+    let agent = Arc::new(octos_agent::Agent::new(
+        AgentId::new("phantom-note-agent"),
+        factory.llm.clone(),
+        tools,
+        memory,
+    ));
+    let (proxy_tx, _proxy_rx) = mpsc::channel(64);
+    let (_inbox_tx, inbox_rx) = mpsc::channel(8);
+    let (self_tx, _self_rx) = mpsc::channel(8);
+    let mut actor = crate::session_actor::tests::session_actor_for_goal_test(
+        key.clone(),
+        agent,
+        handle,
+        proxy_tx,
+        inbox_rx,
+        self_tx,
+        dir.path().to_path_buf(),
+        Some(std::sync::Arc::new(CountingEmptyVerifier {
+            calls: calls.clone(),
+        })),
+    );
+
+    // REAL I/O failure: rename the JSONL aside and put an empty DIRECTORY
+    // at its path — appends to a directory fail everywhere; the verifier
+    // ledger (sibling goal-verifier-ledgers/ dir) is unaffected.
+    let backup = canonical.with_extension("jsonl.backup");
+    std::fs::rename(&canonical, &backup).expect("rename jsonl aside");
+    std::fs::create_dir(&canonical).expect("place dir at jsonl path");
+
+    // First turn: fresh failure verdict + note append FAILS (target is a dir).
+    actor
+        .maybe_advance_goal_runtime_after_turn("phantom-note-prof", None, std::time::Instant::now())
+        .await;
+    let calls_after_failure = calls.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        calls_after_failure >= 1,
+        "the failing turn really ran the verifier"
+    );
+
+    // (a) No PHANTOM in-memory note: the memory mirror must not contain a
+    // note whose durable append failed.
+    {
+        let h = actor.session_handle.lock().await;
+        let phantom = h
+            .session()
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == octos_core::MessageRole::System
+                    && m.content.contains("goal completion not verified")
+            })
+            .count();
+        assert_eq!(
+            phantom, 0,
+            "a failed durable append must not leave a phantom in-memory note"
+        );
+    }
+
+    // (b) Restore the file; the same-evidence replay retries and the
+    // durable file ends with EXACTLY ONE note — with no additional
+    // provider call.
+    std::fs::remove_dir(&canonical).expect("remove dir placeholder");
+    std::fs::rename(&backup, &canonical).expect("restore jsonl");
+    actor
+        .maybe_advance_goal_runtime_after_turn("phantom-note-prof", None, std::time::Instant::now())
+        .await;
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::SeqCst),
+        calls_after_failure,
+        "the recovery retry replays the ledger verdict — no extra provider call"
+    );
+    let durable = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    let notes = durable
+        .session()
+        .messages
+        .iter()
+        .filter(|m| {
+            m.role == octos_core::MessageRole::System
+                && m.content.contains("goal completion not verified")
+        })
+        .count();
+    assert_eq!(
+        notes, 1,
+        "after the persist failure resolves, exactly one durable note exists"
+    );
+}
+
+fn walkdir_find_session_jsonl(users_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    // The test tempdir hosts exactly ONE session; the first .jsonl under
+    // users/ IS the canonical file for it.
+    fn visit(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+        let entries = std::fs::read_dir(dir).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(found) = visit(&path) {
+                    return Some(found);
+                }
+            } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                return Some(path);
+            }
+        }
+        None
+    }
+    visit(users_dir)
+}
+
+/// evening T3 (RAM repair): the durable file already carries the note for
+/// this goal/evidence (written by another path — e.g. a previous actor
+/// generation), but THIS actor's in-memory mirror does not. Driving the
+/// verification surfaces (mirrors) the existing durable row into RAM
+/// WITHOUT appending a second durable row.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_actor_missing_ram_note_mirrors_existing_durable_row() {
+    use crate::autonomy::agent_orchestrator::{
+        AgentOrchestrator as _, GoalSetRequest, default_agent_orchestrator,
+    };
+
+    struct EmptyAlwaysVerifier;
+    #[async_trait::async_trait]
+    impl LlmProvider for EmptyAlwaysVerifier {
+        async fn chat(
+            &self,
+            _m: &[octos_core::Message],
+            _t: &[octos_llm::ToolSpec],
+            _c: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            Ok(octos_llm::ChatResponse {
+                content: None,
+                reasoning_content: Some("thinking…".to_owned()),
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "empty-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "empty-verifier"
+        }
+    }
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let orchestrator = default_agent_orchestrator();
+    let key = octos_core::SessionKey("ramfix-prof:api:ramfix-actor".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: key.clone(),
+            profile_id: "ramfix-prof".to_owned(),
+            objective: "mirror missing ram note".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal");
+    let claim = "All tasks are complete. <goal:complete>";
+
+    // Durable claim row (thread-stamped).
+    let cmid = octos_core::ClientMessageId::new("ramfix-seed-cmid");
+    octos_bus::session::persist_message_through_canonical_path(
+        dir.path(),
+        &key,
+        octos_core::Message::assistant_with_thread(claim, octos_core::ThreadId::rooted_at(&cmid)),
+    )
+    .await
+    .expect("seed durable claim row");
+
+    // Capture the second actor's mirror BEFORE the other actor appends a
+    // note. A fresh open after that write would already include the note
+    // and would not exercise RAM repair.
+    let handle2 = Arc::new(tokio::sync::Mutex::new(
+        octos_bus::session::SessionHandle::open(dir.path(), &key),
+    ));
+
+    // Phase 1: run the actor ONCE so the verdict lands in the ledger and
+    // the note is persisted durably.
+    let (factory, _out_tx, _out_rx) = build_minimal_actor_factory(
+        &dir,
+        SessionTaskQueryStore::default(),
+        Some("ramfix-prof".to_owned()),
+    )
+    .await;
+    let session_handle = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    let handle = Arc::new(tokio::sync::Mutex::new(session_handle));
+    let tools = octos_agent::ToolRegistry::with_builtins(dir.path());
+    let memory = factory.memory.clone();
+    let agent = Arc::new(octos_agent::Agent::new(
+        AgentId::new("ramfix-agent"),
+        factory.llm.clone(),
+        tools,
+        memory,
+    ));
+    let (proxy_tx, _proxy_rx) = mpsc::channel(64);
+    let (_inbox_tx, inbox_rx) = mpsc::channel(8);
+    let (self_tx, _self_rx) = mpsc::channel(8);
+    let mut actor = crate::session_actor::tests::session_actor_for_goal_test(
+        key.clone(),
+        agent,
+        handle,
+        proxy_tx,
+        inbox_rx,
+        self_tx,
+        dir.path().to_path_buf(),
+        Some(Arc::new(EmptyAlwaysVerifier)),
+    );
+    actor
+        .maybe_advance_goal_runtime_after_turn("ramfix-prof", None, std::time::Instant::now())
+        .await;
+    let durable = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    let disk_notes = durable
+        .session()
+        .messages
+        .iter()
+        .filter(|m| {
+            m.role == octos_core::MessageRole::System
+                && m.content.contains("goal completion not verified")
+        })
+        .count();
+    assert_eq!(disk_notes, 1, "phase 1 persisted exactly one note");
+
+    // The disk has a note, but this already-open mirror still has none.
+    {
+        let stale = handle2.lock().await;
+        assert!(stale.session().messages.iter().any(|m| m.content == claim));
+        assert!(
+            !stale.session().messages.iter().any(|m| {
+                m.role == octos_core::MessageRole::System
+                    && m.content.contains("goal completion not verified")
+            }),
+            "repair must start from a genuinely missing RAM note"
+        );
+    }
+    let mut actor2 = crate::session_actor::tests::session_actor_for_goal_test(
+        key.clone(),
+        Arc::new(octos_agent::Agent::new(
+            AgentId::new("ramfix-agent-2"),
+            factory.llm.clone(),
+            octos_agent::ToolRegistry::with_builtins(dir.path()),
+            factory.memory.clone(),
+        )),
+        handle2,
+        {
+            let (proxy2, _rx2) = mpsc::channel(64);
+            proxy2
+        },
+        {
+            let (_tx2, rx2) = mpsc::channel(8);
+            rx2
+        },
+        {
+            let (tx3, _rx3) = mpsc::channel(8);
+            tx3
+        },
+        dir.path().to_path_buf(),
+        Some(Arc::new(EmptyAlwaysVerifier)),
+    );
+    actor2
+        .maybe_advance_goal_runtime_after_turn("ramfix-prof", None, std::time::Instant::now())
+        .await;
+
+    // RAM now mirrors the note (exactly one), and the DURABLE file still
+    // holds exactly one — no duplicate append.
+    {
+        let h = actor2.session_handle.lock().await;
+        let ram_notes = h
+            .session()
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == octos_core::MessageRole::System
+                    && m.content.contains("goal completion not verified")
+            })
+            .count();
+        assert_eq!(ram_notes, 1, "RAM mirrors the existing durable note");
+    }
+    let durable2 = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    let disk_notes2 = durable2
+        .session()
+        .messages
+        .iter()
+        .filter(|m| {
+            m.role == octos_core::MessageRole::System
+                && m.content.contains("goal completion not verified")
+        })
+        .count();
+    assert_eq!(disk_notes2, 1, "no duplicate durable note");
+}

--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -10802,3 +10802,271 @@ async fn session_actor_sentinel_reports_verifier_failure_kind() {
     );
     drop(guard);
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// merged-review 2026-09-10 Fix 2: a REPLAYED verifier failure must not
+// re-append the durable structured note (same evidence re-checked across
+// turns is a replay, not a new failure event). A NEW failure after changed
+// evidence still appends. Real `maybe_advance_goal_runtime_after_turn`
+// + real durable session files.
+// ─────────────────────────────────────────────────────────────────────────
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_actor_replayed_failure_does_not_duplicate_durable_note() {
+    use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let task_store = SessionTaskQueryStore::default();
+    let (factory, _out_tx, _out_rx) =
+        build_minimal_actor_factory(&dir, task_store, Some("replay-note-prof".to_owned())).await;
+
+    let orchestrator = crate::autonomy::agent_orchestrator::default_agent_orchestrator();
+    let key = octos_core::SessionKey("replay-note-prof:api:replay-note-actor".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: key.clone(),
+            profile_id: "replay-note-prof".to_owned(),
+            objective: "one note per distinct failure".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal");
+
+    // Wire the verifier through the REAL factory field the actor reads.
+    struct EmptyReplyVerifier;
+    #[async_trait::async_trait]
+    impl LlmProvider for EmptyReplyVerifier {
+        async fn chat(
+            &self,
+            _m: &[octos_core::Message],
+            _t: &[octos_llm::ToolSpec],
+            _c: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            Ok(octos_llm::ChatResponse {
+                content: None,
+                reasoning_content: Some("thinking…".to_owned()),
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "empty-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "empty-verifier"
+        }
+    }
+
+    // Actor with a claimed completion in its (durable-backed) history.
+    let mut session_handle = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    session_handle
+        .session_mut()
+        .messages
+        .push(octos_core::Message::assistant(
+            "All tasks complete. <goal:complete>",
+        ));
+    let handle = Arc::new(tokio::sync::Mutex::new(session_handle));
+    let (proxy_tx, _proxy_rx) = mpsc::channel(64);
+    let (_inbox_tx, inbox_rx) = mpsc::channel(8);
+    let (self_tx, _self_rx) = mpsc::channel(8);
+    let tools = octos_agent::ToolRegistry::with_builtins(dir.path());
+    let memory = factory.memory.clone();
+    let agent = Arc::new(octos_agent::Agent::new(
+        AgentId::new("replay-note-agent"),
+        factory.llm.clone(),
+        tools,
+        memory,
+    ));
+    let actor = crate::session_actor::tests::session_actor_for_goal_test(
+        key.clone(),
+        agent,
+        handle,
+        proxy_tx,
+        inbox_rx,
+        self_tx,
+        dir.path().to_path_buf(),
+        Some(Arc::new(EmptyReplyVerifier)),
+    );
+
+    // Count durable structured notes in the REAL session file.
+    let durable_note_count = |dir: &tempfile::TempDir, key: &octos_core::SessionKey| -> usize {
+        let handle = octos_bus::session::SessionHandle::open(dir.path(), key);
+        handle
+            .session()
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == octos_core::MessageRole::System
+                    && m.content.contains("goal completion not verified")
+            })
+            .count()
+    };
+
+    let mut actor = actor;
+    // First turn: fresh failure → exactly ONE durable note.
+    actor
+        .maybe_advance_goal_runtime_after_turn("replay-note-prof", None, std::time::Instant::now())
+        .await;
+    assert_eq!(
+        durable_note_count(&dir, &key),
+        1,
+        "fresh failure appends one note"
+    );
+
+    // Same evidence again: the wrapper REPLAYS the stored verdict — the
+    // durable note must NOT duplicate (and the actor's in-memory history
+    // stays at one structured note too).
+    actor
+        .maybe_advance_goal_runtime_after_turn("replay-note-prof", None, std::time::Instant::now())
+        .await;
+    assert_eq!(
+        durable_note_count(&dir, &key),
+        1,
+        "replayed failure must not re-append the durable note"
+    );
+    {
+        let h = actor.session_handle.lock().await;
+        let in_memory = h
+            .session()
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == octos_core::MessageRole::System
+                    && m.content.contains("goal completion not verified")
+            })
+            .count();
+        assert_eq!(
+            in_memory, 1,
+            "replayed failure must not duplicate the in-memory note either"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_actor_new_evidence_failure_appends_fresh_note() {
+    use crate::autonomy::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let task_store = SessionTaskQueryStore::default();
+    let (factory, _out_tx, _out_rx) =
+        build_minimal_actor_factory(&dir, task_store, Some("fresh-note-prof".to_owned())).await;
+
+    let orchestrator = crate::autonomy::agent_orchestrator::default_agent_orchestrator();
+    let key = octos_core::SessionKey("fresh-note-prof:api:fresh-note-actor".to_owned());
+    orchestrator
+        .set_goal(GoalSetRequest {
+            session_id: key.clone(),
+            profile_id: "fresh-note-prof".to_owned(),
+            objective: "fresh note on new failure".to_owned(),
+            status: Some("active".to_owned()),
+            token_budget: None,
+            transition_actor: None,
+        })
+        .expect("set active goal");
+
+    // Scripted provider: first call EMPTY (fresh failure), then the SAME
+    // evidence replays without consuming more script, and after we change
+    // the session history (new evidence tail), the next call fails again.
+    struct EmptyAlwaysVerifier;
+    #[async_trait::async_trait]
+    impl LlmProvider for EmptyAlwaysVerifier {
+        async fn chat(
+            &self,
+            _m: &[octos_core::Message],
+            _t: &[octos_llm::ToolSpec],
+            _c: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            Ok(octos_llm::ChatResponse {
+                content: None,
+                reasoning_content: Some("thinking…".to_owned()),
+                tool_calls: Vec::new(),
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "empty-verifier"
+        }
+        fn provider_name(&self) -> &str {
+            "empty-verifier"
+        }
+    }
+
+    let mut session_handle = octos_bus::session::SessionHandle::open(dir.path(), &key);
+    session_handle
+        .session_mut()
+        .messages
+        .push(octos_core::Message::assistant(
+            "Step one done. <goal:complete>",
+        ));
+    let handle = Arc::new(tokio::sync::Mutex::new(session_handle));
+    let (proxy_tx, _proxy_rx) = mpsc::channel(64);
+    let (_inbox_tx, inbox_rx) = mpsc::channel(8);
+    let (self_tx, _self_rx) = mpsc::channel(8);
+    let tools = octos_agent::ToolRegistry::with_builtins(dir.path());
+    let memory = factory.memory.clone();
+    let agent = Arc::new(octos_agent::Agent::new(
+        AgentId::new("fresh-note-agent"),
+        factory.llm.clone(),
+        tools,
+        memory,
+    ));
+    let mut actor = crate::session_actor::tests::session_actor_for_goal_test(
+        key.clone(),
+        agent,
+        handle,
+        proxy_tx,
+        inbox_rx,
+        self_tx,
+        dir.path().to_path_buf(),
+        Some(Arc::new(EmptyAlwaysVerifier)),
+    );
+
+    let durable_note_count = |dir: &tempfile::TempDir, key: &octos_core::SessionKey| -> usize {
+        let handle = octos_bus::session::SessionHandle::open(dir.path(), key);
+        handle
+            .session()
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == octos_core::MessageRole::System
+                    && m.content.contains("goal completion not verified")
+            })
+            .count()
+    };
+
+    actor
+        .maybe_advance_goal_runtime_after_turn("fresh-note-prof", None, std::time::Instant::now())
+        .await;
+    assert_eq!(durable_note_count(&dir, &key), 1, "first failure appends");
+
+    // CHANGED evidence: a different assistant tail → new digest → fresh
+    // (non-replayed) failure → a SECOND durable note.
+    {
+        let mut h = actor.session_handle.lock().await;
+        h.session_mut()
+            .messages
+            .push(octos_core::Message::assistant(
+                "Step two also done now. <goal:complete>",
+            ));
+    }
+    actor
+        .maybe_advance_goal_runtime_after_turn("fresh-note-prof", None, std::time::Instant::now())
+        .await;
+    assert_eq!(
+        durable_note_count(&dir, &key),
+        2,
+        "new evidence failure appends a fresh note"
+    );
+}

--- a/docs/superpowers/plans/2026-09-09-evo-goal-verifier.md
+++ b/docs/superpowers/plans/2026-09-09-evo-goal-verifier.md
@@ -1,8 +1,16 @@
 # 2026-09-09 evo-goal-verifier — 完成校验错误分类、有界恢复及证据账本
 
-- Spec: `specs/task-evo-goal-verifier.spec.md` **v3**（agent-spec lint 100%，**29 scenarios**；v2 吸收外层复核 8 条，v3 吸收 GLM/k3 设计审查——双 APPROVE-WITH-CHANGES 收编）
+> **历史文档（historical）**：本文记录 2026-09-09 实现轮的设计裁决与当时的 v3/29 场景
+> 快照，其中步骤 6/8 曾按当时预期书写（"fail-open" 等描述与最终实现不符——账本读侧
+> 实际为 fail-closed，见 spec Decisions）。**当前权威**：spec 现行文本（44 scenarios，
+> 含 merged-review 2026-09-10 修复轮 4 个新绑定）与
+> `docs/superpowers/plans/2026-09-10-merged-verifier-review.md`（本轮实际结果：
+> 4/4 定点 + clippy/fmt EXIT0、双模型 final+互读 PASS）。本 plan 不再更新，仅作裁决
+> 史存档。
+
+- Spec: `specs/task-evo-goal-verifier.spec.md`（**历史快照时点 v3/29 scenarios**；现行 44——见上方权威指向；agent-spec lint 100%；v2 吸收外层复核 8 条，v3 吸收 GLM/k3 设计审查——双 APPROVE-WITH-CHANGES 收编）
 - Native goal: `goal_01` (profile `octosfix`)
-- 分支: `fix/evo-goal-verifier`；CARGO_TARGET_DIR=/Users/zhangalex/Work/Projects/FW/octos/target；CARGO_BUILD_JOBS=4；测试 --test-threads=8；无 cargo clean。
+- 分支: `fix/evo-goal-verifier`（已合并 #2273）；构建/测试经共享 target 定点运行（-p octos-cli --features api），全量 all-targets 由外层集成树统一执行。
 
 ## v3 关键裁决（两 peer 分歧点）
 
@@ -19,9 +27,9 @@
 3. [x] 定点互审收编：v3 合并裁决已落 spec；两 peer 结论一致度高，分歧（散文归类 InvalidResponse vs InsufficientEvidence）裁决为 InvalidResponse（k3：无法区分语义 vs 协议违规，归格式错更诚实）。
 4. [x] RED：按 spec 29 个场景写失败测试（外层 runtime 反例 0pass/2fail EXIT101 → .octos/k3-rescue-logs/red-outer-probes.log）。
 5. [x] GREEN：分层实现（纯函数解析 → 自由函数重构 → wrapper → 账本 → 调用点迁移；22pass/0fail/1ignored + 2 outer probes EXIT0 + clippy -D warnings EXIT0，.octos/k3-rescue-logs/）。
-6. [~] 必跑验证（fmt/clippy/done 前候选已过：clippy -D warnings EXIT0、fmt EXIT0；全量 all-targets 由 root d246b74b 10030pass 采信——但本修复增量 delta 的全量待 root 租约释放后重跑）：`cargo test -p octos-cli --features api --all-targets -- --test-threads=8`、`cargo clippy -p octos-cli --features api --all-targets -- -D warnings`、`cargo fmt --all -- --check`、spec lifecycle。
+6. [x]（历史完成度更正）实现轮验证当时全过：clippy -D warnings EXIT0、fmt EXIT0、全量 all-targets 经 root d246b74b 合并树 10030 pass / 0 fail 采信（含两旧 CLI 时序测试）。原文"fail-open"为当时草稿措辞——最终账本读侧 fail-closed（坏行/未知版本/外来 scope 拒收），以 spec Decisions 为准。后续修复增量与全量见 2026-09-10 新 plan。
 7. [x] 独立实现审查 implementation-glm-first.md（APPROVE-WITH-CHANGES）/ implementation-k3-first.md（APPROVE）→ cross-primary-on-k3.md / cross-strong-on-glm.md（含 root 纠偏追加），sha256 全冻结，token_cost.model 双证（glm-5.3 / k3-256k）。
-8. [~] 修复增量（M1/M3/M4/M5 + GAP-1..8 + 16 Filter 绑定）已编辑待租约 RED→GREEN 验证 → 提交候选后续 commit + 通知 root 外层复验。
+8. [x]（历史完成度更正）修复增量（M1/M3/M4/M5 + GAP-1..8 + Filter 绑定）已完成 RED→GREEN 并经双模型互审 + root 8b4da851 全量门采信；后续 merged-review 修复（warning wire 键 / replay note 去重 / spec 44 场景）见 2026-09-10 新 plan。
 
 ## 风险
 

--- a/docs/superpowers/plans/2026-09-10-merged-verifier-review.md
+++ b/docs/superpowers/plans/2026-09-10-merged-verifier-review.md
@@ -1,0 +1,63 @@
+# 2026-09-10 merged-verifier review repair
+
+Branch `fix/merged-verifier-review-20260910` (base 329566d3). Scope: #2273
+merged-review audit gaps. Review artifacts live in the outer repair
+directory (verifier-red2.log / verifier-green.log and the two peer reports).
+
+## Fixes
+
+1. **Interactive sentinel failure warning carries the WIRE session id.**
+   The shared constructor `goal_verifier_failure_warning` normalizes via
+   `wire_key_from_goal_key` internally — one production boundary shared by
+   the interactive call site and the tests. Goal lookups keep the scoped
+   key. Plain sessions pass through unchanged. The AUTONOMOUS station's
+   `goal_verifier_warning_event` intentionally does NOT strip: its argument
+   is the turn's plain wire `session_id`; the scoped goal key
+   (`goal_ctx.goal_session_key`) is a separate, independent value in that
+   context.
+2. **A replayed verifier failure no longer re-appends the durable /
+   in-memory note.** `session_actor` appends only when `!outcome.replayed`;
+   the `tracing::warn!` still fires on every refusal; goal status,
+   charging, and TTL are untouched. Changed evidence produces a fresh
+   verdict and a fresh note.
+3. **Spec/plan sync.** Allowed Changes gained the two test files and this
+   plan; Decision 2(f) documents the NOT_DONE delimiter (fused tokens fall
+   through to InvalidResponse); Decision 5 documents the optional `reason`
+   column (serde default; reader precedence reason → missing_evidence →
+   error → bare outcome; old v3 rows keep the legacy fallback) and the
+   no-GC retention policy — semantic verdicts are permanent replay
+   evidence and any lifecycle bound is an operator decision (wontdo this
+   round, rationale in the spec). Status moved from draft to implemented;
+   personal/machine paths removed.
+
+## Verification
+
+- Behavioral RED → GREEN with real exit codes: a replay duplicated the
+  durable note (2 != 1) before the fix; after the fix the targeted four
+  tests pass. A first-pass compile error (unicode escape) and an early
+  wrong-path note counter (legacy flat layout) are recorded as test bugs,
+  not behavioral RED.
+- The warning test exercises the shared constructor plus a real
+  WsConnection / `send_notification_ephemeral` send — an integration of the
+  boundary, not a full interactive turn dispatch (stated honestly).
+- Cargo window (2026-09-10, real exit codes, logs in the recovery
+  directory): fmt clean; the targeted set INCLUDING the newly added
+  in-memory duplicate assertion passes 4/4 (verifier-final-targeted.log,
+  EXIT0); clippy `-p octos-cli --features api --all-targets -- -D
+  warnings` EXIT0 (verifier-final-clippy.log). All-targets belongs to the
+  outer integration run.
+
+## Handoff
+
+Product and tests are frozen on this branch. The outer combined
+integration run (workspace-wide clippy --all-targets and test
+--all-targets) is owned by ROOT on the review-combined tree; this worktree
+runs no further cargo. Final delivery report with per-item dispositions,
+RED/GREEN exits, frozen SHAs, and the dual-model review trail lives in the
+recovery directory (`verifier-final.md`).
+
+## Dispositions
+
+- Ledger GC: wontdo — permanent semantic replay evidence; see Decision 5.
+- The `diagnostic` field already covers composite outcomes; no new kind,
+  five-value outcome compatibility unchanged.

--- a/docs/superpowers/plans/2026-09-10-merged-verifier-review.md
+++ b/docs/superpowers/plans/2026-09-10-merged-verifier-review.md
@@ -61,3 +61,42 @@ recovery directory (`verifier-final.md`).
 - Ledger GC: wontdo — permanent semantic replay evidence; see Decision 5.
 - The `diagnostic` field already covers composite outcomes; no new kind,
   five-value outcome compatibility unchanged.
+
+## Evening round (PR #2283 post-review follow-up, 2026-09-10)
+
+Defects (verified by the review): the session-actor failure note was gated
+on `!outcome.replayed` and swallowed its own persist error — a crash window
+between the ledger append and the note persist (or a failed note append)
+lost the note forever, and a failed append left a phantom in-memory note.
+
+Fix: `persist_system_note_once_through_canonical_path` (octos-bus) — one
+per-key-locked canonical critical section doing a STRICT read (metadata
+NotFound-only absence, bounded size, valid meta header + supported schema,
+every line a Message or control record, valid UTF-8, mandatory trailing
+newline, rollback-aware visibility via `assemble_session_messages`) and an
+append that returns the durable row (original timestamp/content for an
+existing note id). The actor keys the note as
+`goal-verifier-note:v1:{goal_id}:{evidence_digest}` (digest via the existing
+pub(crate) `verifier_evidence_digest`), mirrors the returned durable row
+into RAM only when missing, and records (does not swallow) persist errors —
+the next same-evidence verification retries naturally. Charging, goal
+status and TTL are untouched.
+
+RED→GREEN (real exits, logs in the evening round dir): T2 phantom RED
+(1 != 0) held from the first round; T1's original RED was retracted as a
+fixture artifact (empty mirror → no claim) and re-established correctly
+after the durable-seed-then-fresh-open rework — old actor behavior
+restored momentarily for `verifier-restart-valid-red.log` (notes 0 != 1,
+provider-count preconditions passing), then the candidate actor returned
+for GREEN. Actor suite 5/5 EXIT0; bus suite 9/9 EXIT0 (idempotency,
+concurrency, bad header/body/newline/UTF-8/directory all fail closed with
+bytes unchanged); clippy -D warnings EXIT0; fmt clean.
+
+
+### 最终整合：持久化恢复边界
+
+- canonical 零字节普通文件按尚未初始化处理；真实空文件回归先失败（exit 101），修复后与其余 helper 回归共 10 项通过。目录目标仍报错。
+- 坏 header 反例保留合法 body 和末尾换行并断言完整字节不变；非法 UTF-8 反例损坏 Message JSON 字符串内部，确认 lossy 解码仍能解析，以隔离严格解码门。
+- RAM 修复测试原候选在注记落盘后才打开第二个 handle，未制造内存缺失。最终版先打开第二个 handle，再由第一个 actor 落盘，断言旧 handle 有 claim、无 note 后驱动恢复。
+- 合约新增 12 个场景，分别绑定实际 actor/helper 测试；agent-spec parse 与 lint --min-score 0.7 均通过。
+- 本轮完整验证与实际 GLM/K3 最终互审结果在提交说明中记录；不是跨进程重启测试，也未修改计费或 TTL 语义。

--- a/specs/task-evo-goal-verifier.spec.md
+++ b/specs/task-evo-goal-verifier.spec.md
@@ -4,8 +4,8 @@ tags: [goal, verifier, autonomy, octos-cli, error-classification]
 ---
 
 - **task**: evo-goal-verifier
-- **status**: draft
-- **worktree**: /Users/zhangalex/.local/tmp/octoloop-evolution-20260909/octos-goal-verifier @ `fix/evo-goal-verifier`
+- **status**: implemented (merged #2273; 2026-09-10 merged-review repair in progress on fix/merged-verifier-review-20260910)
+- **worktree**: fix/merged-verifier-review-20260910（2026-09-10 修复轮；原实现分支 fix/evo-goal-verifier，合并 PR #2273）
 （allowed files 见 ## Boundaries / ### Allowed Changes）
 
 ## Intent
@@ -15,10 +15,10 @@ Native goal completion verifier 的 `NotDone { reason }` 把基础设施故障�
 ## Decisions（v3 — 合并 GLM/k3 设计审查，双方 APPROVE-WITH-CHANGES 收编）
 
 1. **结构化分类（分层 seam，k3 §7.1 + GLM §3 一致采纳）**：新增 `GoalVerifierFailureKind { CallFailed, EmptyResponse, InvalidResponse, InsufficientEvidence }`（goal_loop_runtime.rs）。**单次调用+解析分类保持自由函数** `run_goal_completion_verifier_with_usage`（解析拆为同步纯函数 `classify_verifier_reply(content, reasoning_present) -> (GoalCompletionVerdict, Option<GoalVerifierFailureKind>, missing_evidence)`）；**新增 orchestrator 方法 `verify_goal_completion_bounded(session, profile, snapshot, provider, evidence) -> GoalVerifierOutcome`** 封装 digest gate → attempt → per-attempt charge → 预算状态检查 → 有界重试 → 落账。`GoalVerifierOutcome { verdict, kind: Option<GoalVerifierFailureKind>, attempts, missing_evidence, replayed: bool, usage }`（`kind=None ⟺ Done`，GLM 修正 A），提供 `is_done()` 与 `Display`（k3 建议）。`GoalCompletionVerdict` 保持 Done/NotDone 不变（`maybe_complete_goal_from_model` 全家零改动）。
-2. **严格 DONE 解析（k3 §2 最终规则 + GLM §2 边界，合并采纳）**：现状 first-token 解析已拒绝 `DONEgarbage`；真实活漏洞是 `DONE: but ...` 与 `DONE\nNOT_DONE: ...`（first token 均为 DONE → 误判 Done）。最终可判定规则（纯函数实现）：(a) `content` 为 None/trim 后空 → `EmptyResponse`（纯 reasoning 同此态）；(b) 剥至多一层 markdown fence（``` 开头且 ``` 结尾，仅成对时）→ (c) 剥成对反引号（首尾均为 ` 且长度≥2，可重复；**trim_matches 不保证成对——未配对 `DONE 或 DONE` 一律不剥 → InvalidResponse**）→ (d) 取非空白行集合 L；(e) `|L|==1` 且 `L[0]` 忽略大小写 == `DONE` → Done（`DONE\n` 尾随空行也 Done）；(f) 否则 `L[0]` 剥成对反引号后忽略大小写以 `NOT_DONE` 开头 → `NotDone{InsufficientEvidence}`，missing_evidence=冒号后余文（前 200 字符）；(g) 其余（多行残余、DONE 带正文、`Done.`、散文式否定如 "The build is still failing"）→ `InvalidResponse`，reason 内嵌原始答复截断（前 120 字符）供模型自我纠正（GLM 边界 2）。大小写不敏感**保留现状**（`done`/`Done` 均判 Done，回归面）。
+2. **严格 DONE 解析（k3 §2 最终规则 + GLM §2 边界，合并采纳）**：现状 first-token 解析已拒绝 `DONEgarbage`；真实活漏洞是 `DONE: but ...` 与 `DONE\nNOT_DONE: ...`（first token 均为 DONE → 误判 Done）。最终可判定规则（纯函数实现）：(a) `content` 为 None/trim 后空 → `EmptyResponse`（纯 reasoning 同此态）；(b) 剥至多一层 markdown fence（``` 开头且 ``` 结尾，仅成对时）→ (c) 剥成对反引号（首尾均为 ` 且长度≥2，可重复；**trim_matches 不保证成对——未配对 `DONE 或 DONE` 一律不剥 → InvalidResponse**）→ (d) 取非空白行集合 L；(e) `|L|==1` 且 `L[0]` 忽略大小写 == `DONE` → Done（`DONE\n` 尾随空行也 Done）；(f) 否则 `L[0]` 剥成对反引号后忽略大小写以 `NOT_DONE` 开头，**且下一字符为分隔符（`:`、空白或行尾）** → `NotDone{InsufficientEvidence}`，missing_evidence=冒号后余文（前 200 字符）；融合词（如 `NOT_DONEgarbage`，无分隔符）不满足本条、落入 (g) InvalidResponse——前缀匹配不得吞并融合 token；(g) 其余（多行残余、DONE 带正文、`Done.`、散文式否定如 "The build is still failing"）→ `InvalidResponse`，reason 内嵌原始答复截断（前 120 字符）供模型自我纠正（GLM 边界 2）。大小写不敏感**保留现状**（`done`/`Done` 均判 Done，回归面）。
 3. **有界重试（外层 + 双 peer 收敛）**：仅 `CallFailed`（且 provider 错误 `is_retryable()`，k3 建议）与 `EmptyResponse` 重试，单次验证内最多 1 次额外重试（总计 ≤2 次 `provider.chat`；每次 chat 内部含 lane RetryProvider 最多 4 次 wire 尝试，表述如实）。`InvalidResponse`/`InsufficientEvidence` 不自动重试。**第二次 chat 前置条件：goal.status == "active"**（状态式判据；`charge_goal_tokens_gated` 返回 `Option<Value>` 有五种 None 分支，不可作判据——k3 §7.2）。跨调用去重由持久 gate 承载（Decision 5）：**语义类（Done/InsufficientEvidence/InvalidResponse）同 goal_id+同 digest 永久阻断重放**（幂等）；**infra 类（CallFailed/EmptyResponse）不永久阻断**——同 digest 重放带 `replayed=true` 与 `replayed_of_ts` 标记并加 10 分钟冷却（冷却期内重放旧判词，冷却期满放行新调用），防 provider 恢复后 goal 被陈年 transient 记录楔死（k3 待验证项 + GLM 漏洞 5/6 的并集裁决）。
 4. **失败也计 usage + charge 时点迁移（双 peer 必改项 + 外层细化）**：每次尝试（含失败尝试）的 `TokenUsage` 逐字段（input/output/reasoning/cache_read/cache_write）**saturating_add** 累加（`semantic_checkpoint` 不加，后写者胜并注释）；**每次 attempt 返回立即 charge 该次 usage，然后再做预算判断**（外层裁决：per-attempt 即时收账，attempt 2 的发起条件是 charge 后 goal 仍 active）；**最终合计 usage 仅作报告/落账，不得再收第二遍**。`charge_goal_verifier_usage` 函数签名与 allow_budget_limited=true 语义不动，仅调用位置收敛进 wrapper，4 个调用点的直接 charge 调用与 "Callers must charge BEFORE…" doc comment 删除。gate 重放（replayed=true）不发新调用、不 charge、返回 usage=0/attempts=0 并显示历史来源。provider `Err` 时 octos_llm 错误类型不携带 usage（接口强制），如实按 0 记。usage 不对称注明：charge 只收 input+output（reasoning/cache 只入账本镜像，权威计数在 goals row tokens_used）——与 turn 计费一致，保持。
-5. **持久证据账本（v5 — VG-SCOPE 修订：完整真实 scope 绑定路径与记录）**：`<data_dir>/goal-verifier-ledgers/<scope指纹>.jsonl`（追加式、create_dir_all、一行一记录；独立兄弟目录，不进 goal-ledgers/ 防目录扫描器）。**scope 指纹 = sha256("octos-goal-verifier-scope-v1" + 长度前缀(data_dir 存储身份, cwd-scoped session, profile, goal_id))**——域标签 + 长度前缀序列化，无 sanitize 碰撞/分隔符注入/路径别名错认；data_dir 存储身份取最深存在祖先 canonicalize + 缺失尾段（解析 /var↔/private/var 等符号链接别名，且 preflight 创建目录前后稳定）。记录 schema **v3** 新增必填 `scope` 字段（同指纹）；读侧逐行校验 version==3、record.scope==本 scope 指纹、record.goal_id==本 goal_id，任一不符 fail-closed（旧 v2/缺 scope/未知版本一律 fail-closed，不接受外来 Done）。**同 scope 同 evidence 可跨重启重放；不同 session/profile 同 goal 编号同 evidence 不得重放**（不同文件、不同指纹）。字段 `outcome` **五值**（done/call_failed/empty_response/invalid_response/insufficient_evidence）+ scope、goal_id、ts_ms、attempts、usage（audit mirror，权威是 goals row tokens_used；**cache 重放返回 usage=0/attempts=0** 并在回显标注历史来源 ts，不是沿用历史计数）、missing_evidence、error（call_failed 时截断 provider 错误）、evidence_digest、replayed（重放不追加行、不 charge）。digest = `sha256("octos-goal-verifier-evidence-v1\0" + objective + "\0" + evidence + "\0" + revision)`（域分离标签 + \0 边界分隔；用有边界的序列化而非裸拼接；**诊断/重放事件不得写进 completion_evidence，防止证据流自激变 digest**）。goal resume/reopen 保留历史且同 goal_id；账本判词只用于去重省调用，不得绕过 maybe_complete_goal_from_model 的 snapshot 复查直翻状态。无 data_dir 内存路径用同一完整 scope 指纹做 cache 键 + 同样 10 分钟 infra TTL。
+5. **持久证据账本（v5 — VG-SCOPE 修订：完整真实 scope 绑定路径与记录）**：`<data_dir>/goal-verifier-ledgers/<scope指纹>.jsonl`（追加式、create_dir_all、一行一记录；独立兄弟目录，不进 goal-ledgers/ 防目录扫描器）。**scope 指纹 = sha256("octos-goal-verifier-scope-v1" + 长度前缀(data_dir 存储身份, cwd-scoped session, profile, goal_id))**——域标签 + 长度前缀序列化，无 sanitize 碰撞/分隔符注入/路径别名错认；data_dir 存储身份取最深存在祖先 canonicalize + 缺失尾段（解析 /var↔/private/var 等符号链接别名，且 preflight 创建目录前后稳定）。记录 schema **v3** 新增必填 `scope` 字段（同指纹）；读侧逐行校验 version==3、record.scope==本 scope 指纹、record.goal_id==本 goal_id，任一不符 fail-closed（旧 v2/缺 scope/未知版本一律 fail-closed，不接受外来 Done）。**同 scope 同 evidence 可跨重启重放；不同 session/profile 同 goal 编号同 evidence 不得重放**（不同文件、不同指纹）。字段 `outcome` **五值**（done/call_failed/empty_response/invalid_response/insufficient_evidence）+ scope、goal_id、ts_ms、attempts、usage（audit mirror，权威是 goals row tokens_used；**cache 重放返回 usage=0/attempts=0** 并在回显标注历史来源 ts，不是沿用历史计数）、missing_evidence、error（call_failed 时截断 provider 错误）、**reason（可选，serde(default)：InvalidResponse 等判词的有界 reason 原文持久化；读侧优先级 reason → missing_evidence → error → 裸 outcome 回退，旧 v3 无 reason 行保持 legacy 回退可读）**、evidence_digest、replayed（重放不追加行、不 charge）。digest = `sha256("octos-goal-verifier-evidence-v1\0" + objective + "\0" + evidence + "\0" + revision)`（域分离标签 + \0 边界分隔；用有边界的序列化而非裸拼接；**诊断/重放事件不得写进 completion_evidence，防止证据流自激变 digest**）。goal resume/reopen 保留历史且同 goal_id；账本判词只用于去重省调用，不得绕过 maybe_complete_goal_from_model 的 snapshot 复查直翻状态。无 data_dir 内存路径用同一完整 scope 指纹做 cache 键 + 同样 10 分钟 infra TTL。**账本保留政策：追加式、无 GC——语义类判词是同 scope 同 evidence 的永久重放证据，删除会重新计费已判定的证据；infra 类行仅参与冷却窗判定，体积可忽略。任何生命周期定义（如按 scope 行数上限或语义类过期）属 operator 决策，需明确授权后才引入，本轮不实现。**
    **VG-PREFLIGHT（外层 2RED 裁决）**：有 data_dir 时，wrapper 在任何 `provider.chat` 之前（同 scope single-flight 锁内）先做持久化可用性预检：create_dir_all(data_dir)+is_dir 校验+账本目录创建+以 create+append 打开账本文件并 sync——即 append 将要做的真实操作。不可用 storage（如只读目录/只读账本文件）**两次调用均 0 chat / 0 attempts / 0 charge**，fail-closed 诊断且 goal 保持未完成。真实调用后 append/flush/sync 仍失败 → 组合结局 NotDone + 保留真实 usage，并把该 (scope,digest) infra 失败写入进程内 overlay（10 分钟冷却内重放、0 chat），防止对同坏 storage 无限反复花费；冷却期满放行一次真实重试（恢复的 storage 不被楔死）。
    **IO 语义 fail-closed（外层裁决，覆盖 v3 fail-open）**：有 data_dir 但账本**读失败**（IO 错误、不完整尾行、未知版本字段）→ 保守处理：不回退很旧的 Done、不发新 chat，返回显式诊断类失败（goal 保持未完成）；账本**写失败** → 显式诊断并保持 goal 未完成，不得把已验证 Done 缓存为成功返回。无 data_dir 的 legacy ephemeral 会话 → 明确用进程内 single-flight + 内存 cache，回显标注"无法跨重启恢复"，不得假称已持久化。同 digest 短期冷却（10 分钟）保留为明确瞬态恢复策略（冷却期内重放判词）。
    **并发 single-flight（外层裁决）**：去重不只是 append 时 Mutex——需要 per-goal in-flight reservation：并发两个 gate miss 不得双调 provider；single-flight guard 不得持有整个 orchestrator state 锁跨 await（用独立 per-goal 锁/reservation map）。**恢复语义**：resume/reopen 后证据补齐（digest 变化）应允许重新验证；严禁引导模型仅改写 reason 文本绕过同证据限制。
@@ -38,8 +38,11 @@ crates/octos-cli/src/autonomy/agent_orchestrator.rs
 crates/octos-cli/src/goal_tool.rs
 crates/octos-cli/src/session_actor.rs
 crates/octos-cli/src/api/ui_protocol_transport.rs
+crates/octos-cli/src/session_actor_tests.rs
+crates/octos-cli/src/api/ui_protocol_tests.rs
 specs/task-evo-goal-verifier.spec.md
 docs/superpowers/plans/2026-09-09-evo-goal-verifier.md
+docs/superpowers/plans/2026-09-10-merged-verifier-review.md
 
 ### Forbidden
 
@@ -409,6 +412,40 @@ Scenario: 旧 v3 无 reason 行兼容回退
   Given 预 reason 列时代的 v3 invalid_response 行（无 reason/missing_evidence/error）
   When 重启后读取
   Then 反序列化成功并按 legacy 裸 outcome 回退重放
+
+### Rule: merged-review-20260910 — warning wire 键与 replay note 去重
+
+Scenario: 交互 sentinel 失败告警携带 wire session id
+  Test:
+    Package: octos-cli
+    Filter: interactive_sentinel_failure_warning_carries_wire_session_id
+  Given cwd-scoped goal key（含 NUL + ~cwd- 后缀），verifier 返回空答复产生结构化失败
+  When 共享构造器 goal_verifier_failure_warning 经真实 WsConnection/send_notification_ephemeral 发送告警
+  Then 告警 JSON session_id 为 wire 形（无 NUL、无 ~cwd-）；goal 查询（set_goal/snapshot）仍用 scoped key 且 goal 保持 active
+
+Scenario: plain session 的失败告警 session id 恒等
+  Test:
+    Package: octos-cli
+    Filter: interactive_sentinel_failure_warning_plain_session_unchanged
+  Given 无 scope 后缀的 plain session key
+  When 同一构造器生成失败告警
+  Then WarningEvent.session_id 与输入 plain key 完全一致（无改写）
+
+Scenario: 回放判词不重复追加持久/内存失败注记
+  Test:
+    Package: octos-cli
+    Filter: session_actor_replayed_failure_does_not_duplicate_durable_note
+  Given 真实 session_actor 收尾路径上一次新鲜验证失败（EmptyResponse）已追加 1 条结构化 durable/in-memory note
+  When 同一证据再次验证（wrapper 判词 replayed）
+  Then durable 计数（fresh SessionHandle 读真实 users/<base>/sessions/<topic>.jsonl）保持 1；actor 内存结构化 note 也保持 1；warn 日志路径不受影响
+
+Scenario: 变更证据后的新失败追加新注记
+  Test:
+    Package: octos-cli
+    Filter: session_actor_new_evidence_failure_appends_fresh_note
+  Given 回放态之后 assistant tail 变化（digest 改变）
+  When 再次验证产生非回放的新失败
+  Then durable 结构化 note 计数增至 2（fresh 边界保持可追加）
 
 ## Out of Scope
 

--- a/specs/task-evo-goal-verifier.spec.md
+++ b/specs/task-evo-goal-verifier.spec.md
@@ -33,6 +33,8 @@ Native goal completion verifier 的 `NotDone { reason }` 把基础设施故障�
 
 ### Allowed Changes
 
+crates/octos-bus/src/session.rs
+crates/octos-bus/src/session_tests.rs
 crates/octos-cli/src/autonomy/goal_loop_runtime.rs
 crates/octos-cli/src/autonomy/agent_orchestrator.rs
 crates/octos-cli/src/goal_tool.rs
@@ -446,6 +448,104 @@ Scenario: 变更证据后的新失败追加新注记
   Given 回放态之后 assistant tail 变化（digest 改变）
   When 再次验证产生非回放的新失败
   Then durable 结构化 note 计数增至 2（fresh 边界保持可追加）
+
+### Rule: review-followup-note-recovery — 判词重放修复缺失注记
+
+Scenario: 判词已落账但注记缺失时新 actor 恢复
+  Test:
+    Package: octos-cli
+    Filter: session_actor_restart_with_ledger_verdict_but_missing_note_appends_it
+  Given 判词 ledger 已落盘但尚未写 note，真实 claim 先落盘再由新 SessionHandle 加载
+  When 新 actor 对同一证据再次验证
+  Then provider 调用计数不变；canonical transcript 恰有一条 note
+
+Scenario: 注记持久化失败无内存幻影且可重试
+  Test:
+    Package: octos-cli
+    Filter: session_actor_note_persist_failure_no_phantom_and_retry_recovers
+  Given canonical JSONL 路径被目录占据且 verifier ledger 路径可写
+  When 真实 verifier 判词产生后 note 写入失败，恢复 JSONL 后重试同证据
+  Then 失败后 RAM note 为零；恢复后 durable note 恰一条且 provider 不再调用
+
+Scenario: 磁盘有注记但旧内存镜像缺失时修复
+  Test:
+    Package: octos-cli
+    Filter: session_actor_missing_ram_note_mirrors_existing_durable_row
+  Given 第二个 handle 在第一个 actor 写 note 前打开，磁盘已有 note 而旧 handle 尚无 note
+  When 第二个 actor 重放相同验证
+  Then RAM 补入一条已持久化 note，磁盘仍恰一条
+
+Scenario: 同注记身份返回原始行
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_same_id_returns_original_row_without_duplicate
+  Given 同一 note_id 的首条 note 已写入
+  When 以不同内容再次提交相同 note_id
+  Then 返回首条内容与 timestamp，重开 reader 仅一条
+
+Scenario: 并发相同注记身份只落一行
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_concurrent_same_id_single_durable_row
+  Given 八个并发写入使用相同 note_id
+  When 在 canonical per-key persist lock 内检查并追加
+  Then 所有调用成功且重开 reader 恰一条 durable note
+
+Scenario: 零字节日志初始化失败可恢复
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_zero_byte_file_recovers_and_stays_idempotent
+  Given 真实 canonical 文件已创建但为零字节
+  When 写入 note 后重试相同 note_id
+  Then 初始化合法日志且仅一条 note，重开 reader 可读且重试保留原内容和时间
+
+Scenario: 坏 header 拒绝且字节不变
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_bad_header_fails_closed_file_untouched
+  Given 日志 header 非法但 body 与尾换行完整
+  When 尝试追加 note
+  Then 返回错误且文件每个字节保持不变
+
+Scenario: 坏 body 拒绝
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_bad_body_line_fails_closed
+  Given 日志 body 存在无法解析的行
+  When 尝试追加 note
+  Then 返回错误
+
+Scenario: 缺尾换行拒绝追加
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_missing_trailing_newline_fails_closed
+  Given 非空日志末行缺换行
+  When 尝试追加 note
+  Then 返回错误以免拼接损坏末行
+
+Scenario: 只有 meta 且无尾换行拒绝
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_meta_only_no_newline_fails_closed_bytes_unchanged
+  Given 日志仅 meta 行且无尾换行
+  When 尝试追加 note
+  Then 返回错误且文件字节不变
+
+Scenario: JSON 字符串内部非法 UTF-8 拒绝
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_invalid_utf8_fails_closed_bytes_unchanged
+  Given 合法 Message JSON 字符串内部含非法 UTF-8，lossy 解码仍可解析为 Message
+  When 尝试追加 note
+  Then 严格 UTF-8 校验返回错误且文件字节不变
+
+Scenario: 日志目标为目录拒绝
+  Test:
+    Package: octos-bus
+    Filter: system_note_once_target_is_directory_fails_closed
+  Given canonical JSONL 路径为真实空目录
+  When 尝试追加 note
+  Then 返回错误且目录内容不变
 
 ## Out of Scope
 


### PR DESCRIPTION
Verifier failure warnings now use the client wire session ID while goal lookups retain their internal cwd scope. Failure notes recover correctly when the verifier ledger was saved but the transcript write failed or the actor restarted before appending the note.

Persist notes by a stable goal-and-evidence identity under the existing per-session lock. A replay repairs a missing durable note, returns an existing note without duplication, and updates RAM only after persistence succeeds. Preserve the original note content/timestamp, reject malformed or unreadable transcripts, and recover a zero-byte file left before metadata initialization.

Follow-up to #2273 and the review on this PR. Add 10 persistence tests and 3 actor recovery tests, including real filesystem failure and a truly stale RAM mirror; bind recovery and rejection cases in the behavior contract. Charging, verifier TTL and ledger retention are unchanged.

Merged upstream main into the review branch in `15652e88`. The only content conflict was both branches appending tests to `session_tests.rs`; resolution retains all 10 idempotent-note tests and all 5 upstream torn-tail tests, with their original assertions. The strict note helper and actor recovery logic remain unchanged. After #2282 landed, merge `dd79aa0a` brought in current main `f4b0afcd` to clear the latest-base requirement. Its five added files are identical to main; all nine reviewed verifier files and the complete PR-side diff remain byte-identical to the reviewed candidate.

Validation on `15652e88`:

- `cargo fmt` and `cargo clippy --all-targets -- -D warnings` passed.
- `cargo test --all-targets --no-fail-fast` completed 172 suites: **10,081 passed, 1 failed, 100 ignored**. Both conflicted test groups passed, along with the actor recovery and warning regressions.
- The sole failure remains `should_allocate_bridge_ports_as_consecutive_pair`: an existing local Node service owns port 3101, so allocation returns 3103. The test and production port allocator are unchanged from main. No service was stopped and no assertion was relaxed or newly ignored.
- Independent GLM and Codex source reviews and cross-reviews found no code blockers; root verified the nine source hashes and runtime review receipts.

Validation on final sync `dd79aa0a`: `cargo fmt` and `cargo clippy --all-targets -- -D warnings` passed. `cargo test --all-targets peer_list` compiled all 172 target suites and ran **40 matching tests, all passing**. The full unfiltered run above was on `15652e88`; the verifier source and PR-side diff did not change in this sync.

Non-blocking follow-up: diagnostic line counting skips blank lines in a corrupted transcript, so the reported error location can be too small. Writes still fail closed; this is recorded for a separate correction.

GitHub CI is rerunning on the new merge commit; a fresh reviewer approval is still needed.
