### PR TITLE
fix(cli): fire the documented on_turn_end hook on the OUP turn path

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -32688,6 +32688,19 @@ async fn run_standalone_turn(
             return;
         }
     };
+    // #2244 — `on_turn_end` fires at this turn's terminal below (completed,
+    // errored, or interrupted). On the done/error arms it fires BEFORE the
+    // terminal frame is emitted, so a client that observes the turn's end —
+    // including a one-shot `octos chat -m` whose process exits right after —
+    // can rely on the hook having run; the interrupt arm fires right after
+    // its frame instead, to stay inside the 5s interrupt-ack deadline.
+    // Resolved once here from the same profile the turn's agent hooks come
+    // from; `None` (no hooks configured) makes each fire a no-op.
+    let turn_end_hooks = session_runtime.profile.hook_executor.clone();
+    let turn_end_hook_ctx = octos_agent::HookContext {
+        session_id: Some(session_id.to_string()),
+        profile_id: Some(session_runtime.profile.profile_id.clone()),
+    };
     // Outer-loop #4 (§4.2): this turn's peers root — `Some` ONLY when this
     // session is a peer (topic `peer-<slug>`) running under the profile's
     // data dir. The interrupted-terminal release below keys the slot registry
@@ -35297,6 +35310,10 @@ async fn run_standalone_turn(
     // `session`/`turn` from this span (postfix `.instrument` keeps the block
     // itself untouched).
     let turn_span = crate::turn_trace::turn_span(&session_id, &turn_id);
+    // #2244 — snapshot the turn summary now that every prompt rewrite above
+    // (STT transcription merge, voice-mode suffix) has landed; `prompt`
+    // itself moves into the agent task below.
+    let turn_end_summary = crate::session_actor::git_turn_summary(&prompt);
     let agent_task = tokio::spawn(async move {
         let start = std::time::Instant::now();
         // RFC-3 (#1292): wrap the agent.process_message future in the
@@ -36341,6 +36358,17 @@ async fn run_standalone_turn(
                 // FIX-04: flush any accumulated drops before the lifecycle
                 // terminal so the client knows the cursor is incomplete.
                 flush_replay_lossy(&ws, &ledger, &session_id, &progress_dropped);
+                // #2244 — the turn reached its outcome; fire `on_turn_end`
+                // BEFORE the terminal frame (see the binding above).
+                crate::session_actor::emit_lifecycle_hook_payload(
+                    turn_end_hooks.as_ref(),
+                    &session_id,
+                    octos_agent::HookPayload::on_turn_end(
+                        turn_end_summary.clone(),
+                        Some(&turn_end_hook_ctx),
+                    ),
+                )
+                .await;
                 // Keep continuation admission out of the terminal→receipt gap.
                 // The dispatcher takes this same registry lock before claiming
                 // a queued synthesis. No provider work is awaited under it.
@@ -36477,6 +36505,17 @@ async fn run_standalone_turn(
                 )
                 .await;
                 flush_replay_lossy(&ws, &ledger, &session_id, &progress_dropped);
+                // #2244 — the turn reached its outcome; fire `on_turn_end`
+                // BEFORE the terminal frame (see the binding above).
+                crate::session_actor::emit_lifecycle_hook_payload(
+                    turn_end_hooks.as_ref(),
+                    &session_id,
+                    octos_agent::HookPayload::on_turn_end(
+                        turn_end_summary.clone(),
+                        Some(&turn_end_hook_ctx),
+                    ),
+                )
+                .await;
                 try_emit_terminal(
                     &turn_state,
                     TerminalReason::Errored,
@@ -36915,6 +36954,20 @@ async fn run_standalone_turn(
             steer_buffer.as_ref(),
             peers_root.as_deref(),
             // Outer-loop #4 (§4.2): peer sessions release their held slot at the interrupted terminal; None = no peer context on this path.
+        )
+        .await;
+        // #2244 — the turn reached its outcome; fire `on_turn_end`. Unlike the
+        // done/error arms this fires AFTER the terminal frame: the interrupt
+        // handler is blocked on that frame within a 5s ack deadline
+        // (INTERRUPT_ACK_TIMEOUT), so an up-to-`timeout_ms` hook wait must not
+        // sit between the state flip and the ack.
+        crate::session_actor::emit_lifecycle_hook_payload(
+            turn_end_hooks.as_ref(),
+            &session_id,
+            octos_agent::HookPayload::on_turn_end(
+                turn_end_summary.clone(),
+                Some(&turn_end_hook_ctx),
+            ),
         )
         .await;
         // codex #2 residual — a client-interrupted peer takes THIS branch, not

--- a/crates/octos-cli/src/runtime/local_oup.rs
+++ b/crates/octos-cli/src/runtime/local_oup.rs
@@ -240,6 +240,161 @@ mod tests {
         found
     }
 
+    // #2244 — a documented lifecycle event must actually fire on the OUP
+    // turn path: register an `on_turn_end` hook, run one turn, and assert
+    // the payload landed. The fire happens BEFORE the turn's terminal
+    // frame, so the line is on disk by the time `session.turn` resolves.
+    #[cfg(unix)]
+    fn turn_end_capture_hook(log_path: &Path) -> octos_agent::HookConfig {
+        octos_agent::HookConfig {
+            event: octos_agent::HookEvent::OnTurnEnd,
+            command: vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                r#"payload=$(cat); printf "%s\n" "$payload" >> "$1""#.into(),
+                "sh".into(),
+                log_path.to_string_lossy().into_owned(),
+            ],
+            timeout_ms: 60_000,
+            tool_filter: vec![],
+            path_filter: Vec::new(),
+            requires_bin: None,
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_fire_on_turn_end_hook_after_oup_turn() {
+        let home = tempfile::tempdir().unwrap();
+        let data = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let hook_log = home.path().join("turn-end-hooks.jsonl");
+        let mut options = options(data.path(), home.path(), Arc::new(ContextModel::default()));
+        options.config.hooks = vec![turn_end_capture_hook(&hook_log)];
+        let state = bootstrap(options).await.unwrap();
+        let session = OupSession::open(
+            state.clone(),
+            octos_core::SessionKey::with_profile("ephemeral-fixture", "cli", "hooks"),
+            workspace.path(),
+            octos_agent::EffectivePermissions::workspace_write(),
+        )
+        .await
+        .unwrap();
+        let reply = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            session.turn(
+                "hello   on_turn_end   hook",
+                None,
+                &std::sync::atomic::AtomicBool::new(false),
+                &Frontend,
+            ),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(reply.text, "ephemeral-fixture-answer");
+
+        let payload = std::fs::read_to_string(&hook_log).unwrap();
+        assert_eq!(
+            payload.lines().count(),
+            1,
+            "exactly one on_turn_end fire per turn, payload: {payload}"
+        );
+        let line = payload.lines().next().unwrap();
+        assert!(
+            line.contains("\"event\":\"on_turn_end\""),
+            "payload: {line}"
+        );
+        assert!(
+            line.contains("\"turn_summary\":\"hello on_turn_end hook\""),
+            "whitespace-normalized prompt as summary, payload: {line}"
+        );
+        assert!(
+            line.contains("\"session_id\":\"ephemeral-fixture:cli:hooks\""),
+            "payload: {line}"
+        );
+        assert!(
+            line.contains("\"profile_id\":\"ephemeral-fixture\""),
+            "payload: {line}"
+        );
+        session.close().await.unwrap();
+    }
+
+    struct FailingModel;
+
+    #[async_trait::async_trait]
+    impl LlmProvider for FailingModel {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<octos_llm::ChatResponse> {
+            Err(octos_llm::LlmError::auth("fixture invalid key").into())
+        }
+
+        fn provider_name(&self) -> &str {
+            "local"
+        }
+
+        fn model_id(&self) -> &str {
+            "ephemeral-fixture"
+        }
+    }
+
+    // #2244 — the errored arm is a turn outcome too: a turn that fails
+    // (here: a non-retryable auth error) must still fire `on_turn_end`
+    // before its terminal frame.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_fire_on_turn_end_hook_after_errored_oup_turn() {
+        let home = tempfile::tempdir().unwrap();
+        let data = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let hook_log = home.path().join("errored-turn-end-hooks.jsonl");
+        let mut options = options(data.path(), home.path(), Arc::new(ContextModel::default()));
+        options.provider = Some(Arc::new(FailingModel));
+        options.config.hooks = vec![turn_end_capture_hook(&hook_log)];
+        let state = bootstrap(options).await.unwrap();
+        let session = OupSession::open(
+            state.clone(),
+            octos_core::SessionKey::with_profile("ephemeral-fixture", "cli", "hooks-errored"),
+            workspace.path(),
+            octos_agent::EffectivePermissions::workspace_write(),
+        )
+        .await
+        .unwrap();
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            session.turn(
+                "errored turn",
+                None,
+                &std::sync::atomic::AtomicBool::new(false),
+                &Frontend,
+            ),
+        )
+        .await
+        .unwrap();
+        assert!(outcome.is_err(), "rate-limited turn must fail: {outcome:?}");
+
+        let payload = std::fs::read_to_string(&hook_log).unwrap();
+        assert_eq!(
+            payload.lines().count(),
+            1,
+            "exactly one on_turn_end fire per turn, payload: {payload}"
+        );
+        let line = payload.lines().next().unwrap();
+        assert!(
+            line.contains("\"event\":\"on_turn_end\""),
+            "payload: {line}"
+        );
+        assert!(
+            line.contains("\"turn_summary\":\"errored turn\""),
+            "payload: {line}"
+        );
+        session.close().await.unwrap();
+    }
+
     #[tokio::test]
     async fn local_oup_preserves_model_defaults_and_gateway_sampling() {
         let home = tempfile::tempdir().unwrap();

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2283,7 +2283,64 @@ pub(crate) fn build_completion_review_prompt(
     )
 }
 
-fn git_turn_summary(content: &str) -> String {
+/// Run one observe-only lifecycle hook payload (`on_resume` / `on_turn_end`)
+/// and log — never honor — blocking outcomes: these events fire after the
+/// fact, so a deny/modify cannot stop anything and is a warning, and an
+/// infrastructure failure surfaces as a warning rather than aborting the
+/// turn. Shared by the `SessionActor` chat path and the ui_protocol OUP turn
+/// path (#2244).
+pub(crate) async fn emit_lifecycle_hook_payload(
+    hooks: Option<&Arc<HookExecutor>>,
+    session_key: &SessionKey,
+    payload: HookPayload,
+) {
+    let Some(hooks) = hooks else {
+        return;
+    };
+    let event = payload.event;
+    match hooks.run(event, &payload).await {
+        HookResult::Allow => {}
+        HookResult::Modified(_) => {
+            warn!(
+                session = %session_key,
+                event = ?event,
+                "lifecycle hook attempted to modify payload; ignoring"
+            );
+        }
+        // Context injection is a `user_prompt_submit`-only outcome; these
+        // emitted lifecycle events never produce it. Exhaustive-match arm.
+        HookResult::Context(_) => {}
+        // Feedback is an AfterToolCall-only outcome (checker diagnostics
+        // appended by the agent's own dispatch sites); these lifecycle
+        // events have no tool result to carry it — log and continue.
+        HookResult::Feedback(entries) => {
+            warn!(
+                session = %session_key,
+                event = ?event,
+                count = entries.len(),
+                "lifecycle hook produced feedback; ignored"
+            );
+        }
+        HookResult::Deny(reason) => {
+            warn!(
+                session = %session_key,
+                event = ?event,
+                reason,
+                "lifecycle hook attempted to deny a non-blocking event"
+            );
+        }
+        HookResult::Error(error) => {
+            warn!(
+                session = %session_key,
+                event = ?event,
+                error,
+                "lifecycle hook failed"
+            );
+        }
+    }
+}
+
+pub(crate) fn git_turn_summary(content: &str) -> String {
     let compact = content.split_whitespace().collect::<Vec<_>>().join(" ");
     if compact.is_empty() {
         "agent turn update".to_string()
@@ -4755,50 +4812,7 @@ impl SessionActor {
     }
 
     async fn emit_hook_payload(&self, payload: HookPayload) {
-        let Some(hooks) = self.hooks.as_ref() else {
-            return;
-        };
-        let event = payload.event;
-        match hooks.run(event, &payload).await {
-            HookResult::Allow => {}
-            HookResult::Modified(_) => {
-                warn!(
-                    session = %self.session_key,
-                    event = ?event,
-                    "lifecycle hook attempted to modify payload; ignoring"
-                );
-            }
-            // Context injection is a `user_prompt_submit`-only outcome; these
-            // emitted lifecycle events never produce it. Exhaustive-match arm.
-            HookResult::Context(_) => {}
-            // Feedback is an AfterToolCall-only outcome (checker diagnostics
-            // appended by the agent's own dispatch sites); these lifecycle
-            // events have no tool result to carry it — log and continue.
-            HookResult::Feedback(entries) => {
-                warn!(
-                    session = %self.session_key,
-                    event = ?event,
-                    count = entries.len(),
-                    "lifecycle hook produced feedback; ignored"
-                );
-            }
-            HookResult::Deny(reason) => {
-                warn!(
-                    session = %self.session_key,
-                    event = ?event,
-                    reason,
-                    "lifecycle hook attempted to deny a non-blocking event"
-                );
-            }
-            HookResult::Error(error) => {
-                warn!(
-                    session = %self.session_key,
-                    event = ?event,
-                    error,
-                    "lifecycle hook failed"
-                );
-            }
-        }
+        emit_lifecycle_hook_payload(self.hooks.as_ref(), &self.session_key, payload).await;
     }
 
     async fn emit_resume_hook(&self) {


### PR DESCRIPTION
## Problem

`book/src/advanced.md` documents `on_turn_end` as one of the ten lifecycle events, and the SessionActor (gateway/channel) path fires it — but the OUP turn path (`octos chat`, `octos serve-stdio`, WS `turn/start`) never did: `run_standalone_turn` in `ui_protocol_transport.rs` had no emission, so a hook registered on the event silently never ran for every CLI/local turn. The issue's grep-based claim that *no* runtime path fires it was too broad (the SessionActor emission goes through the `emit_hook_payload` indirection), but the repro is real on the OUP path.

Reproduced on `main` (b54e54e3) with a real binary + mock OpenAI server: an `on_turn_end` hook's output file stays absent after `octos chat -m`, while a `user_prompt_submit` hook in the same config fires — proving hooks are loaded and only this event is missing.

## Root cause

`run_standalone_turn` drives the whole OUP turn and terminates it through `try_emit_terminal` (Completed/Errored/Interrupted) without ever running `HookEvent::OnTurnEnd`.

## Fix

Fire `HookPayload::on_turn_end` at the turn's three outcome points inside `run_standalone_turn`, with the same whitespace-normalized `turn_summary` + `session_id`/`profile_id` context the SessionActor path emits:

- **done / error arms**: the fire is awaited BEFORE the terminal frame, so a client that observes the turn's end can rely on the hook having run — in particular a one-shot `octos chat -m`, whose process exits right after the terminal. In the done arm the fire is placed before the `active_turns_registry()` lock is taken, so the (up to `timeout_ms`) hook wait never happens under that lock.
- **interrupt arm**: the fire follows the terminal frame instead, because the interrupt handler is blocked on that frame within the 5s `INTERRUPT_ACK_TIMEOUT` — an up-to-`timeout_ms` hook wait must not sit between the state flip and the ack.

Short-circuit paths that never ran the agent (slash-command dispatch, voice no-speech, pre-dispatch runtime errors) intentionally do not fire, matching "when an agent turn finishes". Master-continuation turns (goal/loop/peer drains) do fire, matching SessionActor parity.

The observe-only result handling (warn on Deny/Modified/Feedback/Error) is shared with SessionActor via the extracted, behavior-identical `emit_lifecycle_hook_payload`; `git_turn_summary` becomes `pub(crate)`.

## Testing

- New `local_oup` tests drive a full in-process OUP turn (mock LLM) with an `on_turn_end` capture hook registered:
  - completed turn → payload contains `event`, whitespace-normalized `turn_summary`, `session_id`, `profile_id`, and exactly one fire per turn;
  - errored turn (non-retryable auth failure) → still exactly one fire.
  - Both verified RED without the transport/session_actor changes and GREEN with them.
- End-to-end with the real binary + mock OpenAI server on the exact issue repro: `octos chat -m` now emits `{"event":"on_turn_end","session_id":"_main:cli:…","profile_id":"_main","turn_summary":"final e2e check"}` (absent before the fix); a hook that sleeps 2s still completes before process exit, validating the before-terminal ordering.
- `cargo test -p octos-cli --lib`: 3679 passed / 0 failed. `cargo fmt --check` clean. Clippy `-D warnings` clean in all three CI variants (workspace `--all-targets`, minimal `--lib --no-default-features`, `--all-targets` with api+all channel features).
- The interrupt path's fire is covered by code inspection + the shared call shape with the two e2e-verified arms; scripting a mid-turn interrupt against the local harness was not practical (turns complete before the interrupt RPC lands).

## Review

Independent adversarial review (given only the issue, the diff, and file paths) confirmed exactly-once semantics (done/error arms break with `interrupt_observed == false`; the interrupt section is guarded), correct snapshot placement (after STT/voice prompt rewrites, before `prompt` moves into the agent task), and a behavior-identical helper extraction. Its one blocker — the hook wait could blow the 5s interrupt-ack deadline — is fixed by the interrupt-arm reorder described above; its test-coverage nits (exactly-once assertion, error-path test) are adopted. Rejected: firing on pre-agent short-circuits (no agent turn ran) and doc changes (the existing "when an agent turn finishes" wording already covers autonomous turns, matching SessionActor behavior).

Closes #2244
