### PR TITLE
docs(skills): document nested-path resolution for skills install (#2250)

### DIFF
--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -1748,6 +1748,8 @@ octos skills install user/repo --force
 octos skills --profile my-bot install user/repo
 ```
 
+`user/repo` 之后的路径相对仓库根目录解析，因此嵌套目录中的技能需写完整路径——例如位于 `skills/my-skill` 的技能用 `octos skills install user/repo/skills/my-skill` 安装。
+
 **安装过程：**
 1. 尝试从技能注册表下载预编译二进制文件（SHA-256 验证）
 2. 如果存在 `Cargo.toml`，回退到 `cargo build --release`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1840,6 +1840,10 @@ octos skills install user/repo --force
 octos skills --profile my-bot install user/repo
 ```
 
+The path after `user/repo` is resolved against the repository root, so a skill
+kept in a nested directory is addressed by its full path (e.g., a skill at
+`skills/my-skill` installs with `octos skills install user/repo/skills/my-skill`).
+
 **Installation process:**
 1. Tries to download pre-built binary from the skill registry (SHA-256 verified)
 2. Falls back to `cargo build --release` if `Cargo.toml` is present


### PR DESCRIPTION
## Problem

`octos skills install user/repo/name` resolves the trailing path against the repository root (`<clone>/name`). A skill kept under `skills/name` — the layout `octos skills` itself creates in projects — can only be addressed as `user/repo/skills/name`, but neither user guide mentioned this, so installs from nested-layout repos failed with no documented workaround.

## Root cause

Documentation gap, not a code bug: `RepoSpec::parse` (crates/octos-cli/src/commands/skills.rs) maps every path segment after `user/repo` to a subdirectory resolved from the clone root. The behavior is intentional and already pinned by the `resolve_install_source_tracks_subdir_separately` unit test; it was simply undocumented.

## Fix

Adds one note after the install examples in section 14.1 of both user guides (EN + ZH mirror): the path after `user/repo` is resolved against the repository root, so a skill at `skills/my-skill` installs with `octos skills install user/repo/skills/my-skill`. No code changes.

## Test evidence

- `cargo test -p octos-cli --lib commands::skills`: 14/14 pass, including `resolve_install_source_tracks_subdir_separately` which pins the documented parsing.
- End-to-end against a real GitHub fixture repo with a `skills/demo-skill` layout (temporary repo, removed after the run):
  - `octos skills install OWNER/repo/demo-skill` → fails at the targeted-install lookup (resolves `<clone>/demo-skill`, which has no SKILL.md) — reproduces the issue's symptom.
  - `octos skills install OWNER/repo/skills/demo-skill` → `OK Installed 1 skill(s): demo-skill`, `.octos/skills/demo-skill/SKILL.md` + `.source` written — the nested path now documented works as described.

## Review

Independent adversarial review (given only the issue text, the diff, and the relevant file paths) verified the claim against `RepoSpec::parse` and both install paths (git clone and raw-HTTP fallback), checked multi-level nesting, EN/ZH fidelity, and contradictions elsewhere in the guides: no blockers, no majors. Its one adopted suggestion was matching the surrounding "(e.g., ...)" style; an optional "installed under the last path segment" elaboration was left out to keep the change scoped to the reported gap.

Closes #2250