### PR TITLE
test(agent): give the structured-metadata plugin test the shared 120s budget

### DIFF
--- a/crates/octos-agent/src/plugins/tool_tests.rs
+++ b/crates/octos-agent/src/plugins/tool_tests.rs
@@ -1448,7 +1448,7 @@ async fn execute_preserves_plugin_structured_metadata() {
         make_tool_def("metadata_tool", "returns structured metadata"),
         script_path,
     )
-    .with_timeout(Duration::from_secs(5));
+    .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool
         .execute(&json!({}))


### PR DESCRIPTION
## Problem

`plugins::tool::tests::execute_preserves_plugin_structured_metadata` flakes under full-parallel `cargo test -p octos-agent --lib` (#2093) — ~1-in-3 on the reporter's macOS arm64 host, always green in isolation.

## Root cause

The test was the last `plugins::tool` case still on a hardcoded `Duration::from_secs(5)` timeout; every other non-timeout test in the file uses `TEST_PLUGIN_TIMEOUT` (120s), whose doc comment already records this exact failure class ("a loaded host can exceed [5s] just by scheduling the subprocess"). On a saturated host the plugin child cannot get scheduled within 5s, `PluginTool::execute` returns `Err("plugin ... timed out after 5s")` (tool.rs wait-timeout path), and the test panics at `.expect("execute should succeed")`.

## Reproduction (mechanism confirmed, not just hypothesized)

On this repo's `main`, with the host CPU-saturated (14 `yes` burners on 10 cores, 3 suites concurrently) — 3/3 runs failed with the exact signature:

```
thread '...execute_preserves_plugin_structured_metadata' panicked at crates/octos-agent/src/plugins/tool_tests.rs:1456:10:
execute should succeed: plugin 'test-plugin' tool 'metadata_tool' timed out after 5s
````

Without induced load: 4/4 full-suite runs green (consistent with the issue's intermittent, load-dependent character).

## Fix

One line: `.with_timeout(Duration::from_secs(5))` → `.with_timeout(TEST_PLUGIN_TIMEOUT)`. The test asserts `structured_metadata` parsing, not timeout behavior; the one test that genuinely exercises the timeout path (`execute_timeout_returns_error`) keeps its own 1s value and is untouched. The same 120s now also covers the stdin-write timeout (both paths share `self.timeout`).

## Test evidence

- Fixed test in isolation: green.
- Full suite `cargo test -p octos-agent --lib` after the fix: 2889 passed, 0 failed.
- End-to-end before/after under the same saturation that failed 3/3 on main: **3/3 green** after the fix (2889 passed each run).
- `cargo fmt --all -- --check` and `cargo clippy -p octos-agent --all-targets -- -D warnings`: green.

## Review

Independent adversarial review (fresh agent, given only the issue, the diff, and the file paths): APPROVE — verified the timeout raise does not weaken the test's assertions, that both timeout paths (stdin-write + wait) are covered, that no `from_secs(5)` remains in the file, and that the change matches existing convention.

Closes #2093