### PR TITLE
fix(bus): seal torn session JSONL tail on append and fsync session rewrite

### DIFF
--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -17,7 +17,7 @@ const CURRENT_SESSION_SCHEMA: u32 = 1;
 
 /// Observer callback invoked AFTER a successful durable commit by
 /// [`SessionManager::add_message_with_seq`] (and the equivalent
-/// `SessionHandle` path). Implements the post-fsync hook UPCR-2026-012's
+/// `SessionHandle` path). Implements the post-commit hook UPCR-2026-012's
 /// `message/persisted` notification dispatches through.
 ///
 /// Strict-ordering invariant: `add_message_with_seq` calls observers
@@ -149,6 +149,32 @@ fn rewrite_tmp_path(target: &Path) -> PathBuf {
     let pid = std::process::id();
     let seq = REWRITE_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     target.with_extension(format!("jsonl.{pid}-{seq}.tmp"))
+}
+
+/// Seal a torn tail before appending: if the file is non-empty and does
+/// not end in a newline (a crash split an earlier write), write the
+/// missing terminator first so the next row can never fuse with the torn
+/// bytes into one unparseable line. The torn bytes are preserved, never
+/// truncated — they may be a complete row that merely lost its
+/// terminator; the read path skips what it cannot parse. Mirrors
+/// `supervisor_store::write_rows_sealed_locked`.
+///
+/// Callers serialize appends per session key (the persist lock), like the
+/// supervisor store's append lock; the seal does not defend against
+/// unsynchronized cross-process writers to the same file.
+///
+/// O_APPEND: the sealing write lands at EOF regardless of the read seek.
+fn seal_torn_tail(file: &mut std::fs::File, file_len: u64) -> std::io::Result<()> {
+    use std::io::{Read, Seek, SeekFrom, Write};
+    if file_len > 0 {
+        file.seek(SeekFrom::Start(file_len - 1))?;
+        let mut last = [0_u8; 1];
+        file.read_exact(&mut last)?;
+        if last[0] != b'\n' {
+            file.write_all(b"\n")?;
+        }
+    }
+    Ok(())
 }
 
 /// FNV-1a 64-bit hash — deterministic across Rust versions (unlike DefaultHasher).
@@ -1396,12 +1422,13 @@ impl SessionManager {
         session.updated_at = Utc::now();
         record_session_persist("committed");
         let committed_seq = session.messages.len().saturating_sub(1);
-        // UPCR-2026-012: post-fsync observer fan-out. Fires AFTER the
+        // UPCR-2026-012: post-commit observer fan-out. Fires AFTER the
         // append_to_disk above succeeded and the in-memory mirror is
         // updated, so a `message/persisted` notification reflects a row
-        // that is durably visible. A failed disk write returns above
-        // before this point, so the observer never sees a row that did
-        // not commit.
+        // the OS has accepted (the append write returned; per-append
+        // fsync is deliberately not done). A failed disk write returns
+        // above before this point, so the observer never sees a row
+        // that did not commit.
         if let Some(committed) = session.messages.last() {
             notify_message_commit(&observer_root, key, committed, committed_seq);
         }
@@ -1876,6 +1903,7 @@ impl SessionManager {
             use std::io::Write;
 
             let mut file = std::fs::OpenOptions::new()
+                .read(true)
                 .create(true)
                 .append(true)
                 .open(&path)?;
@@ -1921,6 +1949,8 @@ impl SessionManager {
                     updated_at: Utc::now(),
                 };
                 writeln!(file, "{}", serde_json::to_string(&meta)?)?;
+            } else {
+                seal_torn_tail(&mut file, file_len)?;
             }
 
             writeln!(file, "{msg_json}")?;
@@ -1933,7 +1963,9 @@ impl SessionManager {
     }
 
     /// Rewrite a session's JSONL file from the in-memory state.
-    /// Uses atomic write-then-rename to avoid corruption on crash.
+    /// Uses atomic write-then-rename to avoid corruption on crash; the
+    /// temp file is fsynced before the rename and the parent directory
+    /// after it, so the rewrite is durable, not just atomic.
     /// Uses spawn_blocking to avoid blocking the async runtime.
     ///
     /// Serialises on the per-key persist lock so the whole-file rewrite
@@ -1982,12 +2014,25 @@ impl SessionManager {
         let rewrite_result = tokio::task::spawn_blocking(move || {
             use std::io::Write;
             let tmp_path = rewrite_tmp_path(&path);
-            let mut file = std::fs::File::create(&tmp_path)?;
-            file.write_all(content.as_bytes())?;
-            file.flush()?;
-            // Atomic rename (on same filesystem)
-            std::fs::rename(&tmp_path, &path)?;
-            Ok::<_, eyre::Report>(())
+            let write_result = (|| -> Result<(), eyre::Report> {
+                let mut file = std::fs::File::create(&tmp_path)?;
+                file.write_all(content.as_bytes())?;
+                // `flush()` on a std File is a no-op (no userspace buffer) —
+                // `sync_all` is what actually gets the bytes to stable
+                // storage before the rename swaps the inode.
+                file.sync_all()?;
+                // Atomic rename (on same filesystem)
+                std::fs::rename(&tmp_path, &path)?;
+                if let Some(dir) = path.parent() {
+                    fsync_dir(dir);
+                }
+                Ok(())
+            })();
+            if write_result.is_err() {
+                // Best-effort tmp cleanup, same as rewrite_blocking_inner.
+                let _ = std::fs::remove_file(&tmp_path);
+            }
+            write_result
         })
         .await
         .map_err(|e| eyre::eyre!("spawn_blocking join error: {e}"))?;
@@ -2249,7 +2294,15 @@ impl SessionManager {
         let line = rollback_marker_line(num_turns)?;
         tokio::task::spawn_blocking(move || {
             use std::io::Write;
-            let mut file = std::fs::OpenOptions::new().append(true).open(&target)?;
+            let mut file = std::fs::OpenOptions::new()
+                .read(true)
+                .append(true)
+                .open(&target)?;
+            let file_len = file.metadata()?.len();
+            // The marker is what makes `/undo` survive a reload — if it
+            // fused with a torn tail the rollback would silently revert
+            // on the next load.
+            seal_torn_tail(&mut file, file_len)?;
             writeln!(file, "{line}")?;
             Ok::<_, eyre::Report>(())
         })
@@ -2938,11 +2991,24 @@ impl SessionHandle {
         let rewrite_result = tokio::task::spawn_blocking(move || {
             use std::io::Write;
             let tmp_path = rewrite_tmp_path(&path);
-            let mut file = std::fs::File::create(&tmp_path)?;
-            file.write_all(content.as_bytes())?;
-            file.flush()?;
-            std::fs::rename(&tmp_path, &path)?;
-            Ok::<_, eyre::Report>(())
+            let write_result = (|| -> Result<(), eyre::Report> {
+                let mut file = std::fs::File::create(&tmp_path)?;
+                file.write_all(content.as_bytes())?;
+                // `flush()` on a std File is a no-op (no userspace buffer) —
+                // `sync_all` is what actually gets the bytes to stable
+                // storage before the rename swaps the inode.
+                file.sync_all()?;
+                std::fs::rename(&tmp_path, &path)?;
+                if let Some(dir) = path.parent() {
+                    fsync_dir(dir);
+                }
+                Ok(())
+            })();
+            if write_result.is_err() {
+                // Best-effort tmp cleanup, same as rewrite_blocking_inner.
+                let _ = std::fs::remove_file(&tmp_path);
+            }
+            write_result
         })
         .await
         .map_err(|e| eyre::eyre!("spawn_blocking join error: {e}"))?;
@@ -3018,15 +3084,22 @@ impl SessionHandle {
         let write_result = (|| -> Result<()> {
             let mut file = std::fs::File::create(&tmp_path)?;
             file.write_all(content.as_bytes())?;
-            file.flush()?;
+            // `flush()` on a std File is a no-op (no userspace buffer) —
+            // `sync_all` is what actually gets the bytes to stable
+            // storage before the rename swaps the inode.
+            file.sync_all()?;
             std::fs::rename(&tmp_path, path)?;
+            if let Some(dir) = path.parent() {
+                fsync_dir(dir);
+            }
             Ok(())
         })();
         if write_result.is_err() {
-            // Best-effort tmp cleanup. If the rename succeeded but a later
-            // step failed (currently impossible — rename is the last step)
-            // we'd skip this; if `File::create` or `write_all` fail, the
-            // tmp file may exist and must not leak.
+            // Best-effort tmp cleanup. If `File::create`, `write_all`, or
+            // `sync_all` fail, the tmp file may exist and must not leak.
+            // (After a successful rename the tmp path no longer exists and
+            // the removal is a harmless no-op; the trailing `fsync_dir`
+            // cannot fail the closure.)
             let _ = std::fs::remove_file(&tmp_path);
         }
         write_result
@@ -3047,6 +3120,7 @@ impl SessionHandle {
         tokio::task::spawn_blocking(move || {
             use std::io::Write;
             let mut file = std::fs::OpenOptions::new()
+                .read(true)
                 .create(true)
                 .append(true)
                 .open(&path)?;
@@ -3090,6 +3164,8 @@ impl SessionHandle {
                     updated_at: Utc::now(),
                 };
                 writeln!(file, "{}", serde_json::to_string(&meta)?)?;
+            } else {
+                seal_torn_tail(&mut file, file_len)?;
             }
 
             writeln!(file, "{msg_json}")?;

--- a/crates/octos-bus/src/session_tests.rs
+++ b/crates/octos-bus/src/session_tests.rs
@@ -3220,3 +3220,223 @@ async fn should_not_migrate_legacy_file_when_exporting_transcript() {
         "export must not create the per-user tree"
     );
 }
+
+/// Issue #2006: a torn tail (crash mid-write leaves a partial final line
+/// without a newline) must not fuse with the NEXT appended row — the fused
+/// line is unparseable and silently takes the complete row down with it.
+/// The append path seals the torn tail with the missing terminator first,
+/// so only the torn bytes are lost, never the row written after them.
+#[tokio::test]
+async fn torn_tail_does_not_eat_next_appended_message() {
+    use std::io::Write;
+    let tmp = TempDir::new().unwrap();
+    let key = SessionKey::new("cli", "torn-tail-append");
+    let mut mgr = SessionManager::open(tmp.path()).unwrap();
+    mgr.add_message(&key, make_message(MessageRole::User, "before torn"))
+        .await
+        .unwrap();
+
+    // Simulate a crash mid-write: partial JSON row, no trailing newline.
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(mgr.session_path(&key))
+        .unwrap()
+        .write_all(b"{\"role\":\"user\",\"content\":\"torn")
+        .unwrap();
+
+    mgr.add_message(&key, make_message(MessageRole::User, "after torn"))
+        .await
+        .unwrap();
+
+    // A fresh manager reloads from disk: the torn row is skipped, but the
+    // complete row appended after it must survive.
+    let mut reload = SessionManager::open(tmp.path()).unwrap();
+    let session = reload.get_or_create(&key).await;
+    let contents: Vec<&str> = session
+        .messages
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect();
+    assert_eq!(
+        contents,
+        ["before torn", "after torn"],
+        "torn tail must not eat the next appended message"
+    );
+}
+
+/// Issue #2006: the same seal must protect the rollback control line —
+/// otherwise the marker fuses with a torn tail, is dropped on reload, and
+/// `/undo` un-does itself (the rolled-back turn resurrects).
+#[tokio::test]
+async fn torn_tail_does_not_eat_rollback_marker() {
+    use std::io::Write;
+    let tmp = TempDir::new().unwrap();
+    let key = SessionKey::new("cli", "torn-tail-rollback");
+    let mut mgr = SessionManager::open(tmp.path()).unwrap();
+    for n in 1..=2 {
+        let tid = format!("t{n}");
+        let mut user = make_message(MessageRole::User, &format!("turn {n}"));
+        user.client_message_id = Some(tid.clone());
+        user.thread_id = Some(tid.clone());
+        mgr.add_message(&key, user).await.unwrap();
+        let mut asst = make_message(MessageRole::Assistant, &format!("reply {n}"));
+        asst.thread_id = Some(tid.clone());
+        mgr.add_message(&key, asst).await.unwrap();
+    }
+
+    // Crash mid-write leaves a torn tail right before the rollback marker.
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(mgr.session_path(&key))
+        .unwrap()
+        .write_all(b"{\"role\":\"user\",\"content\":\"torn")
+        .unwrap();
+
+    let dropped = mgr.rollback_last_n_user_turns(&key, 1).await.unwrap();
+    assert_eq!(dropped, 1);
+
+    // Fresh reload replays the marker: turn 2 must stay rolled back.
+    let mut reload = SessionManager::open(tmp.path()).unwrap();
+    let session = reload.get_or_create(&key).await;
+    let contents: Vec<&str> = session
+        .messages
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect();
+    assert_eq!(
+        contents,
+        ["turn 1", "reply 1"],
+        "rollback marker fused with a torn tail resurrects the rolled-back turn"
+    );
+}
+
+/// Issue #2006: the SessionHandle append path seals the same way.
+#[tokio::test]
+async fn torn_tail_does_not_eat_handle_appended_message() {
+    use std::io::Write;
+    let tmp = TempDir::new().unwrap();
+    let key = SessionKey::new("cli", "torn-tail-handle");
+    let mut handle = SessionHandle::open(tmp.path(), &key);
+    handle
+        .add_message(Message::user("before torn"))
+        .await
+        .unwrap();
+
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(handle.session_path())
+        .unwrap()
+        .write_all(b"{\"role\":\"user\",\"content\":\"torn")
+        .unwrap();
+
+    handle
+        .add_message(Message::user("after torn"))
+        .await
+        .unwrap();
+
+    let reloaded = SessionHandle::open(tmp.path(), &key);
+    let contents: Vec<&str> = reloaded
+        .session()
+        .messages
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect();
+    assert_eq!(
+        contents,
+        ["before torn", "after torn"],
+        "torn tail must not eat the next handle-appended message"
+    );
+}
+
+/// Issue #2006: torn bytes that are actually a COMPLETE row missing only
+/// their terminator are preserved, never truncated — once sealed, the read
+/// path recovers the row (mirrors the supervisor store's
+/// `append_seals_a_complete_row_missing_its_trailing_newline`).
+#[tokio::test]
+async fn torn_tail_complete_row_is_recovered() {
+    let tmp = TempDir::new().unwrap();
+    let key = SessionKey::new("cli", "torn-tail-complete-row");
+    let mut mgr = SessionManager::open(tmp.path()).unwrap();
+    mgr.add_message(&key, make_message(MessageRole::User, "complete row"))
+        .await
+        .unwrap();
+
+    // Simulate the exact crash point: the row's bytes landed but its
+    // terminator did not — drop the trailing newline.
+    let path = mgr.session_path(&key);
+    let len = std::fs::metadata(&path).unwrap().len();
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .unwrap()
+        .set_len(len - 1)
+        .unwrap();
+
+    mgr.add_message(&key, make_message(MessageRole::User, "after torn"))
+        .await
+        .unwrap();
+
+    let mut reload = SessionManager::open(tmp.path()).unwrap();
+    let session = reload.get_or_create(&key).await;
+    let contents: Vec<&str> = session
+        .messages
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect();
+    assert_eq!(
+        contents,
+        ["complete row", "after torn"],
+        "a complete row that lost only its terminator must be recovered"
+    );
+}
+
+/// Issue #2006: when the per-user layout exists the rollback marker lands
+/// THERE (the production-canonical layout) — the seal must protect the
+/// marker on that file too.
+#[tokio::test]
+async fn torn_tail_does_not_eat_rollback_marker_in_per_user_layout() {
+    use std::io::Write;
+    let tmp = TempDir::new().unwrap();
+    let key = SessionKey::new("cli", "torn-tail-rollback-per-user");
+
+    // Seed via SessionHandle so the transcript lives in the per-user layout.
+    let mut handle = SessionHandle::open(tmp.path(), &key);
+    for n in 1..=2 {
+        let tid = format!("t{n}");
+        let mut user = make_message(MessageRole::User, &format!("turn {n}"));
+        user.client_message_id = Some(tid.clone());
+        user.thread_id = Some(tid.clone());
+        handle.add_message(user).await.unwrap();
+        let mut asst = make_message(MessageRole::Assistant, &format!("reply {n}"));
+        asst.thread_id = Some(tid.clone());
+        handle.add_message(asst).await.unwrap();
+    }
+
+    // Crash mid-write leaves a torn tail on the per-user file.
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(handle.session_path())
+        .unwrap()
+        .write_all(b"{\"role\":\"user\",\"content\":\"torn")
+        .unwrap();
+    drop(handle);
+
+    // Roll back through a manager over the same dir: the marker targets the
+    // per-user file (the only layout present) and must survive the torn tail.
+    let mut mgr = SessionManager::open(tmp.path()).unwrap();
+    let dropped = mgr.rollback_last_n_user_turns(&key, 1).await.unwrap();
+    assert_eq!(dropped, 1);
+
+    let mut reload = SessionManager::open(tmp.path()).unwrap();
+    let session = reload.get_or_create(&key).await;
+    let contents: Vec<&str> = session
+        .messages
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect();
+    assert_eq!(
+        contents,
+        ["turn 1", "reply 1"],
+        "rollback marker on the per-user file must survive a torn tail"
+    );
+}


### PR DESCRIPTION
## Problem

A crash or kill mid-write leaves the session JSONL with a torn tail — a partial final line with no newline. Three consequences, all reproduced on `main`:

1. **A torn tail eats the NEXT message.** The append paths (`SessionManager::append_to_disk`, `SessionHandle::append_to_disk`) open with `append(true)` and `writeln!` straight onto the torn bytes; the fused line is unparseable, and `parse_session_timeline` silently drops it — destroying the complete new row along with the torn one.
2. **A torn tail can resurrect a rolled-back turn.** `append_rollback_marker` uses the same unsealed path; when the marker row is the one fused and dropped, `/undo` un-does itself on the next load.
3. **The documented durability guarantee is stronger than the code.** The UPCR-2026-012 comment called the `message/persisted` observer fan-out "post-fsync" / "durably visible", but no fsync exists on the append path (deliberate tradeoff); and `rewrite` did `File::create` → `write_all` → `flush()` (a no-op on `std::fs::File`) → `rename` with no `sync_all` and no directory fsync.

## Root cause

The session log never adopted the torn-tail discipline octos already has in production in `supervisor_store.rs::write_rows_sealed_locked` — an inconsistently applied pattern, not a missing capability.

## Fix

- New `seal_torn_tail` helper (~15 lines, mirroring `write_rows_sealed_locked`): if the file is non-empty and does not end in `\n`, write the missing terminator first. Torn bytes are preserved, never truncated. Wired into all three append paths; `append_rollback_marker` seals for both flat and per-user targets.
- `rewrite` (all three variants): `sync_all()` the temp file before the rename, `fsync_dir` the parent after it — reusing the helpers already in this file — so the rewrite is durable, not just atomic. The tmp file is now also cleaned up if the newly-real `sync_all` fails (previously only `create`/`write_all` could fail).
- The UPCR-2026-012 comment now says what the code does (post-commit, write(2) returned, per-append fsync deliberately not done). No per-append fsync was added, per the issue's scope.

The supervisor-store read path the issue mentions (`read_ledger_rows`) was already made tolerant by the later #26a change — verified, nothing needed there.

## Test evidence

Five new tests, each **red on `main`, green with the fix** (verified by stashing only `session.rs`):

- `torn_tail_does_not_eat_next_appended_message` — manager append path
- `torn_tail_does_not_eat_handle_appended_message` — SessionHandle append path
- `torn_tail_does_not_eat_rollback_marker` — flat layout
- `torn_tail_does_not_eat_rollback_marker_in_per_user_layout` — per-user (production-canonical) layout
- `torn_tail_complete_row_is_recovered` — torn bytes that are a complete row missing only its terminator are preserved and recovered

`cargo test -p octos-bus`: 247+16+2 passed, 0 failed. `cargo fmt --all -- --check` clean. `cargo clippy -p octos-bus --all-targets -- -D warnings` clean.

**End-to-end:** a throwaway example binary drove the real public API (`SessionManager::open` → `add_message` → simulated crash mid-write → restart → `add_message` → cold reload). Pre-fix: reload yields `["before torn"]` (the post-crash message lost). Post-fix: `["before torn", "after torn"]`. The example was removed after the run and is not in this diff.

**Independent review:** an adversarial maintainer-perspective pass found no blockers/majors; its minor findings are addressed here (per-user rollback test, complete-row test, tmp cleanup on `sync_all` failure, seal docstring scoping note, one stale comment). The `.read(true)` access-mode widening matches the supervisor-store precedent and was judged acceptable.

Closes #2006