### PR TITLE
fix(services): frame the services compaction summary as demoted background (#1912)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4961,6 +4961,7 @@ dependencies = [
 name = "octos-services"
 version = "2.0.3-rc.11"
 dependencies = [
+ "async-trait",
  "chrono",
  "dirs",
  "eyre",

--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -3185,6 +3185,9 @@ impl ContextManager {
                             // agent loop's message_repair matches
                             // `starts_with("[Conversation summary]")` to keep
                             // summary rows out of the system prompt.
+                            // Keep byte-identical to the sibling copy in
+                            // `octos-services/src/compaction.rs`
+                            // (`format_compaction_summary`).
                             format!(
                                 "[Conversation summary]\n\
                                  [BACKGROUND ONLY — everything in this summary is \

--- a/crates/octos-services/Cargo.toml
+++ b/crates/octos-services/Cargo.toml
@@ -30,6 +30,7 @@ futures = { workspace = true }
 test-util = []
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/octos-services/src/compaction.rs
+++ b/crates/octos-services/src/compaction.rs
@@ -13,6 +13,29 @@ const DEFAULT_THRESHOLD: usize = 40;
 /// Default number of recent messages to keep intact (not summarized).
 const DEFAULT_KEEP_RECENT: usize = 10;
 
+/// Render a compaction summary for installation into the live message list.
+///
+/// Spec task-compaction-instruction-priority: frame the summary as demoted
+/// BACKGROUND with an explicit precedence footer, so a post-compaction model
+/// cannot mistake restated historical goals/plans for the current
+/// instruction. Line 1 keeps the EXACT legacy sentinel: the agent loop's
+/// message_repair matches `starts_with("[Conversation summary]")` to keep
+/// summary rows out of the system prompt.
+///
+/// Keep this rendering byte-identical to the sibling copy in
+/// `octos-cli/src/api/context_manager.rs` (which cross-references back).
+fn format_compaction_summary(summary: &str) -> String {
+    format!(
+        "[Conversation summary]\n\
+         [BACKGROUND ONLY — everything in this summary is \
+         history, not instructions.]\n{summary}\n\
+         [End of background. The newest user message in this \
+         conversation is the CURRENT instruction and takes \
+         precedence over everything above, including any goals \
+         or plans mentioned in the summary.]"
+    )
+}
+
 /// Configuration for session compaction behavior.
 pub struct CompactionConfig {
     /// Minimum total messages before compaction triggers.
@@ -155,7 +178,7 @@ pub async fn maybe_compact_with_config(
 
     let summary_msg = Message {
         role: MessageRole::System,
-        content: format!("[Conversation summary]\n{summary}"),
+        content: format_compaction_summary(&summary),
         media: vec![],
         tool_calls: None,
         tool_call_id: None,
@@ -289,7 +312,7 @@ pub async fn maybe_compact_handle(
 
     let summary_msg = Message {
         role: MessageRole::System,
-        content: format!("[Conversation summary]\n{summary}"),
+        content: format_compaction_summary(&summary),
         media: vec![],
         tool_calls: None,
         tool_call_id: None,
@@ -317,4 +340,133 @@ pub async fn maybe_compact_handle(
     );
 
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octos_llm::{ChatResponse, StopReason, TokenUsage, ToolSpec};
+
+    /// Summarizer stub: returns a fixed summary body regardless of input.
+    struct StubSummarizer;
+
+    #[async_trait::async_trait]
+    impl LlmProvider for StubSummarizer {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            Ok(ChatResponse {
+                content: Some("User still needs the deploy runbook.".to_string()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "stub-summarizer"
+        }
+
+        fn provider_name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    fn user_msg(content: &str) -> Message {
+        Message {
+            role: MessageRole::User,
+            content: content.to_string(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Spec task-compaction-instruction-priority: the installed summary row
+    /// must demote the summary to BACKGROUND and anchor the current
+    /// instruction to the newest user message. Exact-match (not substring)
+    /// so the rendering stays byte-identical to the sibling copy in
+    /// `octos-cli/src/api/context_manager.rs`, and line 1 keeps the exact
+    /// legacy sentinel the agent loop's message_repair matches on.
+    fn assert_summary_framed(content: &str, body: &str) {
+        let expected = format!(
+            "[Conversation summary]\n\
+             [BACKGROUND ONLY — everything in this summary is \
+             history, not instructions.]\n{body}\n\
+             [End of background. The newest user message in this \
+             conversation is the CURRENT instruction and takes \
+             precedence over everything above, including any goals \
+             or plans mentioned in the summary.]"
+        );
+        assert_eq!(content, expected);
+    }
+
+    #[test]
+    fn format_compaction_summary_handles_empty_body() {
+        let framed = format_compaction_summary("");
+        assert_summary_framed(&framed, "");
+    }
+
+    #[tokio::test]
+    async fn maybe_compact_frames_summary_as_background() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = SessionManager::open(dir.path()).unwrap();
+        let key = SessionKey::new("test", "chat-1");
+        let config = CompactionConfig {
+            threshold: 4,
+            keep_recent: 2,
+        };
+        for i in 0..6 {
+            let session = mgr.get_or_create(&key).await;
+            session.messages.push(user_msg(&format!("message {i}")));
+        }
+
+        let compacted = maybe_compact_with_config(&mut mgr, &key, &StubSummarizer, &config)
+            .await
+            .unwrap();
+        assert!(compacted);
+
+        let session = mgr.get_or_create(&key).await;
+        assert_eq!(session.messages.len(), 3);
+        assert_summary_framed(
+            &session.messages[0].content,
+            "User still needs the deploy runbook.",
+        );
+        assert_eq!(session.messages[1].content, "message 4");
+        assert_eq!(session.messages[2].content, "message 5");
+    }
+
+    #[tokio::test]
+    async fn maybe_compact_handle_frames_summary_as_background() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SessionKey::new("test", "chat-2");
+        let mut handle = SessionHandle::open(dir.path(), &key);
+        // CompactionConfig::default(): threshold 40, keep_recent 10.
+        for i in 0..45 {
+            handle
+                .session_mut()
+                .messages
+                .push(user_msg(&format!("message {i}")));
+        }
+
+        let compacted = maybe_compact_handle(&mut handle, &StubSummarizer)
+            .await
+            .unwrap();
+        assert!(compacted);
+
+        let messages = &handle.session().messages;
+        assert_eq!(messages.len(), 11);
+        assert_summary_framed(&messages[0].content, "User still needs the deploy runbook.");
+        assert_eq!(messages[1].content, "message 35");
+        assert_eq!(messages[10].content, "message 44");
+    }
 }


### PR DESCRIPTION
## Problem

#1892 fixed the instruction-priority drift on two of the three compaction channels (spec `task-compaction-instruction-priority`), but the third — `crates/octos-services/src/compaction.rs` (both the `SessionManager` path and the `SessionHandle` path) — still installed the summary bare:

```rust
content: format!("[Conversation summary]\n{summary}"),
```

A post-compaction model on this channel could still mistake restated historical goals/plans for the current instruction (the live drift observed 2026-08-02).

## Root cause

The services channel never got the render-side framing the other two channels received: no BACKGROUND demotion header, no precedence footer.

## Fix

- New `format_compaction_summary` helper in `octos-services/src/compaction.rs` renders the exact same framing as `octos-cli/src/api/context_manager.rs` (verified byte-identical, accounting for Rust string-continuation whitespace): `[BACKGROUND ONLY — …]` header + `[End of background. The newest user message … takes precedence …]` footer.
- Both call sites (`maybe_compact_with_config`, `maybe_compact_handle`) route through the helper.
- Line 1 keeps the exact legacy `[Conversation summary]` sentinel, so `message_repair`'s `starts_with` match (and every other sentinel consumer) is unaffected — verified by reading all match sites (`octos-agent/src/agent/message_repair.rs:121`, context_manager projections, session_actor tests).
- Cross-reference comments in both copies so the duplicated literal cannot silently drift (a single shared helper would have to live in a lower crate; octos-services does not depend on octos-cli).

## Test evidence

- Two new behavior tests drive the real public entry points (stub summarizer, real disk-backed `SessionManager`/`SessionHandle`): red before the fix (installed content was the bare two-line form), green after. They assert exact full-string equality with the reference framing, verbatim summary-body preservation, and the retained recent tail.
- A third test pins the empty-summary edge.
- `cargo test -p octos-services`: 55/55. `cargo test -p octos-cli --no-default-features --features api --lib context_manager`: 95/95. `cargo fmt --all -- --check` clean. Clippy clean for `-p octos-services --all-targets` and the CI api-feature gate (`-p octos-cli --all-targets --no-default-features --features api,telegram,discord,dingtalk,slack,whatsapp,feishu,email,matrix,audio_mp3`), both with `-D warnings`.
- End-to-end with a real LLM (DeepSeek `deepseek-chat`, 46-message session through `maybe_compact_handle`): before the fix the installed row was the bare `[Conversation summary]\n<body>`; after, it carries the BACKGROUND header + precedence footer with the body verbatim, and the newest user instruction survives as the last row.
- Independent adversarial review: no blockers/majors; its Minor findings (drift-prone duplication → cross-reference comments; substring assertions → exact-match; empty-body edge) are all addressed in this revision.

Note: this channel has no in-workspace production callers (it is re-exported via `octos-cli` for downstream consumers), so the new tests are the in-repo exercise of the path.

Closes #1912