### PR TITLE
ci: add check-darwin so required checks compile the macOS target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -833,6 +833,41 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && !cancelled() }}
         run: cargo test --workspace --doc
 
+  check-darwin:
+    # Runs on PRs, like check-windows: the workspace has 89
+    # `cfg(target_os = "macos")` sites that NEVER compile on the Linux runners
+    # every other PR job uses, so a macOS-only break was invisible until after
+    # merge — #2239 alone produced two such breaks (#2258's E0599 in the
+    # default build, #2263's E0425 in api-feature test code) while every
+    # required check stayed green. The existing macOS jobs do not close this:
+    # e2e-tool-regression builds octos-cli (api+telegram features) but fires
+    # only on e2e path changes, and the security suite compiles one
+    # octos-agent test binary only on security-path changes — so an ordinary
+    # PR gets no macOS compile signal at all.
+    #
+    # Compile-only, so the cost is one macos-14 runner for a cargo check, not
+    # a test run. Both steps pass --all-targets so cfg(test) code is compiled
+    # too — #2263's break lived in feature-gated test modules, which a
+    # lib-only check would never see.
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: darwin
+
+      - name: Check workspace (all targets)
+        run: cargo check --workspace --all-targets
+
+      - name: Check octos-cli + all features (all targets)
+        run: cargo check -p octos-cli --all-targets --features ${{ env.FEATURES }}
+
   # ── Release artifact builds (main only) ──────────────────────────
   build-macos-arm:
     if: github.event_name == 'push'
@@ -1254,6 +1289,7 @@ jobs:
       - test-octos-cli
       - check-matrix
       - check-windows
+      - check-darwin
       - e2e-changes
       - e2e-tool-regression
       - security
@@ -1270,7 +1306,7 @@ jobs:
           for job in dashboard swarm-app typos ux-gate-report \
             windows-deploy-script web-app-base-url-windows check \
             test-octos-agent test-octos-cli check-matrix check-windows \
-            e2e-changes security; do
+            check-darwin e2e-changes security; do
             result=$(echo "$RESULTS" | jq -r --arg job "$job" '.[$job].result')
             if [ "$result" != success ]; then
               echo "::error::required job $job finished with $result"


### PR DESCRIPTION
## Problem

None of the required checks on `main` compile for macOS. Every PR job runs on Linux or Windows; the only two macOS jobs are conditional — `e2e-tool-regression` (macos-14) fires only on e2e path changes, and the `security` suite compiles a single `octos-agent` test binary only on security-path changes. An ordinary PR gets no macOS compile signal at all, so a `cfg(target_os = "macos")`-only compile error sails through green.

That blind spot already burned main twice from a single PR: #2239 broke the macOS default build (#2258, E0599) and the api-feature test code (#2263, E0425) while every required check stayed green.

## Root cause

The workspace has 89 `cfg(target_os = "macos")` sites that the Linux runners every other PR job uses can never compile. Compile coverage for macOS existed only behind path filters, never as a gate.

## Fix

Add a compile-only `check-darwin` job (macos-14) to the PR matrix and wire it into the `ci-required` aggregate (both the `needs:` list and the required-jobs loop):

- `cargo check --workspace --all-targets`
- `cargo check -p octos-cli --all-targets --features ${{ env.FEATURES }}`

Both steps pass `--all-targets` so `cfg(test)` code is compiled too — #2263's break lived in feature-gated test modules, which a lib-only check would never see. Compile-only (no test execution), so the cost is one macos-14 runner for the duration of a cargo check.

## Test evidence

Verified on an Apple Silicon Mac (macOS 26.5, cargo 1.96.0) against `origin/main` (11db2902):

- `cargo check --workspace --all-targets` — **green** (1m43s)
- `cargo check -p octos-cli --all-targets --features "api,telegram,discord,dingtalk,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"` — **green** (1m42s). This also confirms the #2263 call sites have since been cfg-gated on main, so the full feature + test-target combination compiles today.
- **End-to-end negative proof**: temporarily reverting the #2258 fix (dropping the macOS-gated `WrapErr` import in `crates/octos-cli/src/auth/keychain.rs`) makes the gate's command fail with the exact E0599 signature from #2258 at keychain.rs:384/428; restoring it returns to green. The gate catches the failure class it exists for.
- `actionlint` on the modified workflow: no new findings (the single `ubuntu-24.04-riscv` label warning pre-exists on main and is the intentional manual-only job).
- YAML parse verified; `ci-required` fails closed on a skipped/cancelled `check-darwin` (result != `success`), so the new job cannot silently report green without running — the failure mode this repo has hit before.

The job's own execution on this PR is the final end-to-end check: `check-darwin` should appear and go green below.

## Review

Independent adversarial review (given only the issue, the diff, and the repo paths) returned REQUEST_CHANGES with one Major and two Minors; all addressed:

- **Major**: the feature step originally omitted `--all-targets`, leaving the #2263 failure class ungated. Local verification showed the combination compiles on main today, so `--all-targets` was added to step 2 — the class is now covered outright, no deferred follow-up.
- **Minor**: corrected an over-broad claim about `e2e-tool-regression`'s feature set (it builds api+telegram, not all features).
- **Minor**: clarified that #2239 produced both breaks from one merge.

Note for the operator: `ci-required` already aggregates this job, so no ruleset change is needed for it to gate — the existing branch-protection status simply turns red if `check-darwin` fails.

Closes #2259