### PR TITLE
test(pipeline): widen the codergen worker-timeout promptness ceiling to 5s (#1932)

### DIFF
--- a/crates/octos-pipeline/tests/codergen_worker_timeout.rs
+++ b/crates/octos-pipeline/tests/codergen_worker_timeout.rs
@@ -89,8 +89,19 @@ async fn codergen_timeout_secs_cancels_stalled_worker() {
         "unexpected outcome: {}",
         outcome.content
     );
+    // #1932 — the ceiling's job is to prove the timeout is not WEDGED (a
+    // regression there hangs on the provider's 3_600s sleep, three orders of
+    // magnitude out). The fixed overhead on top of the 1s timeout is machine
+    // weather: 13ms measured on a fast dev host, but 620–730ms SOLO on the
+    // Windows Server runner that reported the flake (1.62s/1.63s/1.73s solo
+    // against the old 1_750ms ceiling — a ~20ms margin any suite-level load
+    // consumed). 5s still catches a unit-scale regression (secs↔minutes =
+    // 60s); what it no longer catches on fast hosts is a 2–4x wrong-scale
+    // timeout, a trade-off any ceiling above ~2.7s accepts — and on the
+    // runner that flaked, 1_750ms never had that coverage either (2s + 730ms
+    // overhead already exceeds it).
     assert!(
-        elapsed < Duration::from_millis(1_750),
+        elapsed < Duration::from_secs(5),
         "worker timeout should trip promptly, got {elapsed:?}"
     );
 }


### PR DESCRIPTION
## Problem

`codergen_timeout_secs_cancels_stalled_worker` asserts the 1s worker timeout trips within a 750ms wall-clock margin (`elapsed < 1_750ms`). #1932 documents it flaking under load on real hardware: on the Windows Server runner the identical test passes **solo** at 1.62s / 1.63s / 1.73s — fixed per-run overhead of 620–730ms on top of the 1s timeout — so the ceiling has a ~20ms effective margin that any suite-level load consumes. It already cost one red `check-windows`.

## Root cause

The assert measures wall-clock elapsed of the whole `handler.execute` call — provider resolution, tool-registry construction, prompt assembly, agent setup, sqlite-backed episode recall — against a fixed 750ms margin. That overhead is machine weather, not code behavior: 13ms measured on a fast dev host (1.013s internal elapsed), 620–730ms solo on the reporting runner. A fixed ceiling this tight asserts on machine speed.

## Fix

Widen the promptness ceiling from 1_750ms to 5s, per the issue's own first suggestion. What the ceiling protects is unchanged in kind:

- **Wedged timeout** (the regression this test exists for): the run would hang on `HangingProvider`'s 3_600s sleep — traced the path: nothing else bounds the blocked `chat()` call (the agent's own activity budget is only checked at loop-iteration boundaries, tool-batch timeouts wrap tool calls, not the LLM call). 5s catches it with three orders of magnitude of headroom.
- **Unit-scale regression** (secs↔minutes = 60s): still caught.
- The functional assertions (`OutcomeStatus::Error`, "timed out after 1s") are untouched, so the test still proves the outer `timeout_secs` branch — not an internal fallback — is what fired.

Acknowledged trade-off (also in the code comment): a 2–4x wrong-scale timeout is no longer caught on fast hosts. Any ceiling above ~2.7s accepts that — and on the runner that flaked, 1_750ms never had that coverage either (2s + 730ms overhead already exceeds it).

## Test evidence

- Solo before change: 15/15 pass on a fast host, internal elapsed 1.013s (measured via temporary instrumentation, removed before commit) — confirming the ~13ms fast-host overhead and that the margin is weather-dependent.
- Under CPU saturation (load average 33–44 on a 10-core host): 15/15 pass; this host is too fast to reach the 750ms ceiling — the red evidence is the issue's CI run plus the margin arithmetic above.
- After change: target test 6/6 green; full `cargo test -p octos-pipeline` green; `cargo fmt --check` clean; `cargo clippy -p octos-pipeline --tests` no warnings.

## End-to-end

The test itself is the end-to-end path: a real `CodergenHandler` with a real 1s `tokio::time::timeout` over a provider that hangs for 3_600s. Verified it still fires at ~1s, returns the `Error` outcome with the configured-duration message, and that the only behavior change is the ceiling.

## Review

One independent adversarial review (given only the issue, the diff, and the file): no Blockers/Majors; its three Minors (comment should name the wrong-scale trade-off, attribute the 13ms figure as measured, `from_secs(5)` over `from_millis(5_000)`) are all applied in the final diff, after which fmt/test/clippy were re-run green.

Closes #1932