### PR TITLE
refactor(ui-protocol): drop the dead profile-scope arm from the replay send loop

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -14562,8 +14562,9 @@ async fn should_retain_only_same_profile_goal_events_when_open_session_result_re
     );
 }
 
-/// #2067 boundaries 2 and 3 (session/open replay send loop + live forwarder):
-/// neither may put profile-b's durable goal frames on a profile-a connection.
+/// #2067 boundaries 1 and 3 (the `open_session_result` retain + live
+/// forwarder), observed on the wire: neither may put profile-b's durable goal
+/// frames on a profile-a connection.
 #[tokio::test]
 async fn should_drop_cross_profile_goal_frames_when_connection_scopes_another_profile() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -14626,7 +14627,7 @@ async fn should_drop_cross_profile_goal_frames_when_connection_scopes_another_pr
     .await;
     assert!(opened, "alpha must be able to open the shared session");
 
-    // Boundary 2 — the replay send loop.
+    // Boundary 1's retain, observed through the replay send loop.
     let frames = drain_session_open_frames(&mut rx).await;
     assert_eq!(
         replayed_goal_objectives(&frames),

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -19055,10 +19055,12 @@ async fn handle_session_open(
     // so dropping them is not lossy from their perspective.
     //
     // Reusing the helper keeps replay and live capability behavior in lockstep.
+    //
+    // No profile-scope arm here: `open_session_result` already retained this
+    // exact vector against this exact scope (`outcome.profile_scope`), so a
+    // second filter could never fire — and reading it as an independent gate
+    // would overstate the delivery path's defences.
     for event in outcome.replay {
-        if !ledger_event_matches_profile_scope(&event.event, outcome.profile_scope.as_deref()) {
-            continue;
-        }
         let projected = features
             .projection_envelope_v2
             .then(|| project_v2_ledger_event(ledger, &event.event, &event.cursor))
@@ -19208,9 +19210,9 @@ fn ledger_event_matches_topic_scope(
 }
 
 /// #2067 — a durable event that names a profile must reach ONLY connections
-/// resolved to that profile. This filter runs at all three delivery boundaries
-/// (the `replay.retain` in `open_session_result`, the session/open replay send
-/// loop, and the live forwarder pump), so a variant it does not recognise
+/// resolved to that profile. This filter runs at both delivery boundaries
+/// (the `replay.retain` in `open_session_result` and the live forwarder
+/// pump), so a variant it does not recognise
 /// leaks across tenants on every shared/unprofiled wire session key — which is
 /// exactly what `session/goal/updated` and `session/goal/cleared` did — and
 /// what the `loop/*` and `monitor/*` frames beside them did, since most of them


### PR DESCRIPTION
## Problem

#2078: `handle_session_open`'s replay send loop re-filters `outcome.replay` with `ledger_event_matches_profile_scope` against `outcome.profile_scope` — but `open_session_result` already retained that exact vector against that exact scope value. The second arm is dead by construction: it reads as defence-in-depth while providing none, and an auditor counting gates sees two where only one exists.

## Root cause

Same predicate, same input, same scope value at both boundaries:

- Boundary 1 (`open_session_result`): `replay.retain(|| ... && ledger_event_matches_profile_scope(&event.event, profile_scope.as_deref()))`, then `replay` is moved unmutated into `SessionOpenOutcome { replay, ..., profile_scope }` (the only constructor).
- Boundary 2 (`handle_session_open`): the send loop skipped events failing `ledger_event_matches_profile_scope(&event.event, outcome.profile_scope.as_deref())` — the same value, moved through the struct.

Traced on current main: no mutation of `replay` between retain and construction, no rebinding of `profile_scope`, single constructor, single consumer.

## Fix

Option 2 from the issue: delete the dead arm, point the send-loop comment at where filtering actually happens, and correct the two stale "three gates" attributions the arm left behind (the filter's doc comment and the wire-level test's boundary numbering). Option 1 (a genuinely independent send-time scope) is deliberately not applicable: #2067 made the per-connection scope frozen for the connection's lifetime, so `outcome.profile_scope` *is* the per-connection scope.

## Test evidence

- `cargo test -p octos-cli --features api --lib`: 3678 passed, 0 failed.
- The surviving guard is falsifiable at the wire level: `should_drop_cross_profile_goal_frames_when_connection_scopes_another_profile` drives `handle_session_open` end-to-end and asserts beta's frames never reach the alpha connection — after this PR that test actually pins boundary 1 (before, boundary 2 would have masked a boundary-1 regression). `should_retain_only_same_profile_goal_events_when_open_session_result_replays` pins the retain directly.
- `cargo fmt --all -- --check` clean; clippy with `-D warnings` clean on both the `api`-feature lib and the full feature matrix (`api,telegram,discord,dingtalk,slack,whatsapp,feishu,email,matrix,audio_mp3`, all-targets).
- End-to-end behaviour difference: none by construction (provably dead arm; same predicate/vector/scope, no side effects beyond `continue`). The wire-level suite above is the substitute evidence, and an independent review pass re-traced the dataflow and confirmed the deletion cannot change behaviour.

Closes #2078