### PR TITLE
docs: present Octos as an embeddable OUP harness kernel

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,114 +1,379 @@
-<div align="center">
+# Octos
 
-<pre>
- ██████╗  ██████╗████████╗ ██████╗ ███████╗
-██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔════╝
-██║   ██║██║        ██║   ██║   ██║███████╗
-██║   ██║██║        ██║   ██║   ██║╚════██║
-╚██████╔╝╚██████╗   ██║   ╚██████╔╝███████║
- ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝ ╚══════╝
-</pre>
+**用 Rust 编写、可嵌入应用的 AI Agent Harness 内核。**
 
-</div>
+Octos 为 AI Agent 应用提供执行循环、上下文管理、记忆、工具、技能、工作流和
+Agent 协作能力。你可以将内核编译进自己的应用，也可以通过 **OUP（Octos UI
+Protocol，Octos UI 协议）** 托管和控制它，让原生应用、终端、浏览器或另一个
+Agent 驱动同一套运行时。
 
-> 像章鱼一样——9 个大脑（1 个中央 + 8 个分布在手臂中，每条手臂一个）。每条手臂独立思考，但共享一个大脑。
+Octos 的核心架构是 **可复用的内核 + 可编程的协议边界**。应用负责界面和产品
+流程，Octos 负责 Agent 执行与运行时状态。面向人的客户端和自动化控制端，都能
+通过同一套 OUP 契约操作这个内核。
 
-一个 Rust 原生、API 优先的 Agentic 操作系统。
+[构建应用](#基于-octos-构建应用) · [通过 OUP 控制内核](#通过-oup-控制内核) ·
+[文档](https://octos-org.github.io/octos/zh/) · [English](README.md)
 
-31MB 静态二进制。约 140 个 REST 端点。16 个 LLM 提供者。14 个消息频道。多租户。零外部运行时依赖。
+## 想直接使用编码 Agent？
 
-## Octos 是什么？
+请从基于内核构建的应用开始：
 
-Octos 是一个开源 AI Agent 平台，能将任何 LLM 变成多频道、多用户的智能助手。你只需部署一个 Rust 二进制文件，连接 LLM API 密钥和消息频道（Telegram、Discord、Slack、WhatsApp、Matrix、邮件、微信、企业微信、飞书、Twilio 短信、QQ 等），Octos 会处理其余一切——对话路由、工具执行、记忆、提供者故障转移和多租户隔离。
+| 应用 | 从哪里开始 |
+| --- | --- |
+| **[Octoscode](https://github.com/octos-org/octoscode)** | 安装终端客户端；首次启动时会自动准备兼容的本地 Octos 运行时。 |
+| **[Octoscode Web](https://github.com/octos-org/octoscode-web)** | 按照[入门指南](https://github.com/octos-org/octoscode-web/blob/main/docs/getting-started.md)部署浏览器客户端，并连接 Octos 运行时。 |
 
-可以把它理解为 **AI Agent 的后端操作系统**。无需为每个场景从零构建聊天机器人，你只需配置 Octos 配置文件——每个配置拥有独立的系统提示、模型、工具和频道——然后通过 Web 仪表盘或 REST API 统一管理。一个小团队可以在一台机器上运行数百个专用 AI Agent。
+本仓库面向嵌入、扩展或集成 Harness 内核的开发者。应用安装和日常编码操作，
+请查看上面的客户端仓库。
 
-## 为什么选择 Octos
+## 基于 Octos 构建应用
 
-- **API 优先的 Agentic OS**：约 140 个 REST 端点（chat、sessions、admin、profiles、skills、swarm、pipeline、metrics、webhooks、SSE）。任何前端——Web、移动端、CLI、CI/CD——都可以基于其构建。
-- **原生多租户**：16GB 机器上 200+ 配置。每个配置是独立 OS 进程。Family Plan 子账户体系。
-- **多 LLM DOT 流水线**：DOT 图定义工作流。逐节点模型选择。动态并行扇出，带有限流以保证 Fleet 稳定性。
-- **Swarm 调度器**：将契约扇出到 N 个子 Agent，聚合产物，通过校验器审核，汇总成本——已接入 `/api/swarm/dispatch`。
-- **3 层提供者故障转移**：RetryProvider → ProviderChain → AdaptiveRouter。Hedge 竞速、Lane 评分、熔断器。
-- **静态、按配置收窄的工具面**：每轮向模型发送全部已启用工具的完整 schema（无动态淘汰——prompt 前缀保持缓存稳定）。`coding` 等运行时配置可收窄启用集合，`coding-full` 恢复完整工具面。`spawn_only` 工具自动转后台执行。
-- **5 种队列模式**：Followup、Collect、Steer、Interrupt、Speculative——通过 `/queue` 控制 Agent 并发。
-- **任意频道会话控制**：`/new`、`/s <名称>`、`/sessions`、`/back`——在 Telegram、Discord、Slack、WhatsApp、Matrix、飞书中可用。
-- **Sticky thread_id + committed_seq**：每个 SSE 事件都绑定到 thread；按提交序号确定性回放（M8.10）。
-- **3 层记忆**：长期（实体库，自动注入）、情景（任务结果在 redb）、会话（JSONL + LLM 三层压缩）。
-- **原生办公套件**：纯 Rust 操作 PPTX/DOCX/XLSX。
-- **沙箱隔离**：bwrap + sandbox-exec + Docker + Windows AppContainer。全工作区 `deny(unsafe_code)`。67 项注入测试。
+用 Octos 构建编码应用、带 Agent 能力的桌面应用、研究服务、工作流引擎，或一组
+协作 Agent。界面、模型提供者、工具和宿主环境都由你的应用选择。
 
-## 快速开始
+### 内核架构
 
-```bash
-# 默认 features 与 scripts/milestone-ci.sh 保持一致。
-# 不带 features 安装会得到一个缺少 `octos serve` 与各频道适配器的二进制。
-cargo install --path crates/octos-cli \
-    --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"
-octos init
-export ANTHROPIC_API_KEY=your-key-here
-octos chat
+将 Rust crates 或任务执行绑定嵌入应用，或通过 OUP 连接托管运行时。
+OUP 将命令传入内核，并将响应与事件返回客户端或控制端。
+
+```mermaid
+flowchart TB
+    Native["你的原生应用"]
+    Clients["Octoscode · Octoscode Web<br/>你的 OUP 客户端"]
+    Controllers["Codex · Claude Code<br/>其他 Agent"]
+    Adapter["你的 OUP 控制端适配器"]
+
+    subgraph Octos["Octos Harness 内核"]
+        OUP["OUP dispatcher<br/>WebSocket · stdio · 进程内适配器"]
+        Runtime["Agent 执行<br/>会话与轮次"]
+        Context["上下文 · 记忆<br/>持久化历史与回放"]
+        Execution["工具 · 技能 · 工作流<br/>权限与沙箱"]
+        Agents["子 Agent · Peer<br/>任务监督"]
+        Models["模型提供者<br/>路由与故障转移"]
+
+        OUP <--> Runtime
+        Runtime <--> Context
+        Runtime <--> Execution
+        Runtime <--> Agents
+        Runtime <--> Models
+    end
+
+    Native <-->|Rust crates 或任务执行绑定| Runtime
+    Clients <-->|请求、响应与事件| OUP
+    Controllers <--> Adapter
+    Adapter <--> OUP
 ```
 
-## 本地源码开发
+### 原生内核与库
 
-仓库顶层的 `Makefile` 封装了常见的本地开发流程；可用 `make help` 查看全部目标：
+Rust workspace 可以按应用需要组合：
 
-```bash
-make init                         # 交互式创建 ./.octos/config.json
-# 设置 init 中所选提供者对应的 API Key 环境变量，例如：
-export OPENAI_API_KEY=你的密钥
-make serve                        # 启动 API，并启用免密码本地登录
-make dev                          # 构建 /admin/、/app/ 后启动服务
-```
+| Crate | 在应用中的职责 |
+| --- | --- |
+| [`octos-core`](crates/octos-core) | 共享类型、OUP 命令、通知与协议编解码 |
+| [`octos-agent`](crates/octos-agent) | Agent 执行、上下文处理、工具、hooks、沙箱与任务监督 |
+| [`octos-memory`](crates/octos-memory) | 持久化记忆、任务经验与检索 |
+| [`octos-llm`](crates/octos-llm) | 模型提供者接口、路由、重试与故障转移 |
+| [`octos-plugin`](crates/octos-plugin) | 技能与插件集成 |
+| [`octos-pipeline`](crates/octos-pipeline) / [`octos-swarm`](crates/octos-swarm) | 工作流图、并行执行、验证与结果汇总 |
+| [`octos-bus`](crates/octos-bus) / [`octos-cli`](crates/octos-cli) | 会话基础设施、运行时组装、OUP 托管与适配层 |
 
-`make serve` 默认仅构建 `api` feature，并监听 `127.0.0.1:50080`。需要时可覆盖，例如
-`make serve PORT=50081 FEATURES=api,telegram`。`make dev` 需要 Node.js；它会初始化
-`octos-web` 子模块并调用现有的前端构建脚本。
-
-## 在 Zed 中使用 octos（ACP）
-
-`octos acp` 让 octos 成为一个 **ACP（[Agent Client Protocol](https://agentclientprotocol.com)）服务器**，可被 [Zed](https://zed.dev) 等 ACP 编辑器作为一等的编码 Agent 驱动——具备与 `octos chat` 相同的能力：你的工具 + 沙箱、长期记忆 + `MEMORY.md` 注入、技能/插件、MCP、hooks、上下文压缩、提供者故障转移。
-
-**1. 安装 octos 并初始化**（若尚未安装——完整安装方式见 [English README 的 Start here](README.md#start-here)）：
+在源码仓库中，构建原生 Agent 库或供其他语言调用的库：
 
 ```bash
-npm install -g @octos-org/octos      # 或用 Homebrew / 从源码构建（见快速开始）
-octos init                           # 选择提供者与模型，并粘贴该提供者的 API key
+cargo build --release -p octos-agent
+cargo build --release -p octos-ffi
 ```
 
-`octos init` 会引导你选择提供者与模型（本指南以 **DeepSeek** 为例），并提示你**粘贴该提供者的 API key**——安全存入 `auth.json`，且不依赖环境变量（`octos acp` 与 `octos chat` 一样解析 LLM）。按 Enter 跳过了？之后可用 `octos auth login --provider deepseek` 补上。Dock 启动的 Zed 不会继承你 shell 的环境变量，若想用环境变量传 key，请写进下面的 `env` 块。
+集成到其他 workspace 时，将相关 Octos crates 固定在同一个 Git revision。
+其他宿主语言可以使用 [C ABI](crates/octos-ffi/README.md)、
+[原生 Python 绑定](crates/octos-pyo3/README.md)或
+[Swift/Kotlin 绑定](crates/octos-uniffi/README.md)。C ABI 同时提供动态库和静态库。
+这些绑定提供任务执行接口；下文的 OUP 提供会话、轮次、监督与回放接口。
 
-**2. 在 Zed 设置中注册 octos**（`~/.config/zed/settings.json`，或运行 *zed: open settings*）。若 `octos` 在 `PATH` 中可用则用 `"command": "octos"`，否则填 `which octos` 的绝对路径（Dock 启动的 Zed 的 `PATH` 很精简，可能找不到裸 `octos`）：
+### 操作系统与处理器架构
 
-```jsonc
+面向 **Linux、Windows、macOS** 构建原生应用。CI 配置包含 Linux x86-64 与
+ARM64、macOS ARM64，以及 Windows x86-64。**RISC-V** 已定义手动 CI 任务，
+但仍是未验证的目标：配置中记录该任务尚未有 runner 执行。根据目标选择 crates、
+features 和原生依赖，具体支持取决于这一组合。
+
+其他操作系统上的应用可以通过 OUP 接入，也可以移植内核的平台集成部分，包括
+进程执行、文件系统访问与沙箱；应用和内核之间继续使用同一套协议边界。
+
+浏览器应用可以使用 [WASM crate](crates/octos-wasm/README.md)中的协议与工具类型。
+完整 Agent 内核运行在原生环境中，浏览器通过 OUP 与之通信。
+
+## 通过 OUP 控制内核
+
+**OUP（Octos UI Protocol）** 是面向应用与 Agent 控制端的 JSON-RPC 2.0 接口，
+通过 WebSocket 或按行分隔的 stdio 传输请求、响应和类型化运行时事件。
+本地运行时适配层也通过进程内连接使用 OUP dispatcher。
+
+本地控制端可以使用参考宿主 `octos serve --stdio`，由启用 `api` feature 的
+`octos-cli` 构建。WebSocket 客户端连接运行中宿主的 `/api/ui-protocol/ws`
+端点，并使用该宿主的认证配置。JSON-RPC 请求 ID 使用字符串。
+
+Stdio 客户端通过 `client_hello` 协商 features；WebSocket 客户端通过
+`X-Octos-Ui-Features` 或 `ui_feature` 查询参数请求 features。然后查询
+`config/capabilities/list`，根据运行时公告的方法与能力选择控制方式和事件格式。对话历史、执行状态、压缩、权限与已提交
+结果由运行时管理；客户端通过协议展示这些状态，或据此采取行动。
+
+### 让另一个 Agent 驱动 Octos
+
+控制端集成可以将 OUP 请求封装成 **Codex、Claude Code 或其他 Agent** 可调用的
+工具，让控制 Agent 向 Octos Agent 分配任务、观察执行、介入过程并收集结果。
+OUP 客户端或桥接层由这项集成提供。
+
+典型控制流程：
+
+1. **连接并协商能力。** 建立传输连接，协商 features，并查询
+   `config/capabilities/list`。
+2. **打开有明确作用域的会话。** 通过 `session/open` 指定会话标识、profile 和
+   workspace，保存运行时确认的会话标识。
+3. **分配工作。** 使用新的 turn ID 和结构化输入发送 `turn/start`。
+   RPC 响应表示轮次已被接纳；通过协商后的事件流跟踪最终结果。
+4. **观察并介入。** 接收消息、工具、任务和进度事件。使用 `turn/steer` 追加指令，
+   使用 `turn/interrupt` 停止轮次；需要授权决定或回答时，调用
+   `approval/respond` 或 `user_question/respond`。
+5. **协作与恢复。** 通过 `peer/prepare` 准备 Peer 的任务说明和可选 worktree，
+   再打开其会话并启动轮次。通过 `peer/gather` 收集持久化结果，通过 `task/*`
+   检查输出和产物；重连后重新加载会话，或从已提交的 cursor 继续回放。
+
+轮次被接纳后，控制端通过事件流跟踪执行。审批、提问与控制端介入按需发生；
+完成、失败或中断都会结束当前轮次。
+
+```mermaid
+flowchart TB
+    Connect["连接并协商能力<br/>config/capabilities/list"]
+    Session["打开有明确作用域的会话<br/>session/open"]
+    Start["分配工作<br/>turn/start"]
+    Run["内核执行轮次<br/>上下文、模型、工具与可选任务委派"]
+    Observe["控制端观察运行时事件"]
+    Next{"接下来发生什么？"}
+    Respond["回应待处理请求<br/>approval/respond 或 user_question/respond"]
+    Intervene["引导或停止当前轮次<br/>turn/steer 或 turn/interrupt"]
+    Collect["收集最终结果<br/>完成、失败或中断"]
+
+    Connect --> Session --> Start
+    Start -->|已接纳| Run
+    Run --> Observe --> Next
+    Next -->|更多事件| Observe
+    Next -->|审批或提问| Respond
+    Respond --> Run
+    Next -->|控制端介入| Intervene
+    Intervene --> Observe
+    Next -->|终结事件| Collect
+    Collect -.->|下一个任务| Start
+```
+
+例如，打开会话后，控制端可以发送下面的 `turn/start` 请求。将会话占位符替换为
+运行时确认的标识，并为每个轮次生成新的 UUID：
+
+```json
 {
-  "agent_servers": {
-    "Octos": {
-      "command": "octos",
-      "args": ["acp", "--provider", "deepseek", "--model", "deepseek-chat"],
-      "env": {}
-    }
+  "jsonrpc": "2.0",
+  "id": "request-1",
+  "method": "turn/start",
+  "params": {
+    "session_id": "<confirmed-session-id>",
+    "turn_id": "550e8400-e29b-41d4-a716-446655440000",
+    "input": [
+      { "kind": "text", "text": "审查这个工作区中的改动，报告问题并标明文件与行号。" }
+    ]
   }
 }
 ```
 
-> `args` 中的 `--provider`/`--model` 必须与第 1 步配置的提供者一致（本指南以 DeepSeek 为例）。`octos acp` 会从你的 `octos init` 配置继承其余字段——`base_url`、`api_type`、`api_key_env`——因此用 `deepseek` 参数指向另一个已配置的提供者会把错误的 key/端点发出去，导致会话失败。
+同一个控制端可以让 Octos 执行研究或实现任务，检查结果，再调整下一轮工作。
+OUP 提供将这种协作方式集成到应用中所需的控制接口与执行证据。
 
-**3. 在 Zed 中使用。** 先**打开一个文件夹**（外部 Agent 需要工作区，否则 Agent 面板只显示 *"Open Project"*），打开 **Agent 面板**（右侧停靠栏），点击 **＋ New Thread** 下拉（或按 `⌥⌘⇧N`），选择 **Octos**，然后输入提示词。octos 会运行完整 Agent 循环，并把工具、思考与结果流式返回 Zed，还会通过你的 `MEMORY.md` 跨轮次记忆。
+## 从 OUP 看内核能力
 
-> **找不到 Octos？** 它在 **＋ New Thread** 菜单（外部 Agent）里，**不在** `⋯` → *MCP / Context Servers* 列表中（那是另一个功能）。修改 `agent_servers` 后请用 `Cmd-Q` 彻底退出并重开 Zed 以重新加载配置。
+OUP 让应用能够在任务的整个生命周期中控制 Harness：检查 Agent 正在使用的
+上下文、回应工具审批、监督并行工作、恢复已提交的结果，都使用同一套运行时契约。
+内核负责执行与持久化，应用决定如何呈现状态、何时介入，以及如何组织下一步工作。
 
-> **当前限制：** 交互式工具审批提示与 `ask_user_question` 暂未透传到编辑器——octos 以自身（非交互）审批策略运行工具，而非 ACP 的 `session/request_permission`，因此在 `octos chat` 中会暂停等待审批的工具，在 Zed 中不会向你提示。其余能力一致。
+下列接口的可用性取决于运行时、传输方式和已协商的 features。集成时通过
+`config/capabilities/list` 发现能力，检查 `supported_methods` 与
+`supported_features`，并按协商后的格式接收事件，让应用适配实际连接的运行时。
 
-标志与 `octos chat` 一致：`--provider`、`--model`、`--base-url`、`--config`、`--data-dir`、`--cwd`、`--profile`、`--max-iterations`。Zed 通过 `session/new` 传入每会话工作目录，octos 以此作为工具、技能与文件系统作用域的根。
+### 上下文管理
 
-## 文档
+长任务会不断积累对话、工具输出与中间结果。Octos 管理模型的上下文预算，压缩较早
+的内容，并保留近期工具调用与结果之间的对应关系。压缩可以采用 LLM 摘要或启发式
+策略；稳定的提示前缀有助于提供者复用缓存，变化中的任务状态则进入持续演进的对话。
 
-📖 **[完整文档](https://octos-org.github.io/octos/zh/)** — 安装、配置、频道、提供者、记忆、技能、高级功能等。
+- **检查状态：** 协商 `context.lifecycle.v1` 后，通过 `session/status/read`
+  和 `session/hydrate` 读取运行时的上下文状态与压缩记录，了解处理后模型实际
+  可以看到的上下文。
+- **主动控制：** 使用 `session/compact` 请求压缩，使用
+  `session/compact/mode/set` 选择当前会话的压缩模式。
+- **观察变化：** 通过 `context/compaction_started` 和
+  `context/compaction_completed`，向用户或控制 Agent 解释上下文何时发生了变化。
 
-**English:** [English README](README.md) | [Documentation](https://octos-org.github.io/octos/)
+编码应用可以展示上下文用量与压缩历史；控制 Agent 可以在分配长任务的下一阶段前，
+检查执行 Agent 的上下文状态。
+
+### 跨任务记忆
+
+记忆层提供长期笔记、实体页面、任务经验记录与检索能力。混合索引将关键词搜索与
+可用 embedding 的向量相似度结合，让应用能够在不同会话间保留项目约定、设计决策
+和有用的任务结论。
+
+- **查看已有知识：** 在公告 `auxiliary.rest_to_ws.v1` 的 WebSocket 连接上，
+  通过 `memory/overview` 和 `memory/entity` 查看 profile 记忆。
+  这两个方法在 stdio 连接上不可用。
+- **在执行中读写：** 配备记忆工具的 Agent 可以使用 `recall_memory`、
+  `save_memory` 等工具检索和更新知识；这些名称属于 Agent 工具，并非 OUP RPC。
+- **区分用途：** 记忆提供可复用的知识；会话历史与事件回放记录某次对话实际发生了什么。
+
+### 持久化会话与恢复
+
+Octos 管理会话标识、工作区作用域、对话历史和已提交事件。客户端可以在重新加载后
+重建运行时中的对话状态，也可以为同一个已存储会话提供不同的交互界面。
+
+- **打开与检查：** `session/open` 建立会话并确认工作区；`session/hydrate`
+  恢复消息、轮次、待处理审批等请求的状态；`turn/state/get` 查询指定轮次的生命周期。
+- **断线重连：** 保存最后应用的持久化 cursor，重新打开会话时传入 `after`。
+  运行时先回放保留的已提交事件，再接入实时事件。尚未提交的增量可能丢失，过期 cursor
+  需要重新加载状态；能够回放历史也不代表断线前的轮次仍在运行。
+- **分支与回退：** `session/fork` 创建对话分支，`session/rollback` 回退对话轮次。
+  对话回退不会撤销文件系统中的修改。
+
+### 工具、权限与人工输入
+
+内核按照宿主的工具策略与平台沙箱配置执行文件系统、shell、Web 和 MCP 工具。
+宿主配置的生命周期 hooks 可以在模型调用和工具执行前后介入。OUP 暴露执行过程与
+需要决定的节点，让应用提供自己的审批界面，或将已授权范围内的决定交给控制 Agent。
+
+- **发现与观察：** `tool/status/list` 和 `mcp/status/list` 报告可用集成；
+  `tool/started`、`tool/progress` 和 `tool/completed` 让客户端跟踪工具执行。
+- **控制权限：** 使用 `permission/profile/list` 与 `permission/profile/set`
+  发现并选择权限配置；对于待处理的修改提案，通过 `diff/preview/get` 读取运行时
+  提供的差异预览。
+- **回应待处理决定：** 用 `approval/respond` 回应 `approval/requested`，
+  用 `user_question/respond` 回应 `user_question/requested`，关联原请求的标识，
+  并遵守宿主的授权策略。
+
+应用由此可以展示修改提案、收集决定、继续等待中的操作，并保留这次交互与所属轮次
+之间的关联。
+
+### 技能与扩展
+
+技能封装可复用指令和可执行能力；插件通过 manifest 声明工具与动作，并支持发现及
+环境条件检查。宿主可以为 Agent 加入领域能力，继续复用内核的执行与监督机制。
+
+- **管理 profile 技能：** 使用 `profile/skills/list`、
+  `profile/skills/registry/search`、`profile/skills/install` 和
+  `profile/skills/remove` 完成查询、搜索、安装与移除。
+- **提供应用动作：** `skill/action/list` 发现已声明动作，`skill/action/invoke`
+  执行动作。宿主可以把动作呈现为按钮、自动化步骤，或另一个 Agent 可调用的工具。
+- **跟踪后台动作：** `skill/action/job/list` 和 `skill/action/job/read`
+  查询持久化任务；支持时，通过 `skill/action/job/updated` 跟踪生命周期变化。
+
+### 工作流与任务监督
+
+Pipeline 库用 DOT 图描述多步骤任务，支持逐节点模型选择、并行分支、条件、检查点、
+人工确认节点与产物验证。宿主可以通过 Rust 库组装工作流，也可以让 Agent 通过工具
+启动已配置的工作流，再通过 OUP 监督生成的任务。
+
+- **跟踪执行：** `task/list`、`task/updated` 和 `task/output/delta` 提供任务
+  状态与实时输出；`task/output/read` 读取已记录的输出；`task/artifact/list`
+  和 `task/artifact/read` 提供保留的产物。
+- **介入与恢复：** `task/cancel` 停止指定作用域中的活动任务；
+  `task/restart_from_node` 重新启动已结束的任务并返回新的任务 ID，支持此能力的
+  Pipeline 任务可以从指定节点重新开始。
+- **使用内置编排入口：** 当运行时公告 `review/start` 时，可以启动受监督的审查
+  工作流，并通过同一套轮次、任务和 Agent 接口跟踪进展。
+
+应用可以展示工作流进度，检查失败的验证步骤及其输出，再请求适当的重试并跟踪新任务。
+
+### 子 Agent 与 Peer 协作
+
+Octos 提供多种并行执行方式：子 Agent 接受委派任务并向父 Agent 返回结果；Peer
+拥有独立会话，可由客户端或控制端检查和引导；受监督的后台工具任务可以不创建新的
+LLM 循环。
+
+- **监督委派工作：** 使用 `agent/list`、`agent/status/read`、`agent/output/read`
+  和 `agent/artifact/*` 查询状态、输出与产物。这套监督接口也覆盖支持的后台任务，
+  因而其中的条目不一定对应独立的模型对话。
+- **准备独立 Peer：** `peer/prepare` 保存持久化任务说明，并可创建独立 Git
+  worktree。这个调用负责准备资源；控制端随后通过 `session/open` 和 `turn/start`
+  启动各 Peer 的工作。
+- **协调与收集：** 通过普通轮次控制接口引导 Peer，使用 `peer/gather` 读取任务
+  说明和 Peer 轮次结束时持久化的最新结果，再由控制端决定如何汇总。
+
+例如，宿主可以为实现和审查分配不同会话与 worktree，在审查任务中指定待审查的修改，
+再把双方的结论收集到协调会话。
+
+### 目标、循环与监控
+
+Goal 记录 Agent 要完成什么，Loop 安排周期性轮次，Monitor 观察命令输出并在匹配
+事件出现时唤醒 Agent。这些机制组合起来，支持跨多个轮次持续推进的工作，并让应用
+能够检查和控制其状态。
+
+- **持久化目标：** `session/goal/set`、`session/goal/get` 和
+  `session/goal/clear` 管理目标。目标记录包含状态、Token 预算、Token 用量和累计
+  使用时间；`session/goal/updated` 报告变化。
+- **安排周期性工作：** `loop/create`、`loop/list`、`loop/pause`、`loop/resume`、
+  `loop/fire_now` 和 `loop/delete` 管理循环执行；循环事件报告触发与完成。
+- **响应外部信号：** `monitor/create` 配置命令、输出过滤条件与投递限制；
+  `monitor/list`、`monitor/pause`、`monitor/resume` 和 `monitor/delete`
+  管理监控；`monitor/fired` 报告匹配的活动。
+
+宿主可以安排定期项目检查，或在受监控的构建输出错误时唤醒 Agent；界面同时展示目标、
+已用预算、活动计划，以及暂停后续工作的控制项。
+
+### 模型提供者与路由
+
+模型层集成不同提供者，支持模型配置、重试与故障转移链，以及自适应路由。应用可以为
+交互式任务选择模型，也可以为工作流节点配置不同的提供者通道。
+
+- **配置提供者：** `profile/llm/catalog`、`profile/llm/list`、`profile/llm/upsert`、
+  `profile/llm/test` 和 `profile/llm/select` 支持发现、配置、连接测试与选择。
+- **配置工作流通道：** 已公告的 `profile/sub_providers/*` 方法管理逐节点路由使用的
+  命名提供者通道；修改在对应运行时重新构建后生效。
+- **检查路由：** `router/status` 和 `router/failover` 提供路由事件；
+  `router/get_metrics` 与 `router/set_mode` 提供已公告的指标查询和控制接口。
+
+### 把这些能力组合起来
+
+通过适配器接入的 Codex、Claude Code 或自定义 Agent，可以基于这些机制实现
+“实现—审查—修正”的控制流程：
+
+1. 打开绑定工作区的会话，发现可用能力；支持 Goal 时，设置具体目标与预算。
+2. 为范围明确的实现或调查任务准备 Peer，打开各自的会话，并带着明确任务说明启动轮次。
+3. 跟踪工具和任务事件，回应已授权的审批，在出现新约束时引导正在执行的工作。
+   各会话内的上下文管理、工具调用与已配置工作流由内核执行。
+4. 收集 Peer 结果，检查任务输出与产物，再启动审查或验证工作，根据证据决定是否需要
+   下一轮修改。
+5. 保存会话标识与持久化 cursor，让界面在重连时重新加载已提交状态。
+
+宿主实现协调策略，Octos 提供执行、状态与控制机制，并通过 OUP 暴露可观察的过程。
+
+## 开发者文档
+
+- [OUP 协议规范](api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md)
+- [OUP 类型与编解码](crates/octos-core/src/ui_protocol.rs)
+- [运行时架构](docs/ARCHITECTURE.md)
+- [Harness 开发者接口](docs/OCTOS_HARNESS_DEVELOPER_INTERFACE.md)
+- [产物与工作流集成指南](docs/OCTOS_HARNESS_DEVELOPER_GUIDE.md)
+- [Harness 兼容性与版本管理](docs/OCTOS_HARNESS_ABI_VERSIONING.md)
+- [文档站点](https://octos-org.github.io/octos/zh/)
+
+## 参与开发
+
+根据修改涉及的 crates 运行相应检查。Workspace 检查命令：
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+协议变更需要同步维护规范、Rust 类型、运行时分发、能力公告与客户端行为。
 
 ## 许可证
 
-详见 [LICENSE](LICENSE) 文件。
+Apache-2.0，详见 [LICENSE](LICENSE)。

--- a/README.md
+++ b/README.md
@@ -1,658 +1,446 @@
-<div align="center">
+# Octos
 
-<pre>
- ██████╗  ██████╗████████╗ ██████╗ ███████╗
-██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔════╝
-██║   ██║██║        ██║   ██║   ██║███████╗
-██║   ██║██║        ██║   ██║   ██║╚════██║
-╚██████╔╝╚██████╗   ██║   ╚██████╔╝███████║
- ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝ ╚══════╝
-</pre>
+**An embeddable AI agent harness kernel, written in Rust.**
 
-</div>
+Octos provides the execution loop, context management, memory, tools, skills,
+workflows, and agent coordination for applications built around AI agents.
+Compile the kernel into your own application, or host it behind **OUP — the
+Octos UI Protocol** — and control it from a native app, a terminal, a browser,
+or another agent.
 
-> Like an octopus — 9 brains (1 central + 8 in the arms, one per arm). Every arm thinks independently, but they share one brain.
+The defining architecture is **a reusable kernel with a programmable protocol
+boundary**. Your application owns its interface and product workflow; Octos
+owns agent execution and runtime state. The same OUP contract lets a human-facing
+client and an automated controller operate that runtime.
 
-Octos is your own AI assistant, running on your own computer. Install one small program, connect any major AI provider (Anthropic, OpenAI, Gemini, DeepSeek, …), and chat with an agent that can run code, browse the web, remember things, schedule jobs, and build documents — from your browser, your terminal, or apps like Telegram, WhatsApp, and Discord. Your sessions, memory, and data stay on your machine — prompts go only to the AI provider you choose.
+[Build with Octos](#build-with-octos) · [Control through OUP](#control-through-oup) ·
+[Documentation](https://octos-org.github.io/octos/) · [中文](README-zh.md)
 
-## Start here
+<a id="start-here"></a>
+<a id="quick-start"></a>
 
-The fastest way to a working assistant, on the supported platforms (macOS Apple Silicon, Linux x86-64/arm64, Windows x64):
+## Looking for a coding agent to use?
+
+Start with an application built on the kernel:
+
+| Application | Where to start |
+| --- | --- |
+| **[Octoscode](https://github.com/octos-org/octoscode)** | Install the terminal client. It provisions a compatible local Octos runtime on first launch. |
+| **[Octoscode Web](https://github.com/octos-org/octoscode-web)** | Set up the browser client using its [getting-started guide](https://github.com/octos-org/octoscode-web/blob/main/docs/getting-started.md), and connect it to an Octos runtime. |
+
+This repository is for developers embedding, extending, or integrating the
+harness kernel. Application installation and everyday coding workflows belong
+in the client repositories above.
+
+<a id="embed-octos"></a>
+
+## Build with Octos
+
+Use Octos as the foundation for a coding application, an agent-powered desktop
+app, a research service, a workflow engine, or a fleet of cooperating agents.
+Bring your own interface, model providers, tools, and host environment.
+
+### Kernel architecture
+
+Embed the Rust crates or task bindings in your application, or connect through
+OUP to a hosted runtime. OUP carries both commands into the kernel and responses
+and events back to the client or controller.
+
+```mermaid
+flowchart TB
+    Native["Your native application"]
+    Clients["Octoscode · Octoscode Web<br/>Your OUP client"]
+    Controllers["Codex · Claude Code<br/>Other agents"]
+    Adapter["Your OUP controller adapter"]
+
+    subgraph Octos["Octos harness kernel"]
+        OUP["OUP dispatcher<br/>WebSocket · stdio · in-process adapters"]
+        Runtime["Agent execution<br/>Sessions and turns"]
+        Context["Context · memory<br/>Durable history and replay"]
+        Execution["Tools · skills · workflows<br/>Permissions and sandboxing"]
+        Agents["Sub-agents · peers<br/>Task supervision"]
+        Models["Model providers<br/>Routing and failover"]
+
+        OUP <--> Runtime
+        Runtime <--> Context
+        Runtime <--> Execution
+        Runtime <--> Agents
+        Runtime <--> Models
+    end
+
+    Native <-->|Rust crates or task bindings| Runtime
+    Clients <-->|Requests, responses, events| OUP
+    Controllers <--> Adapter
+    Adapter <--> OUP
+```
+
+### Native kernel and libraries
+
+The Rust workspace lets you compose the parts your application needs:
+
+| Crate | Role in your application |
+| --- | --- |
+| [`octos-core`](crates/octos-core) | Shared types, OUP commands, notifications, and wire codecs |
+| [`octos-agent`](crates/octos-agent) | Agent execution, context handling, tools, hooks, sandboxing, and task supervision |
+| [`octos-memory`](crates/octos-memory) | Persistent memory, episodes, and retrieval |
+| [`octos-llm`](crates/octos-llm) | Provider interfaces, model routing, retries, and failover |
+| [`octos-plugin`](crates/octos-plugin) | Skill and plugin integration |
+| [`octos-pipeline`](crates/octos-pipeline) / [`octos-swarm`](crates/octos-swarm) | Workflow graphs, parallel workers, validation, and result aggregation |
+| [`octos-bus`](crates/octos-bus) / [`octos-cli`](crates/octos-cli) | Session infrastructure, runtime composition, and OUP hosting/adapters |
+
+From a checkout, build the native agent library or a library for a non-Rust host:
 
 ```bash
-# 1. Install
-brew tap octos-org/octos https://github.com/octos-org/octos
-brew install octos-org/octos/octos      # or: npm install -g @octos-org/octos
-
-# 2. Choose your AI provider and a model (interactive — pick a real
-#    model name; some providers reject the "auto" default)
-octos init
-
-# 3. Sign in to that provider — or paste its API key; stored securely
-octos auth login --provider deepseek    # use the provider you chose above
-
-# 4. Start your agent with password-free local sign-in
-octos serve --solo
+cargo build --release -p octos-agent
+cargo build --release -p octos-ffi
 ```
 
-Now open **http://localhost:50080** (it lands on `/app/`), click the local sign-in button, and say hello. That's the whole setup.
+Pin related Octos crates to the same Git revision when integrating them into
+another workspace. For other host languages, use the
+[C ABI](crates/octos-ffi/README.md), [native Python binding](crates/octos-pyo3/README.md),
+or [Swift/Kotlin bindings](crates/octos-uniffi/README.md). The C ABI produces
+shared and static libraries. These bindings expose task execution; OUP provides
+the session, turn, supervision, and replay interface described below.
 
-Prefer a hands-off install that runs Octos as a background service (auto-start, bundled skills, dashboard on port 8080)? Use the installer script instead — see [self-hosted install options](https://github.com/octos-org/octos-web#self-hosting--deployment):
+### Platforms and architectures
 
-```bash
-# macOS / Linux
-curl -fsSL https://github.com/octos-org/octos/releases/latest/download/install.sh | bash
+Build native applications for **Linux, Windows, and macOS**. CI configurations
+include Linux x86-64 and ARM64, macOS ARM64, and Windows x86-64. **RISC-V** has a
+manual CI definition, but remains an unverified target: the configuration records
+that no runner has executed the job. Select the crates, features, and native
+dependencies for your target; support depends on that combination.
+
+Other operating systems can connect an application through OUP or port the
+kernel's platform integrations, including process execution, filesystem access,
+and sandboxing. The application/protocol boundary stays the same.
+
+For browser applications, [the WASM crate](crates/octos-wasm/README.md) supplies
+protocol and utility types. The full agent kernel runs natively, with the
+browser communicating over OUP.
+
+## Control through OUP
+
+**OUP (Octos UI Protocol)** is a JSON-RPC 2.0 interface for applications and agent
+controllers. It carries requests, responses, and typed runtime events over
+WebSocket or newline-delimited stdio. Local runtime adapters also use an
+in-process connection to the OUP dispatcher.
+
+For a local controller, the reference host is `octos serve --stdio`, built from
+`octos-cli` with the `api` feature. A WebSocket client connects to a running
+host's `/api/ui-protocol/ws` endpoint using that host's authentication settings.
+Use string JSON-RPC request IDs.
+
+Stdio clients negotiate features with `client_hello`; WebSocket clients request
+them through `X-Octos-Ui-Features` or the `ui_feature` query parameter. Query
+`config/capabilities/list` to discover supported methods, then use the advertised
+capabilities to choose controls and event formats. The runtime owns conversation history, execution state,
+compaction, permissions, and committed results; clients render or act on that
+state through the protocol.
+
+### Drive Octos from another agent
+
+A controller integration can expose OUP requests as tools callable by **Codex,
+Claude Code, or another agent**. This gives the controlling agent a way to
+assign work to Octos agents, observe execution, intervene, and collect results.
+The integration supplies the OUP client or bridge.
+
+A typical controller flow is:
+
+1. **Connect and negotiate.** Establish a transport, negotiate feature support,
+   and query `config/capabilities/list`.
+2. **Open a scoped session.** Use `session/open` with the session identity,
+   profile, and workspace; retain the identity confirmed by the runtime.
+3. **Assign work.** Send `turn/start` with a fresh turn ID and structured input.
+   The RPC acknowledgement means the turn was accepted; follow the negotiated
+   event stream to its terminal outcome.
+4. **Observe and intervene.** Consume message, tool, task, and progress events.
+   Use `turn/steer` to add instructions, `turn/interrupt` to stop a turn, and
+   `approval/respond` or `user_question/respond` when an authorized decision or
+   answer is needed.
+5. **Coordinate and recover.** Use `peer/prepare` to stage a peer's brief and
+   optional worktree, then open its session and start its turn. Gather durable
+   peer results through `peer/gather`; inspect task output and artifacts through
+   `task/*`. Rehydrate a session or resume from its committed cursor after a
+   reconnect.
+
+The controller follows the event stream after a turn is accepted. Approvals,
+questions, and interventions are optional; completion, failure, or interruption
+ends the turn.
+
+```mermaid
+flowchart TB
+    Connect["Connect and negotiate features<br/>config/capabilities/list"]
+    Session["Open a scoped session<br/>session/open"]
+    Start["Assign work<br/>turn/start"]
+    Run["Kernel executes the turn<br/>Context, models, tools, optional delegation"]
+    Observe["Controller observes runtime events"]
+    Next{"What happens next?"}
+    Respond["Respond to a pending request<br/>approval/respond or user_question/respond"]
+    Intervene["Guide or stop the live turn<br/>turn/steer or turn/interrupt"]
+    Collect["Collect the final outcome<br/>Result, failure, or interruption"]
+
+    Connect --> Session --> Start
+    Start -->|Accepted| Run
+    Run --> Observe --> Next
+    Next -->|More events| Observe
+    Next -->|Approval or question| Respond
+    Respond --> Run
+    Next -->|Controller intervention| Intervene
+    Intervene --> Observe
+    Next -->|Terminal event| Collect
+    Collect -.->|Next task| Start
 ```
 
-### If something looks wrong
-
-| Symptom | Fix |
-|---|---|
-| The page doesn't load | Is `octos serve --solo` still running? Solo serve uses port **50080**; the service installer uses port **8080** — check the one you set up. |
-| The agent doesn't reply | No provider credential yet — run `octos auth login --provider <name>` (or export the provider's API key env var, or add the key in the dashboard settings). An `invalid model` error means the provider rejected the configured model name — re-run `octos init` and pick a real one (e.g. `deepseek-v4-flash`). |
-| The dashboard (`/admin/`) asks for a login | Use the **"Login with admin token"** tab with the `Auth token:` the installer printed (also stored in the service file — see *First login to the dashboard* in the [octos-web self-hosting guide](https://github.com/octos-org/octos-web#self-hosting--deployment)). |
-| Not sure what's wrong | `octos status` shows what's running; `octos doctor` checks your environment. |
-
-### The pieces
-
-- **octos** (this repo) — the **kernel**: the agent runtime, LLM providers, tools, sandbox, memory, channels, and the API everything else speaks. Install this first — then live in a client:
-- **[octos-web](https://github.com/octos-org/octos-web)** — the full app experience in the browser (chat, voice, projects, slides, admin, and the hosted multi-tenant signup). A build ships inside the server — open `/app/`.
-- **[octoscode](https://github.com/octos-org/octoscode)** — the terminal experience, in the spirit of Claude Code.
-
-**Stuck?** [Documentation](https://octos-org.github.io/octos/) · [Issues](https://github.com/octos-org/octos/issues)
-
----
-
-A Rust-native, API-first Agentic OS.
-
-31MB static binary. 80+ REST endpoints + UI Protocol v1 over WebSocket/stdio. 16 LLM providers. 14 messaging channels. Multi-tenant. Zero external runtime services.
-
-## What is Octos?
-
-Octos is an open-source AI agent platform that lets you run your own AI system on a single machine or across a cloud-and-device pair. You deploy one Rust binary, connect your LLM provider and channels, and Octos handles routing, sessions, tools, memory, and multi-user isolation through a web dashboard and REST API.
-
-You can think of it as the **backend operating system for AI agents**. Instead of building a new chatbot stack for every use case, you configure Octos profiles with their own prompts, models, tools, and channels, then manage them from one control plane.
-
-Beyond the quick local setup above, Octos can be deployed three ways:
-
-1. **Octos Cloud signup** — a hosted multi-tenant account at [octos.cloud](https://octos.cloud); the signup experience belongs to the web client (see the [octos-web README](https://github.com/octos-org/octos-web#octos-cloud)).
-2. **Self-hosted local** — run Octos only on your own machine or local network.
-3. **Self-hosted cloud + tenant pair** — run your own public VPS plus your own tenant device for internet-accessible remote use.
-
-## Why Octos
-
-Most agentic systems are single-tenant chat assistants — one user, one model, one conversation at a time. Octos is different:
-
-- **API-first Agentic OS**: 80+ REST endpoints (chat, sessions, admin, profiles, skills, swarm, pipeline, metrics, webhooks) plus **UI Protocol v1** — a JSON-RPC contract over WebSocket and stdio for interactive clients. Any frontend — web, mobile, CLI, CI/CD — can be built on top.
-- **Multi-tenant by design**: One 31MB binary serves 200+ profiles on a 16GB machine. Each profile is a separate OS process with isolated memory, sessions, and data. Family Plan sub-accounts.
-- **Multi-LLM DOT pipelines**: Define workflows as DOT graphs. Per-node model selection. Dynamic parallel fan-out spawns N concurrent workers at runtime, with bounded concurrency for fleet stability.
-- **Multi-agent topologies**: sub-agents (in-process children you own), peer agents (sovereign sibling sessions via `peer_handoff`/`peer_gather`), and a **swarm dispatcher** (fan contracts to N workers — native or external `claude -p`/`codex exec` — validator-gated, cost rolled up, at `/api/swarm/dispatch`). See [Agent topologies](#agent-topologies-sub-agents-peers--swarm).
-- **3-layer provider failover**: RetryProvider → ProviderChain → AdaptiveRouter. Hedge racing, lane scoring, circuit breakers.
-- **Static, profile-scoped tool surface**: every enabled tool's full schema is sent to the LLM each turn (no dynamic eviction — the prompt prefix stays cache-stable). Runtime profiles such as `coding` narrow the enabled set; `coding-full` restores the broad surface. `spawn_only` tools auto-redirect to background execution.
-- **5 queue modes per session**: Followup, Collect, Steer, Interrupt, Speculative — users control agent concurrency via `/queue`.
-- **Session control in any channel**: `/new`, `/s <name>`, `/sessions`, `/back` — works in Telegram, Discord, Slack, WhatsApp, DingTalk, Matrix, Feishu.
-- **Sticky thread_id + committed_seq**: Every SSE event is bound to a thread; replay is deterministic by committed sequence number (M8.10).
-- **3-layer memory**: Long-term (entity bank, auto-injected), episodic (task outcomes in redb), session (JSONL + LLM compaction, three-tier).
-- **Autonomy — goals & loops**: `/goal <objective>` keeps the agent working across turns via checkpointed continuations (under a token budget); `/loop` runs a task on a fixed interval or self-paced. The agent keeps going between your messages — see [Autonomy: goals & loops](#autonomy-goals--loops).
-- **Session time-travel**: `session/rollback` RPC with resume/rewind checkpoint pickers in both clients; every session can be rolled back to any prior user turn.
-- **Live reasoning**: streams the model's thinking as it happens, with per-session `/thinking` effort control.
-- **Voice**: per-profile cloud TTS voices, rich HTML/image voice output, dedicated batch-ASR routing via `ASR_API_URL`, and an OMiniX fallback for local ASR/TTS.
-- **Native office suite**: PPTX/DOCX/XLSX via pure Rust (zip + quick-xml).
-- **Sandbox isolation**: bwrap + Landlock/seccomp + sandbox-exec + Docker + Windows AppContainer. `deny(unsafe_code)` workspace-wide. 67 prompt injection tests.
-
-## Self-hosting & deployment
-
-The full setup and hosting guide — the three deployment paths (Octos Cloud
-signup, self-hosted local, and self-hosted cloud + tenant pair), the install
-scripts, package-manager installs, first dashboard login, uninstall, config
-locations, and runtime modes — lives in the **[octos-web README →
-Self-hosting & deployment](https://github.com/octos-org/octos-web#self-hosting--deployment)**.
-
-The [Start here](#start-here) steps above are the quickest local install; that
-guide covers the managed-signup, background-service, and public-VPS options.
-
-## Build from source
-
-For development against an unreleased checkout:
-
-### Local development shortcuts
-
-The repository's `Makefile` wraps the common local workflow while retaining
-the existing build scripts. Run `make help` to see every target.
-
-```bash
-make init                         # creates ./.octos/config.json interactively
-# set the API key variable for the provider selected during init, for example:
-export OPENAI_API_KEY=your-key-here
-make serve                        # API + local password-free sign-in
-make dev                          # build /admin/ and /app/, then start the server
-```
-
-`make serve` builds only the `api` feature and serves on `127.0.0.1:50080` by
-default. Override values when needed, for example
-`make serve PORT=50081 FEATURES=api,telegram`. `make dev` requires Node.js;
-it initializes the `octos-web` submodule and invokes the existing frontend
-build scripts.
-
-```bash
-# Build and install. The features below are the canonical default
-# (matches scripts/milestone-ci.sh) — `octos serve` requires `api`,
-# and the gateway needs the relevant channel feature for each
-# transport (telegram, discord, etc.). A bare `cargo install --path
-# crates/octos-cli` will give you a binary missing `serve` and
-# without channel adapters.
-cargo install --path crates/octos-cli \
-    --features "api,telegram,discord,dingtalk,whatsapp,feishu,twilio,wecom,wecom-bot"
-
-# Initialize workspace
-octos init
-
-# Set API key (any supported provider — auto-detected during install)
-export OPENAI_API_KEY=your-key-here    # or ANTHROPIC_API_KEY, GEMINI_API_KEY, etc.
-
-# Interactive chat
-octos chat
-
-# Multi-channel gateway
-octos gateway
-
-# Web dashboard + REST API + UI Protocol
-octos serve
-octos serve --solo     # same, plus password-free local login for the web app
-octos serve --stdio    # UI Protocol over stdio (how octoscode embeds a backend)
-```
-
-The full CLI surface (see `octos help`):
-
-| Command | Purpose |
-|---|---|
-| `chat` / `gateway` / `serve` | the three runtime modes |
-| `init` / `status` / `doctor` | workspace init, node status, environment diagnostics |
-| `auth` / `account` / `admin` | provider login (OAuth/PKCE), sub-accounts, tenant & tunnel admin |
-| `channels` / `cron` / `skills` | messaging channels, scheduled jobs, skill install/remove |
-| `mcp-serve` | run octos as an MCP server, so outer orchestrators can drive it as a sub-agent |
-| `mcp` | `mcp login` / `logout` for OAuth-gated MCP servers octos connects to as a **client** (external MCP tools are declared in `config.json` → `mcp_servers`) |
-| `acp` | run octos as an [Agent Client Protocol](https://agentclientprotocol.com) agent over stdio, so editors like Zed drive it as their coding agent |
-| `office` | PPTX/DOCX/XLSX manipulation from the shell |
-| `update` / `clean` / `completions` / `docs` | release check, cache cleanup, shell completions, doc generation |
-
-For a repo-local tenant deploy (builds from source, sets up the same service + tunnel as `install.sh`), use `scripts/local-tenant-deploy.sh --full`.
-
-### Iterating on a system-installed octos
-
-`cargo install --path crates/octos-cli --features "api,..."` only drops a binary into `~/.cargo/bin`. It does **not** rebuild the embedded admin dashboard or touch the service installed by `scripts/install.sh` (the LaunchDaemon on macOS / systemd unit on Linux runs `/usr/local/bin/octos`). If you have already run `install.sh` and want to redeploy local changes, use:
-
-```bash
-./scripts/build-local-bundle.sh --install           # build + bundle + reinstall
-./scripts/build-local-bundle.sh --install --tunnel  # same, with tunnel flags passed through
-./scripts/build-local-bundle.sh --skip-dashboard    # only Rust changed, skip npm/vite
-```
-
-What it does:
-
-1. Detects your host triple (mirrors `install.sh`'s platform mapping).
-2. Runs `scripts/build-dashboard.sh` (admin SPA → `/admin/`) and `scripts/build-web-app.sh` (the octos-web submodule → `/app/`) so `rust_embed` bakes both SPAs into the binary. Skip the dashboard build and `/admin/` returns a 503 `admin_bundle_missing` diagnostic; skip the web build and `/app/` returns `web_bundle_missing` (and the root `/` falls back to redirecting to `/admin/`).
-3. Delegates `cargo build --release` to `scripts/milestone-ci.sh release-bundle` (single source of truth for `FEATURES` / `SKILL_CRATES`).
-4. Tars binaries into `scripts/octos-bundle-<TRIPLE>.tar.gz`, which `install.sh` auto-detects via `file://`, skipping the GitHub download.
-5. With `--install`, chains into `install.sh` — copies binaries to `$PREFIX`, rewrites the service plist/unit, reloads the daemon.
-
-Use this when:
-
-- You changed Rust **or** dashboard code and need to see it running under the installed service.
-- You want to exercise the full installer flow against a local build.
-
-Skip it when you just need the CLI — `cargo install --path crates/octos-cli --features "api,telegram,discord,dingtalk,whatsapp,feishu,twilio,wecom,wecom-bot"` is faster. Trim the feature list to only the channels you need (or just `api` for `octos chat` + `octos serve`); leaving `api` off is what causes `octos serve` to fail with `unrecognized subcommand 'serve'`.
-
-## Use octos as a library
-
-Everything above builds the **binary**. octos is also embeddable — as Rust crates, or through C/Python/Swift/Kotlin/JS bindings that wrap the same agent loop.
-
-### Rust
-
-The crates are **not published to crates.io** (`publish = false` in the workspace), so depend on them by git. Pin a tag; `main` moves fast:
-
-```toml
-[dependencies]
-octos-core  = { git = "https://github.com/octos-org/octos", tag = "v2.0.2" }
-octos-agent = { git = "https://github.com/octos-org/octos", tag = "v2.0.2" }
-```
-
-```rust
-use octos_agent::{HookConfig, HookEvent, HookExecutor};
-
-let executor = HookExecutor::new(vec![HookConfig {
-    event: HookEvent::BeforeSpawnVerify,
-    command: vec!["/usr/local/bin/verify-motion".into()],
-    timeout_ms: 5000,
-    tool_filter: vec![],
-    path_filter: vec![],
-    requires_bin: None,
-}]);
-```
-
-Take the smallest layer that does the job — each row pulls in the ones above it:
-
-| Crate | Use it for | Weight |
-| --- | --- | --- |
-| `octos-core` | protocol types, task model, IDs, codecs | leaf — pure deps, the only crate that compiles to `wasm32` |
-| `octos-llm` | provider abstraction, failover/routing | + HTTP/TLS |
-| `octos-memory` | episodic store, hybrid BM25 + vector recall | + `redb` (filesystem) |
-| `octos-agent` | the full loop: tools, sandbox, approvals, hooks | + `tokio` multi-thread, browser/CDP |
-
-Worked examples live in `crates/octos-agent/examples/` — `robot_domain_hook.rs` shows the domain-hook pattern integrators use to veto a dispatched sub-task from live telemetry, without adding domain-specific variants to the core.
-
-Feature flags worth knowing: `octos-agent` defaults to `browser` (CDP `web_search` fallback) and offers `git` and `ast`; in-process embeddings come from `octos-embed-llama` (`embed-llama`, plus `metal` / `cuda`), which is cross-platform and defaults to a CPU backend.
-
-### From other languages
-
-`octos-ffi` is the native core; `octos-pyo3` and `octos-uniffi` are built over it, so those three share behaviour and feature flags. `octos-wasm` is separate — it binds `octos-core` only (see below).
-
-| Binding | Target | Build |
-| --- | --- | --- |
-| **`octos-pyo3`** | Python — **the recommended Python path** | `maturin build --release` (from `crates/octos-pyo3/`) |
-| `octos-ffi` | C ABI — C, Go, Node, anything with FFI | `cargo build -p octos-ffi --release` → `.a` / `.dylib` / `.so` + generated header |
-| `octos-uniffi` | Python, Swift, Kotlin from one definition | `cargo build -p octos-uniffi`, then `cargo run -p octos-uniffi --bin uniffi-bindgen -- generate ...` |
-| `octos-wasm` | Browser / JS | `wasm-pack build --target web` |
-
-Add the in-process GGUF embedder to any of them with the same flag, e.g. `cargo build -p octos-ffi --release --features embed-llama` (or `embed-llama-metal` on Apple GPUs).
-
-**The browser is protocol-only.** `octos-wasm` binds `octos-core` — wire (de)serialization, message/task/ID modelling — and nothing more. The agent loop cannot run in a browser: `redb` needs a filesystem, `tokio`'s multi-thread runtime needs OS threads, and native TLS and llama.cpp do not target `wasm32-unknown-unknown`. Run the agent behind `octos serve` and talk to it over the network.
-
-Each binding has its own README with the full API and examples: [octos-ffi](crates/octos-ffi/README.md) · [octos-pyo3](crates/octos-pyo3/README.md) · [octos-uniffi](crates/octos-uniffi/README.md) · [octos-wasm](crates/octos-wasm/README.md).
-
-## Clients and the UI Protocol
-
-Interactive clients talk to `octos serve` over **UI Protocol v1** — a JSON-RPC contract carried on WebSocket (`/api/ui-protocol/ws`) or stdio (`octos serve --stdio`). It covers session open with cursor replay, streamed turns, durable persistence events, tool activity, approvals, background tasks, and rollback. The protocol spec is the contract: server and clients release independently against it.
-
-- **[octos-web](https://github.com/octos-org/octos-web)** — the browser client: chat, voice/video, studio, slides, and sites. A build is embedded in the server binary at `/app/`, so `octos serve` works with zero extra deploys. (The admin dashboard is a separate SPA, embedded at `/admin/`.)
-- **[octoscode](https://github.com/octos-org/octoscode)** — the terminal client. Connects to a running server over WebSocket, or spawns `octos serve --stdio` as its own private backend.
-- **`octos mcp-serve`** — the inverse direction: octos as an MCP server, callable as a sub-agent from outer orchestrators.
-- **MCP client** — octos also *consumes* external MCP servers. Declare them in `config.json` under `mcp_servers` and any octos agent (`chat`, `serve`, `gateway`, `acp`) gains their tools in its own registry — stdio (`command` + `args`) or HTTP (`url`); run `octos mcp login <url>` for OAuth-gated servers.
-
-  ```json
-  "mcp_servers": [
-    { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/data"] },
-    { "url": "https://mcp.example.com/mcp", "oauth": true }
-  ]
-  ```
-
-  Stdio children receive a **sanitized environment** — only the names explicitly listed under the server's `env` map are forwarded (injection vectors like `LD_PRELOAD` are stripped even from that map), so a server expecting inherited credentials must get them explicitly or read its own secrets file. Set `"concurrency_class": "exclusive"` to serialize a server's tools (default `"safe"` allows concurrent calls) — the right knob for a single-resource server such as a one-device driver. Handshake timeout is 30s and each `tools/call` times out after 60s, so long-running work should be started detached by the server and polled through read-only tools.
-- **`octos acp`** — the editor-facing direction: octos as an **[Agent Client Protocol](https://agentclientprotocol.com) (ACP)** agent over stdio, so ACP-speaking editors (Zed and others) run octos as their coding agent — with the **same capabilities as `octos chat`** (your tools + sandbox, long-term memory + `MEMORY.md`, skills/plugins, MCP, hooks, context compaction, provider failover). It appears in the editor's agent picker alongside Claude Code and Gemini CLI. See [Use octos in Zed](#use-octos-in-zed-acp).
-
-### Use octos in Zed (ACP)
-
-`octos acp` turns octos into an **ACP server** that [Zed](https://zed.dev) (and other ACP editors) drive as a first-class coding agent. You get the same agent stack as `octos chat` — your tools + sandbox, long-term memory + `MEMORY.md` injection, bundled skills/plugins, MCP servers, hooks, and context compaction — but inside the editor.
-
-> **One gap today:** interactive tool-approval prompts and `ask_user_question` aren't surfaced to the editor yet — octos runs tools under its own (non-interactive) approval policy rather than ACP `session/request_permission`, so a tool that would pause for approval in `octos chat` won't prompt you in Zed. Everything else matches.
-
-**1. Install octos and initialize it** (skip if you already have it — see [Start here](#start-here) for all install options):
-
-```bash
-npm install -g @octos-org/octos      # or Homebrew / build from source — see Start here
-octos init                           # pick a provider + model, then paste that provider's API key
-```
-
-`octos init` walks you through choosing a provider + model (this guide uses **DeepSeek**) and then prompts you to **paste that provider's API key** — stored securely in `auth.json` and read regardless of environment (`octos acp` resolves its LLM exactly like `octos chat`). Pressed Enter to skip it? Add the key later with `octos auth login --provider deepseek`. A Dock-launched Zed does **not** inherit your shell's env vars, so if you'd rather pass the key by an env var, put it in the `env` block below instead.
-
-**2. Register octos as an agent server** in Zed's settings (`~/.config/zed/settings.json`, or run *zed: open settings*). Use `"command": "octos"` if it's on your `PATH`, or the absolute path from `which octos` — a Dock-launched Zed has a minimal `PATH` and may not find a bare `octos`:
-
-```jsonc
+For example, after opening a session, a controller can send this `turn/start`
+request. Replace the session placeholder with the confirmed session ID and use
+a new UUID for each turn:
+
+```json
 {
-  "agent_servers": {
-    "Octos": {
-      "command": "octos",
-      "args": ["acp", "--provider", "deepseek", "--model", "deepseek-chat"],
-      "env": {}
-    }
+  "jsonrpc": "2.0",
+  "id": "request-1",
+  "method": "turn/start",
+  "params": {
+    "session_id": "<confirmed-session-id>",
+    "turn_id": "550e8400-e29b-41d4-a716-446655440000",
+    "input": [
+      { "kind": "text", "text": "Review the changes in this workspace and report findings with file and line references." }
+    ]
   }
 }
 ```
 
-> The `--provider`/`--model` in `args` must match the provider you set up in step 1 (this guide uses DeepSeek). `octos acp` inherits the rest — `base_url`, `api_type`, `api_key_env` — from your `octos init` config, so pointing `deepseek` args at a differently-configured provider sends the wrong key/endpoint and the session fails.
+The same controller can let Octos perform research or implementation, inspect
+its findings, then steer the next turn. OUP exposes the controls and evidence
+needed to build that collaboration into your own application.
 
-**3. Play with it in Zed.**
-- **Open a folder** — external agents need a workspace (with none open, the Agent Panel just shows *"Open Project"*).
-- Open the **Agent Panel** (right dock), click the **＋ New Thread** dropdown (or press `⌥⌘⇧N`), and choose **Octos**.
-- Type a prompt. octos runs the agent loop and streams tools, thinking, and results back into Zed — and it remembers across turns via your `MEMORY.md`.
+## Kernel capabilities through the OUP lens
 
-> **Can't find Octos?** It lives in the **＋ New Thread** menu (external agents) — **not** the `⋯` → *MCP / Context Servers* list (that's a different feature). After editing `agent_servers`, fully quit and reopen Zed (`Cmd-Q`) so it reloads the config.
+OUP makes the harness programmable throughout a task's lifecycle. An application
+can inspect the context an agent is using, respond to a tool approval, supervise
+parallel work, and recover committed results through the same runtime contract.
+The kernel manages execution and persistence; the application decides how to
+present that state and when to intervene.
 
-Flags mirror `octos chat`: `--provider`, `--model`, `--base-url`, `--config`, `--data-dir`, `--cwd`, `--profile`, and `--max-iterations`. Zed sends a per-session working directory with `session/new`; that's where octos roots tools, skills, and the filesystem scope.
+The surfaces below depend on the runtime, transport, and negotiated features.
+Discover them through `config/capabilities/list`, check `supported_methods` and
+`supported_features`, and consume the negotiated event format. Capability
+discovery lets an integration adapt to the runtime it is actually connected to.
 
-## Headless agent mode & code review (`octos chat`)
+### Context management
 
-`octos chat` is both an interactive REPL and a **one-shot headless agent** — the
-`claude -p "…"` / `codex exec` equivalent. It has file, search, and shell tools,
-so it reads code, runs `git diff`, and runs tests on its own; you just give it a
-task.
+Long tasks accumulate conversation, tool output, and intermediate results.
+Octos manages the model's context budget, compacts older material, and preserves
+recent tool-call/result relationships. Compaction can use LLM summarization or
+heuristics. Stable prompt prefixes support provider cache reuse, while changing
+task state remains part of the evolving conversation.
+
+- **Inspect:** `session/status/read` and `session/hydrate` expose the runtime's
+  context state when `context.lifecycle.v1` is negotiated, including compaction
+  metadata. These describe the context available to the model after processing.
+- **Control:** `session/compact` requests a compaction pass;
+  `session/compact/mode/set` selects the session's compaction mode.
+- **Observe:** `context/compaction_started` and `context/compaction_completed`
+  let an application explain when and how context changed during execution.
+
+A coding app can show context usage and compaction history; an agent controller
+can inspect that state before assigning the next stage of a long task.
+
+### Memory across tasks
+
+The memory layer provides long-term notes and entity pages, episodic task
+records, and retrieval. Its hybrid index combines keyword search with vector
+similarity when embeddings are available. An application can retain project
+conventions, decisions, and useful task outcomes across sessions.
+
+- **Inspect stored knowledge:** `memory/overview` and `memory/entity` expose
+  profile memory on WebSocket connections that advertise
+  `auxiliary.rest_to_ws.v1`. These methods are unavailable over stdio.
+- **Use memory during execution:** agents equipped with memory tools can
+  retrieve and update knowledge through tools such as `recall_memory` and
+  `save_memory`. Those are agent tools, not OUP RPC method names.
+- **Keep the roles distinct:** memory supplies reusable knowledge; session
+  history and event replay record what happened in a particular conversation.
+
+### Durable sessions and recovery
+
+Octos owns session identity, workspace scope, conversation history, and committed
+events. A client can reconstruct the runtime's view of a conversation after a
+reload, or build a different interface over the same stored session.
+
+- **Open and inspect:** `session/open` establishes the session and confirmed
+  workspace. `session/hydrate` restores messages, turns, pending approvals, and
+  other requested state; `turn/state/get` inspects a specific turn's lifecycle.
+- **Reconnect:** retain the last applied durable cursor and pass `after` when
+  reopening the session. The runtime replays retained committed events before
+  live delivery. Uncommitted deltas may be lost, and expired cursors require
+  fresh hydration; replay does not imply an active turn survived a disconnect.
+- **Branch or rewind:** `session/fork` creates a conversation branch, and
+  `session/rollback` rewinds conversation turns. Conversation rollback does not
+  undo filesystem changes.
+
+### Tools, permissions, and human input
+
+The kernel executes filesystem, shell, web, and MCP tools under the host's tool
+policy and platform sandbox configuration. Host-configured lifecycle hooks can
+participate around model calls and tool execution. OUP exposes execution and
+decision points so the application can provide its own approval interface or
+delegate authorized decisions to a controller.
+
+- **Discover and observe:** `tool/status/list` and `mcp/status/list` report
+  available integrations. `tool/started`, `tool/progress`, and `tool/completed`
+  expose tool execution to the client.
+- **Control permissions:** discover and select permission profiles through
+  `permission/profile/list` and `permission/profile/set`. For a pending change
+  proposal, `diff/preview/get` provides the canonical diff preview.
+- **Resolve a pending decision:** answer `approval/requested` with
+  `approval/respond`, or `user_question/requested` with `user_question/respond`,
+  using the originating request's identity and the host's authorization policy.
+
+This supports an application that shows a proposed edit, collects a decision,
+and resumes the waiting operation while preserving its connection to the turn.
+
+### Skills and extensions
+
+Skills package reusable instructions and executable capabilities. Plugins add
+manifest-declared tools and actions, with discovery and environment gating.
+These let a host give its agents domain-specific behavior while reusing the
+kernel's execution and supervision machinery.
+
+- **Manage the profile's skills:** use `profile/skills/list`,
+  `profile/skills/registry/search`, `profile/skills/install`, and
+  `profile/skills/remove`.
+- **Expose application actions:** `skill/action/list` discovers declared
+  actions; `skill/action/invoke` runs them. A host can present an action as a
+  button, an automation step, or a tool for another agent.
+- **Track background actions:** `skill/action/job/list` and
+  `skill/action/job/read` inspect persisted jobs;
+  `skill/action/job/updated` reports lifecycle changes when supported.
+
+### Workflows and task supervision
+
+The pipeline library represents multi-step work as DOT graphs, with per-node
+model selection, parallel branches, conditions, checkpoints, human gates, and
+artifact validation. A host can compose workflows through the Rust library, or
+let an agent launch a configured workflow through its tools. OUP exposes the
+resulting supervised tasks to the application.
+
+- **Follow execution:** `task/list`, `task/updated`, and `task/output/delta`
+  provide task state and live output. `task/output/read` retrieves recorded
+  output; `task/artifact/list` and `task/artifact/read` expose retained artifacts.
+- **Intervene and recover:** `task/cancel` stops a scoped active task.
+  `task/restart_from_node` relaunches a terminal task and returns a new task ID;
+  supported pipeline tasks can restart from a selected node.
+- **Use a built-in orchestration entry point:** when advertised, `review/start`
+  starts the runtime's supervised review workflow and reports progress through
+  the same turn, task, and agent surfaces.
+
+An application can present a workflow's progress, inspect a failed validation
+and its output, then request an appropriate retry and track the successor task.
+
+### Sub-agents and peers
+
+Octos supports several forms of concurrent work. A child agent handles a
+delegated task and returns its result to its parent. A peer owns an independent
+session that a client or controller can inspect and steer. A supervised
+background tool task can run without creating another LLM loop.
+
+- **Supervise delegated work:** `agent/list`, `agent/status/read`,
+  `agent/output/read`, and `agent/artifact/*` expose status, output, and
+  artifacts. This supervision surface also covers supported background tasks;
+  an entry does not necessarily represent a separate model conversation.
+- **Prepare independent peers:** `peer/prepare` stores a durable brief and can
+  create a separate Git worktree. Preparation stages resources; the controller
+  then uses `session/open` and `turn/start` to launch each peer's work.
+- **Coordinate and gather:** steer a peer through its ordinary turn controls,
+  and use `peer/gather` to read staged briefs and the latest results persisted
+  at peer turn termination. The controller decides how to combine those results.
+
+For example, a host can give implementation and review separate sessions and
+worktrees, point the reviewer at the implementation's changes, then collect
+their findings into a coordinating session.
+
+### Goals, loops, and monitors
+
+A goal records what the agent is working toward. A loop schedules recurring
+turns. A monitor watches a command's output and wakes an agent when matching
+events arrive. Together, these primitives support work that spans multiple
+turns, with state the application can inspect and control.
+
+- **Persist an objective:** `session/goal/set`, `session/goal/get`, and
+  `session/goal/clear` manage goal state. Goal records include status, token
+  budget, token usage, and elapsed usage time; `session/goal/updated` reports
+  changes.
+- **Schedule recurring work:** `loop/create`, `loop/list`, `loop/pause`,
+  `loop/resume`, `loop/fire_now`, and `loop/delete` manage recurring execution.
+  Loop events expose when runs fire and complete.
+- **React to external signals:** `monitor/create` configures a command, output
+  filter, and delivery limits. `monitor/list`, `monitor/pause`, `monitor/resume`,
+  and `monitor/delete` manage it; `monitor/fired` reports matching activity.
+
+A host might schedule periodic project checks or wake an agent when a monitored
+build emits an error. Its interface can show the objective, consumed budget,
+active schedules, and controls for pausing further work.
+
+### Model providers and routing
+
+The model layer provides provider adapters, configurable model choices, retry
+and fallback chains, and adaptive routing. The application can choose models
+for interactive work and configure separate provider lanes for workflow nodes.
+
+- **Configure providers:** `profile/llm/catalog`, `profile/llm/list`,
+  `profile/llm/upsert`, `profile/llm/test`, and `profile/llm/select` support
+  discovery, configuration, connection testing, and selection.
+- **Configure workflow lanes:** the advertised `profile/sub_providers/*`
+  methods manage named provider lanes for per-node routing. Changes take effect
+  when the corresponding runtime is rebuilt.
+- **Inspect routing:** `router/status` and `router/failover` expose routing
+  events; `router/get_metrics` and `router/set_mode` provide the advertised
+  metrics and control surface.
+
+### Putting the capabilities together
+
+A Codex, Claude Code, or custom-agent integration can build a review-and-fix
+controller around these primitives:
+
+1. Open a workspace-scoped session, discover capabilities, and set a concrete
+   objective and budget if goal support is available.
+2. Prepare peers for bounded implementation or investigation tasks, open their
+   sessions, and start their turns with explicit briefs.
+3. Follow tool and task events, resolve authorized approvals, and steer ongoing
+   work when new constraints arrive. The kernel manages context and executes
+   the configured tools and workflows within each session.
+4. Gather peer results, inspect task output and artifacts, then launch review or
+   verification work. Use that evidence to decide whether another turn is needed.
+5. Retain session identities and durable cursors so the interface can rehydrate
+   committed state when it reconnects.
+
+The host implements the coordination policy. Octos supplies the execution,
+state, and control primitives that make that policy observable through OUP.
+
+## Developer documentation
+
+- [OUP specification](api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md)
+- [OUP types and codecs](crates/octos-core/src/ui_protocol.rs)
+- [Runtime architecture](docs/ARCHITECTURE.md)
+- [Harness developer interface](docs/OCTOS_HARNESS_DEVELOPER_INTERFACE.md)
+- [Artifact and workflow integration guide](docs/OCTOS_HARNESS_DEVELOPER_GUIDE.md)
+- [Harness compatibility and versioning](docs/OCTOS_HARNESS_ABI_VERSIONING.md)
+- [Documentation site](https://octos-org.github.io/octos/)
+
+## Contributing
+
+Run the checks appropriate to the crates you change. The workspace checks are:
 
 ```bash
-octos chat                             # interactive REPL
-octos chat "explain crates/octos-agent/src/agent.rs"   # one-shot: run one turn, exit
-octos chat -m "…" --json               # one-shot, machine-readable result on stdout
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 ```
 
-### Modes: interactive, one-shot, JSON
-
-| Invocation | Behavior |
-| --- | --- |
-| `octos chat` | interactive REPL (multi-turn) |
-| `octos chat "PROMPT"` **or** `octos chat -m "PROMPT"` | one-shot: run a single turn and exit (`claude -p` parity) |
-| `octos chat -m "PROMPT" --json` | one-shot, one JSON result object on **stdout** (logs/UI → stderr) |
-
-Rules: give the prompt **positionally OR** via `-m`/`--message`, never both (that's
-an error — the positional prompt is otherwise folded into `--message`). `--json`
-needs a **one-shot prompt** (positional *or* `-m`); only **interactive** `--json`
-(no prompt at all) is rejected, since a REPL can't keep stdout clean. On any error
-`--json` still prints `{"error":"…"}` on stdout and exits non-zero, so stdout stays
-machine-parseable.
-
-### Scripting: the JSON result & exit codes
-
-In `--json` mode stdout carries exactly one object (everything else — logs, the
-status line, approval prompts — goes to stderr). On success:
-
-```json
-{ "text": "…final answer…", "model": "glm-5.3", "input_tokens": 1234, "output_tokens": 567 }
-```
-
-`text` is the final assistant answer; `model` is the model that actually
-produced it (honest about adaptive failover to a fallback lane); the token
-counts cover the whole turn. On any failure the object is `{"error":"…"}`
-instead, so stdout is always parseable:
-
-```bash
-out=$(octos chat --profile dev -m "summarize the branch diff" --json)
-echo "$out" | jq -r '.text'           # the answer
-echo "$out" | jq -r '.output_tokens'  # token usage, e.g. for cost tracking
-```
-
-| Exit | Meaning |
-| --- | --- |
-| `0` | success |
-| `2` | usage error — unknown / conflicting flags, `--json` without `-m`, or the prompt given both positionally and via `-m` |
-| `1` | runtime error (auth / provider / agent). In `--json` mode `{"error":…}` is still written to stdout first, so a caller can read the reason |
-
-### Sandbox × approval — every combination
-
-Two orthogonal axes set what the agent may do unattended: **`--sandbox`**
-(filesystem/network reach) and **`--ask-for-approval`** (whether risky commands
-pause). `--yolo` is a shortcut for the most permissive corner. What each
-combination resolves to:
-
-| `--sandbox` | `--ask-for-approval` | Resolves to | The agent can… |
-| --- | --- | --- | --- |
-| *(omitted)* | *(omitted)* | **workspace-write + ask** — the default | read + write inside `--cwd`; pause for approval on risky commands |
-| `read-only` | *(omitted → `ask`)* | read-only + ask | read + read-only commands (`git diff`, `grep`); write/edit tools fail |
-| `read-only` | `never` | read-only + never | **unattended review** — reads only, never pauses |
-| `workspace-write` | *(omitted → `ask`)* | workspace-write + ask | edit inside `--cwd`, pause on risky |
-| `workspace-write` | `never` | workspace-write + never | **unattended edits** inside `--cwd` |
-| `danger-full-access` | *(forced `never`)* | full access, no prompts | host filesystem + network, no approvals |
-| `--yolo` | — | = `danger-full-access` + `never` | **full autonomy** (the shortcut) |
-
-**Contradictions are rejected — the command errors, it doesn't silently pick one:**
-- `--yolo` (or `--sandbox danger-full-access`) **+** `--ask-for-approval ask` — danger-full-access never asks.
-- `--yolo` **+** `--sandbox read-only`/`workspace-write` — `--yolo` *is* danger-full-access.
-
-`--ask-for-approval never` fails a risky command **closed** at the tool boundary
-(there's no interactive approver in a headless run) rather than prompting.
-Guardrails that stay on even under `danger-full-access`/`--yolo`:
-`before_tool_call` hooks, `ToolPolicy` deny-lists, SSRF protection,
-`BLOCKED_ENV_VARS`.
-
-### Reuse an existing profile (model + API key)
-
-`--profile <id>` reads a stored serve/onboarding profile
-(`~/.octos/profiles/<id>.json`, created by `octos serve` or octoscode) and
-reuses its provider, model, route, and API key — so you don't re-enter them:
-
-```bash
-octos chat --profile dev --yolo "refactor this module"   # uses dev's model + key
-```
-
-Precedence: `--config` > `--profile <id>` > ambient `config.json`.
-`--provider` / `--model` / `--base-url` / `--api-type` each override their own
-field on top. Naming a **different** `--provider` than the profile's does a
-**clean switch** — it detaches the profile's route (base-url, key-env, wire
-protocol) so the new provider's own defaults apply, rather than reusing the old
-provider's key against the new one; add `--model` too, since the profile's model
-won't fit the new provider. Re-naming the *same* provider keeps the route.
-
-### Code review
-
-The agent reads the code and returns its findings as its final answer on
-**stdout** — capture it with your shell. (Stdout is outside the sandbox, so a
-`read-only` reviewer, which cannot touch the repo, can still "produce a file".)
-
-```bash
-octos chat --profile dev --cwd ~/repo \
-  --sandbox read-only --ask-for-approval never --effort high \
-  -m "Review the diff of this branch against main. For each issue give file:line,
-      severity, and a concrete failure scenario. Rank most-severe first." \
-  > review.md
-```
-
-If you want the **agent itself** to write files (not shell capture), use
-`--sandbox workspace-write` and tell it to write them — `read-only` blocks the
-write. `workspace-write` lets it write anywhere under `--cwd`, so for a contained
-run point it at a fresh `git worktree` and inspect the diff afterward.
-
-### Run many agents in parallel on one profile
-
-Add `--no-session-persistence` and point N agents at one `--data-dir` (hence one
-shared `--profile`); they run concurrently — the ephemeral flag drops the
-exclusive episode-store lock that would otherwise serialize them.
-
-```bash
-# Review fan-out — one repo, many lenses, each writes its own report
-for lens in correctness security performance; do
-  octos chat --profile dev --cwd ~/repo \
-    --sandbox read-only --ask-for-approval never --no-session-persistence \
-    -m "Review only for $lens. Write findings to REVIEW-$lens.md." &
-done; wait
-
-# Edit fan-out — one agent per folder, each changes its own tree
-for d in svc-a svc-b svc-c; do
-  octos chat --profile dev --cwd ~/work/$d \
-    --sandbox workspace-write --ask-for-approval never --no-session-persistence \
-    -m "Implement the TODOs in this folder." &
-done; wait
-```
-
-Without `--no-session-persistence`, a second `octos chat` on the same
-`--data-dir` fails with `Database already open` — that flag is what makes the
-fan-out non-blocking.
-
-### Full flag reference
-
-| Flag | Default | Purpose |
-| --- | --- | --- |
-| `PROMPT` *(positional)* / `-m`, `--message <s>` | — | one-shot prompt (two spellings of the same thing; supplying both errors) |
-| `--json` | off | one JSON result object on stdout; needs a one-shot prompt (positional or `-m`) — only interactive `--json` is rejected |
-| `--sandbox <mode>` | `workspace-write` | `read-only` \| `workspace-write` \| `danger-full-access` (see the matrix above) |
-| `--ask-for-approval <mode>` | `ask` | `ask` \| `never` (danger-full-access is always `never`) |
-| `--yolo` | off | shortcut for `--sandbox danger-full-access` (approvals never). Alias of `--dangerously-bypass-approvals-and-sandbox`. **Local single-user boxes only.** |
-| `--profile <id>` | `coding` | runtime **tool surface** (`coding` = files/shell/search/memory/spawn; `coding-full` adds web/pipelines/skills; or a user id). If `<id>` names a stored serve/tui profile, also reuses its **model + API key**. |
-| `--provider <name>` | from config/profile | LLM provider override |
-| `--model <id>` | from config/profile | model override |
-| `--base-url <url>` | from config/profile | custom API endpoint |
-| `--api-type <t>` | from config/profile | wire protocol for `--base-url`: `anthropic` \| `openai` \| `responses` (alias `--api-style`) |
-| `--config <path>` | — | explicit flat config file — **wins over** `--profile` |
-| `--cwd <dir>` | current dir | workspace root the agent reads/writes |
-| `--data-dir <dir>` | `$OCTOS_HOME` / `~/.octos` | episodes / memory / sessions store |
-| `--effort <e>` | provider default | `none` \| `low` \| `medium` \| `high` \| `max` (`none` disables reasoning where supported) |
-| `--no-session-persistence` | off | ephemeral run (no episode saved); also **enables parallel agents** on one `--data-dir` |
-| `--max-iterations <n>` | `20` | per-turn tool-call cap |
-| `--no-retry` | off | disable automatic retry on transient LLM errors |
-| `-v`, `--verbose` | off | show tool outputs |
-
-**Model/credential precedence:** `--config` > `--profile <id>` > ambient
-`config.json`; `--provider` / `--model` / `--base-url` / `--api-type` override
-whichever of those supplied them. **Prerequisite:** a configured provider
-(`octos auth login`, or the provider's API-key env var) **or** a `--profile` that
-already carries one.
-
-## Autonomy: goals & loops
-
-Beyond a single turn, octos can keep working on its own — between your messages,
-or on a schedule. Both are driven by slash commands in any client (octos-web,
-octoscode) or channel session, and run on `octos serve` / `octos gateway`.
-
-### Goals — keep going until it's done
-
-`/goal <objective>` gives the agent a standing objective. After each turn it
-checkpoints a **continuation** and re-fires itself to keep making progress across
-turns — without you prompting again — until the objective is met or its budget
-runs out.
-
-```text
-/goal build a REST API for the todo app, with tests   # start a goal
-/goal <objective> --budget 5000000                    # cap it (default 2,000,000 tokens)
-/goal stop                                            # end the goal
-/goal resume                                          # re-activate a stopped goal
-```
-
-Each goal carries a **token budget** (default **2M**). When it's exhausted the
-goal moves to `budget_limited`, wraps up the current state, and tells you how to
-resume — reply `/goal <objective> --budget <N>` with a higher `N`, or `/goal
-stop`. Continuations are rate-limited (≥30s apart, ≤12/hour) so a goal can't spin.
-
-### Loops — run on a cadence
-
-`/loop <prompt>` runs a recurring task. Give it an interval (`s`/`m`/`h`/`d`) for
-a **fixed-interval** loop, or omit one for a **self-paced** loop where the agent
-decides when to wake itself next:
-
-```text
-/loop 30m check CI and triage new failures        # fixed interval (leading)
-/loop summarize unread email every 1h             # fixed interval (trailing)
-/loop watch the deploy and report when it's green  # self-paced (no interval)
-/loop resume <id>                                 # resume a paused loop
-```
-
-Loops persist across restarts (parked as paused on a solo reboot; you resume
-them explicitly), and can be paused, listed, fired now, or deleted.
-
-## Agent topologies: sub-agents, peers & swarm
-
-A single `octos chat` or session runs one agent. When work needs *several*
-agents, octos offers three relationships — they differ by **who owns whom** and
-**how results come back**:
-
-| | **Sub-agents** | **Peer agents** | **Agent swarm** |
-| --- | --- | --- | --- |
-| Relationship | hierarchical — a parent **owns** its children | lateral — **sovereign** sibling sessions | a dispatcher fans **contracts** to N workers |
-| Started by | the `spawn_agent` tool, mid-turn | `peer_handoff` stages one; the **client** opens it | `Swarm::dispatch` / `POST /api/swarm/dispatch` |
-| Live where | in-process children of the caller | independent sessions (own history, own client tab) | wherever the backend runs |
-| Results | returned to the parent (final answer only; internals stay private) | fan-in via `peer_gather` over a shared blackboard | aggregated, validator-gated, cost rolled up |
-| Workers | native octos agents | native octos sessions | native **or external CLI/MCP** agents |
-
-### Sub-agents — delegation you own
-
-A running agent calls **`spawn_agent`** (or its MCP-backed `delegate` variant)
-to hand a scoped task to a child that runs **in the same process**. The parent
-supervises the whole tree: status and token cost surface upward, cancelling the
-parent cascade-fails its live children, and each child runs in its own sandbox.
-A child's internal messages never leak back — only its final result. Spawns nest
-(bounded by a max depth). The tools sit in the default `coding` tool surface, so
-any agent with that profile can delegate; background (`spawn_only`) children run
-detached and report when done.
-
-### Peer agents — sovereign siblings
-
-Sometimes you want a *second, equal* session rather than a child — its own tab
-with its own history that a human can watch and steer. Sessions are coupled to a
-client connection, so the model can't open one itself: **`peer_handoff`** instead
-*stages* a peer server-side (a durable brief ≤ 64 KB, optionally fenced in its
-own git worktree) and the host asks your **client** to open it in the background.
-The originating agent later pulls results back with **`peer_gather`** — a shared
-blackboard where handoff fans out and gather fans in. Guardrails live at the
-serve layer: peer sessions can't themselves hand off (depth-1) and a per-turn
-handoff cap applies. This path is **opt-in** and exists only on the
-`serve`/WebSocket turn path (a client that can open sessions) — not `chat`,
-`gateway`, or ACP.
-
-### Agent swarm — a dispatcher over N workers
-
-For fan-out at scale, **`octos-swarm`** runs the PM/supervisor pattern as a
-primitive: a supervisor writes a **contract**, `Swarm::dispatch` fans it into N
-sub-contracts across a **topology** — `Parallel` (bounded concurrency),
-`Sequential` (one-at-a-time, aborts on the first terminal failure, crash/resume
-aware), `Pipeline` (output of *i* feeds *i+1*), or `Fanout` (expand a typed
-pattern, then run it parallel) — aggregates the artifacts, gates the aggregate
-through a **validator**, and rolls up cost in an idempotent redb **ledger**
-(re-dispatching the same id returns the stored result verbatim). Reachable at
-`POST /api/swarm/dispatch`. A swarm worker need **not** be a native octos agent:
-with **`--swarm-backend`**, contracts dispatch to *external* agents — an MCP
-server, or a one-shot CLI like `claude -p` / `codex exec` (`CliAgentBackend`).
-
-### "External agent" points two ways
-
-The term is directional — check who is calling whom:
-
-- **Inbound** — an outside orchestrator drives octos: a Zed/ACP client, or any
-  MCP client via `octos mcp-serve`. Octos is the *callee* (a sub-agent to someone
-  else).
-- **Outbound** — octos drives an outside agent as a **swarm worker** via
-  `--swarm-backend`. Octos is the *caller*.
-
-Same phrase, opposite arrows.
-
-## Documentation
-
-📖 **[Full Documentation](https://octos-org.github.io/octos/)** — installation, configuration, channels, providers, memory, skills, advanced features, and more.
-
-**Quick links:**
-- [Installation & Deployment](https://octos-org.github.io/octos/installation.html)
-- [Configuration](https://octos-org.github.io/octos/configuration.html)
-- [LLM Providers & Routing](https://octos-org.github.io/octos/providers.html)
-- [Gateway & Channels](https://octos-org.github.io/octos/channels.html)
-- [Memory & Skills](https://octos-org.github.io/octos/memory-skills.html)
-- [Advanced Features](https://octos-org.github.io/octos/advanced.html) (queue modes, hooks, sandbox, tools)
-- [CLI Reference](https://octos-org.github.io/octos/cli-reference.html)
-- [Skill Development](https://octos-org.github.io/octos/skill-development.html)
-
-**中文:** [中文 README](README-zh.md) | [用户指南](https://octos-org.github.io/octos/zh/) (doc site)
-
-## Architecture
-
-12 `octos-*` crates + 13 app-skill crates + 1 platform-skill crate (26 workspace members total). The runtime auto-installs only the 8 entries in `BUNDLED_APP_SKILLS` plus the `voice` platform-skill — see `crates/octos-agent/src/bundled_app_skills.rs`.
-
-```
-octos-cli   (CLI entrypoint, REST API server, dashboard, config watcher, wizard)
-   │
-octos-agent (agent loop, tool registry, MCP, hooks, three-tier compaction,
-             profile system, sub-agent output router, task supervisor)
-   │
-   ├─ octos-bus       (14 channels, sessions w/ sticky thread_id, coalescing, cron)
-   ├─ octos-llm       (15 providers, AdaptiveRouter → ProviderChain → RetryProvider)
-   ├─ octos-memory    (long-term + episodic + HNSW vector + BM25 hybrid search)
-   ├─ octos-pipeline  (DOT-graph workflows, per-node model, bounded fan-out)
-   ├─ octos-plugin    (skill manifest, discovery, gating, lifecycle, protocol v2)
-   ├─ octos-sandbox   (platform sandbox helper binary — bwrap/Landlock/seccomp)
-   ├─ octos-swarm     (PM/swarm dispatcher, ledger, topology, validator gate)
-   ├─ octos-diagnostics (shared doctor diagnostics + update planning)
-   ├─ octos-dora-mcp  (compat re-export of the dora bridge in octos-agent)
-   └─ octos-core      (Task, Message, Error types — no internal deps)
-
-Runtime view:
-  octos serve (control plane + dashboard, 80+ REST endpoints + UI Protocol WS)
-    ├── Profile A → gateway process (Telegram, WhatsApp)
-    ├── Profile B → gateway process (Feishu, Slack, Matrix)
-    └── Profile C → gateway process (CLI)
-         │
-         ├── LLM Provider (Anthropic, OpenAI, Gemini, DeepSeek, Moonshot, …)
-         │   └── AdaptiveRouter → ProviderChain → RetryProvider
-         ├── Tool Registry (~50 built-in + plugins + 8 app-skills)
-         │   └── Full enabled set emitted per turn (profiles narrow it)
-         ├── Pipeline Engine (DOT graphs, per-node model, bounded fan-out)
-         ├── Swarm Dispatcher (fan-out → aggregate → validator gate → cost rollup)
-         ├── Sandbox (bwrap / Landlock+seccomp / sandbox-exec / Docker / AppContainer)
-         ├── Session Store (JSONL, LRU cache, three-tier compaction, thread_id)
-         ├── Memory (MEMORY.md + entity bank + episodes.redb + HNSW)
-         └── Skills (bundled + installable from octos-hub)
-```
+Protocol changes must keep the specification, Rust types, runtime dispatch,
+capability advertisement, and client behavior aligned.
 
 ## License
 
-See [LICENSE](LICENSE).
+Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
The README currently introduces Octos as a standalone assistant and sends end users through runtime installation and chat setup. Reframe both English and Chinese READMEs around the embeddable Rust harness kernel and OUP, directing coding-agent users to Octoscode or Octoscode Web.

Document native library and language-binding integration, qualified platform support, and OUP connection and negotiation details. Add architecture and controller-workflow Mermaid diagrams, expand nine kernel capability areas with concrete controls and events, and show how an external agent can coordinate implementation, review, and verification through an OUP adapter.

Validation:
- Checked all 21 local links per README and parsed the JSON-RPC examples.
- Checked 76 OUP method/event references per language against the latest main's protocol types, transport, and specification; English and Chinese references match.
- All four Mermaid diagrams rendered successfully; the committed diagram sources match the validated versions.
- `git diff --check` passed. Documentation-only change; Rust build and test suites were not run.
