### PR TITLE
fix(release): ship .sha256 checksum sidecars so installers can verify bundle downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,14 @@ jobs:
         shell: bash
         run: '"$BASH" scripts/tests/test-build-web-app-base-url.sh'
 
+  bundle-release-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test bundle checksum sidecar
+        run: scripts/test-bundle-release.sh
+
   check:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,12 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: macos-arm
-          path: octos-bundle-aarch64-apple-darwin.tar.gz
+          # Fail loudly when the bundle or its sidecar is missing instead of
+          # letting verify-release fail 3 jobs later with a cryptic gap.
+          if-no-files-found: error
+          path: |
+            octos-bundle-aarch64-apple-darwin.tar.gz
+            octos-bundle-aarch64-apple-darwin.tar.gz.sha256
 
   build-linux-x86:
     needs: check-version
@@ -144,7 +149,10 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: linux-x86
-          path: octos-bundle-x86_64-unknown-linux-gnu.tar.gz
+          if-no-files-found: error
+          path: |
+            octos-bundle-x86_64-unknown-linux-gnu.tar.gz
+            octos-bundle-x86_64-unknown-linux-gnu.tar.gz.sha256
 
   build-linux-arm:
     needs: check-version
@@ -194,7 +202,10 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: linux-arm
-          path: octos-bundle-aarch64-unknown-linux-gnu.tar.gz
+          if-no-files-found: error
+          path: |
+            octos-bundle-aarch64-unknown-linux-gnu.tar.gz
+            octos-bundle-aarch64-unknown-linux-gnu.tar.gz.sha256
 
   build-windows:
     needs: check-version
@@ -246,7 +257,10 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: windows
-          path: octos-bundle-x86_64-pc-windows-msvc.zip
+          if-no-files-found: error
+          path: |
+            octos-bundle-x86_64-pc-windows-msvc.zip
+            octos-bundle-x86_64-pc-windows-msvc.zip.sha256
 
   # TODO: uncomment after Dockerfile is fixed
   # build-docker:
@@ -348,9 +362,13 @@ jobs:
           set -euo pipefail
           actual=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
           expected='octos-bundle-aarch64-apple-darwin.tar.gz
+          octos-bundle-aarch64-apple-darwin.tar.gz.sha256
           octos-bundle-aarch64-unknown-linux-gnu.tar.gz
+          octos-bundle-aarch64-unknown-linux-gnu.tar.gz.sha256
           octos-bundle-x86_64-unknown-linux-gnu.tar.gz
+          octos-bundle-x86_64-unknown-linux-gnu.tar.gz.sha256
           octos-bundle-x86_64-pc-windows-msvc.zip
+          octos-bundle-x86_64-pc-windows-msvc.zip.sha256
           install.sh
           install.ps1
           deploy.ps1
@@ -364,7 +382,12 @@ jobs:
 
           mkdir verify
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
-            --pattern 'octos-bundle-x86_64-unknown-linux-gnu.tar.gz' --dir verify
+            --pattern 'octos-bundle-*' --dir verify
+          # Every published sidecar must match the published bytes — this is
+          # the exact verification octoscode's auto-install performs (#1929).
+          # Darwin sidecars are produced by shasum, the rest by sha256sum, so
+          # checking all four covers both producer paths.
+          (cd verify && sha256sum -c ./*.sha256)
           tar -tzf verify/octos-bundle-x86_64-unknown-linux-gnu.tar.gz >/dev/null
 
   package-publishers:

--- a/scripts/bundle-release.sh
+++ b/scripts/bundle-release.sh
@@ -63,6 +63,15 @@ case "$out" in
   *) echo "error: unknown archive format: $out (want .tar.gz or .zip)" >&2; exit 1 ;;
 esac
 
+# Checksum sidecar so installers can verify the download (`sha256sum -c`
+# format) — without it octoscode's auto-provision silently skips verification
+# (#1929). macOS runners ship shasum instead of sha256sum; output is identical.
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$(dirname "$out")" && sha256sum "$(basename "$out")" > "$(basename "$out").sha256")
+else
+  (cd "$(dirname "$out")" && shasum -a 256 "$(basename "$out")" > "$(basename "$out").sha256")
+fi
+
 echo "bundled $out:"
 case "$out" in
   *.tar.gz) tar tzf "$out" ;;

--- a/scripts/test-bundle-release.sh
+++ b/scripts/test-bundle-release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Test scripts/bundle-release.sh: the bundle must ship with a checksum sidecar
+# (`<archive>.sha256`, standard `sha256sum -c` format) so downstream installers
+# (octoscode auto-provision) can verify the download instead of silently
+# skipping verification (#1929).
+#
+# Runs against a fake target/release tree — no real build outputs needed.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUNDLE="$ROOT_DIR/scripts/bundle-release.sh"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# Same cross-runner reality as the bundle script itself: Linux/Windows runners
+# ship sha256sum, macOS ships shasum.
+checksum_verify() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        (cd "$1" && sha256sum -c "$2.sha256")
+    else
+        (cd "$1" && shasum -a 256 -c "$2.sha256")
+    fi
+}
+
+make_fake_release_tree() {
+    # Keep this list in sync with BINARIES in bundle-release.sh: the fake tree
+    # must offer every binary the bundle script requires (a missing one fails
+    # the bundle step, which the script itself enforces loudly).
+    local dir="$1"
+    mkdir -p "$dir/target/release"
+    for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email \
+        account_manager voice clock weather smart_home; do
+        echo "fake $b" >"$dir/target/release/$b"
+    done
+    echo '{}' >"$dir/model_catalog.json"
+}
+
+assert_checksum_sidecar() {
+    local archive="$1" sidecar="$1.sha256" dir name
+    dir="$(dirname "$archive")"
+    name="$(basename "$archive")"
+
+    [ -f "$archive" ] || fail "missing bundle archive: $archive"
+    [ -f "$sidecar" ] || fail "missing checksum sidecar: $sidecar"
+
+    # Standard `sha256sum -c` line: "<64 lowercase hex>  <filename>". Checking
+    # with the tool itself proves both the format and the value at once.
+    checksum_verify "$dir" "$name" >/dev/null 2>&1 \
+        || fail "sidecar does not verify against $name: $(cat "$sidecar")"
+}
+
+main() {
+    WORK_DIR="$(mktemp -d /tmp/octos-bundle-release-test.XXXXXX)"
+    trap 'rm -rf "$WORK_DIR"' EXIT
+
+    make_fake_release_tree "$WORK_DIR"
+    cd "$WORK_DIR"
+
+    bash "$BUNDLE" test-bundle-aarch64-apple-darwin.tar.gz \
+        || fail "bundle-release.sh failed for the tar.gz case"
+    assert_checksum_sidecar test-bundle-aarch64-apple-darwin.tar.gz
+
+    if command -v 7z >/dev/null 2>&1; then
+        bash "$BUNDLE" test-bundle-x86_64-pc-windows-msvc.zip \
+            || fail "bundle-release.sh failed for the zip case"
+        assert_checksum_sidecar test-bundle-x86_64-pc-windows-msvc.zip
+        echo "PASS: bundle-release.sh ships a matching .sha256 sidecar (tar.gz + zip)"
+    else
+        echo "SKIP: 7z not found — zip case not exercised (tar.gz sidecar passed)"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Problem

#1929: no release has ever shipped `<bundle>.sha256` sidecars. A from-scratch octoscode auto-provision on a clean Linux box logs a 404 for `…/octos-bundle-aarch64-unknown-linux-gnu.tar.gz.sha256`, **silently skips verification**, and installs the 209 MB binary unverified.

## Root cause

`scripts/bundle-release.sh` (the single source of truth for what ships) produces only the archive. Nothing in `release.yml` generates, uploads, or checks a checksum — the release pipeline had no checksum concept at all.

## Fix

- **`scripts/bundle-release.sh`** — after creating the archive, write `<archive>.sha256` next to it in standard `sha256sum -c` format (`"<hex>  <filename>"`, relative filename). Uses `sha256sum`, falling back to `shasum -a 256` (macOS runners); both emit byte-identical lines, verified below. The hash is computed on the build runner against the exact built bytes.
- **`release.yml`** — each platform build uploads its sidecar alongside the bundle, with `if-no-files-found: error` so a missing file fails the build job instead of surfacing three jobs later. The publish job's existing `find artifacts -name 'octos-bundle-*'` picks the sidecars up unchanged. `verify-release` now expects all four sidecars and round-trips every published sidecar against the published bytes with `sha256sum -c ./*.sha256` — the exact check octoscode's auto-install performs (Darwin sidecars are produced via `shasum`, the others via `sha256sum`, so checking all four covers both producer paths).
- **`scripts/test-bundle-release.sh`** (new, same style as the other `scripts/test-*.sh`) — builds a fake `target/release` tree, runs the bundle script for the tar.gz and zip cases, and asserts each sidecar exists and verifies with `sha256sum -c` itself. Wired into a new lightweight `bundle-release-check` job in `ci.yml` so the behavior can't regress silently (Linux runners exercise the tar.gz case; the zip case runs where `7z` exists and reports a distinct skip message otherwise).

octoscode needs no changes: it already fetches `<asset>.sha256` and parses the first whitespace-delimited token (64 hex, case-insensitive) — exactly the line format above. Older releases can't be back-filled retroactively; octoscode's existing warn-and-skip path keeps covering them.

## Testing evidence

- **Red → green**: on baseline `origin/main`, `scripts/test-bundle-release.sh` fails with `FAIL: missing checksum sidecar: …tar.gz.sha256` (issue reproduced); on this branch it passes for both archive formats.
- **Cross-tool**: the `shasum -a 256` fallback branch was exercised explicitly (restricted `PATH` on macOS): output is byte-identical to `sha256sum` output and verifies under `sha256sum -c`.
- **End-to-end (local replay of the full release path)**: built all four platform bundles from a fake release tree → assembled the 12-asset release directory (4 bundles + 4 sidecars + 4 install scripts) → replayed the updated `verify-release` run block verbatim with the two `gh` calls localized: expected-assets gate passes, all four sidecars verify (`OK ×4`), `tar -tzf` passes. Negative check: a corrupted sidecar line makes `sha256sum -c` fail with exit 1.
- **Workflow lint**: `actionlint` clean on both touched workflows (the `ubuntu-24.04-riscv` warning in `ci.yml` predates this change — verified identical on `origin/main`).
- A true tag-push release can't be exercised from a PR; the replay above walks the same bytes through the same script bodies, and the first real release will additionally run the new `verify-release` checks in CI.

## Review

One independent maintainer-perspective review pass (issue text + diff + workflows only): no blockers; its findings — wiring the test into CI, round-tripping all four sidecars (not just one), fail-loud artifact uploads, skip-message accuracy, and a sync note on the fake-binary list — are all addressed in this change.

Closes #1929