### PR TITLE
fix(pipeline): assign only router-resolvable models from the catalog (#1901)

### DIFF
--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -1117,17 +1117,22 @@ fn spawn_pipeline_heartbeat(
 }
 
 /// Resolve an LLM provider from a model key using an optional router.
+///
+/// `node` names the pipeline node the key came from so the fallback warn
+/// pins WHICH node has the router gap (#1901 Layer 4) instead of leaving
+/// the operator to correlate the bare model key against the graph by hand.
 fn resolve_provider(
     default: &Arc<dyn LlmProvider>,
     router: Option<&Arc<ProviderRouter>>,
     model_key: Option<&str>,
+    node: &str,
 ) -> Result<Arc<dyn LlmProvider>> {
     match (model_key, router) {
         // A missing/unknown model key must degrade to the default provider,
-        // matching CodergenHandler::resolve_provider (handler.rs) — the
-        // model-assignment pass may rewrite lane keys (e.g. `strong`) to
-        // catalog models this profile's router never registered, and that
-        // must not fail the whole pipeline.
+        // matching CodergenHandler::resolve_provider (handler.rs) — an
+        // explicit `model=` the router never registered (e.g. a stale
+        // catalog or a hand-written lane key on a narrower profile) must
+        // not fail the whole pipeline.
         (Some(key), Some(r)) => match r.resolve(key) {
             Ok(provider) => Ok(provider),
             // Keep the router's error: it names the keys that ARE registered
@@ -1136,6 +1141,7 @@ fn resolve_provider(
             // but not what would have worked.
             Err(err) => {
                 warn!(
+                    node,
                     model = key,
                     %err,
                     "pipeline model not in provider router; using default provider"
@@ -1145,6 +1151,7 @@ fn resolve_provider(
         },
         (Some(key), None) => {
             warn!(
+                node,
                 model = key,
                 "model override but no provider router; using default"
             );
@@ -1805,7 +1812,11 @@ impl PipelineExecutor {
             .catalog_dir
             .as_deref()
             .unwrap_or(&self.config.working_dir);
-        crate::model_assignment::assign_from_catalog_dir(&mut graph, catalog_dir);
+        crate::model_assignment::assign_from_catalog_dir(
+            &mut graph,
+            catalog_dir,
+            self.config.provider_router.as_deref(),
+        );
 
         // ── Pipeline start: log graph structure ──
         let node_summary: Vec<String> = graph
@@ -3161,6 +3172,7 @@ impl PipelineExecutor {
                         .as_deref()
                         .or(node.model.as_deref())
                         .or(graph.default_model.as_deref()),
+                    &node.id,
                 )?;
                 let planner_provider: Arc<dyn LlmProvider> = Arc::new(
                     SemaphoreThrottledProvider::new(planner_provider, llm_semaphore.clone()),

--- a/crates/octos-pipeline/src/executor_tests.rs
+++ b/crates/octos-pipeline/src/executor_tests.rs
@@ -2882,7 +2882,7 @@ async fn resolve_provider_falls_back_to_default_when_key_absent() {
     router.register("strong", Arc::new(NamedMock("research-strong")));
 
     // The bug: an assigned-but-unregistered model must NOT fail the run.
-    let fallback = resolve_provider(&default, Some(&router), Some("qwen3-max"))
+    let fallback = resolve_provider(&default, Some(&router), Some("qwen3-max"), "synthesize")
         .expect("an unresolvable model key must not error the pipeline");
     assert_eq!(
         fallback.model_id(),
@@ -2892,7 +2892,7 @@ async fn resolve_provider_falls_back_to_default_when_key_absent() {
 
     // A registered key still resolves to its own lane — the fallback must not
     // swallow everything.
-    let resolved = resolve_provider(&default, Some(&router), Some("strong"))
+    let resolved = resolve_provider(&default, Some(&router), Some("strong"), "analyze")
         .expect("a registered key must resolve");
     assert_eq!(
         resolved.model_id(),
@@ -2901,6 +2901,7 @@ async fn resolve_provider_falls_back_to_default_when_key_absent() {
     );
 
     // No key at all: unchanged behaviour.
-    let none = resolve_provider(&default, Some(&router), None).expect("no key must resolve");
+    let none =
+        resolve_provider(&default, Some(&router), None, "analyze").expect("no key must resolve");
     assert_eq!(none.model_id(), "pipeline-default");
 }

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -595,13 +595,14 @@ impl CodergenHandler {
     /// the resolved provider is wrapped with capability-compatible fallbacks.
     /// This ensures that if the primary model times out or errors, the pipeline
     /// automatically falls back to another provider with sufficient max_output_tokens.
-    fn resolve_provider(&self, model: Option<&str>) -> Result<Arc<dyn LlmProvider>> {
+    fn resolve_provider(&self, model: Option<&str>, node_id: &str) -> Result<Arc<dyn LlmProvider>> {
         match (model, &self.provider_router) {
             (Some(model_key), Some(router)) => match router.resolve(model_key) {
                 Ok(primary) => {
                     let fallbacks = router.compatible_fallbacks(model_key);
                     if !fallbacks.is_empty() {
                         info!(
+                            node = node_id,
                             model = model_key,
                             fallback_count = fallbacks.len(),
                             "pipeline node provider resolved with fallbacks"
@@ -619,6 +620,7 @@ impl CodergenHandler {
                 // partially-configured (or absent) research lane still runs.
                 Err(_) => {
                     warn!(
+                        node = node_id,
                         model = model_key,
                         "pipeline node model not in provider router; using default provider"
                     );
@@ -627,6 +629,7 @@ impl CodergenHandler {
             },
             (Some(model_key), None) => {
                 warn!(
+                    node = node_id,
                     model = model_key,
                     "model override specified but no provider router; using default"
                 );
@@ -646,7 +649,7 @@ impl Handler for CodergenHandler {
         let worker_id = AgentId::new(format!("pipeline-{}-{worker_num}", node.id));
 
         // Resolve LLM provider
-        let base_provider = self.resolve_provider(node.model.as_deref())?;
+        let base_provider = self.resolve_provider(node.model.as_deref(), &node.id)?;
         let provider: Arc<dyn LlmProvider> = match node.context_window {
             Some(cw) => Arc::new(ContextWindowOverride::new(base_provider, cw)),
             None => base_provider,
@@ -1603,7 +1606,9 @@ mod tests {
         .with_provider_router(router);
 
         // Absent key ("cheap" not registered) → coding default, node still runs.
-        let fallback = handler.resolve_provider(Some("cheap")).unwrap();
+        let fallback = handler
+            .resolve_provider(Some("cheap"), "test-node")
+            .unwrap();
         assert_eq!(
             fallback.model_id(),
             "coding-default",
@@ -1611,7 +1616,9 @@ mod tests {
         );
 
         // Present key ("strong") → the research lane, NOT the coding default.
-        let resolved = handler.resolve_provider(Some("strong")).unwrap();
+        let resolved = handler
+            .resolve_provider(Some("strong"), "test-node")
+            .unwrap();
         assert_ne!(
             resolved.model_id(),
             "coding-default",
@@ -1619,7 +1626,7 @@ mod tests {
         );
 
         // No model key → the shared coding provider (unchanged behavior).
-        let default = handler.resolve_provider(None).unwrap();
+        let default = handler.resolve_provider(None, "test-node").unwrap();
         assert_eq!(default.model_id(), "coding-default");
     }
 

--- a/crates/octos-pipeline/src/model_assignment.rs
+++ b/crates/octos-pipeline/src/model_assignment.rs
@@ -43,6 +43,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use octos_llm::ProviderRouter;
 use serde::Deserialize;
 
 use crate::graph::{HandlerKind, PipelineGraph};
@@ -127,12 +128,28 @@ impl ModelPools {
 /// operator's explicit choice takes precedence so this remains a default
 /// rather than a policy.
 ///
-/// Returns `Ok(())` even when no catalog is found or no models match —
-/// the policy is "best-effort default-fill, never block a pipeline".
-/// Tracing emits a single `info!` line indicating how many nodes were
-/// touched (or `debug!` for the no-op cases) so operators can confirm
-/// the assignment fired without scraping per-node logs.
-pub fn assign_from_catalog_dir(graph: &mut PipelineGraph, data_dir: &Path) {
+/// When `router` is present, candidates are filtered to models the
+/// `ProviderRouter` can actually `resolve` (#1901). The persisted
+/// `model_catalog.json` is a deliberate superset (researched entries +
+/// live scores), so without this filter a profile whose router registers
+/// only lane keys (`cheap`/`strong`) gets nodes assigned catalog models
+/// it can never resolve — the executor then silently degrades every such
+/// node to the default provider. Filtering uses the router's own
+/// resolution semantics (exact → case-insensitive → prefix split →
+/// suffix alias), NOT `keys()` membership, so lane keys and aliases keep
+/// passing; the pre-execution validator is intentionally not narrowed.
+/// `None` (no router) fails open: assignment behaves as before.
+///
+/// Never blocks a pipeline: a missing catalog, no healthy models, or a
+/// fully-unresolvable pool each leave the graph untouched (with a
+/// `debug!` line). Tracing emits a single `info!` line indicating how
+/// many nodes were touched so operators can confirm the assignment
+/// fired without scraping per-node logs.
+pub fn assign_from_catalog_dir(
+    graph: &mut PipelineGraph,
+    data_dir: &Path,
+    router: Option<&ProviderRouter>,
+) {
     let Some(catalog) = load_catalog(data_dir) else {
         tracing::debug!(
             data_dir = %data_dir.display(),
@@ -141,8 +158,11 @@ pub fn assign_from_catalog_dir(graph: &mut PipelineGraph, data_dir: &Path) {
         return;
     };
 
-    let Some(pools) = build_pools(&catalog) else {
-        tracing::debug!("model_assignment: catalog had no healthy strong/fast models");
+    let Some(pools) = build_pools(&catalog, router) else {
+        tracing::debug!(
+            "model_assignment: no usable strong/fast pool \
+             (unhealthy or unresolvable by the provider router)"
+        );
         return;
     };
 
@@ -216,15 +236,42 @@ fn load_catalog(data_dir: &Path) -> Option<ModelCatalog> {
     None
 }
 
-fn build_pools(catalog: &ModelCatalog) -> Option<ModelPools> {
+fn build_pools(catalog: &ModelCatalog, router: Option<&ProviderRouter>) -> Option<ModelPools> {
     // Keep only entries with passable stability so we don't herd-route
     // to a broken provider. The 0.5 threshold matches the historical
     // plugin so behavior is preserved.
-    let healthy: Vec<&CatalogEntry> = catalog
+    let mut healthy: Vec<&CatalogEntry> = catalog
         .models
         .iter()
         .filter(|m| m.stability > 0.5)
         .collect();
+
+    // #1901 Layer 1: an assignment is only useful if the executor can later
+    // resolve it, so keep candidates to what THIS profile's ProviderRouter
+    // resolves. The persisted `model_catalog.json` is a deliberate superset
+    // (all researched entries + live scores for configured lanes), so an
+    // unfiltered pool hands nodes models the router never registered — every
+    // such node then silently degrades to the default provider at execution
+    // time. The predicate is the router's own `resolve` (exact →
+    // case-insensitive → prefix split → suffix alias), NOT `keys()`
+    // membership: the router resolves lane keys and aliases that a literal
+    // membership check rejects (#1904's defect). With no router, fail open —
+    // assignment keeps using the catalog as-is.
+    if let Some(router) = router {
+        let before = healthy.len();
+        healthy.retain(|m| router.resolve(m.model_key()).is_ok());
+        let dropped = before - healthy.len();
+        if dropped > 0 {
+            // Sorted so repeated runs diff cleanly (`keys()` iterates a HashMap).
+            let mut router_keys = router.keys();
+            router_keys.sort();
+            tracing::warn!(
+                dropped,
+                ?router_keys,
+                "model_assignment: skipped healthy catalog models the provider router cannot resolve"
+            );
+        }
+    }
 
     let mut strong: Vec<&CatalogEntry> = healthy
         .iter()
@@ -384,11 +431,17 @@ fn assign_to_graph(graph: &mut PipelineGraph, pools: &ModelPools) {
     }
 
     if assigned > 0 {
+        // #1901 Layer 4: log the lane→model pools alongside the counts, so a
+        // later "no provider registered for key '…'" resolution failure can
+        // be traced back to the lane (strong/fast) that produced the model
+        // in one grep instead of re-deriving the assignment by hand.
         tracing::info!(
             assigned,
             skipped_explicit,
             strong_pool_size = pools.strong.len(),
             fast_pool_size = pools.fast.len(),
+            strong_pool = ?pools.strong,
+            fast_pool = ?pools.fast,
             "model_assignment: applied defaults to {} pipeline node attribute(s)",
             assigned
         );
@@ -555,10 +608,195 @@ mod tests {
                 },
             ],
         };
-        let pools = build_pools(&catalog).expect("non-empty");
+        let pools = build_pools(&catalog, None).expect("non-empty");
         // The unstable strong should have been filtered out — only
         // healthy-strong survives.
         assert_eq!(pools.strong, vec!["healthy-strong".to_string()]);
         assert_eq!(pools.fast, vec!["fast-a".to_string()]);
+    }
+
+    /// Minimal lane provider for router-backed tests: `resolve()` only
+    /// clones Arcs, `chat` is never reached.
+    struct LaneStub(&'static str);
+
+    #[async_trait::async_trait]
+    impl octos_llm::LlmProvider for LaneStub {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            unreachable!("assignment must not call chat()")
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatStream> {
+            unreachable!("assignment must not call chat_stream()")
+        }
+
+        fn model_id(&self) -> &str {
+            self.0
+        }
+
+        fn provider_name(&self) -> &str {
+            self.0
+        }
+    }
+
+    /// A router registering only the given lane keys, mirroring a profile
+    /// whose research lanes are `cheap`/`strong` but nothing else.
+    fn lane_router(keys: &[&str]) -> std::sync::Arc<ProviderRouter> {
+        use std::sync::Arc;
+        let router = Arc::new(ProviderRouter::new());
+        for key in keys {
+            router.register(key, Arc::new(LaneStub("lane")));
+        }
+        router
+    }
+
+    fn write_catalog(dir: &Path, models_json: &str) {
+        std::fs::write(
+            dir.join("model_catalog.json"),
+            format!(r#"{{"models":[{models_json}]}}"#),
+        )
+        .unwrap();
+    }
+
+    /// #1901 Layer 1: the persisted `model_catalog.json` is a deliberate
+    /// superset, so a profile whose router registers only lane keys
+    /// (`cheap`/`strong`) must not have those catalog models assigned to
+    /// nodes — every assignment would be unresolvable at execution time and
+    /// silently run on the default provider instead. Unset nodes stay unset
+    /// (the documented no-catalog behavior); explicit models keep winning.
+    #[test]
+    fn unregistered_catalog_models_are_never_assigned() {
+        let dir = tempfile::tempdir().unwrap();
+        write_catalog(
+            dir.path(),
+            concat!(
+                r#"{"provider":"x/qwen3-max","type":"strong","stability":0.99,"score":0.10},"#,
+                r#"{"provider":"y/kimi-fast","type":"fast","stability":0.95,"score":0.15}"#,
+            ),
+        );
+        let router = lane_router(&["cheap", "strong"]);
+
+        let mut g = graph_with(vec![
+            n("plan_and_search", HandlerKind::DynamicParallel),
+            n("search_news", HandlerKind::Codergen),
+            (
+                "analyze".into(),
+                PipelineNode {
+                    id: "analyze".into(),
+                    handler: HandlerKind::Codergen,
+                    model: Some("operator-pinned".into()),
+                    ..Default::default()
+                },
+            ),
+            n("synthesize", HandlerKind::Codergen),
+        ]);
+        assign_from_catalog_dir(&mut g, dir.path(), Some(&router));
+
+        for id in ["plan_and_search", "search_news", "synthesize"] {
+            assert!(
+                g.nodes[id].model.is_none(),
+                "node `{id}` must not be assigned an unregistered catalog model"
+            );
+        }
+        assert_eq!(g.nodes["analyze"].model.as_deref(), Some("operator-pinned"));
+        assert!(
+            g.nodes["plan_and_search"].planner_model.is_none(),
+            "the strong pool was entirely unregistered, so no planner model either"
+        );
+    }
+
+    /// The filter uses the router's own resolution semantics (exact →
+    /// case-insensitive → prefix split → suffix alias), NOT `keys()`
+    /// membership — narrowing to `keys()` was the #1904 defect, because the
+    /// router resolves lane keys and aliases a literal membership check
+    /// rejects. `moonshotai/kimi-k2.5` registered as a compound key keeps a
+    /// `moonshotai/kimi-k2.5` catalog entry assignable via the suffix-alias
+    /// arm, while `qwen3-max` (resolvable by nothing) is skipped.
+    #[test]
+    fn router_filter_uses_resolution_semantics_not_key_membership() {
+        let dir = tempfile::tempdir().unwrap();
+        write_catalog(
+            dir.path(),
+            concat!(
+                r#"{"provider":"x/qwen3-max","type":"strong","stability":0.99,"score":0.05},"#,
+                r#"{"provider":"moonshotai/kimi-k2.5","type":"strong","stability":0.98,"score":0.10}"#,
+            ),
+        );
+        let router = lane_router(&["moonshotai/kimi-k2.5", "cheap"]);
+
+        let mut g = graph_with(vec![n("synthesize", HandlerKind::Codergen)]);
+        assign_from_catalog_dir(&mut g, dir.path(), Some(&router));
+
+        assert_eq!(
+            g.nodes["synthesize"].model.as_deref(),
+            Some("kimi-k2.5"),
+            "the resolvable catalog model must be assigned (via the router's \
+             suffix-alias arm), not skipped for not being a literal router key"
+        );
+    }
+
+    /// Fails open: with no router in play, assignment keeps using the
+    /// catalog as-is (#1902's tolerance semantics — a router-less profile
+    /// must not lose strong/fast defaults).
+    #[test]
+    fn absent_router_keeps_catalog_assignment_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        write_catalog(
+            dir.path(),
+            r#"{"provider":"x/qwen3-max","type":"strong","stability":0.99,"score":0.10}"#,
+        );
+
+        let mut g = graph_with(vec![n("synthesize", HandlerKind::Codergen)]);
+        assign_from_catalog_dir(&mut g, dir.path(), None);
+
+        assert_eq!(
+            g.nodes["synthesize"].model.as_deref(),
+            Some("qwen3-max"),
+            "no router ⇒ no new strictness; the catalog pool still fills unset nodes"
+        );
+    }
+
+    /// The DynamicParallel `model=` attribute is a comma-joined POOL, so the
+    /// filter must apply per entry: only resolvable fast-lane models may end
+    /// up in the joined string (every entry is round-robined onto a worker
+    /// that later resolves it individually).
+    #[test]
+    fn dynamic_parallel_pool_joins_only_resolvable_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        write_catalog(
+            dir.path(),
+            concat!(
+                r#"{"provider":"x/qwen3-max","type":"strong","stability":0.99,"score":0.10},"#,
+                r#"{"provider":"y/kimi-fast","type":"fast","stability":0.95,"score":0.15},"#,
+                r#"{"provider":"z/gpt-4o-mini","type":"fast","stability":0.97,"score":0.20}"#,
+            ),
+        );
+        let router = lane_router(&["cheap", "strong", "kimi-fast"]);
+
+        let mut g = graph_with(vec![n("plan_and_search", HandlerKind::DynamicParallel)]);
+        assign_from_catalog_dir(&mut g, dir.path(), Some(&router));
+
+        // qwen3-max (strong pool) and gpt-4o-mini (fast pool) are
+        // unregistered → skipped; kimi-fast survives. The strong pool is
+        // empty, so it aliases to the surviving fast pool.
+        assert_eq!(
+            g.nodes["plan_and_search"].model.as_deref(),
+            Some("kimi-fast"),
+            "only router-resolvable entries may appear in the worker pool"
+        );
+        assert_eq!(
+            g.nodes["plan_and_search"].planner_model.as_deref(),
+            Some("kimi-fast"),
+            "empty strong pool aliases to the surviving fast pool (existing behavior)"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`model_assignment.rs` rewrites unset lane models using the on-disk catalog, but the persisted `model_catalog.json` is a deliberate superset (93 researched entries, most never registered by the profile's `ProviderRouter`). So assignment keeps handing nodes unresolvable model keys — and since #1902, the run no longer crashes but **silently executes those nodes on the default provider**, with a `warn!` firing on every run. That's the remaining Layer 1 + Layer 4 work scoped in the issue.

## Root cause

`build_pools` filtered candidates by health (stability) only. It never consulted the router, so the strong/fast pools routinely contained models only `router.resolve` could reject. The executor's `resolve_provider` fallback (the #1902 stop-gap) then fired as the *normal* path instead of a safety net.

## Fix

- **Layer 1** — `assign_from_catalog_dir` now takes `Option<&ProviderRouter>` (threaded from `ExecutorConfig.provider_router` at the existing call site) and `build_pools` retains only candidates the router can actually `resolve`. The predicate is deliberately the router's own resolution semantics (exact → case-insensitive → prefix split → suffix alias), **not** `keys()` membership — a literal membership check is the #1904 defect class, because the router resolves lane keys and aliases that a literal set rejects. With no router, the filter fails open: assignment behaves exactly as before.
- **Layer 4** — the original lane key is physically lost by the time the router is consulted (assignment already rewrote it), so `router.rs:154` cannot report it without a signature change through the whole resolution chain. Instead the fix closes the gap at the assignment boundary, where the lane still exists:
  - `build_pools` warns once with the dropped count and the sorted registered keys,
  - the assignment `info!` now logs the concrete `strong_pool` / `fast_pool` contents, so `no provider registered for key 'X'` traces back to the lane that produced `X` in one grep,
  - both fallback warns (`executor.rs` free fn, `CodergenHandler`) now carry `node=` so the gap is pinned to a node, not just a model key.

Constraint check (from the issue discussion): the filter lives **only** in `model_assignment.rs` candidate selection — `known_model_keys_from_catalog_dir` and the pre-execution validator are untouched. The #1902 fallback behavior and `resolve_provider_falls_back_to_default_when_key_absent` are preserved verbatim (only a `node` parameter was added for attribution); it is now a safety net that stays silent in normal operation.

## Testing evidence

- 4 new unit tests in `model_assignment.rs`, each verified RED against the pre-fix code by no-op'ing the retain: superset catalog + lane-only router assigns nothing and injects no planner model; the filter passes a compound-key catalog entry via the suffix-alias arm while dropping an unresolvable one (pins the resolution-semantics-not-membership rule); `None` router fails open; the `dynamic_parallel` comma pool joins only resolvable entries.
- Full suite: `cargo test -p octos-pipeline` — 464 passed, 0 failed; `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean (CI parity).
- Real-LLM e2e (temporary harness, DeepSeek, not part of the diff): a 3-node DOT pipeline, no `model=` attrs, catalog seeded with `qwen3-max` (best score, unresolvable) + `deepseek/deepseek-reasoner` (resolvable), router registering `cheap`/`strong`/`deepseek/deepseek-reasoner`, default provider = `deepseek-chat`.
  - **Before (main):** nodes got `qwen3-max`, each logged `pipeline node model not in provider router; using default provider`, and actually ran on the default `deepseek-chat` — the exact silent-downgrade from the issue.
  - **After (this branch):** one `skipped healthy catalog models … dropped=1` warn, all three nodes assigned `deepseek-reasoner`, all three ran on `openai/deepseek-reasoner` via the router, zero fallback warns.

## Review

Self-reviewed full diff, then an independent reviewer (issue text + diff + related sources only) returned SHIP with no blocker/major findings; the actionable notes (sorted `router_keys`, a stale "Returns Ok(())" doc line, an executor comment that still described the now-fixed rewrite as current behavior) are addressed in this final state. One pre-existing remnant is knowingly left out of scope: for a `dynamic_parallel` node with an explicit `model=` but no `planner_model=`, assignment can still inject a planner model that outranks the explicit one (`planner_model > model` in the executor). That behavior predates this fix and is only narrowed by it (the injected model is now guaranteed resolvable); flagging it here in case you want it tracked separately.

Happy to take an adversarial pass on the Layer 4 placement — the alternative (threading the lane key down to `router.rs`) would need a new resolve entry point used only by pipelines, which seemed worse than logging at the boundary where the information still exists.

Closes #1901