### PR TITLE
fix: avoid redundant CLI rebuilds in Git worktrees

### DIFF
--- a/crates/octos-cli/build.rs
+++ b/crates/octos-cli/build.rs
@@ -1,14 +1,70 @@
+use std::path::Path;
 use std::process::Command;
 
-fn main() {
-    // Git short hash
-    let hash = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+/// Run `git -C <dir> <args>`; Ok(stdout) only when the command exited 0.
+fn git_out(dir: &Path, args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
         .output()
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_default();
+}
+
+/// Resolve an ABSOLUTE, actually-existing git metadata path via
+/// `git rev-parse --path-format=absolute --git-path <name>`.
+/// Returns None when git is unavailable, the repo doesn't exist, or the
+/// resolved path doesn't exist on disk (e.g. packed refs have no loose
+/// ref file) — a rerun-if-changed on a nonexistent path makes cargo mark
+/// the unit dirty on EVERY build (the linked-worktree rebuild bug).
+fn existing_git_path(dir: &Path, name: &str) -> Option<std::path::PathBuf> {
+    let out = git_out(
+        dir,
+        &["rev-parse", "--path-format=absolute", "--git-path", name],
+    )?;
+    let path = Path::new(&out);
+    (path.is_file() || path.is_dir()).then(|| path.to_path_buf())
+}
+
+/// The current branch name from HEAD (`ref: refs/heads/<b>`), or None for
+/// detached HEAD / unreadable HEAD.
+fn head_branch(dir: &Path) -> Option<String> {
+    let head = existing_git_path(dir, "HEAD")?;
+    let text = std::fs::read_to_string(head).ok()?;
+    let branch = text.trim().strip_prefix("ref: ")?;
+    if branch == "HEAD" || !branch.starts_with("refs/heads/") {
+        return None; // detached
+    }
+    Some(branch.to_string())
+}
+
+/// This package belongs to `<project>/crates/octos-cli`. An archive nested
+/// in another repository must not inherit that outer repository's version.
+/// Let Git resolve `.git` files (including relative worktree pointers).
+fn owning_repo(dir: &Path) -> Option<()> {
+    let manifest = dir.canonicalize().ok()?;
+    let root = manifest.parent()?.parent()?;
+    if !root.join(".git").exists() {
+        return None;
+    }
+    let toplevel = git_out(dir, &["rev-parse", "--show-toplevel"])?;
+    (Path::new(&toplevel).canonicalize().ok()? == root).then_some(())
+}
+
+fn main() {
+    // The build script's CWD is the package manifest dir.
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    // Git short hash — only when this package genuinely belongs to the
+    // repository that owns its manifest dir (see owning_repo).
+    let trusted_git = owning_repo(manifest).is_some();
+    let hash = if trusted_git {
+        git_out(manifest, &["rev-parse", "--short", "HEAD"]).unwrap_or_default()
+    } else {
+        String::new()
+    };
     println!("cargo:rustc-env=OCTOS_GIT_HASH={hash}");
 
     // Build date (YYYY-MM-DD)
@@ -21,7 +77,43 @@ fn main() {
         .unwrap_or_default();
     println!("cargo:rustc-env=OCTOS_BUILD_DATE={date}");
 
-    // Re-run if git HEAD changes
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../.git/refs/heads/");
+    // Re-run only on REAL metadata paths, each verified to exist:
+    //  * HEAD — text changes on branch switch / detached checkout.
+    //  * the current branch ref file — rewritten on every same-branch
+    //    commit (HEAD text does NOT change then; watching HEAD alone
+    //    leaves the hash stale).
+    //  * packed-refs — when refs are packed there is no loose ref file;
+    //    packing/pruning changes this file. A later commit may instead
+    //    create a loose ref, detected by the refs-directory watch below.
+    // Watching a nonexistent path (the old `../../.git/HEAD` shapes) makes
+    // cargo treat the unit as dirty on every no-change build — the
+    // linked-worktree rebuild bug. In git-less trees (and non-adopted
+    // archives) we emit no git watch lines at all.
+    // A nonempty rerun set REPLACES cargo's default (watch the whole
+    // package). In git-less trees an EMPTY set would fall back to
+    // watch-everything; pin the build script itself instead so unrelated
+    // source edits still behave and the set is never empty.
+    if trusted_git {
+        if let Some(head) = existing_git_path(manifest, "HEAD") {
+            println!("cargo:rerun-if-changed={}", head.display());
+        }
+        if let Some(branch) = head_branch(manifest) {
+            if let Some(ref_file) = existing_git_path(manifest, &branch) {
+                println!("cargo:rerun-if-changed={}", ref_file.display());
+            } else {
+                // Packed refs: the loose ref file does not exist YET. A
+                // same-branch commit then creates it WITHOUT touching HEAD
+                // or packed-refs — watch the refs DIRECTORY so the creation
+                // (a new entry in the dir) re-runs the script, which
+                // re-resolves and switches to watching the loose file.
+                if let Some(refs_dir) = existing_git_path(manifest, "refs") {
+                    println!("cargo:rerun-if-changed={}", refs_dir.display());
+                }
+            }
+        }
+        if let Some(packed) = existing_git_path(manifest, "packed-refs") {
+            println!("cargo:rerun-if-changed={}", packed.display());
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/crates/octos-cli/build.rs
+++ b/crates/octos-cli/build.rs
@@ -84,7 +84,7 @@ fn main() {
     //    leaves the hash stale).
     //  * packed-refs — when refs are packed there is no loose ref file;
     //    packing/pruning changes this file. A later commit may instead
-    //    create a loose ref, detected by the refs-directory watch below.
+    //    create a loose ref, detected by its nearest existing parent below.
     // Watching a nonexistent path (the old `../../.git/HEAD` shapes) makes
     // cargo treat the unit as dirty on every no-change build — the
     // linked-worktree rebuild bug. In git-less trees (and non-adopted
@@ -103,11 +103,18 @@ fn main() {
             } else {
                 // Packed refs: the loose ref file does not exist YET. A
                 // same-branch commit then creates it WITHOUT touching HEAD
-                // or packed-refs — watch the refs DIRECTORY so the creation
-                // (a new entry in the dir) re-runs the script, which
-                // re-resolves and switches to watching the loose file.
-                if let Some(refs_dir) = existing_git_path(manifest, "refs") {
-                    println!("cargo:rerun-if-changed={}", refs_dir.display());
+                // or packed-refs. Watch its nearest existing parent so the
+                // creation is detected, without watching unrelated remote
+                // refs when refs/heads (or a narrower parent) exists. Walk
+                // upward because packing may remove nested branch dirs.
+                // Direct refs also work when HEAD reflogs are disabled.
+                let mut ancestor = branch.as_str();
+                while let Some((parent, _)) = ancestor.rsplit_once('/') {
+                    if let Some(directory) = existing_git_path(manifest, parent) {
+                        println!("cargo:rerun-if-changed={}", directory.display());
+                        break;
+                    }
+                    ancestor = parent;
                 }
             }
         }

--- a/crates/octos-cli/tests/build_git_metadata.rs
+++ b/crates/octos-cli/tests/build_git_metadata.rs
@@ -1,0 +1,582 @@
+//! task-build-git-metadata-watch — the production build script must watch
+//! REAL git metadata paths (`git rev-parse --git-path ...`), never the
+//! nonexistent `../../.git/HEAD` / `../../.git/refs/heads/` shapes that a
+//! linked worktree doesn't have (no-change rebuilds), and must refresh
+//! `OCTOS_GIT_HASH` after a same-branch commit (HEAD text does not change
+//! on a same-branch commit — the branch ref file does).
+//!
+//! The fixtures replicate the PRODUCTION build script byte-for-byte via
+//! `include_str!("../build.rs")` into tiny no-dependency Cargo workspaces,
+//! drive real `git` and real `cargo` (`env!("CARGO")`), and count actual
+//! `rustc` invocations from `cargo build -vv` output — never string-contain
+//! shortcuts.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// One tiny workspace: `dep` (no-dep lib) + `probe` (bin, build.rs copied
+/// from the production file, prints OCTOS_GIT_HASH to prove env refresh).
+fn write_fixture(root: &Path) {
+    fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/dep\", \"crates/probe\"]\nresolver = \"2\"\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("crates/dep/src")).unwrap();
+    fs::write(
+        root.join("crates/dep/Cargo.toml"),
+        "[package]\nname = \"dep\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("crates/dep/src/lib.rs"),
+        "pub fn one() -> u32 { 1 }\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("crates/probe/src")).unwrap();
+    fs::write(
+        root.join("crates/probe/Cargo.toml"),
+        "[package]\nname = \"probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\nbuild = \"build.rs\"\n[dependencies]\ndep = { path = \"../dep\" }\n",
+    )
+    .unwrap();
+    // THE production script, byte-for-byte.
+    fs::write(
+        root.join("crates/probe/build.rs"),
+        include_str!("../build.rs"),
+    )
+    .unwrap();
+    fs::write(
+        root.join("crates/probe/src/main.rs"),
+        "fn main() { println!(\"hash={}\", option_env!(\"OCTOS_GIT_HASH\").unwrap_or(\"\")); }\n",
+    )
+    .unwrap();
+}
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(["-C", dir.to_str().unwrap()])
+        .args(args)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("git runs");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// `git add` ONLY the fixture SOURCE files — never a bare `add .` (the
+/// fixture-target build outputs must not enter the repo history).
+fn git_add_sources(dir: &Path) {
+    for path in [
+        "Cargo.toml",
+        "crates/dep/Cargo.toml",
+        "crates/dep/src/lib.rs",
+        "crates/probe/Cargo.toml",
+        "crates/probe/build.rs",
+        "crates/probe/src/main.rs",
+    ] {
+        let out = Command::new("git")
+            .args(["-C", dir.to_str().unwrap(), "add", "--", path])
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .output()
+            .expect("git add runs");
+        assert!(
+            out.status.success(),
+            "git add {path} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+/// Commit the fixture sources at the CURRENT state (so both detached
+/// commits carry the full Cargo tree) plus an optional extra tracked path.
+fn commit_fixture(dir: &Path, msg: &str, extra: Option<&str>) {
+    git_add_sources(dir);
+    if let Some(e) = extra {
+        let out = Command::new("git")
+            .args(["-C", dir.to_str().unwrap(), "add", "--", e])
+            .output()
+            .expect("git add runs");
+        assert!(out.status.success());
+    }
+    git(dir, &["commit", "-q", "-m", msg]);
+}
+
+fn init_repo(dir: &Path) {
+    fs::create_dir_all(dir).unwrap();
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "t@t"]);
+    git(dir, &["config", "user.name", "t"]);
+    fs::write(dir.join("readme.txt"), "v1\n").unwrap();
+    // Explicit adds only — never `add .` (fixture-target outputs live here).
+    git(dir, &["add", "--", "readme.txt"]);
+    git(dir, &["commit", "-q", "-m", "init"]);
+}
+
+/// Run cargo in a fixture. Returns (exit, combined_log). Uses the SAME
+/// fixture-local target dir across calls, `-vv` so rustc lines appear, and
+/// a clean env (no inherited RUSTC_WRAPPER / CARGO_INCREMENTAL etc).
+fn cargo_vv(ws: &Path, extra_env: &[(&str, &str)]) -> (i32, String) {
+    let target = ws.join("fixture-target");
+    let mut cmd = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()));
+    cmd.args(["build", "--offline", "-vv"])
+        .current_dir(ws)
+        .env("CARGO_TARGET_DIR", &target)
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_INCREMENTAL")
+        .env_remove("RUSTFLAGS");
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("cargo runs");
+    let log = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.code().unwrap_or(-1), log)
+}
+
+/// Probe crate is Fresh ⇔ its `Running \`…rustc … --crate-name probe\` line
+/// is ABSENT from the -vv log (a Fresh unit shows no rustc invocation).
+fn probe_rustc_count(log: &str) -> usize {
+    log.lines()
+        .filter(|l| {
+            l.contains("Running `") && l.contains("rustc") && l.contains("--crate-name probe")
+        })
+        .count()
+}
+
+fn probe_dirty(log: &str) -> bool {
+    log.lines().any(|l| l.contains("Dirty probe"))
+}
+
+fn run_binary_hash(ws: &Path) -> String {
+    let out = Command::new(ws.join("fixture-target/debug/probe"))
+        .output()
+        .expect("probe binary runs");
+    assert!(out.status.success());
+    let line = String::from_utf8_lossy(&out.stdout);
+    line.trim()
+        .strip_prefix("hash=")
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Self-cleaning tempdir: the guard's Drop removes the whole fixture
+/// (repo, its worktree registrations under this tree, and the
+/// fixture-target build outputs) so a test-fixing round never litters
+/// rustc artifacts, even when an assertion fails mid-test.
+struct FixtureDir(PathBuf);
+impl FixtureDir {
+    fn new(name: &str) -> Self {
+        let base = std::env::temp_dir().join(format!(
+            "bwm-{}-{}-{name}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&base).unwrap();
+        FixtureDir(base)
+    }
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+impl Drop for FixtureDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+// -------------------------------------------------------------------------
+// 1. Regular repo: second no-change build must be Fresh with 0 rustc calls.
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_regular_repo_second_build_fresh() {
+    let dir_ws = FixtureDir::new("regular");
+    let ws = dir_ws.path().to_path_buf();
+    init_repo(&ws);
+    write_fixture(&ws);
+    let (e1, l1) = cargo_vv(&ws, &[]);
+    assert_eq!(e1, 0, "first build: {l1}");
+    assert_eq!(probe_rustc_count(&l1), 1, "first build compiles probe once");
+    let (e2, l2) = cargo_vv(&ws, &[]);
+    assert_eq!(e2, 0, "second build: {l2}");
+    assert!(
+        !probe_dirty(&l2),
+        "second no-change build must be Fresh, got Dirty. Log tail:\n{}",
+        l2.lines().rev().take(12).collect::<Vec<_>>().join("\n")
+    );
+    assert_eq!(
+        probe_rustc_count(&l2),
+        0,
+        "no rustc invocation for probe on no-change rebuild"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 2. Linked worktree: the ORIGINAL bug — ../../.git/HEAD does not exist
+//    here, cargo marked the unit Dirty on EVERY build. Must now be Fresh.
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_linked_worktree_second_build_fresh() {
+    let dir_main = FixtureDir::new("lw-main");
+    let main = dir_main.path().to_path_buf();
+    init_repo(&main);
+    let dir_linked = FixtureDir::new("lw-linked");
+    let linked = dir_linked.path().to_path_buf();
+    let _ = fs::remove_dir_all(&linked);
+    git(
+        &main,
+        &["worktree", "add", linked.to_str().unwrap(), "-b", "topic"],
+    );
+    write_fixture(&linked);
+    commit_fixture(&linked, "fixture", None);
+    let (e1, l1) = cargo_vv(&linked, &[]);
+    assert_eq!(e1, 0, "linked first: {l1}");
+    let (e2, l2) = cargo_vv(&linked, &[]);
+    assert_eq!(e2, 0, "linked second: {l2}");
+    assert!(
+        !probe_dirty(&l2),
+        "linked worktree no-change rebuild must be Fresh (was Dirty with ../../.git/HEAD missing). Log tail:\n{}",
+        l2.lines().rev().take(12).collect::<Vec<_>>().join("\n")
+    );
+    assert_eq!(probe_rustc_count(&l2), 0);
+}
+
+// -------------------------------------------------------------------------
+// 3. Same-branch commit: HEAD text is UNCHANGED, but the branch ref file
+//    is rewritten — the watch must catch it and refresh OCTOS_GIT_HASH.
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_same_branch_commit_updates_hash() {
+    let dir = FixtureDir::new("commit");
+    let ws = dir.path().to_path_buf();
+    init_repo(&ws);
+    write_fixture(&ws);
+    let (_e, _l) = cargo_vv(&ws, &[]);
+    let before = run_binary_hash(&ws);
+    assert!(!before.is_empty(), "hash is populated in a git repo");
+    fs::write(ws.join("readme.txt"), "v2\n").unwrap();
+    git(&ws, &["add", "--", "readme.txt"]);
+    git(&ws, &["commit", "-q", "-m", "second"]);
+    let (e3, l3) = cargo_vv(&ws, &[]);
+    assert_eq!(e3, 0, "post-commit build: {l3}");
+    let after = run_binary_hash(&ws);
+    assert_ne!(
+        before, after,
+        "same-branch commit must refresh OCTOS_GIT_HASH (watch the branch ref, not HEAD text only)"
+    );
+    let short = git(&ws, &["rev-parse", "--short", "HEAD"]);
+    assert_eq!(after, short, "hash equals the NEW commit's short sha");
+}
+
+// -------------------------------------------------------------------------
+// 4. Detached HEAD in a linked worktree: HEAD file itself carries the sha;
+//    checking out a different commit must trigger a rebuild + hash update.
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_detached_head_change_triggers() {
+    let dir_main = FixtureDir::new("det-main");
+    let main = dir_main.path().to_path_buf();
+    init_repo(&main);
+    write_fixture(&main);
+    commit_fixture(&main, "fixture-c1", None);
+    // Second commit differs ONLY in the version-relevant readme (the full
+    // Cargo tree exists at BOTH commits — switching must never land on a
+    // commit missing Cargo.toml).
+    fs::write(main.join("readme.txt"), "v2\n").unwrap();
+    git(&main, &["add", "--", "readme.txt"]);
+    git(&main, &["commit", "-q", "-m", "second"]);
+    let first = git(&main, &["rev-parse", "HEAD~1"]);
+    let dir_linked = FixtureDir::new("det-linked");
+    let linked = dir_linked.path().to_path_buf();
+    let _ = fs::remove_dir_all(&linked);
+    git(
+        &main,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            linked.to_str().unwrap(),
+            &first,
+        ],
+    );
+    let first_fixture = git(&linked, &["rev-parse", "--short", "HEAD"]);
+    let _ = cargo_vv(&linked, &[]);
+    assert_eq!(run_binary_hash(&linked), first_fixture);
+    // Switch the detached HEAD to the other commit (same Cargo tree).
+    let second = git(&main, &["rev-parse", "HEAD"]);
+    git(&linked, &["checkout", "-q", &second]);
+    let (e, l) = cargo_vv(&linked, &[]);
+    assert_eq!(e, 0, "post-checkout build: {l}");
+    let short2 = git(&linked, &["rev-parse", "--short", "HEAD"]);
+    assert_eq!(
+        run_binary_hash(&linked),
+        short2,
+        "detached checkout refreshes the hash"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 5. Packed refs: refs/heads/<b> may not exist as a loose file. Watch
+//    packed-refs as well; a commit rewrites it (or creates the loose ref).
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_packed_refs_fresh_and_commit_triggers() {
+    let dir = FixtureDir::new("packed");
+    let ws = dir.path().to_path_buf();
+    init_repo(&ws);
+    write_fixture(&ws);
+    git(&ws, &["pack-refs", "--all"]);
+    let (e1, l1) = cargo_vv(&ws, &[]);
+    assert_eq!(e1, 0, "packed first: {l1}");
+    let (e2, l2) = cargo_vv(&ws, &[]);
+    assert_eq!(e2, 0);
+    assert!(
+        !probe_dirty(&l2),
+        "packed-refs repo, no-change rebuild Fresh. Log:\n{l2}"
+    );
+    assert_eq!(probe_rustc_count(&l2), 0);
+    fs::write(ws.join("readme.txt"), "v2\n").unwrap();
+    git(&ws, &["add", "--", "readme.txt"]);
+    git(&ws, &["commit", "-q", "-m", "second"]);
+    let (e3, l3) = cargo_vv(&ws, &[]);
+    assert_eq!(e3, 0, "packed post-commit: {l3}");
+    let short = git(&ws, &["rev-parse", "--short", "HEAD"]);
+    assert_eq!(
+        run_binary_hash(&ws),
+        short,
+        "commit after pack-refs refreshes hash"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 6. No git at all: no rerun-if-changed output may reference git paths,
+//    build succeeds, hash empty. (The original script emitted
+//    ../../.git/HEAD even here — nonexistent watch path.)
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_no_git_dir_builds_without_rerun() {
+    let dir = FixtureDir::new("nogit");
+    let ws = dir.path().to_path_buf();
+    write_fixture(&ws);
+    // We cannot observe the build script's stdout directly in the -vv log,
+    // but a nonexistent watched path makes cargo mark the unit Dirty on the
+    // SECOND build — so Fresh-on-rebuild IS the observable contract.
+    let (e1, l1) = cargo_vv(&ws, &[]);
+    assert_eq!(e1, 0, "no-git first build ok: {l1}");
+    let (e2, l2) = cargo_vv(&ws, &[]);
+    assert_eq!(e2, 0);
+    assert!(
+        !probe_dirty(&l2),
+        "no-git rebuild must stay Fresh (original script watched nonexistent ../../.git/HEAD). Log:\n{l2}"
+    );
+    assert_eq!(run_binary_hash(&ws), "", "hash empty without git");
+}
+
+// -------------------------------------------------------------------------
+// 7. Archive inside an OUTER git repo: git -C walks UP and would adopt the
+//    outer repository's HEAD. The build script must NOT adopt it.
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_archive_inside_outer_repo_not_adopted() {
+    let dir_outer = FixtureDir::new("outer");
+    let outer = dir_outer.path().to_path_buf();
+    init_repo(&outer);
+    // A source archive extracted INSIDE the outer repo: no .git of its own,
+    // and its files are NOT tracked by the outer repo.
+    let archive_ws = outer.join("extracted");
+    fs::create_dir_all(&archive_ws).unwrap();
+    write_fixture(&archive_ws);
+    let (e1, l1) = cargo_vv(&archive_ws, &[]);
+    assert_eq!(e1, 0, "archive build ok: {l1}");
+    assert_eq!(
+        run_binary_hash(&archive_ws),
+        "",
+        "archive source must NOT adopt the outer repo's hash"
+    );
+    let (e2, l2) = cargo_vv(&archive_ws, &[]);
+    assert_eq!(e2, 0);
+    assert!(!probe_dirty(&l2), "archive rebuild stays Fresh: {l2}");
+    // And adopting the outer repo would be observable: outer's hash differs.
+    let outer_short = git(&outer, &["rev-parse", "--short", "HEAD"]);
+    assert_ne!(outer_short, "", "outer repo has a hash");
+}
+
+// -------------------------------------------------------------------------
+// 7b. Archive TRACKED by the outer repo (ROOT review): ls-files would say
+//     tracked; the guard must still not adopt — the archive has no .git of
+//     its own, so the owning-repo check (git-dir under the nearest
+//     toplevel's .git entry) fails and we stay git-less.
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_tracked_archive_inside_outer_repo_not_adopted() {
+    let dir_outer = FixtureDir::new("outer-tracked");
+    let outer = dir_outer.path().to_path_buf();
+    init_repo(&outer);
+    let archive_ws = outer.join("extracted");
+    fs::create_dir_all(&archive_ws).unwrap();
+    write_fixture(&archive_ws);
+    // The outer repo TRACKS the extracted files (the harder case: a naive
+    // ls-files guard would adopt the outer repo).
+    // Track the ARCHIVE SOURCE files explicitly (never `add .` — the
+    // fixture-target outputs must not be tracked either).
+    for path in [
+        "extracted/Cargo.toml",
+        "extracted/crates/dep/Cargo.toml",
+        "extracted/crates/dep/src/lib.rs",
+        "extracted/crates/probe/Cargo.toml",
+        "extracted/crates/probe/build.rs",
+        "extracted/crates/probe/src/main.rs",
+    ] {
+        git(&outer, &["add", "--", path]);
+    }
+    git(&outer, &["commit", "-q", "-m", "track archive"]);
+    let (e1, l1) = cargo_vv(&archive_ws, &[]);
+    assert_eq!(e1, 0, "tracked-archive build ok: {l1}");
+    assert_eq!(
+        run_binary_hash(&archive_ws),
+        "",
+        "tracked-by-outer archive must still NOT adopt the outer repo's hash"
+    );
+    let (e2, l2) = cargo_vv(&archive_ws, &[]);
+    assert_eq!(e2, 0);
+    assert!(
+        !probe_dirty(&l2),
+        "tracked-archive rebuild stays Fresh: {l2}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 5b. pack-refs --all --prune then a SAME-BRANCH commit: the commit
+//     CREATES the loose ref file (HEAD text and packed-refs are both
+//     unchanged) — watching only those two would MISS it. The refs-dir
+//     watch catches the creation and refreshes the hash.
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_packed_pruned_same_branch_commit_refreshes() {
+    let dir = FixtureDir::new("packed-prune");
+    let ws = dir.path().to_path_buf();
+    init_repo(&ws);
+    write_fixture(&ws);
+    git(&ws, &["pack-refs", "--all", "--prune"]);
+    let short1 = git(&ws, &["rev-parse", "--short", "HEAD"]);
+    let _ = cargo_vv(&ws, &[]);
+    assert_eq!(run_binary_hash(&ws), short1);
+    // Same-branch commit after pruned packing: creates refs/heads/main.
+    fs::write(ws.join("readme.txt"), "v2\n").unwrap();
+    git(&ws, &["add", "--", "readme.txt"]);
+    git(&ws, &["commit", "-q", "-m", "second"]);
+    let (e, l) = cargo_vv(&ws, &[]);
+    assert_eq!(e, 0, "post-commit build: {l}");
+    let short2 = git(&ws, &["rev-parse", "--short", "HEAD"]);
+    assert_ne!(short1, short2);
+    assert_eq!(
+        run_binary_hash(&ws),
+        short2,
+        "loose-ref creation after pack-refs --prune must refresh the hash (refs-dir watch)"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 8. Branch switch: HEAD text changes (ref: …main → ref: …topic); the
+//    commit is different too. Rebuild must refresh the hash.
+// -------------------------------------------------------------------------
+#[test]
+fn build_git_watch_branch_switch_triggers() {
+    let dir = FixtureDir::new("switch");
+    let ws = dir.path().to_path_buf();
+    init_repo(&ws);
+    write_fixture(&ws);
+    commit_fixture(&ws, "fixture", None); // full tree at the common ancestor
+    git(&ws, &["checkout", "-q", "-b", "topic"]);
+    fs::write(ws.join("readme.txt"), "topic\n").unwrap();
+    git(&ws, &["add", "--", "readme.txt"]);
+    git(&ws, &["commit", "-q", "-m", "fixture-topic"]);
+    let topic_short = git(&ws, &["rev-parse", "--short", "HEAD"]);
+    let _ = cargo_vv(&ws, &[]);
+    assert_eq!(run_binary_hash(&ws), topic_short);
+    // Switch back to main — whose commit ALSO carries the full Cargo tree.
+    git(&ws, &["checkout", "-q", "main"]);
+    let (e, l) = cargo_vv(&ws, &[]);
+    assert_eq!(e, 0, "post-switch build: {l}");
+    let main_short = git(&ws, &["rev-parse", "--short", "HEAD"]);
+    assert_eq!(
+        run_binary_hash(&ws),
+        main_short,
+        "branch switch refreshes the hash"
+    );
+}
+
+#[test]
+fn build_git_watch_relative_gitdir_and_linked_commit_refresh() {
+    let holder = FixtureDir::new("relative");
+    let main = holder.path().join("main");
+    let linked = holder.path().join("linked");
+    init_repo(&main);
+    write_fixture(&main);
+    commit_fixture(&main, "fixture", None);
+    git(
+        &main,
+        &[
+            "worktree",
+            "add",
+            linked.to_str().unwrap(),
+            "-b",
+            "relative",
+        ],
+    );
+    fs::write(
+        linked.join(".git"),
+        "gitdir: ../main/.git/worktrees/linked\n",
+    )
+    .unwrap();
+    let (exit, log) = cargo_vv(&linked, &[]);
+    assert_eq!(exit, 0, "{log}");
+    assert_eq!(
+        run_binary_hash(&linked),
+        git(&linked, &["rev-parse", "--short", "HEAD"])
+    );
+    let (exit, log) = cargo_vv(&linked, &[]);
+    assert_eq!(exit, 0, "{log}");
+    assert_eq!(probe_rustc_count(&log), 0, "relative gitdir no-op: {log}");
+    fs::write(linked.join("readme.txt"), "linked commit\n").unwrap();
+    commit_fixture(&linked, "linked change", Some("readme.txt"));
+    let (exit, log) = cargo_vv(&linked, &[]);
+    assert_eq!(exit, 0, "{log}");
+    assert_eq!(
+        run_binary_hash(&linked),
+        git(&linked, &["rev-parse", "--short", "HEAD"])
+    );
+}
+
+#[test]
+fn build_git_fixture_cleanup_preserves_ancestor_worktrees() {
+    let outer = FixtureDir::new("cleanup-parent");
+    init_repo(outer.path());
+    let linked = outer.path().join("stale-linked");
+    git(
+        outer.path(),
+        &["worktree", "add", linked.to_str().unwrap(), "-b", "stale"],
+    );
+    fs::remove_dir_all(&linked).unwrap();
+    let registration = outer.path().join(".git/worktrees/stale-linked");
+    assert!(registration.exists());
+    let archive = outer.path().join("archive");
+    fs::create_dir(&archive).unwrap();
+    drop(FixtureDir(archive));
+    assert!(
+        registration.exists(),
+        "cleanup must not prune the ancestor repository"
+    );
+}

--- a/crates/octos-cli/tests/build_git_metadata.rs
+++ b/crates/octos-cli/tests/build_git_metadata.rs
@@ -125,7 +125,8 @@ fn init_repo(dir: &Path) {
 fn cargo_vv(ws: &Path, extra_env: &[(&str, &str)]) -> (i32, String) {
     let target = ws.join("fixture-target");
     let mut cmd = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()));
-    cmd.args(["build", "--offline", "-vv"])
+    // CLI precedence also defeats an explicit inherited/extra color setting.
+    cmd.args(["build", "--offline", "--color", "never", "-vv"])
         .current_dir(ws)
         .env("CARGO_TARGET_DIR", &target)
         .env_remove("RUSTC_WRAPPER")
@@ -243,6 +244,7 @@ fn build_git_watch_linked_worktree_second_build_fresh() {
     commit_fixture(&linked, "fixture", None);
     let (e1, l1) = cargo_vv(&linked, &[]);
     assert_eq!(e1, 0, "linked first: {l1}");
+    assert_eq!(probe_rustc_count(&l1), 1, "first compile: {l1}");
     let (e2, l2) = cargo_vv(&linked, &[]);
     assert_eq!(e2, 0, "linked second: {l2}");
     assert!(
@@ -340,6 +342,7 @@ fn build_git_watch_packed_refs_fresh_and_commit_triggers() {
     git(&ws, &["pack-refs", "--all"]);
     let (e1, l1) = cargo_vv(&ws, &[]);
     assert_eq!(e1, 0, "packed first: {l1}");
+    assert_eq!(probe_rustc_count(&l1), 1, "first compile: {l1}");
     let (e2, l2) = cargo_vv(&ws, &[]);
     assert_eq!(e2, 0);
     assert!(
@@ -375,6 +378,7 @@ fn build_git_watch_no_git_dir_builds_without_rerun() {
     // SECOND build — so Fresh-on-rebuild IS the observable contract.
     let (e1, l1) = cargo_vv(&ws, &[]);
     assert_eq!(e1, 0, "no-git first build ok: {l1}");
+    assert_eq!(probe_rustc_count(&l1), 1, "first compile: {l1}");
     let (e2, l2) = cargo_vv(&ws, &[]);
     assert_eq!(e2, 0);
     assert!(
@@ -400,6 +404,7 @@ fn build_git_watch_archive_inside_outer_repo_not_adopted() {
     write_fixture(&archive_ws);
     let (e1, l1) = cargo_vv(&archive_ws, &[]);
     assert_eq!(e1, 0, "archive build ok: {l1}");
+    assert_eq!(probe_rustc_count(&l1), 1, "first compile: {l1}");
     assert_eq!(
         run_binary_hash(&archive_ws),
         "",
@@ -444,6 +449,7 @@ fn build_git_watch_tracked_archive_inside_outer_repo_not_adopted() {
     git(&outer, &["commit", "-q", "-m", "track archive"]);
     let (e1, l1) = cargo_vv(&archive_ws, &[]);
     assert_eq!(e1, 0, "tracked-archive build ok: {l1}");
+    assert_eq!(probe_rustc_count(&l1), 1, "first compile: {l1}");
     assert_eq!(
         run_binary_hash(&archive_ws),
         "",
@@ -543,6 +549,7 @@ fn build_git_watch_relative_gitdir_and_linked_commit_refresh() {
     .unwrap();
     let (exit, log) = cargo_vv(&linked, &[]);
     assert_eq!(exit, 0, "{log}");
+    assert_eq!(probe_rustc_count(&log), 1, "first compile: {log}");
     assert_eq!(
         run_binary_hash(&linked),
         git(&linked, &["rev-parse", "--short", "HEAD"])
@@ -579,4 +586,139 @@ fn build_git_fixture_cleanup_preserves_ancestor_worktrees() {
         registration.exists(),
         "cleanup must not prune the ancestor repository"
     );
+}
+
+#[test]
+fn build_git_watch_color_override_keeps_detection_live() {
+    let dir = FixtureDir::new("color-control");
+    let ws = dir.path();
+    init_repo(ws);
+    write_fixture(ws);
+    let colors = [("CARGO_TERM_COLOR", "always")];
+    let (exit, log) = cargo_vv(ws, &colors);
+    assert_eq!(exit, 0, "{log}");
+    assert_eq!(
+        probe_rustc_count(&log),
+        1,
+        "first compile must be visible: {log}"
+    );
+    let (exit, log) = cargo_vv(ws, &colors);
+    assert_eq!(exit, 0, "{log}");
+    assert!(!probe_dirty(&log), "{log}");
+    assert_eq!(probe_rustc_count(&log), 0, "{log}");
+
+    // A deliberately broken watch must be detected even with inherited colors.
+    fs::write(
+        ws.join("crates/probe/build.rs"),
+        "fn main() { println!(\"cargo:rerun-if-changed=missing-color-control\"); }\n",
+    )
+    .unwrap();
+    let (exit, log) = cargo_vv(ws, &colors);
+    assert_eq!(exit, 0, "{log}");
+    let (exit, log) = cargo_vv(ws, &colors);
+    assert_eq!(exit, 0, "{log}");
+    assert!(probe_dirty(&log), "broken watch must be detected: {log}");
+    assert_eq!(
+        probe_rustc_count(&log),
+        1,
+        "unexpected recompilation must be visible: {log}"
+    );
+}
+
+fn packed_remote_fetch_stays_fresh(linked_worktree: bool) {
+    let holder = FixtureDir::new("packed-fetch");
+    let main = holder.path().join("main");
+    init_repo(&main);
+    write_fixture(&main);
+    commit_fixture(&main, "fixture", None);
+    let ws = if linked_worktree {
+        let linked = holder.path().join("linked");
+        git(
+            &main,
+            &[
+                "worktree",
+                "add",
+                linked.to_str().unwrap(),
+                "-b",
+                "review/topic",
+            ],
+        );
+        linked
+    } else {
+        main.clone()
+    };
+    // A separate local remote avoids network access and local branch updates.
+    let remote = holder.path().join("remote");
+    init_repo(&remote);
+    git(&ws, &["config", "core.logAllRefUpdates", "false"]);
+    git(&ws, &["pack-refs", "--all", "--prune"]);
+    // Exercise the fallback above a missing nested branch directory.
+    let nested = main.join(".git/refs/heads/review");
+    if nested.exists() {
+        fs::remove_dir(&nested).unwrap();
+    }
+    let logs = main.join(".git/logs");
+    fs::remove_dir_all(&logs).unwrap();
+    if linked_worktree {
+        let log = PathBuf::from(git(
+            &ws,
+            &[
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-path",
+                "logs/HEAD",
+            ],
+        ));
+        if log.exists() {
+            fs::remove_file(log).unwrap();
+        }
+    }
+    let (exit, log) = cargo_vv(&ws, &[]);
+    assert_eq!(exit, 0, "{log}");
+    assert_eq!(probe_rustc_count(&log), 1, "{log}");
+    let before = run_binary_hash(&ws);
+    for msg in ["fetch-one", "fetch-two"] {
+        fs::write(remote.join("readme.txt"), msg).unwrap();
+        git(&remote, &["add", "--", "readme.txt"]);
+        git(&remote, &["commit", "-q", "-m", msg]);
+        git(
+            &ws,
+            &[
+                "fetch",
+                "--no-tags",
+                remote.to_str().unwrap(),
+                "main:refs/remotes/test/main",
+            ],
+        );
+        let (exit, log) = cargo_vv(&ws, &[]);
+        assert_eq!(exit, 0, "{log}");
+        assert!(
+            !probe_dirty(&log),
+            "remote-only fetch must stay Fresh: {log}"
+        );
+        assert_eq!(probe_rustc_count(&log), 0, "{log}");
+        assert_eq!(run_binary_hash(&ws), before);
+    }
+    fs::write(ws.join("readme.txt"), "current-branch-commit\n").unwrap();
+    commit_fixture(&ws, "current branch", Some("readme.txt"));
+    let (exit, log) = cargo_vv(&ws, &[]);
+    assert_eq!(exit, 0, "{log}");
+    assert_eq!(
+        probe_rustc_count(&log),
+        1,
+        "current branch must rebuild: {log}"
+    );
+    let after = run_binary_hash(&ws);
+    assert_ne!(before, after);
+    assert_eq!(after, git(&ws, &["rev-parse", "--short", "HEAD"]));
+}
+
+#[test]
+fn build_git_watch_packed_remote_fetch_stays_fresh() {
+    packed_remote_fetch_stays_fresh(false);
+}
+
+#[test]
+fn build_git_watch_linked_packed_remote_fetch_stays_fresh() {
+    packed_remote_fetch_stays_fresh(true);
 }

--- a/docs/superpowers/plans/2026-09-12-build-watch.md
+++ b/docs/superpowers/plans/2026-09-12-build-watch.md
@@ -1,0 +1,23 @@
+# Git metadata watch implementation plan
+
+Linked worktrees store `.git` as a pointer file. Watching nonexistent
+`.git/HEAD` makes Cargo rerun the version build script on every build.
+
+1. Resolve existing HEAD, current loose branch ref and packed-refs paths with Git.
+   Watch the refs directory when a packed branch has no loose ref yet, so the
+   next same-branch commit is detected. Always watch build.rs itself.
+2. Accept Git ownership only when the expected project root has `.git` and
+   canonical `git rev-parse --show-toplevel` matches it. Let Git resolve pointer
+   files, including relative paths. Archives nested in other repositories retain
+   an empty Git hash even when the parent tracks their files.
+3. Exercise the exact production build script in tiny offline Cargo fixtures:
+   normal/linked no-op builds, same-branch commits, branch and detached changes,
+   packed/pruned refs, relative gitdir, Git-less and tracked/untracked archives.
+   Assert actual compiler invocations and the executable's embedded hash.
+4. Delete only fixture-owned directories. Never invoke Git cleanup from a
+   directory that could resolve an unrelated ancestor repository.
+5. Run fmt, clippy and all-targets tests for octos-cli with its api feature;
+   independently review the source and recorded command exits before commit.
+
+kache is a separate optional cache experiment; this fix does not install it or
+change global Cargo configuration.

--- a/docs/superpowers/plans/2026-09-12-build-watch.md
+++ b/docs/superpowers/plans/2026-09-12-build-watch.md
@@ -21,3 +21,21 @@ Linked worktrees store `.git` as a pointer file. Watching nonexistent
 
 kache is a separate optional cache experiment; this fix does not install it or
 change global Cargo configuration.
+
+## Claude review follow-up (2026-09-12)
+
+Approved scope: make the regression detectors independent of inherited Cargo
+colors and avoid rebuilding for unrelated remote refs after packing a branch.
+
+- [ ] Reproduce the existing test under `CARGO_TERM_COLOR=always`, and add a
+  real Cargo positive/negative control with an intentionally missing watch path.
+- [ ] Add ordinary and linked packed-branch fixtures that fetch local remote
+  updates, stay Fresh, then commit on the current branch and refresh the hash.
+  Include disabled reflogs and a missing nested branch directory.
+- [ ] Force `cargo build --color never` in the fixture subprocess and check the
+  first compile in Fresh tests. Watch the nearest existing parent of the current
+  branch ref; keep the wider fallback only when narrower parents do not exist.
+  This retains direct ref correctness without depending on reflog settings.
+- [ ] Update the behavior contract; run fmt, clippy, all-targets and color
+  matrix checks. Verify the old build script still fails the no-op regression.
+- [ ] Review the final diff, commit owned files and update PR #2310 and its CI.

--- a/specs/task-build-git-metadata-watch.spec.md
+++ b/specs/task-build-git-metadata-watch.spec.md
@@ -9,6 +9,8 @@ tags: [build, cargo, git, octos-cli]
 - 路径解析：git rev-parse --path-format=absolute --git-path（HEAD / refs/heads/<branch> / packed-refs），逐个存在才输出 rerun-if-changed。
 - 同分支提交触发：refs/heads/<branch> 文件内容随提交改写（HEAD 文本不变）→ 必须监听该 ref 文件。detached HEAD 场景 HEAD 文件本身含 commit。
 - packed refs：存在 packed-refs 时监听之；提交/分支操作改写它或生成 loose ref，build script 重跑后重解析路径集合。
+- loose ref 缺失时监听该分支最近的已存在父目录；refs/heads 存在时不因 refs/remotes 更新重编译。更窄目录均缺失才退回 refs，不依赖 reflog。
+- 测试子进程使用 --color never 覆盖继承的颜色配置；Fresh 检查先证明首次构建能够检测到一次 probe 编译。
 - 无 Git/归档防误采：包目录祖父为项目根，要求根有 .git 且 Git 解析的 canonical toplevel 与根相等；Git 自行处理相对或绝对 gitdir。无 Git 时版本 hash 为空，仅监听 build.rs。
 - 禁止硬编码本机路径；零新增依赖。
 
@@ -107,7 +109,7 @@ Scenario: pack-refs --prune 后同分支提交刷新 hash
     Filter: build_git_watch_packed_pruned_same_branch_commit_refreshes
   Given pack-refs --all --prune 后预热的 fixture（无 loose ref）
   When 同分支新 commit（仅创建 loose ref，HEAD/packed-refs 不变）
-  Then 重建且 hash == 新短 SHA（refs 目录监听发现创建）
+  Then 重建且 hash == 新短 SHA（分支最近已存在父目录监听发现创建）
 
 Scenario: 相对 gitdir 与 linked worktree 提交更新
   Test:
@@ -124,3 +126,27 @@ Scenario: fixture 清理不修改父仓库
   Given fixture 位于含过期 worktree 登记的自有外层测试仓库
   When 清理无 Git 的子 fixture
   Then 仅删除该 fixture,外层仓库登记保持不变
+
+Scenario: 彩色环境不能让编译检测失效
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_color_override_keeps_detection_live
+  Given 子进程环境显式设置 CARGO_TERM_COLOR=always
+  When 执行首次构建、无改动重建，再注入不存在路径的错误监听
+  Then 首次准确检测到一次编译，无改动检测到零次，错误监听准确检测到 Dirty 和重复编译
+
+Scenario: packed 分支在远端引用更新后不误重编译
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_packed_remote_fetch_stays_fresh
+  Given 普通仓库的当前分支已 packed/pruned 且关闭并移除 reflog
+  When 两次 fetch 本地远端更新，随后在当前分支提交
+  Then fetch 后 probe 保持 Fresh，当前分支提交后编译且 hash 更新
+
+Scenario: linked packed 分支目录缺失时仍正确监听
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_linked_packed_remote_fetch_stays_fresh
+  Given linked worktree 当前分支 review/topic 已打包，review 目录和 reflog 不存在
+  When 两次 fetch 本地远端更新，随后在当前分支提交并创建嵌套目录
+  Then fetch 后 probe 保持 Fresh，当前分支提交后编译且 hash 更新

--- a/specs/task-build-git-metadata-watch.spec.md
+++ b/specs/task-build-git-metadata-watch.spec.md
@@ -1,0 +1,126 @@
+spec: task
+name: "build.rs 监听真实 Git 元数据路径（普通/linked/detached/packed/无 Git/归档）"
+tags: [build, cargo, git, octos-cli]
+---
+## Intent
+ crates/octos-cli/build.rs 的 rerun-if-changed 必须指向真实存在的 Git 元数据路径：linked worktree 不再因监听不存在的 ../../.git/HEAD 而无改动重复编译；同分支新提交仍更新 OCTOS_GIT_HASH；归档源码不得误采外层仓库。
+
+## Decisions
+- 路径解析：git rev-parse --path-format=absolute --git-path（HEAD / refs/heads/<branch> / packed-refs），逐个存在才输出 rerun-if-changed。
+- 同分支提交触发：refs/heads/<branch> 文件内容随提交改写（HEAD 文本不变）→ 必须监听该 ref 文件。detached HEAD 场景 HEAD 文件本身含 commit。
+- packed refs：存在 packed-refs 时监听之；提交/分支操作改写它或生成 loose ref，build script 重跑后重解析路径集合。
+- 无 Git/归档防误采：包目录祖父为项目根，要求根有 .git 且 Git 解析的 canonical toplevel 与根相等；Git 自行处理相对或绝对 gitdir。无 Git 时版本 hash 为空，仅监听 build.rs。
+- 禁止硬编码本机路径；零新增依赖。
+
+## Boundaries
+
+### Allowed Changes
+- crates/octos-cli/build.rs
+- crates/octos-cli/tests/build_git_metadata.rs
+- specs/task-build-git-metadata-watch.spec.md
+- docs/superpowers/plans/2026-09-12-build-watch.md
+
+### Forbidden
+- 硬编码绝对路径或假造存在性
+- 新增任何 crate 依赖
+- 监听不存在路径
+- 以字符串包含代替 -vv rustc 计数断言
+
+## Completion Criteria
+
+### Rule: git-metadata-watch — 元数据监听与构建新鲜度
+Scenario: 普通仓库二次无改动 Fresh
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_regular_repo_second_build_fresh
+  Given 一个普通 git 仓库 fixture（复制生产 build.rs）
+  When cargo build --offline -vv 连续两次（同一 fixture target）
+  Then 第二次 probe 为 Fresh 且 rustc 调用 0 次
+
+Scenario: linked worktree 二次无改动 Fresh
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_linked_worktree_second_build_fresh
+  Given git worktree add 的 linked worktree fixture
+  When cargo build --offline -vv 连续两次
+  Then 第二次 Fresh 且 rustc 0 次（修复前 Dirty：监听 ../../.git/HEAD 不存在）
+
+Scenario: 同分支提交后 hash 更新
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_same_branch_commit_updates_hash
+  Given 预热后的 fixture 仓库
+  When 同分支新 commit 后第三次 build
+  Then probe Dirty 且 OCTOS_GIT_HASH == 新 commit 短 SHA
+
+Scenario: detached HEAD 提交切换触发
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_detached_head_change_triggers
+  Given linked detached worktree fixture 预热
+  When checkout 到另一 commit
+  Then 重建且 hash 更新
+
+Scenario: packed refs 二次 Fresh 且提交触发
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_packed_refs_fresh_and_commit_triggers
+  Given git pack-refs --all 后的 fixture
+  When 二次无改动 build（Fresh/rustc0）；随后同分支提交
+  Then 先 Fresh；提交后 Dirty 且 hash 更新
+
+Scenario: 无 Git 目录仅监听 build.rs 且构建成功
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_no_git_dir_builds_without_rerun
+  Given 无 .git 的 tempdir fixture
+  When cargo build
+  Then 成功且 build.rs 输出仅含 build.rs 的 rerun-if-changed 行、hash 为空
+
+Scenario: 归档不误采外层仓库
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_archive_inside_outer_repo_not_adopted
+  Given 外层 git 仓库内以 git archive 解出的源码归档（无 .git）
+  When cargo build
+  Then 成功、仅监听 build.rs、hash 为空（不采用外层仓库 hash）
+
+Scenario: 分支切换触发重建
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_branch_switch_triggers
+  Given 预热 fixture
+  When git checkout 另一分支后 build
+  Then 重建且 hash 更新
+
+Scenario: 被父仓库 track 的归档不误采
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_tracked_archive_inside_outer_repo_not_adopted
+  Given 外层 git 仓库内解出归档且外层仓库已 track 归档文件（ls-files 会命中）
+  When cargo build
+  Then 成功、hash 为空、二次 Fresh（owning-repo 校验：项目根 .git 与 canonical toplevel 一致）
+
+Scenario: pack-refs --prune 后同分支提交刷新 hash
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_packed_pruned_same_branch_commit_refreshes
+  Given pack-refs --all --prune 后预热的 fixture（无 loose ref）
+  When 同分支新 commit（仅创建 loose ref，HEAD/packed-refs 不变）
+  Then 重建且 hash == 新短 SHA（refs 目录监听发现创建）
+
+Scenario: 相对 gitdir 与 linked worktree 提交更新
+  Test:
+    Package: octos-cli
+    Filter: build_git_watch_relative_gitdir_and_linked_commit_refresh
+  Given linked worktree 的 .git 使用合法相对 gitdir 路径
+  When 连续构建两次后在当前分支提交并再次构建
+  Then 无改动构建不调用 probe rustc,提交后版本 hash 等于新 HEAD
+
+Scenario: fixture 清理不修改父仓库
+  Test:
+    Package: octos-cli
+    Filter: build_git_fixture_cleanup_preserves_ancestor_worktrees
+  Given fixture 位于含过期 worktree 登记的自有外层测试仓库
+  When 清理无 Git 的子 fixture
+  Then 仅删除该 fixture,外层仓库登记保持不变


### PR DESCRIPTION
In a linked worktree, .git is a pointer file. Watching nonexistent .git/HEAD paths made Cargo rebuild the CLI even with no source changes. Cargo colors in CI also broke the regression tests' log detectors, allowing the old linked-worktree bug to pass undetected.

Resolve existing Git metadata paths through Git and keep the embedded hash fresh after commits and branch/detached switches. When a packed branch lacks a loose ref, watch its nearest existing parent; this avoids remote-ref fetch rebuilds when refs/heads or a narrower directory exists and still catches new branch-ref creation without relying on reflogs. Archives nested in another repository retain an empty hash.

Fixture Cargo commands force --color never. Freshness tests positively check the first compile, and a deliberately broken watcher must produce a detected Dirty/recompile. Real local-fetch tests cover ordinary and linked worktrees, disabled/removed reflogs, and missing nested branch directories. No global Cargo configuration or cache wrapper is changed.

Validation: fmt and cargo clippy -p octos-cli --features api --all-targets -- -D warnings passed. All 15 build regressions passed under outer CARGO_TERM_COLOR=always and never. Replacing build.rs with the original main version makes the corrected linked-worktree regression fail under both settings, demonstrating that it detects the original bug. Independent source review found no blocker in the delta.

Full cargo test -p octos-cli --features api --all-targets --no-fail-fast ran all 25 suites: 3,859 passed, 1 failed, 13 ignored. The only failure is the unchanged should_allocate_bridge_ports_as_consecutive_pair test: the existing Node service occupies port 3101. Its baseline failure on unmodified main f4e44b19 was recorded previously, and the service still owns that port. The previously flaky stdio test passed this run. Source hashes stayed unchanged during validation. The full-run failure is not presented as green.

Draft: GLM/K3 final cross-review of the updated head remains incomplete; the previous K3 attempt hit weekly quota HTTP 403. The automated fixtures and Codex source review are not substitutes for live dual-model review receipts.
