### PR TITLE
test(api): rebuild callsite interest cache in the http_trace test

### DIFF
--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -50,6 +50,7 @@ eyre = { workspace = true }
 uuid = { workspace = true }
 color-eyre = { workspace = true }
 tracing = { workspace = true }
+tracing-core = "0.1.36"
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 rustyline = { workspace = true }

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -1477,6 +1477,12 @@ mod tests {
             .unwrap();
 
         tracing::subscriber::with_default(subscriber, || {
+            // #2276: this shared debug_span! callsite may have been lazily
+            // registered by a no-subscriber sibling test first (the JustOne
+            // rebuilder only asks the current thread's default), leaving a
+            // stale NEVER in the interest cache. Force a rebuild so the
+            // victim's DEBUG span is re-asked under this subscriber.
+            tracing_core::callsite::rebuild_interest_cache();
             runtime.block_on(async {
                 for uri in [
                     "/api/ui-protocol/ws?token=synthetic-query-marker%21&feature=chat",


### PR DESCRIPTION
The deterministic fix for #2276 (root cause fully pinned in the issue thread — the four-step tracing-core/tracing-subscriber source verification).

**Root cause**: the shared debug_span! callsite is lazily registered on first execution; DefaultCallsite::register's JustOne branch only asks the CURRENT thread's default dispatcher, so a no-subscriber sibling test executing the router builder first caches Interest::never for the shared callsite. The victim test's with_default does not re-ask (the macro short-circuits on the cached never) → the trace span dies → the credential-omission assertion fails under full-parallel cargo test --lib. Solo runs cache correctly → always pass.

**Fix**: force rebuild_interest_cache() inside the victim's with_default closure — the current thread default = the victim subscriber, so both the JustOne and multi-dispatcher rebuilt paths deterministically re-ask. Plus the self-documenting assertion from the #2276 triage (the next occurrence, if any, prints the full captured logs).

Test-only, one hunk + one assertion upgrade. Refs #2276.