### PR TITLE
fix(cli): reap serve's gateway children on SIGTERM with a bounded drain (#2086)

### DIFF
--- a/.github/workflows/ci-self-hosted.yml
+++ b/.github/workflows/ci-self-hosted.yml
@@ -44,8 +44,11 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # The serve_sigterm e2e spawns real `octos serve` children that starve
+      # under default test parallelism; ci.yml runs it in a dedicated serial
+      # step (see the #21 outer-loop ruling there).
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace -- --skip serve_sigterm
 
       - name: API feature tests
         run: cargo test -p octos-cli --features api api::auth_handlers
@@ -83,7 +86,9 @@ jobs:
           cargo build --workspace
           cargo build -p octos-cli --features ${{ env.FEATURES }}
           cargo test --workspace --no-run
-          cargo test --workspace
+          # serve_sigterm e2e: serial-only (see the ci.yml #21 ruling); the
+          # broad run skips it.
+          cargo test --workspace -- --skip serve_sigterm
 
   windows:
     name: windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,16 +444,17 @@ jobs:
         run: cargo test -p octos-cli --lib
 
       - name: Test octos-cli (integration, excluding serve process e2e)
-        run: cargo test -p octos-cli --tests -- --skip serve_broken_pipe
+        run: cargo test -p octos-cli --tests -- --skip serve_broken_pipe --skip serve_sigterm
 
-      # Real-octos-process BrokenPipe/SIGINT e2e (serve_broken_pipe). These
-      # spawn real `octos serve` children that contend for model catalog /
-      # profile store resources with other test binaries; under the default
+      # Real-octos-process BrokenPipe/SIGINT e2e (serve_broken_pipe) and
+      # SIGTERM gateway-reap e2e (serve_sigterm). These spawn real
+      # `octos serve` children that contend for model catalog / profile
+      # store resources with other test binaries; under the default
       # thread-per-core parallelism the children starve and the 15s port
       # barrier times out. Dedicated serial step per the #21 outer-loop
       # ruling (2026-08-27): layer at the CI command level, never #[ignore].
-      - name: serve BrokenPipe process e2e (serial)
-        run: cargo test -p octos-cli --features api --test serve_broken_pipe -- --test-threads=1
+      - name: serve BrokenPipe/SIGTERM process e2e (serial)
+        run: cargo test -p octos-cli --features api --test serve_broken_pipe --test serve_sigterm -- --test-threads=1
 
       # Co-located here so they reuse this job's warm octos-cli build cache.
       - name: API feature tests
@@ -621,8 +622,13 @@ jobs:
         run: cargo test -p octos-agent --tests
       - name: Test octos-cli (lib)
         run: cargo test -p octos-cli --lib
-      - name: Test octos-cli (integration)
-        run: cargo test -p octos-cli --tests
+      # Same serve-process exclusions as the test-octos-cli PR job: the
+      # serve_broken_pipe / serve_sigterm e2e suites spawn real `octos serve`
+      # children that starve under default thread-per-core parallelism. They
+      # get their dedicated serial run in test-octos-cli; skipping here keeps
+      # this manual lane's coverage semantics identical to the PR lane's.
+      - name: Test octos-cli (integration, excluding serve process e2e)
+        run: cargo test -p octos-cli --tests -- --skip serve_broken_pipe --skip serve_sigterm
       - name: Test harness starter skills
         run: |
           cargo test -p harness-starter-generic
@@ -696,8 +702,10 @@ jobs:
         run: cargo test -p octos-agent --tests
       - name: Test octos-cli (lib)
         run: cargo test -p octos-cli --lib
-      - name: Test octos-cli (integration)
-        run: cargo test -p octos-cli --tests
+      # Same serve-process exclusions as the test-octos-cli PR job (see the
+      # matching comment in check-arm).
+      - name: Test octos-cli (integration, excluding serve process e2e)
+        run: cargo test -p octos-cli --tests -- --skip serve_broken_pipe --skip serve_sigterm
       - name: Test harness starter skills
         run: |
           cargo test -p harness-starter-generic

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,8 +72,11 @@ jobs:
           save-if: false
       - name: Check the all-feature CLI surface
         run: cargo check -p octos-cli --features "$FEATURES" --locked
+      # The serve_sigterm e2e spawns real `octos serve` children that starve
+      # under default test parallelism; ci.yml runs it in a dedicated serial
+      # step (see the #21 outer-loop ruling there).
       - name: Test the workspace
-        run: cargo test --workspace --locked
+        run: cargo test --workspace --locked -- --skip serve_sigterm
 
   check-windows:
     name: Windows workspace tests

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -455,6 +455,114 @@ fn stdio_task_query_store(stdio: bool) -> Option<crate::session_actor::SessionTa
     stdio.then(crate::session_actor::SessionTaskQueryStore::default)
 }
 
+/// How long the serve keeps draining in-flight connections after the stop
+/// signal before it stops waiting and proceeds to `stop_all()` + exit anyway.
+/// Axum's graceful shutdown waits for open connections, and an SSE stream
+/// (`GET /api/events/harness`) never ends on its own — without a cap a
+/// `systemctl stop` would hang until `TimeoutStopSec` escalates to SIGKILL,
+/// skipping `stop_all()` and orphaning the gateways exactly like the pre-fix
+/// #2086 behavior.
+const SERVE_SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Install the HTTP serve's stop-signal handlers EARLY — before the gateway
+/// auto-start loop — and return the watch half the graceful-shutdown future
+/// will await.
+///
+/// Registration must precede auto-start: each enabled profile spends ~2s in
+/// its gateway startup health check before the loop moves on, so with the
+/// handlers installed only inside `axum::serve`'s shutdown future there is a
+/// N×2s window (right when a restarting supervisor sends its SIGTERM) in
+/// which the signal still hits the OS default disposition — the exact #2086
+/// orphaning this fix targets. A dedicated watcher task owns the signal
+/// listeners and latches the first one into the watch channel; because the
+/// channel is stateful, a signal that arrives before `axum::serve` starts
+/// polling its shutdown future is not lost — the future observes it on its
+/// first poll.
+///
+/// On Unix this catches SIGINT (ctrl-c) and SIGTERM — the signal
+/// `pkill`/`systemctl stop`/supervisors send. Off Unix only ctrl-c exists.
+/// If the SIGTERM listener cannot be installed the watcher degrades to
+/// ctrl-c-only with a warning instead of panicking: a panic here would
+/// unwind nowhere near `stop_all()` and reintroduce the orphaning the
+/// handler exists to prevent.
+///
+/// The SIGTERM listener is registered synchronously, before the watcher
+/// task spawns: tokio installs the handler only when `signal()` runs, and a
+/// spawned task is not polled until the runtime yields — deferring
+/// registration into the task would leave a window in which the caller has
+/// already spawned the first gateway while SIGTERM is still on the OS
+/// default disposition. Once the first signal latches the watcher task
+/// ends, but tokio keeps the handler installed for the process lifetime, so
+/// a second signal during the bounded drain is captured-but-unobserved: it
+/// cannot kill the serve before `stop_all()` runs.
+fn spawn_serve_shutdown_signal_watcher() -> tokio::sync::watch::Receiver<bool> {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    #[cfg(unix)]
+    let sigterm = {
+        use tokio::signal::unix::{SignalKind, signal};
+        match signal(SignalKind::terminate()) {
+            Ok(sigterm) => Some(sigterm),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "failed to install SIGTERM handler; serving until ctrl-c"
+                );
+                None
+            }
+        }
+    };
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            match sigterm {
+                Some(mut sigterm) => {
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => {}
+                        _ = sigterm.recv() => {}
+                    }
+                }
+                None => {
+                    let _ = tokio::signal::ctrl_c().await;
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+        let _ = shutdown_tx.send(true);
+    });
+    shutdown_rx
+}
+
+/// The graceful-shutdown future: resolve once the early-registered watcher
+/// (see `spawn_serve_shutdown_signal_watcher`) latched a stop signal.
+async fn serve_shutdown_signal(mut shutdown_rx: tokio::sync::watch::Receiver<bool>) {
+    // The watcher may already have fired (signal arrived during auto-start,
+    // before this future was first polled) — borrow first so a latched true
+    // resolves immediately instead of waiting for another change.
+    if !*shutdown_rx.borrow() {
+        let _ = shutdown_rx.changed().await;
+    }
+    let _ = super::serve_console::print_stdout("");
+    let _ = super::serve_console::print_stdout(&format!("{}", "Shutting down server...".yellow()));
+}
+
+/// Resolve `grace` after the stop signal latches — the drain cap the serve
+/// loop races against. Waiting for the latch FIRST matters: wrapping
+/// `axum::serve` in a plain `tokio::time::timeout(grace, ..)` would start
+/// the clock when the serve future is first polled and kill a healthy,
+/// signal-free serve once the grace period passes.
+async fn shutdown_drain_deadline(
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    grace: std::time::Duration,
+) {
+    if !*shutdown_rx.borrow() {
+        let _ = shutdown_rx.changed().await;
+    }
+    tokio::time::sleep(grace).await;
+}
+
 /// Bind the HTTP listener before constructing `AppState`.
 ///
 /// Port `0` asks the OS for an ephemeral port. Resolving it here ensures every
@@ -1571,6 +1679,15 @@ impl ServeCommand {
             return Ok(());
         }
 
+        // Install the stop-signal watcher BEFORE the gateway auto-start loop:
+        // each profile's startup health check holds the loop for ~2s, and a
+        // SIGTERM arriving in that window (a restarting supervisor's pkill is
+        // exactly this) must already be caught, or it hits the OS default
+        // disposition and orphans every gateway (#2086). The stdio path above
+        // returns before this point and keeps its existing behavior — it
+        // spawns no gateways, so there is nothing to orphan.
+        let shutdown_rx = spawn_serve_shutdown_signal_watcher();
+
         // Auto-start enabled profiles
         let profiles = profile_store.list().unwrap_or_default();
         let enabled_count = profiles.iter().filter(|p| p.enabled).count();
@@ -1588,6 +1705,20 @@ impl ServeCommand {
                             "skipping auto-start: no LLM provider configured"
                         );
                         continue;
+                    }
+                    // A stop signal already latched must not START more
+                    // gateways: each `start()` spends ~2s in its startup
+                    // health check, so finishing the loop for every profile
+                    // would keep spawning children for N×2s after the
+                    // operator asked to stop — children `stop_all()` then
+                    // has to reap under the drain deadline. The in-flight
+                    // `start()` completes (it cannot be interrupted); the
+                    // loop just stops starting new ones.
+                    if *shutdown_rx.borrow() {
+                        tracing::info!(
+                            "stop signal latched during auto-start; skipping remaining gateways"
+                        );
+                        break;
                     }
                     tracing::info!(profile = %p.id, "auto-starting gateway");
                     if let Err(e) = process_manager.start(p).await {
@@ -1834,16 +1965,33 @@ impl ServeCommand {
         }
         let _ = serve_console::print_stdout("");
 
-        axum::serve(
-            listener,
-            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-        )
-        .with_graceful_shutdown(async {
-            let _ = tokio::signal::ctrl_c().await;
-            let _ = serve_console::print_stdout("");
-            let _ = serve_console::print_stdout(&format!("{}", "Shutting down server...".yellow()));
-        })
-        .await?;
+        // Cap the drain: after the stop signal axum waits for in-flight
+        // connections, and an SSE stream never closes on its own. Past the
+        // cap we proceed to stop_all() + exit(0) anyway — better to cut a
+        // long-lived stream than to let the supervisor SIGKILL us with the
+        // gateways still running (#2086).
+        // Both arms funnel into the gateway cleanup below: a serve-loop
+        // error must not `?`-return past `stop_all()` (that would orphan
+        // the gateways it spawned), so log it, reap the children, and
+        // reflect it in the exit code instead.
+        let serve_result = tokio::select! {
+            result = axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .with_graceful_shutdown(serve_shutdown_signal(shutdown_rx.clone())) => result,
+
+            _ = shutdown_drain_deadline(shutdown_rx, SERVE_SHUTDOWN_GRACE) => {
+                tracing::warn!(
+                    grace_secs = SERVE_SHUTDOWN_GRACE.as_secs(),
+                    "shutdown grace period expired with connections still open; stopping gateways anyway"
+                );
+                Ok(())
+            }
+        };
+        if let Err(e) = &serve_result {
+            tracing::error!(error = %e, "HTTP serve loop failed; stopping gateways before exit");
+        }
 
         // Stop all gateway child processes before exiting
         tracing::info!("stopping all gateway child processes");
@@ -1856,7 +2004,7 @@ impl ServeCommand {
 
         // Force exit — background tokio tasks (profile watcher, auth cleanup,
         // admin bot) have no shutdown signal and would hang indefinitely.
-        std::process::exit(0);
+        std::process::exit(if serve_result.is_ok() { 0 } else { 1 });
     }
 
     /// F-010: construct an `Option<Arc<SwarmState>>` from the

--- a/crates/octos-cli/tests/serve_broken_pipe.rs
+++ b/crates/octos-cli/tests/serve_broken_pipe.rs
@@ -205,11 +205,13 @@ mod serve_broken_pipe {
             std::time::Duration::from_secs(10),
         );
         assert!(banner, "startup banner never arrived on the stdout pipe");
-        // …but the banner is printed BEFORE axum::serve runs, and tokio's
-        // ctrl_c() handler is only registered once the graceful-shutdown
-        // future is polled inside axum::serve. A settle wait lets that
-        // happen; without it an early SIGINT hits the default disposition
-        // and kills the process (observed: signal=Some(2)).
+        // …but the banner is printed BEFORE axum::serve runs. Before #2086
+        // tokio's ctrl_c() handler was only registered once the
+        // graceful-shutdown future was polled inside axum::serve, so an
+        // early SIGINT could hit the default disposition and kill the
+        // process (observed: signal=Some(2)); serve now installs its
+        // stop-signal watcher before gateway auto-start, and the settle
+        // wait stays as defense-in-depth for the watcher task's first poll.
         // #37 — settle was a fixed 1500ms sleep; on a fast runner that is
         // wasted time and on a slow CI runner it may STILL be too early for
         // the ctrl_c handler registration. Poll the stdout pipe for the

--- a/crates/octos-cli/tests/serve_sigterm.rs
+++ b/crates/octos-cli/tests/serve_sigterm.rs
@@ -1,0 +1,702 @@
+//! Integration test: `octos serve` must reap its gateway children on SIGTERM.
+//!
+//! #2086 (comment "Separate finding"): killing `octos serve` with SIGTERM —
+//! what `pkill`/`systemctl stop`/supervisors send — left every auto-started
+//! `octos gateway` child orphaned (38 accumulated over ~15 restart cycles in
+//! the reporter's session), because the graceful-shutdown future only caught
+//! SIGINT (`tokio::signal::ctrl_c`), so SIGTERM fell through to the OS
+//! default disposition and `stop_all()` never ran. The fix installs a
+//! stop-signal watcher BEFORE the gateway auto-start loop and routes either
+//! signal into the same graceful-shutdown → `stop_all()` → exit(0) sequence
+//! ctrl-c already used. These tests drive the REAL octos binary:
+//!
+//! - `serve_sigterm_reaps_gateway_children` — steady state (HTTP serving),
+//!   one enabled profile → one spawned gateway, SIGTERM, assert the gateway
+//!   dies with the parent.
+//! - `serve_sigterm_during_startup_reaps_gateways` — SIGTERM landing inside
+//!   the auto-start window (first of four gateways up, second still
+//!   starting), which pins the handler-registration-before-auto-start
+//!   ordering: a handler installed only inside axum's shutdown future would
+//!   still orphan the gateways here — and that the loop stops STARTING the
+//!   remaining profiles once the signal latches.
+//!
+//! The `serve` subcommand exists under the `api` feature (a default of
+//! octos-cli). Process control needs libc setsid/kill — the module is
+//! unix-only by design, mirroring `serve_broken_pipe`. The dedicated serial
+//! CI step is:
+//! `cargo test -p octos-cli --features api --test serve_sigterm -- --test-threads=1`
+//! (the broad integration step skips it via `--skip serve_sigterm`).
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+mod serve_sigterm {
+    use std::process::{Command, Stdio};
+    use std::sync::Mutex;
+
+    /// Serve tests spawn real processes that contend for shared resources
+    /// (model catalog, profile store) — serialize them.
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn serial_guard() -> std::sync::MutexGuard<'static, ()> {
+        match SERIAL.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    /// Path to a real octos binary that includes the `serve` subcommand.
+    ///
+    /// When this harness itself is compiled WITH the `api` feature, Cargo
+    /// already built `CARGO_BIN_EXE_octos` with `serve` — reuse it directly.
+    /// When compiled WITHOUT `api`, bootstrap one via `cargo build` so the
+    /// spawned process is always the REAL octos binary with production code
+    /// (same strategy as `serve_broken_pipe::octos_binary`).
+    fn octos_binary() -> std::path::PathBuf {
+        if cfg!(feature = "api") {
+            return env!("CARGO_BIN_EXE_octos").into();
+        }
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let target_dir = std::path::Path::new(manifest_dir).join("../../target/serve-sigterm");
+        let bin = target_dir.join("debug/octos");
+        let out = std::process::Command::new("cargo")
+            .args(["build", "-p", "octos-cli", "--features", "api"])
+            .current_dir(std::path::Path::new(manifest_dir).join("../.."))
+            .env("CARGO_TARGET_DIR", &target_dir)
+            .output()
+            .expect("failed to bootstrap api-enabled octos binary");
+        assert!(
+            out.status.success(),
+            "bootstrap cargo build failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        bin
+    }
+
+    /// Build a serve Command with a private instance data dir, mirroring
+    /// `serve_broken_pipe::serve_command`. `pre_exec(setsid)` detaches the
+    /// child from the test runner's process group so SIGTERM reaches the
+    /// real octos process (not suppressed by shell job control).
+    /// child.id() IS the real octos PID.
+    fn serve_command(port: u16, data_dir: &std::path::Path) -> Command {
+        let mut cmd = Command::new(octos_binary());
+        cmd.args([
+            "serve",
+            "--instance-data-dir",
+            data_dir.to_str().unwrap(),
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "--solo",
+            "--danger-full-access",
+            "-p",
+            &port.to_string(),
+        ])
+        .stdin(Stdio::null())
+        // The gateway child constructs its LLM provider at boot and exits
+        // ("DEEPSEEK_API_KEY not set") when the env var is missing — the
+        // profile family below is deepseek, so seed a dummy value. It only
+        // needs to be non-empty; nothing connects anywhere before the parent
+        // receives SIGTERM. Without it the gateway would crash-loop and the test
+        // would at best sample a short-lived process instead of the stable
+        // long-running child the #2086 orphan bug is about.
+        .env("DEEPSEEK_API_KEY", "sigterm-e2e-dummy")
+        // Bearer token for the SSE endpoint the third test subscribes to.
+        // Harmless to the other scenarios (they never authenticate).
+        .env("OCTOS_AUTH_TOKEN", "sigterm-e2e-token")
+        // The host session may export OCTOS_INSTANCE_DATA_DIR (shared instance
+        // lock). Remove it so the child uses ONLY our private --instance-data-dir.
+        .env_remove("OCTOS_INSTANCE_DATA_DIR")
+        .env_remove("OCTOS_HOME")
+        .env_remove("OCTOS_DATA_DIR");
+        #[cfg(unix)]
+        unsafe {
+            use std::os::unix::process::CommandExt;
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        cmd
+    }
+
+    /// Wait for a port to accept TCP connections.
+    fn wait_for_port(port: u16, timeout: std::time::Duration) -> bool {
+        let start = std::time::Instant::now();
+        loop {
+            if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                return true;
+            }
+            if start.elapsed() > timeout {
+                return false;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+    }
+
+    /// Find a free port by binding to port 0.
+    fn find_free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    /// PIDs of live `octos gateway` processes spawned for `marker` (the
+    /// private data dir appears in the gateway's `--profile`/`--data-dir`
+    /// argv). This is exactly the operator-visible orphan check from #2086
+    /// (`pgrep -f 'octos gateway.*<data-dir>'`), so the assertion covers
+    /// what a restarting supervisor would actually leave behind.
+    fn gateway_orphan_pids(marker: &str) -> Vec<u32> {
+        let out = match Command::new("ps").args(["-eo", "pid=,args="]).output() {
+            Ok(out) => out,
+            Err(_) => return Vec::new(),
+        };
+        let text = String::from_utf8_lossy(&out.stdout);
+        text.lines()
+            .filter_map(|line| {
+                let line = line.trim_start();
+                let (pid, args) = line.split_once(' ')?;
+                // " gateway " with spaces: the subcommand token, so argv[0]
+                // paths can't false-positive on a "gateway" substring.
+                if args.contains(" gateway ") && args.contains(marker) {
+                    pid.parse::<u32>().ok()
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Last-resort cleanup so a failing assertion cannot leak gateway
+    /// orphans into later CI steps.
+    fn kill_orphans(marker: &str) {
+        for pid in gateway_orphan_pids(marker) {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
+            }
+        }
+    }
+
+    /// Panic-safe cleanup: on ANY failure path (including asserts inside the
+    /// scenario body) kill the serve child and any gateway orphans it left,
+    /// and remove the scratch data dir, so a failing run cannot poison later
+    /// CI steps. On the happy path the serve child has already exited (kill
+    /// is then a no-op on a reaped pid).
+    struct Cleanup {
+        marker: String,
+        data_dir: std::path::PathBuf,
+        child: Option<std::process::Child>,
+    }
+
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            if let Some(mut child) = self.child.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            kill_orphans(&self.marker);
+            // Best-effort scratch-dir removal, with one retry: the gateway
+            // children were killed a moment ago and their log handles can
+            // take a beat to release, which makes a single immediate
+            // remove_dir_all fail spuriously and leak the dir.
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            if std::fs::remove_dir_all(&self.data_dir).is_err() {
+                std::thread::sleep(std::time::Duration::from_millis(800));
+                let _ = std::fs::remove_dir_all(&self.data_dir);
+            }
+        }
+    }
+
+    /// Assert every gateway for `marker` is gone — and stays gone. Two
+    /// phases: first wait out the drain window for the processes to die,
+    /// then keep sampling for 3s (longer than the 2s auto-restart sleep in
+    /// process_manager) so a restart blip cannot fake a pass by landing
+    /// between two samples.
+    fn assert_gateways_gone_and_stay_gone(marker: &str, phase: &str) {
+        let drain_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut orphans = gateway_orphan_pids(marker);
+        while !orphans.is_empty() && std::time::Instant::now() < drain_deadline {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            orphans = gateway_orphan_pids(marker);
+        }
+        assert!(
+            orphans.is_empty(),
+            "gateway children survived serve's SIGTERM shutdown ({phase}): {orphans:?} (the #2086 orphan bug)"
+        );
+        let settle_deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while std::time::Instant::now() < settle_deadline {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            orphans = gateway_orphan_pids(marker);
+            assert!(
+                orphans.is_empty(),
+                "gateway children re-appeared after SIGTERM shutdown ({phase}): {orphans:?} — auto-restart blip"
+            );
+        }
+    }
+
+    /// Write `count` enabled deepseek profiles into `data_dir/profiles/`.
+    /// Each carries a concrete LLM selection — the exact precondition of
+    /// serve's auto-start loop (`enabled && config.has_llm_selection()`) —
+    /// so boot spawns one gateway child per profile. The dummy
+    /// DEEPSEEK_API_KEY seeded in `serve_command` lets each child finish
+    /// provider construction and stay up; nothing ever contacts the network.
+    fn write_enabled_profiles(data_dir: &std::path::Path, prefix: &str, count: usize) {
+        for i in 0..count {
+            let profile_id = format!("{prefix}-{i}");
+            std::fs::write(
+                data_dir.join("profiles").join(format!("{profile_id}.json")),
+                format!(
+                    r#"{{"id":"{profile_id}","name":"sigterm probe {i}","enabled":true,"config":{{"llm":{{"primary":{{"family_id":"deepseek","model_id":"deepseek-chat"}}}}}},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}"#
+                ),
+            )
+            .unwrap();
+        }
+    }
+
+    /// Wait for the serve child to exit and assert it exited via its
+    /// shutdown path (exit code 0), not by signal.
+    fn wait_for_clean_exit(child: &mut std::process::Child, data_dir: &std::path::Path) {
+        let exit_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut status = None;
+        while std::time::Instant::now() < exit_deadline {
+            match child.try_wait() {
+                Ok(Some(s)) => {
+                    status = Some(s);
+                    break;
+                }
+                Ok(None) => std::thread::sleep(std::time::Duration::from_millis(200)),
+                Err(e) => panic!("try_wait failed: {e}"),
+            }
+        }
+        let stderr_log = std::fs::read_to_string(data_dir.join("stderr.log")).unwrap_or_default();
+        let status = status.unwrap_or_else(|| {
+            panic!("serve did not exit within 30s of SIGTERM; stderr:\n{stderr_log}")
+        });
+        #[cfg(unix)]
+        let termsig = {
+            use std::os::unix::process::ExitStatusExt;
+            status.signal()
+        };
+        assert_eq!(
+            status.code(),
+            Some(0),
+            "serve must run its shutdown path under SIGTERM (exit 0), not die by signal (signal={termsig:?}); stderr:\n{stderr_log}"
+        );
+    }
+
+    /// Assert serve's tracing log recorded the `stop_all` cleanup, polling
+    /// because the tracing writer's flush can trail process exit on a slow
+    /// runner.
+    fn assert_stop_all_logged(data_dir: &std::path::Path) {
+        let log_dir = data_dir.join("logs");
+        let marker_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut tracing_log = read_dir_logs_concat(&log_dir);
+        while !(tracing_log.contains("stopping all gateway child processes")
+            || tracing_log.contains("gateways stopped"))
+            && std::time::Instant::now() < marker_deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            tracing_log = read_dir_logs_concat(&log_dir);
+        }
+        assert!(
+            tracing_log.contains("stopping all gateway child processes")
+                || tracing_log.contains("gateways stopped"),
+            "stop_all cleanup marker missing from tracing log (data_dir/logs), log:\n{tracing_log}"
+        );
+    }
+
+    /// Open an SSE subscription on `/api/events/harness` and return the
+    /// live stream. The caller must keep it alive for the connection to
+    /// count as in-flight during the shutdown under test.
+    fn open_sse_stream(port: u16) -> Option<std::net::TcpStream> {
+        use std::io::{Read, Write};
+        let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).ok()?;
+        let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(2)));
+        let _ = stream.set_write_timeout(Some(std::time::Duration::from_secs(2)));
+        stream
+            .write_all(
+                b"GET /api/events/harness HTTP/1.1\r\nHost: localhost\r\n\
+                  Authorization: Bearer sigterm-e2e-token\r\n\
+                  Accept: text/event-stream\r\n\r\n",
+            )
+            .ok()?;
+        // Read until the status line confirms the subscription is live.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut buf = Vec::new();
+        let mut byte = [0u8; 1];
+        while std::time::Instant::now() < deadline {
+            match stream.read(&mut byte) {
+                Ok(1) => {
+                    buf.push(byte[0]);
+                    if buf.starts_with(b"HTTP/1.1 200") || buf.starts_with(b"HTTP/1.0 200") {
+                        return Some(stream);
+                    }
+                    if buf.len() > 64 {
+                        return None; // a status line arrived, but not the 200 we need
+                    }
+                }
+                // Ok(0) is EOF; Ok(n>1) is impossible with a 1-byte buffer
+                // but the Read signature permits it — treat both as failure.
+                Ok(_) | Err(_) => return None,
+            }
+        }
+        None
+    }
+
+    /// Concatenate every *.log file under a directory (tracing rolling sink).
+    fn read_dir_logs_concat(dir: &std::path::Path) -> String {
+        std::fs::read_dir(dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .unwrap_or_default()
+    }
+
+    /// Test: SIGTERM to `octos serve` must stop the auto-started gateway
+    /// children before the process exits.
+    ///
+    /// Pre-fix behavior: SIGTERM hits the default disposition — the parent
+    /// dies by signal (never reaching `stop_all`), the gateway keeps running
+    /// (orphaned), and the tracing log never records the cleanup marker.
+    #[test]
+    fn serve_sigterm_reaps_gateway_children() {
+        let _guard = serial_guard();
+        let port = find_free_port();
+        let data_dir = std::env::temp_dir().join(format!("octos_sigterm_{}", std::process::id()));
+        std::fs::create_dir_all(data_dir.join("profiles")).unwrap();
+
+        // One enabled profile → boot spawns exactly one gateway child.
+        let profile_prefix = format!("sigterm-probe-{}", std::process::id());
+        write_enabled_profiles(&data_dir, &profile_prefix, 1);
+
+        let err_path = data_dir.join("stderr.log");
+        let err_file = std::fs::File::create(&err_path).unwrap();
+        let mut cmd = serve_command(port, &data_dir);
+        cmd.stdout(Stdio::null()).stderr(Stdio::from(err_file));
+        let child = cmd.spawn().expect("failed to start octos serve");
+
+        let marker = data_dir.to_str().unwrap().to_string();
+        let mut cleanup = Cleanup {
+            marker: marker.clone(),
+            data_dir: data_dir.clone(),
+            child: Some(child),
+        };
+        run_sigterm_scenario(port, &data_dir, &marker, cleanup.child.as_mut().unwrap());
+        // Happy path: serve already exited and was waited inside the scenario,
+        // so detach it from the guard (killing a reaped pid is not just a
+        // no-op — the pid could in theory be recycled). The guard still
+        // sweeps any orphan that slipped through and removes the scratch dir.
+        let _ = cleanup.child.take();
+        drop(cleanup);
+    }
+
+    /// The test body, split out so the Drop guard above can clean up on any
+    /// failure path without drowning the original panic message.
+    fn run_sigterm_scenario(
+        port: u16,
+        data_dir: &std::path::Path,
+        marker: &str,
+        child: &mut std::process::Child,
+    ) {
+        // Boot barrier 1: the listener is bound.
+        if !wait_for_port(port, std::time::Duration::from_secs(45)) {
+            panic!("serve did not listen on {port} within 45s");
+        }
+        // Boot barrier 2: the auto-started gateway child is alive AND stable —
+        // two samples 500ms apart, so the test proves a long-running gateway
+        // is reaped, not that a crash-looping one happened to be down at the
+        // end. The auto-start loop runs BEFORE axum::serve, so this also
+        // implies the boot sequence is nearly done.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        let mut gateways = Vec::new();
+        while std::time::Instant::now() < deadline {
+            if !gateway_orphan_pids(marker).is_empty() {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                gateways = gateway_orphan_pids(marker);
+                if !gateways.is_empty() {
+                    break;
+                }
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+        }
+        assert!(
+            !gateways.is_empty(),
+            "no stable `octos gateway` child appeared for {marker} — auto-start precondition broken"
+        );
+
+        // Boot barrier 3: an actual HTTP response byte proves axum::serve is
+        // polling, i.e. boot is fully done and the steady state is reached.
+        // The stop-signal watcher itself is registered much earlier (before
+        // the auto-start loop — that ordering has its own test below); this
+        // barrier pins the classic steady-state kill a supervisor performs on
+        // a long-running serve.
+        let http_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut http_ready = false;
+        while std::time::Instant::now() < http_deadline && !http_ready {
+            if let Ok(mut stream) = std::net::TcpStream::connect(("127.0.0.1", port)) {
+                use std::io::{Read, Write};
+                // Bound the probe: if serve ever accepted a connection but
+                // hung mid-response, a blocking read would stall this test
+                // until the CI job timeout instead of failing fast.
+                let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(2)));
+                let _ = stream.set_write_timeout(Some(std::time::Duration::from_secs(2)));
+                let _ = stream.write_all(b"GET /admin/ HTTP/1.0\r\nHost: localhost\r\n\r\n");
+                let mut byte = [0u8; 1];
+                http_ready = matches!(stream.read(&mut byte), Ok(1));
+            }
+            if !http_ready {
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+        }
+        assert!(http_ready, "serve never answered an HTTP request on {port}");
+        // Handler-registration floor (same observed-value reasoning as
+        // serve_broken_pipe #37): the response byte proves the future is
+        // being polled; this floor absorbs scheduling jitter after it.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        // The act under test: SIGTERM, the signal `pkill`/`systemctl stop`
+        // send. rc=0 also proves the parent was still alive to receive it.
+        let rc = unsafe { libc::kill(child.id() as i32, libc::SIGTERM) };
+        assert_eq!(rc, 0, "kill(SIGTERM) failed");
+
+        // The parent must exit — by finishing its shutdown, not by signal.
+        wait_for_clean_exit(child, data_dir);
+
+        // The gateway children must be gone — and stay gone.
+        assert_gateways_gone_and_stay_gone(marker, "steady state");
+
+        // Cleanup evidence from a non-stdout sink: serve's rolling tracing
+        // log under data_dir/logs must show stop_all ran.
+        assert_stop_all_logged(data_dir);
+    }
+
+    /// Test: SIGTERM arriving DURING the gateway auto-start window must also
+    /// reap the gateways — and must not keep STARTING the remaining ones.
+    ///
+    /// The stop-signal watcher is registered before the auto-start loop;
+    /// each profile's gateway startup health check holds that loop for ~2s,
+    /// so with four profiles the first gateway is already up while the
+    /// second is still starting — exactly the window a restarting
+    /// supervisor's SIGTERM can land in (the #2086 reporter's kill loop
+    /// restarts serve every few seconds, so the kill and the boot overlap).
+    /// Killing at "first gateway alive", before any HTTP byte, pins two
+    /// properties at once: had the handler been installed only inside
+    /// axum's graceful-shutdown future, this SIGTERM would hit the OS
+    /// default disposition, exit by signal, and orphan every gateway; and
+    /// without the latch check in the loop, profiles 3–4 would keep being
+    /// started after the operator already asked to stop.
+    #[test]
+    fn serve_sigterm_during_startup_reaps_gateways() {
+        let _guard = serial_guard();
+        let port = find_free_port();
+        let data_dir =
+            std::env::temp_dir().join(format!("octos_sigterm_startup_{}", std::process::id()));
+        std::fs::create_dir_all(data_dir.join("profiles")).unwrap();
+
+        let profile_prefix = format!("sigterm-startup-{}", std::process::id());
+        write_enabled_profiles(&data_dir, &profile_prefix, 4);
+
+        let err_path = data_dir.join("stderr.log");
+        let err_file = std::fs::File::create(&err_path).unwrap();
+        let mut cmd = serve_command(port, &data_dir);
+        cmd.stdout(Stdio::null()).stderr(Stdio::from(err_file));
+        let child = cmd.spawn().expect("failed to start octos serve");
+
+        let marker = data_dir.to_str().unwrap().to_string();
+        let mut cleanup = Cleanup {
+            marker: marker.clone(),
+            data_dir: data_dir.clone(),
+            child: Some(child),
+        };
+        run_startup_window_scenario(&marker, cleanup.child.as_mut().unwrap(), &data_dir);
+        // Happy path: serve already exited and was waited inside the scenario.
+        let _ = cleanup.child.take();
+        drop(cleanup);
+    }
+
+    /// The startup-window scenario body (see the test above for why it
+    /// exists). Split out for the same Drop-guard reason as
+    /// `run_sigterm_scenario`.
+    fn run_startup_window_scenario(
+        marker: &str,
+        child: &mut std::process::Child,
+        data_dir: &std::path::Path,
+    ) {
+        // Boot barrier: the FIRST gateway child is alive and stable — two
+        // samples 500ms apart. No HTTP barrier on purpose: the kill must
+        // land while the second profile's startup check is still holding the
+        // auto-start loop, i.e. before axum::serve is even polling. With the
+        // fix, the signal watcher registered before the loop latches this
+        // SIGTERM and the shutdown future observes it on its first poll.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        let mut gateways = Vec::new();
+        while std::time::Instant::now() < deadline {
+            if !gateway_orphan_pids(marker).is_empty() {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                gateways = gateway_orphan_pids(marker);
+                if !gateways.is_empty() {
+                    break;
+                }
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+        }
+        assert!(
+            !gateways.is_empty(),
+            "no `octos gateway` child appeared for {marker} — auto-start precondition broken"
+        );
+
+        // The act under test: SIGTERM while the second profile is still
+        // starting up.
+        let rc = unsafe { libc::kill(child.id() as i32, libc::SIGTERM) };
+        assert_eq!(rc, 0, "kill(SIGTERM) failed");
+
+        // The in-flight startup check finishes (nothing interrupts it
+        // mid-start), then the latched signal stops the loop and the
+        // shutdown future fires immediately — well within the 30s window.
+        wait_for_clean_exit(child, data_dir);
+
+        // Every gateway that DID start must be gone — and stay gone.
+        assert_gateways_gone_and_stay_gone(marker, "startup window");
+
+        assert_stop_all_logged(data_dir);
+
+        // The loop must not keep STARTING gateways after the signal latched:
+        // of the four enabled profiles at most two "auto-starting gateway"
+        // log lines may appear — the one in flight when the signal landed
+        // plus, at worst, the next iteration if the kill slipped past one
+        // startup check. Profiles 3–4 must never start. This also makes the
+        // test fail loudly instead of passing vacuously if the kill ever
+        // degraded past the whole auto-start window (all four started).
+        // These early-boot lines land in the rolling log seconds before
+        // exit, so they are long since flushed.
+        let tracing_log = read_dir_logs_concat(&data_dir.join("logs"));
+        let autostarts = tracing_log.matches("auto-starting gateway").count();
+        assert!(
+            (1..=2).contains(&autostarts),
+            "auto-start loop started {autostarts}/4 gateways around the SIGTERM — \
+             the latched-stop break is not bounding it; log:\n{tracing_log}"
+        );
+    }
+
+    /// Test: SIGTERM with an open SSE stream must still terminate the serve
+    /// within the drain cap and reap the gateway.
+    ///
+    /// Axum's graceful shutdown waits for in-flight connections, and an SSE
+    /// stream (`GET /api/events/harness`) never ends on its own — without a
+    /// cap the serve would hang until the supervisor escalates to SIGKILL,
+    /// skipping `stop_all()` and re-creating the #2086 orphans. The fix
+    /// bounds the drain after the signal (10s) and proceeds to the gateway
+    /// cleanup anyway.
+    ///
+    /// The pre-SIGTERM wait also pins that the cap's clock starts at the
+    /// SIGNAL, not at boot: a mis-wired deadline (e.g. wrapping
+    /// `axum::serve` in a plain `tokio::time::timeout`) would kill a
+    /// healthy, signal-free serve inside that window and the kill below
+    /// would target a dead pid.
+    #[test]
+    fn serve_sigterm_with_open_sse_stream_still_reaps_gateways() {
+        let _guard = serial_guard();
+        let port = find_free_port();
+        let data_dir =
+            std::env::temp_dir().join(format!("octos_sigterm_sse_{}", std::process::id()));
+        std::fs::create_dir_all(data_dir.join("profiles")).unwrap();
+
+        let profile_prefix = format!("sigterm-sse-{}", std::process::id());
+        write_enabled_profiles(&data_dir, &profile_prefix, 1);
+
+        let err_path = data_dir.join("stderr.log");
+        let err_file = std::fs::File::create(&err_path).unwrap();
+        let mut cmd = serve_command(port, &data_dir);
+        cmd.stdout(Stdio::null()).stderr(Stdio::from(err_file));
+        let child = cmd.spawn().expect("failed to start octos serve");
+
+        let marker = data_dir.to_str().unwrap().to_string();
+        let mut cleanup = Cleanup {
+            marker: marker.clone(),
+            data_dir: data_dir.clone(),
+            child: Some(child),
+        };
+        run_sse_scenario(port, &marker, cleanup.child.as_mut().unwrap(), &data_dir);
+        // Happy path: serve already exited and was waited inside the scenario.
+        let _ = cleanup.child.take();
+        drop(cleanup);
+    }
+
+    /// The SSE scenario body (see the test above for why it exists). Split
+    /// out for the same Drop-guard reason as `run_sigterm_scenario`.
+    fn run_sse_scenario(
+        port: u16,
+        marker: &str,
+        child: &mut std::process::Child,
+        data_dir: &std::path::Path,
+    ) {
+        // Boot barrier: listener + HTTP response byte (the SSE handshake
+        // needs a fully serving axum).
+        if !wait_for_port(port, std::time::Duration::from_secs(45)) {
+            panic!("serve did not listen on {port} within 45s");
+        }
+        let http_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut http_ready = false;
+        while std::time::Instant::now() < http_deadline && !http_ready {
+            if let Ok(mut stream) = std::net::TcpStream::connect(("127.0.0.1", port)) {
+                use std::io::{Read, Write};
+                let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(2)));
+                let _ = stream.set_write_timeout(Some(std::time::Duration::from_secs(2)));
+                let _ = stream.write_all(b"GET /admin/ HTTP/1.0\r\nHost: localhost\r\n\r\n");
+                let mut byte = [0u8; 1];
+                http_ready = matches!(stream.read(&mut byte), Ok(1));
+            }
+            if !http_ready {
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+        }
+        assert!(http_ready, "serve never answered an HTTP request on {port}");
+
+        // Outlive the drain cap (10s) with NO signal sent: a serve whose
+        // deadline started at boot would exit on its own inside this window.
+        let age_floor = std::time::Instant::now() + std::time::Duration::from_secs(12);
+        while std::time::Instant::now() < age_floor {
+            assert!(
+                child.try_wait().expect("try_wait failed").is_none(),
+                "serve exited before any signal — the drain cap must start at the signal, not at boot"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+
+        // The gateway must be up by now (auto-start precedes axum); assert
+        // it so the orphan check below cannot pass vacuously.
+        let gateways = gateway_orphan_pids(marker);
+        assert!(
+            !gateways.is_empty(),
+            "no `octos gateway` child appeared for {marker} — auto-start precondition broken"
+        );
+
+        // Subscribe an SSE stream and keep it open across the kill — this is
+        // the in-flight connection graceful shutdown cannot wait out.
+        let sse =
+            open_sse_stream(port).expect("failed to open an SSE stream (auth or handshake broken)");
+
+        // The act under test: SIGTERM with the stream open. The serve must
+        // exit via its shutdown path (drain cap → stop_all → exit 0), not
+        // hang and not die by signal.
+        let rc = unsafe { libc::kill(child.id() as i32, libc::SIGTERM) };
+        assert_eq!(rc, 0, "kill(SIGTERM) failed");
+
+        // The cap gives 10s of drain + stop_all; comfortably inside 30s.
+        wait_for_clean_exit(child, data_dir);
+
+        // The gateway must still have been reaped despite the open stream.
+        assert_gateways_gone_and_stay_gone(marker, "open SSE stream");
+
+        assert_stop_all_logged(data_dir);
+        drop(sse);
+    }
+}


### PR DESCRIPTION
## Problem

#2086 (comment "Separate finding"): killing `octos serve` with SIGTERM — what `pkill`, `systemctl stop`, and every supervisor sends — left every auto-started `octos gateway` child running. The reporter accumulated **38 orphaned gateways over ~15 restart cycles** (5 per start), each still holding its profile data dir, which both leaks resources unboundedly and mimics the issue's other failure mode (orphan contention makes the server listen but answer nothing).

Baseline on `main` (27ad221a), one enabled profile + `kill -TERM`:

- serve dies by signal (`signal=Some(15)`, exit code `None`) — the shutdown path never runs
- no `stopping all gateway child processes` in the tracing log — `stop_all()` is never reached
- the gateway child keeps running after the parent is gone

## Root cause

serve's graceful-shutdown future only caught SIGINT:

```rust
.with_graceful_shutdown(async {
    let _ = tokio::signal::ctrl_c().await;   // SIGINT only
    ...
})
```

SIGTERM fell through to the OS default disposition. Two secondary defects sat in the same path:

1. The handler was registered only when axum's shutdown future was first **polled** — i.e. after the gateway auto-start loop (each profile's startup health check holds that loop ~2s) — so even SIGINT could still hit the default disposition during boot, exactly when a restarting supervisor's kill lands.
2. `axum::serve(...).await?` returns early on a serve-loop error — past `stop_all()` — orphaning the gateways. And graceful shutdown waits for in-flight connections indefinitely: one open SSE stream (`GET /api/events/harness` never ends on its own) hangs a `systemctl stop` until `TimeoutStopSec` escalates to SIGKILL, which skips `stop_all()` the same way the signal death does.

## Fix (`crates/octos-cli/src/commands/serve.rs`)

- New `spawn_serve_shutdown_signal_watcher()` installs the SIGTERM listener **synchronously** (tokio only installs the handler when `signal()` runs, and a spawned task isn't polled until the runtime yields) and catches SIGINT-or-SIGTERM into a `watch` channel. It is called **before** the gateway auto-start loop, so the handler is in place before any child exists. The channel is stateful: a signal arriving before `axum::serve` polls its shutdown future is observed on the first poll, not lost.
- The auto-start loop checks the latch each iteration — once the stop signal is latched it stops **starting** new gateways (the in-flight `start()` completes; it cannot be interrupted mid-start).
- The serve future races a bounded drain: after the signal latches, `SERVE_SHUTDOWN_GRACE` (10s) for in-flight connections, then proceed to `stop_all()` + exit anyway rather than let a supervisor SIGKILL the process with the gateways still running.
- Both arms (clean shutdown and grace expiry) funnel into `stop_all()`. A serve-loop error no longer `?`-returns past it: it is logged, the children are reaped, and the exit code reflects the failure.
- Second-signal semantics: tokio keeps the handler installed for the process lifetime, so a second SIGTERM during the drain is captured-but-unobserved — it cannot kill serve before `stop_all()` runs (verified empirically: double SIGTERM 1s apart → shutdown completes, exit 0).

## Tests

New `crates/octos-cli/tests/serve_sigterm.rs` — unix-gated e2e driving the **real** octos binary, serial-only alongside `serve_broken_pipe` per the #21 outer-loop ruling:

1. `serve_sigterm_reaps_gateway_children` — steady state (HTTP serving, one gateway up): SIGTERM → parent exits **0, not by signal**, gateway gone and stays gone (3s settle window outlasts the 2s auto-restart), `stop_all` marker present in the tracing log.
2. `serve_sigterm_during_startup_reaps_gateways` — SIGTERM inside the auto-start window (first of four gateways up, second still in its startup check): pins handler-before-auto-start ordering (a handler installed only inside axum's shutdown future would still orphan here) and the latch break (at most 2 of 4 `auto-starting gateway` lines may appear).
3. `serve_sigterm_with_open_sse_stream_still_reaps_gateways` — open SSE stream + a 12s signal-free age floor (pins that the drain clock starts at the **signal**, not at boot — a plain `tokio::time::timeout` around `axum::serve` would kill a healthy idle serve): SIGTERM → exit 0 within the cap, gateway reaped.

Baseline red on pristine `main`: `serve must run its shutdown path under SIGTERM (exit 0), not die by signal (signal=Some(15))`.

CI wiring: the serial step becomes `--test serve_broken_pipe --test serve_sigterm`; every broad `cargo test` lane that runs the suite unskipped (test-octos-cli PR lane, check-arm, check-riscv, nightly check-arm, self-hosted fast-linux and linux-arm) adds `--skip serve_sigterm`. nightly check-windows and the self-hosted windows job are unchanged — the suite is unix-gated and compiles to zero tests there.

Validation (macOS aarch64, rustc 1.98.1, CI-exact commands):

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓, `cargo clippy -p octos-cli --lib --no-default-features -- -D warnings` ✓, all-features all-targets matrix variant ✓
- `cargo test -p octos-cli --features api --test serve_broken_pipe --test serve_sigterm -- --test-threads=1` → **7/7** ✓
- `cargo test -p octos-cli --lib` → **3693/3693** ✓
- `cargo test -p octos-cli --tests -- --skip serve_broken_pipe --skip serve_sigterm` → all targets ✓
- Manual e2e beyond the suite: grace-expiry path with an open SSE stream logs `WARN shutdown grace period expired ... grace_secs=10` → `stopping all gateway child processes` → `gateways stopped count=1`, exit 0; double-SIGTERM 1s apart survives with exit 0.

## Review

An independent review pass over the full diff led to five applied changes: synchronous SIGTERM registration (before the watcher task spawns, closing a registration window the task-spawn form would leave), the auto-start latch break plus a bounding assertion in the startup-window test, the serve-loop error no longer bypassing `stop_all()` (exit code now reflects it), skip coverage extended to the nightly/self-hosted lanes, and a stale comment fix in `serve_broken_pipe`. One mechanism claim from the review (a second signal during drain killing the process) was rebutted with the manual double-SIGTERM e2e above; all review-driven changes were re-validated with the full command set.

Notes / explicitly out of scope:

- The 10s grace sits under typical supervisor budgets (systemd `TimeoutStopSec` default 90s, `docker stop` 10s) so the serve cuts an immortal stream itself instead of being SIGKILLed mid-drain.
- Pre-existing narrow race between `stop_all()` and the 2s auto-restart monitor for a gateway that crashes exactly during shutdown — predates this change, untouched here.
- The ledger-hang defect from the same issue (serve hangs with `ui-protocol/` content present) is **not** addressed by this PR.

Refs #2086 (the gateway-orphaning finding only).
