### PR TITLE
fix(api): roll back sub-account creation when keychain relocation fails

### DIFF
--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -16,7 +16,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 use super::router::AuthIdentity;
 use super::{AppState, ominix_runtime};
-use crate::profiles::{ProfileConfig, UserProfile, mask_secrets};
+use crate::profiles::{ProfileConfig, ProfileStore, UserProfile, mask_secrets};
 
 const DEFAULT_SERVE_LOG_TAIL_N: usize = 200;
 const MAX_SERVE_LOG_TAIL_N: usize = 5_000;
@@ -1851,6 +1851,48 @@ pub(crate) fn validate_channel_credentials(
     Ok(())
 }
 
+/// The secret-relocation hook applied to a profile's env vars before they are
+/// persisted — the signature of [`relocate_keychain_backed_secrets`]. Carried
+/// as a parameter so tests can drive the failure path without writing to the
+/// developer's keychain.
+pub(crate) type RelocateSecretsHook =
+    fn(&mut std::collections::HashMap<String, String>, &str) -> Result<(), (StatusCode, String)>;
+
+/// Apply freshly supplied sub-account env vars, relocating keychain-backed
+/// secrets (e.g. the Vertex SA JSON) into the OS keychain before the save so a
+/// sub-account never writes a private key to plaintext config. The store has
+/// already persisted the fresh profile by the time this runs, so a relocation
+/// failure rolls the profile back — otherwise the API would report "creation
+/// failed" while leaving a sub-account whose id can never be retried ("already
+/// exists", #1472).
+pub(crate) fn apply_sub_account_env_vars(
+    store: &ProfileStore,
+    sub: &mut UserProfile,
+    env_vars: std::collections::HashMap<String, String>,
+    relocate: RelocateSecretsHook,
+) -> Result<(), (StatusCode, String)> {
+    sub.config.env_vars = env_vars;
+    let sub_id = sub.id.clone();
+    if let Err(e) = relocate(&mut sub.config.env_vars, &sub_id) {
+        // Roll the just-created profile back: the sub-account was saved
+        // keychain-less minutes ago and nothing else references it yet, so
+        // removing it restores the pre-request state instead of stranding a
+        // half-configured id behind "already exists".
+        if let Err(rollback) = store.delete(&sub.id) {
+            tracing::error!(
+                profile = %sub.id,
+                error = %rollback,
+                "failed to roll back sub-account after secret relocation failure"
+            );
+        }
+        return Err(e);
+    }
+    sub.updated_at = Utc::now();
+    store
+        .save(sub)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
 /// POST /api/admin/profiles/:id/accounts — Create a sub-account.
 pub async fn create_sub_account(
     State(state): State<Arc<AppState>>,
@@ -1884,15 +1926,12 @@ pub async fn create_sub_account(
 
     // Set channel-specific env vars if provided
     if !req.env_vars.is_empty() {
-        sub.config.env_vars = req.env_vars;
-        // Relocate keychain-backed secrets (e.g. the Vertex SA JSON) before
-        // persisting so a sub-account never writes a private key to disk.
-        let sub_id = sub.id.clone();
-        relocate_keychain_backed_secrets(&mut sub.config.env_vars, &sub_id)?;
-        sub.updated_at = Utc::now();
-        store
-            .save(&sub)
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        apply_sub_account_env_vars(
+            store,
+            &mut sub,
+            req.env_vars,
+            relocate_keychain_backed_secrets,
+        )?;
     }
 
     // Create a User entry so the sub-account can log in via OTP
@@ -5630,6 +5669,156 @@ mod tests {
             );
             assert!(slot.starts_with('{'), "raw value left untouched");
         }
+    }
+
+    // #1472 test fixture: a persisted parent profile plus a fresh (already
+    // saved, env-less) sub-account, i.e. the state `create_sub_account`
+    // handlers have when they reach the env-var step.
+    fn parent_profile() -> UserProfile {
+        UserProfile {
+            id: "parent".into(),
+            name: "Parent".into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn fresh_sub_account_with_parent(store: &ProfileStore) -> UserProfile {
+        store.save(&parent_profile()).unwrap();
+        store
+            .create_sub_account(
+                "parent",
+                "sub1",
+                "sub1",
+                "Sub",
+                vec![],
+                crate::profiles::GatewaySettings::default(),
+            )
+            .unwrap()
+    }
+
+    // #1472: the store has already persisted the fresh sub-account when a
+    // keychain-backed secret fails to relocate (raw Vertex SA JSON on a host
+    // with no secret store, or a keychain write error) — the failed creation
+    // must roll the profile back so retrying the same id doesn't hit
+    // "already exists".
+    #[test]
+    fn should_roll_back_fresh_sub_account_when_secret_relocation_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
+        let mut sub = fresh_sub_account_with_parent(&store);
+        let sub_id = sub.id.clone();
+
+        let res = apply_sub_account_env_vars(
+            &store,
+            &mut sub,
+            std::collections::HashMap::from([(
+                "VERTEX_SA_JSON".to_string(),
+                r#"{"type":"service_account","private_key":"x"}"#.to_string(),
+            )]),
+            |_env_vars, _profile_id| {
+                Err((
+                    StatusCode::BAD_REQUEST,
+                    "VERTEX_SA_JSON: keychain-backed credential storage is unavailable".into(),
+                ))
+            },
+        );
+
+        assert_eq!(res.unwrap_err().0, StatusCode::BAD_REQUEST);
+        assert!(
+            store.get(&sub_id).unwrap().is_none(),
+            "failed creation must not strand the sub-account"
+        );
+        store
+            .create_sub_account(
+                "parent",
+                "sub1",
+                "sub1",
+                "Sub",
+                vec![],
+                crate::profiles::GatewaySettings::default(),
+            )
+            .expect("retrying the same id must succeed after the rollback");
+    }
+
+    // The happy path is unchanged: benign env vars (nothing needing
+    // relocation) pass through the production relocate hook untouched and are
+    // persisted on the sub-account.
+    #[test]
+    fn should_persist_env_vars_when_nothing_needs_relocation() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
+        let mut sub = fresh_sub_account_with_parent(&store);
+        let sub_id = sub.id.clone();
+
+        let res = apply_sub_account_env_vars(
+            &store,
+            &mut sub,
+            std::collections::HashMap::from([("DEPLOY_ENV".to_string(), "production".to_string())]),
+            relocate_keychain_backed_secrets,
+        );
+
+        assert!(res.is_ok());
+        let saved = store.get(&sub_id).unwrap().expect("sub-account persisted");
+        assert_eq!(
+            saved.config.env_vars.get("DEPLOY_ENV").map(String::as_str),
+            Some("production")
+        );
+    }
+
+    // #1472 wiring: the admin create path routes env vars through the shared
+    // helper — benign vars (nothing to relocate) still land on the saved
+    // sub-account.
+    #[tokio::test]
+    async fn should_create_sub_account_with_env_vars_via_admin_handler() {
+        use crate::api::AppState;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
+        let state = AppState {
+            profile_store: Some(profile_store.clone()),
+            process_manager: Some(Arc::new(crate::process_manager::ProcessManager::new(
+                profile_store.clone(),
+            ))),
+            ..AppState::empty_for_tests()
+        };
+        profile_store.save(&parent_profile()).unwrap();
+
+        let (status, Json(resp)) = create_sub_account(
+            axum::extract::State(Arc::new(state)),
+            axum::extract::Path("parent".into()),
+            axum::extract::Json(CreateSubAccountRequest {
+                sub_account_id: "sub1".into(),
+                name: "Sub".into(),
+                public_subdomain: "sub1".into(),
+                email: None,
+                channels: vec![],
+                gateway: None,
+                env_vars: std::collections::HashMap::from([(
+                    "DEPLOY_ENV".to_string(),
+                    "production".to_string(),
+                )]),
+            }),
+        )
+        .await
+        .expect("creation succeeds");
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(resp.profile.id, "parent--sub1");
+        let saved = profile_store
+            .get("parent--sub1")
+            .unwrap()
+            .expect("sub-account persisted");
+        assert_eq!(
+            saved.config.env_vars.get("DEPLOY_ENV").map(String::as_str),
+            Some("production")
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -3653,14 +3653,12 @@ pub async fn create_my_sub_account(
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
     if !req.env_vars.is_empty() {
-        sub.config.env_vars = req.env_vars;
-        // Relocate keychain-backed secrets (e.g. the Vertex SA JSON) before
-        // persisting so a sub-account never writes a private key to disk.
-        let sub_id = sub.id.clone();
-        super::admin::relocate_keychain_backed_secrets(&mut sub.config.env_vars, &sub_id)?;
-        sub.updated_at = chrono::Utc::now();
-        ps.save(&sub)
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        super::admin::apply_sub_account_env_vars(
+            ps,
+            &mut sub,
+            req.env_vars,
+            super::admin::relocate_keychain_backed_secrets,
+        )?;
     }
 
     if let Some(email) = &req.email {
@@ -6322,6 +6320,57 @@ mod tests {
         assert_eq!(home["settings"]["city"], "Kyoto");
         assert_eq!(home["settings"]["clock_format"], "24h");
         assert_eq!(home["events"][0]["title"], "School pickup");
+    }
+
+    // #1472 wiring: the self-service create path routes env vars through the
+    // same shared helper as the admin path — benign vars (nothing to
+    // relocate) land on the saved sub-account.
+    #[tokio::test]
+    async fn should_create_my_sub_account_with_env_vars_via_my_handler() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let state = AppState {
+            process_manager: Some(Arc::new(crate::process_manager::ProcessManager::new(
+                profile_store.clone(),
+            ))),
+            ..state
+        };
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant Owner"))
+            .unwrap();
+
+        let (status, Json(resp)) = create_my_sub_account(
+            State(Arc::new(state)),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            axum::Json(crate::api::admin::CreateSubAccountRequest {
+                sub_account_id: "sub1".into(),
+                name: "Sub".into(),
+                public_subdomain: "sub1".into(),
+                email: None,
+                channels: vec![],
+                gateway: None,
+                env_vars: std::collections::HashMap::from([(
+                    "DEPLOY_ENV".to_string(),
+                    "production".to_string(),
+                )]),
+            }),
+        )
+        .await
+        .expect("creation succeeds");
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(resp.profile.id, "tenant--sub1");
+        let saved = profile_store
+            .get("tenant--sub1")
+            .unwrap()
+            .expect("sub-account persisted");
+        assert_eq!(
+            saved.config.env_vars.get("DEPLOY_ENV").map(String::as_str),
+            Some("production")
+        );
     }
 
     // #1470: same partial nested-section patch as above, but through the


### PR DESCRIPTION
## 问题（#1472）

admin 的 `create_sub_account` 和自助 `create_my_sub_account` 都先用 `ProfileStore::create_sub_account` 落盘 profile，之后才调 `relocate_keychain_backed_secrets`。失败路径——非 macOS 主机上的裸 Vertex SA JSON（被拒）或 keychain 写入错误——`?` 在账号已保存后才返回错误：API 报 "creation failed"，却留下一个没有 env vars 的子账号；重试同一 id 直接撞 "already exists"。

## 根因

env-var 步骤（赋值 → 迁移 secret → 落盘）在两个 handler 里内联执行，发生在 profile 已持久化**之后**，且错误路径没有任何回滚。子域唯一性派生自 profile 记录本身（`ensure_public_subdomain_available` 扫描磁盘上的 profile），所以被搁浅的记录同时也占住了子域。

## 修复

把 env-var 步骤抽成共享的 `apply_sub_account_env_vars`（admin.rs），迁移失败时 `store.delete` 刚创建的 profile，恢复请求前状态（回滚失败则 `tracing::error` 记录并保留原始迁移错误）。relocate 钩子作为参数注入，测试可以驱动失败路径而不写开发机的 keychain。两个调用点（admin + 自助）都走该 helper；成功路径行为逐行不变（赋值顺序、`updated_at`、错误状态码均保持）。

## 测试证据

- 新增 4 个测试：
  - `should_roll_back_fresh_sub_account_when_secret_relocation_fails` — 注入失败钩子：返回 BAD_REQUEST、`store.get` 为 None、**同 id 重试成功**（issue 的核心症状）；
  - `should_persist_env_vars_when_nothing_needs_relocation` — 生产钩子 + 良性变量（`needs_keychain_relocation` 为 false，不触 keychain）正常持久化；
  - `should_create_sub_account_with_env_vars_via_admin_handler` / `should_create_my_sub_account_with_env_vars_via_my_handler` — 两个 handler 的接线测试，真实 `ProfileStore` 落盘断言。
- 本地全绿（单次运行，无重跑掩盖）：
  - `cargo test -p octos-cli --features api --lib` → **3697 passed / 0 failed**（10 ignored，macOS）；
  - `cargo fmt --all -- --check` ✓；`cargo clippy --workspace --all-targets -- -D warnings` ✓；
  - check-matrix 两档：`cargo clippy -p octos-cli --lib --no-default-features -- -D warnings` ✓、`cargo clippy -p octos-cli --all-targets --no-default-features --features api,telegram,discord,dingtalk,slack,whatsapp,feishu,email,matrix,audio_mp3 -- -D warnings` ✓。

Closes #1472